### PR TITLE
Get display properties only when display exists

### DIFF
--- a/src/devicex.hpp
+++ b/src/devicex.hpp
@@ -65,15 +65,19 @@ public:
             decomposed = (Depth >= 15 ? 1 : 0);
           } 
         }
-        Visual *visual=DefaultVisual( display, DefaultScreen(display) ); 
-        switch ( visual->c_class )
-        {
-         case TrueColor:
-         case StaticColor:
-         case StaticGray:
-          staticDisplay=1;
-             break; //ok, are static
-         default: //dynamic: problems if cmaps not initialized.
+        if (display != NULL) {
+          Visual *visual=DefaultVisual( display, DefaultScreen(display) );
+          switch ( visual->c_class )
+          {
+           case TrueColor:
+           case StaticColor:
+           case StaticGray:
+            staticDisplay=1;
+               break; //ok, are static
+           default: //dynamic: problems if cmaps not initialized.
+            staticDisplay=0;
+          }
+        } else {
           staticDisplay=0;
         }
  


### PR DESCRIPTION
Otherwise, we run into a segmentation fault when (Python-)GDL is used without a display