### PR TITLE
Implement DELVAR procedure, .RNEW (includes the HEAP_REFCOUNT changes)

### DIFF
--- a/src/GDLInterpreter.hpp
+++ b/src/GDLInterpreter.hpp
@@ -34,7 +34,8 @@
 //#define GDL_DEBUG
 //#undef GDL_DEBUG
 //#define GDL_DEBUG_HEAP
-
+bool IsEnabledGC(); // defined in GDLInterpreter.hpp with EnableGC(bool);
+void EnableGC(bool);
 
 class CUSTOM_API GDLInterpreter : public antlr::TreeParser, public GDLInterpreterTokenTypes
 {
@@ -223,7 +224,8 @@ public:
 //             }
 //         return false;
 //     }
-
+ //   static bool IsEnabledGC() { return enable_GC;}
+	static bool IsEnabledGC() { return true;}
     // the New... functions 'own' their BaseGDL*
     SizeT NewObjHeap( SizeT n=1, DStructGDL* var=NULL)
     {
@@ -302,9 +304,90 @@ public:
        }
     }
 
-   static void DecRef( DPtr id)
+   static DByteGDL* IsEnabledGC( DPtrGDL* p)
+   {
+		SizeT nEl=p->N_Elements();
+		if( nEl == 0) return new DByteGDL( 0);
+		DByteGDL* ret = new DByteGDL( p->Dim());
+		Guard<DByteGDL> guard(ret);
+		for( SizeT ix=0; ix < nEl; ix++)
+		{
+			DPtr id= (*p)[ix];
+		   if( id != 0)
+			   {
+			   HeapT::iterator it=heap.find( id);
+			   if( it != heap.end() and (*it).second.IsEnabledGC())
+					(*ret)[ix] = 1;
+			   }
+		}
+		return guard.release();
+   }
+   static DByteGDL* IsEnabledGCObj( DObjGDL* p)
+   {
+        SizeT nEl=p->N_Elements();
+        if( nEl == 0) return new DByteGDL( 0);
+        DByteGDL* ret = new DByteGDL( p->Dim());
+        Guard<DByteGDL> guard(ret);
+        for( SizeT ix=0; ix < nEl; ix++)
+   {
+            DObj id= (*p)[ix];
+		   if( id != 0)
+			   {
+			   ObjHeapT::iterator it=objHeap.find( id);
+			   if( it != objHeap.end() and (*it).second.IsEnabledGC())
+					(*ret)[ix] = 1;
+			   }
+        }
+        return guard.release();
+   }
+
+   static void EnableGC( DPtr id, bool set=true)
    {
        if( id != 0)
+           {
+		   HeapT::iterator it=heap.find( id);
+		   if( it != heap.end()) (*it).second.EnableGC(set);
+           }
+   }
+   static void EnableGC( DPtrGDL* p, bool set=true)
+   {
+        SizeT nEl=p->N_Elements();
+        for( SizeT ix=0; ix < nEl; ix++)
+        {
+            DPtr id= (*p)[ix];
+            EnableGC( id, set);
+       }
+   }
+   static void EnableAllGC() {
+        SizeT nEl = heap.size();
+        for( HeapT::iterator it=heap.begin(); it != heap.end(); ++it)
+			it->second.EnableGC(true);
+        nEl = objHeap.size();
+        for( ObjHeapT::iterator it=objHeap.begin(); it != objHeap.end(); ++it)
+			it->second.EnableGC(true);
+   }
+
+   static void EnableGCObj( DObj id, bool set=true)
+   {
+       if( id != 0)
+           {
+		   ObjHeapT::iterator it=objHeap.find( id);
+		   if( it != objHeap.end()) (*it).second.EnableGC(set);
+           }
+   }
+   static void EnableGCObj( DObjGDL* p, bool set=true)
+   {
+        SizeT nEl=p->N_Elements();
+        for( SizeT ix=0; ix < nEl; ix++)
+        {
+            DObj id= (*p)[ix];
+            EnableGCObj( id, set);
+       }
+   }
+
+   static void DecRef( DPtr id)
+   {
+       if( id != 0 and IsEnabledGC())
            {
 #ifdef GDL_DEBUG_HEAP
                std::cout << "-- <PtrHeapVar" << id << ">" << std::endl; 
@@ -312,7 +395,7 @@ public:
                HeapT::iterator it=heap.find( id);
                if( it != heap.end()) 
                    { 
-                       if( (*it).second.Dec())
+					   if( (*it).second.Dec() and (*it).second.IsEnabledGC() )
                            {
 #ifdef GDL_DEBUG_HEAP
                                std::cout << "Out of scope (garbage collected): <PtrHeapVar" << id 
@@ -341,7 +424,7 @@ public:
     }
    static void DecRefObj( DObj id)
     {
-        if( id != 0)
+        if( id != 0 and IsEnabledGC())
             {
 #ifdef GDL_DEBUG_HEAP
 std::cout << "-- <ObjHeapVar" << id << ">" << std::endl; 
@@ -349,7 +432,7 @@ std::cout << "-- <ObjHeapVar" << id << ">" << std::endl;
                 ObjHeapT::iterator it=objHeap.find( id);
                 if( it != objHeap.end()) 
                     { 
-                       if( (*it).second.Dec())
+					   if( (*it).second.Dec() and (*it).second.IsEnabledGC() )
                            {
 #ifdef GDL_DEBUG_HEAP
                                std::cout << "Out of scope (garbage collected): <ObjHeapVar" << id 
@@ -380,7 +463,7 @@ std::cout << "<ObjHeapVar" << id << "> = " << (*it).second.Count() << std::endl;
     }
    static void IncRef( DPtr id)
     {
-        if( id != 0)
+        if( id != 0 and IsEnabledGC())
             {
 #ifdef GDL_DEBUG_HEAP
 std::cout << "++ <PtrHeapVar" << id << ">" << std::endl; 
@@ -409,6 +492,26 @@ std::cout << add << " + <PtrHeapVar" << id << ">" << std::endl;
                     }
             }
     }
+   static SizeT RefCountHeap( DPtr id)
+    {
+		SizeT result = 0;
+        if( id != 0)
+            {
+                HeapT::iterator it=heap.find( id);
+                if( it != heap.end()) result = (*it).second.Count();
+			}
+		return result;
+	   }
+   static SizeT RefCountHeapObj( DObj id)
+    {
+		SizeT result = 0;
+        if( id != 0)
+            {
+                ObjHeapT::iterator it=objHeap.find( id);
+                if( it != objHeap.end()) result = (*it).second.Count();
+			}
+		return result;
+	   }
    static void IncRef( DPtrGDL* p)
     {
         SizeT nEl=p->N_Elements();
@@ -420,14 +523,13 @@ std::cout << add << " + <PtrHeapVar" << id << ">" << std::endl;
     }
    static void IncRefObj( DObj id)
     {
-        if( id != 0)
+        if( id != 0 and IsEnabledGC())
             {
 #ifdef GDL_DEBUG_HEAP
 std::cout << "++ <ObjHeapVar" << id << ">" << std::endl; 
 #endif
                 ObjHeapT::iterator it=objHeap.find( id);
-                if( it != objHeap.end()) 
-                    { 
+                if( it != objHeap.end())   { 
                         (*it).second.Inc(); 
                     }
             }
@@ -463,6 +565,12 @@ std::cout << add << " + <ObjHeapVar" << id << ">" << std::endl;
         HeapT::iterator it=heap.find( ID);
         if( it == heap.end()) 
             throw HeapException();
+        return it->second.get();
+    }
+    static BaseGDL* GetHeapNoThrow( DPtr ID)
+    {
+        HeapT::iterator it=heap.find( ID);
+        if( it == heap.end())  return NULL;
         return it->second.get();
     }
     static DStructGDL*& GetObjHeap( DObj ID)
@@ -613,6 +721,9 @@ std::cout << add << " + <ObjHeapVar" << id << ">" << std::endl;
             delete (*it).second.get();
             objHeap.erase( it->first); 
         }
+// The counters are reset for easier human readability.
+       heapIx = 1;
+       objHeapIx = 1;
     }
 
     // name of data
@@ -638,7 +749,7 @@ std::cout << add << " + <ObjHeapVar" << id << ">" << std::endl;
     static void ReportCompileError( GDLException& e, const std::string& file = "");
 
     // interpreter
-    static void ReportError( GDLException& e, const std::string &emsg, 
+    static void ReportError( GDLException& e, const std::string emsg, 
                              bool dumpStack=true)
     {
         DString msgPrefix = SysVar::MsgPrefix();

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -42,7 +42,9 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
         STRICTARR=8,
         LOGICAL_PREDICATE=16, // *** functionality not implemeted yet
         IDL2=DEFINT32 | STRICTARR,
-        STRICTARRSUBS=32
+        STRICTARRSUBS=32,
+	STATIC=64,
+	NOSAVE=128
     };
 
     void SetCompileOpt( unsigned int cOpt)
@@ -60,6 +62,8 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
         else if( opt == "LOGICAL_PREDICATE") compileOpt |= LOGICAL_PREDICATE;
         else if( opt == "IDL2")              compileOpt |= IDL2;
         else if( opt == "STRICTARRSUBS")     compileOpt |= STRICTARRSUBS;
+        else if( opt == "STATIC")	     compileOpt |= STATIC;
+        else if( opt == "NOSAVE")	     compileOpt |= NOSAVE;
         else throw GDLException("Unrecognised COMPILE_OPT option: "+opt);
 //        SetActualCompileOpt( compileOpt);
     }

--- a/src/basic_fun.hpp
+++ b/src/basic_fun.hpp
@@ -46,6 +46,9 @@ namespace lib {
 
   BaseGDL* ptr_new( EnvT* e);
   BaseGDL* obj_new( EnvT* e);
+
+  BaseGDL* heap_refcount( EnvT* e);
+
   BaseGDL* call_function( EnvT* e);
   BaseGDL* call_method_function( EnvT* e);
   

--- a/src/basic_pro.hpp
+++ b/src/basic_pro.hpp
@@ -47,6 +47,8 @@ namespace lib {
 	void help_item(std::ostream& os,
 		BaseGDL* par, DString parString, bool doIndentation);
 	void help_pro(EnvT* e);
+    void delvar_pro( EnvT* e);
+    void findvar_pro( EnvT* e);
 	void exitgdl(EnvT* e);
 
 	// in print.cpp

--- a/src/dpro.cpp
+++ b/src/dpro.cpp
@@ -443,6 +443,11 @@ bool DSubUD::isObsolete()
   return compileOpt & GDLParser::OBSOLETE;
 }
 
+bool DSubUD::isStatic()
+{
+  return compileOpt & GDLParser::STATIC;
+}
+
 bool DSubUD::isHidden()
 {
   return compileOpt & GDLParser::HIDDEN;

--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -323,11 +323,19 @@ public:
   void SetTree( ProgNodeP t) { tree = t;}
 
   void AddCommon(DCommonBase* c) { common.push_back(c);}
-  void DeleteLastAddedCommon()
+  void DeleteLastAddedCommon(bool kill=true)
   {
-    delete common.back();
+    if(kill) delete common.back();
     common.pop_back();
   }
+    void commonPtrs( std::vector<DCommonBase *>& cptr)
+{
+	cptr.clear();
+    CommonBaseListT::iterator c = common.begin();
+    for(; c != common.end(); ++c)
+       cptr.push_back((*c));
+    return;
+	}
   
   void ResolveAllLabels();
   LabelListT& LabelList() { return labelList;}
@@ -352,6 +360,7 @@ public:
 
   void     DelVar(const int ix) {var.erase(var.begin() + ix);}
 
+   void Resize( SizeT s) { var.resize( s);}
   SizeT Size() {return var.size();}
   SizeT CommonsSize() {
    SizeT commonsize=0;
@@ -393,6 +402,11 @@ public:
     return (c != common.end())? *c : NULL;
   }
 
+void ReName( SizeT ix, const std::string& s)
+  {
+    var[ix] = s;
+    return;
+  }
   const std::string& GetVarName( SizeT ix)
   {
     return var[ix];
@@ -485,6 +499,7 @@ public:
   void SetCompileOpt(const unsigned int n) { compileOpt = n; }
   bool isObsolete();
   bool isHidden();
+  bool isStatic();
 
   friend class EnvUDT;
 };

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -1228,7 +1228,9 @@ BaseGDL*& EnvBaseT::GetParDefined(SizeT i)
   SizeT ix = i + pro->key.size();
 
   // cout << i << " -> " << ix << "  " << env.size() << "  env[ix] " << env[ix] << endl;
-  if( ix >= env.size() || env[ ix] == NULL || env[ ix] == NullGDL::GetSingleInstance())
+  if( ix >= env.size())
+    Throw("Incorrect number of arguments.");
+  if( env[ ix] == NULL || env[ ix] == NullGDL::GetSingleInstance())
     Throw("Variable is undefined: "+GetString( ix));
   return env[ ix];
 }
@@ -1274,6 +1276,75 @@ SizeT EnvBaseT::NParam( SizeT minPar)
 SizeT EnvT::NParam( SizeT minPar)
 {
   return EnvBaseT::NParam( minPar);
+}
+
+bool EnvBaseT::Removeall() 
+{
+	DSubUD* proD=dynamic_cast<DSubUD*>(pro);
+	int osz = env.size();
+	for( SizeT ix=0; ix < osz; ix++) {
+		if( env[ix] != NULL) GDLDelete( env[ix]);
+		env.pop_back();
+	}
+	proD->Resize(0);
+	return true;
+}
+	
+bool EnvBaseT::Remove(int* rindx)
+{
+	DSubUD* proD=dynamic_cast<DSubUD*>(pro);
+
+	static volatile bool debug( false);  // switch off/on
+	static int ix, osz, inrem;
+
+	osz = env.size();
+	inrem = 0;
+	int itrg = rindx[0];
+	ix=itrg;
+		if(debug)	printf(" env.size() = %d", osz);	
+	while( ix >= 0)
+	{
+		inrem++;
+		if(debug)	printf(" env.now.size() = %d  env[%d] = 0x%x ",
+				osz - inrem,
+				ix,static_cast <const void *>(env[ix]) );
+		if ( env[ix] != NULL) GDLDelete( env[ix]);
+		int esrc = rindx[inrem];
+		if(esrc < 0) esrc = osz;
+		if(debug) cout << " limit:"<< esrc ;
+		while( ++ix < esrc) {
+			if(debug) cout << ", @:"<<itrg<<"<"<<ix;
+				env.Set( itrg, env.Loc(ix));
+				proD->ReName(itrg++, proD->GetVarName(ix));
+			}
+		ix=rindx[inrem];
+		if(debug) cout << " inrem:"<<inrem <<" ix:" << ix << endl; 
+		}				 // zero all with GDLDelete
+	if(inrem <= 0) return false;
+	
+	osz = osz - inrem;
+    while(inrem-- > 0) env.pop_back();
+
+	env.resize(osz);
+	proD->Resize(osz);
+	return true;
+ }
+ 
+int EnvBaseT::findvar(const std::string& s)
+{
+	DSubUD* proD=dynamic_cast<DSubUD*>(pro);
+	int kIx = proD->FindVar(s);
+	return kIx;
+}
+
+int EnvBaseT::findvar(BaseGDL* delP)
+{
+  static BaseGDL* null=NULL;
+	for(int Ix=0; Ix < env.size(); Ix++) {
+		if(delP != env[ Ix] ) continue;
+	return Ix;
+	}
+	return -1;
 }
 
 void EnvBaseT::SetNextParUnchecked( BaseGDL* const nextP) // by value (reset loc)
@@ -1350,7 +1421,7 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 				       pro->warnKey.end(),
 				       strAbbrefEq_k);
       if( wf == pro->warnKey.end()) 
-	Throw(  "Keyword parameter "+k+" not allowed in call "
+	Throw(  "Keyword parameter -"+k+"- not allowed in call "
 		"to: "+pro->Name());
       // 	throw GDLException(callingNode,
       // 			   "Keyword parameter "+k+" not allowed in call "
@@ -1379,7 +1450,7 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 					   pro->warnKey.end(),
 					   strAbbrefEq_k);
 	  if( wf == pro->warnKey.end()) 
-	    Throw( "Keyword parameter "+k+" not allowed in call "
+	    Throw( "Keyword parameter <"+k+"> not allowed in call "
 		   "to: "+pro->Name());
 	  /*	    throw GDLException(callingNode,
 	    "Keyword parameter "+k+" not allowed in call "
@@ -1411,10 +1482,12 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 
   // already set? -> Warning 
   // (move to Throw by AC on June 25, 2014, bug found by Levan.)
-  if( KeywordPresent(varIx)) // just a message in the original
-    {
-      Throw( "Duplicate keyword "+k+" in call to: "+pro->Name());
-    }
+// Removed G. Jung 2016:
+// mungs things up.  Could not determine 2014 bug.
+//  if( KeywordPresent(varIx)) // just a message in the original
+//    {
+//      Throw( "Duplicate keyword "+k+" in call to: "+pro->Name());
+//    }
 
   return varIx;
 }

--- a/src/envt.hpp
+++ b/src/envt.hpp
@@ -120,6 +120,11 @@ public:
   // and used by WRAPPED subroutines
   int GetKeywordIx( const std::string& k);
 
+	
+  int findvar(const std::string& s);
+  int findvar(BaseGDL* delP);
+  bool Remove(int* rindx);
+  bool Removeall();
   
   bool StealLocalKW( SizeT ix) 
   { 

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -169,7 +169,9 @@ tokens {
         STRICTARR=8,
         LOGICAL_PREDICATE=16, // *** functionality not implemeted yet
         IDL2=DEFINT32 | STRICTARR,
-        STRICTARRSUBS=32
+        STRICTARRSUBS=32,
+        STATIC=64,
+        NOSAVE=128
     };
 
     void SetCompileOpt( unsigned int cOpt)
@@ -187,6 +189,8 @@ tokens {
         else if( opt == "LOGICAL_PREDICATE") compileOpt |= LOGICAL_PREDICATE;
         else if( opt == "IDL2")              compileOpt |= IDL2;
         else if( opt == "STRICTARRSUBS")     compileOpt |= STRICTARRSUBS;
+        else if( opt == "STATIC")            compileOpt |= STATIC;
+        else if( opt == "NOSAVE")            compileOpt |= NOSAVE;
         else throw GDLException("Unrecognised COMPILE_OPT option: "+opt);
 //        SetActualCompileOpt( compileOpt);
     }

--- a/src/gdlc.i-1523252260.g
+++ b/src/gdlc.i-1523252260.g
@@ -67,9 +67,6 @@ header {
 //#undef GDL_DEBUG
 //#define GDL_DEBUG_HEAP
 
-bool IsEnabledGC(); // defined in GDLInterpreter.cpp with EnableGC(bool);
-void EnableGC(bool);
-
 }
 
 options {

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -302,6 +302,9 @@ void LibInit()
   new DLibPro(lib::heap_gc,string("HEAP_GC"),0,heap_gcKey); 
   new DLibPro(lib::heap_free,string("HEAP_FREE"),1,heap_gcKey);
 
+  const string heap_refcount[]={"DISABLE","ENABLE","IS_ENABLED",KLISTEND};
+  new DLibFunRetNew(lib::heap_refcount,string("HEAP_REFCOUNT"),1,heap_refcount);
+
 
   new DLibPro(lib::ptr_free,string("PTR_FREE"),-1);
 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -261,6 +261,9 @@ void LibInit()
   const string helpWarnKey[]={"BREAKPOINTS","DLM","FILES","HEAP_VARIABLES","MESSAGES",
 			      "OBJECTS","SHARED_MEMORY", KLISTEND};
   new DLibPro(lib::help_pro,string("HELP"),-1,helpKey,helpWarnKey);
+  new DLibPro(lib::delvar_pro,string("DELVAR"),-1,NULL,NULL);
+  DLibPro* hide = new DLibPro(lib::findvar_pro,string("FINDVAR"),-1,NULL,NULL);
+  hide->SetHideHelp(true);
   
   //stub to avoid setting errors on pref_set. One may want to really write pref_set,
   // but this function is just here to prevent setting !ERR=-1 when stumbling on a pref_set command,

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -67,11 +67,18 @@ GDLFileListT  fileUnits;
 volatile bool sigControlC;
 int           debugMode;
 bool  strictInterpreter;
+//	global garbage collection flag in support of HEAP_REFCOUNT:
+static bool enabled_GC=true;
+	bool IsEnabledGC()  // Referenced from GDLInterpreter.hpp
+	 { return enabled_GC; }
+	void EnableGC( bool set=true) // same names, many contexts.
+	 { enabled_GC = set; }
 
 namespace structDesc {
   // set in InitStructs()
   DStructDesc* LIST = NULL;
   DStructDesc* HASH = NULL;
+  DStructDesc* GDL_CONTAINER = NULL;
   DStructDesc* GDL_CONTAINER_NODE = NULL;
   DStructDesc* GDL_HASHTABLEENTRY = NULL;
 }
@@ -203,6 +210,16 @@ void InitStructs()
   structList.push_back(gdlContainerNode);
   structDesc::GDL_CONTAINER_NODE = gdlContainerNode;
 
+  DStructDesc* gdlContainer = new DStructDesc( "GDL_CONTAINER");
+  gdlContainer->AddTag("GDL_CONTAINER_TOP", &aLong64);
+  gdlContainer->AddTag("GDLCONTAINERVERSION", &aInt);
+  gdlContainer->AddTag("PHEAD", &aPtrRef);
+  gdlContainer->AddTag("PTAIL", &aPtrRef);
+  gdlContainer->AddTag("NLIST", &aLong);
+  gdlContainer->AddTag("GDL_CONTAINER_BOTTOM", &aLong64);
+//  gdlContainer->AddParent(gdl_object);// no operator overloading
+  structList.push_back(gdlContainer);
+  structDesc::GDL_CONTAINER = gdlContainer;
   DStructDesc* gdlHash = new DStructDesc( "HASH");
   gdlHash->AddTag("TABLE_BITS", &aULong);
   gdlHash->AddTag("TABLE_SIZE", &aULong);

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -106,7 +106,11 @@ template <typename T> class RefHeap {
   private:
     T* ptr;
     SizeT count;
-      
+    // 2016.05.13 GJ:
+    bool doSave; // IDL 6.1 flag whether to include in a SAVE operation (HEAP_SAVE)
+    // access via HEAP_SAVE( Heapvars) and HEAP_NOSAVE( Heapvars [,SET=[0/1]])
+    bool enableGC;   // IDL 8.0 flag whether to perform automatic garbage collection 
+    // access via HEAP_REFCOUNT([,/ENABLE] [,/DISABLE] [,IS_ENABLED=])
     // prevent usage
     RefHeap<T>& operator=(const RefHeap<T>& other) {	return *this;}
     template<class newType> operator RefHeap<newType>() {return RefHeap<newType>(ptr);}
@@ -116,16 +120,22 @@ template <typename T> class RefHeap {
 
     SizeT Count() const { return count;}
 
+	bool IsEnabledGC() const {	return enableGC; }
+	void EnableGC( bool set=true) { enableGC = set; }
+	
+	bool IsEnabledSave() const { return doSave; }
+	void EnableSave( bool set=true) { doSave = set; }
+	
     void Inc() {++count;}
     void Add( SizeT add) {count += add;}
     bool Dec() {assert(count > 0); return (--count==0);}
 
     RefHeap(T* p = 0)
-    : ptr(p), count(1)
+    : ptr(p), count(1), doSave(false), enableGC(true)
     {}
 
     RefHeap( const RefHeap<T>& other)
-    : ptr( other.ptr), count( other.count) 
+    : ptr( other.ptr), count( other.count),  doSave( other.doSave), enableGC( other.enableGC)
     {}
 
     ~RefHeap()


### PR DESCRIPTION
delvar_pro is found in basic_pro.cpp;
methods to GDL internals are added to facilitate this in envt and in dpro.
The .RNEW command is activated in dinterpreter.cpp
compile option flags STATIC and NOSAVE are in place, although they are not in use.

findvar_pro may be useful in a development context - normally it is not compiled.
DELVAR is to be used only from the $MAIN program, as per IDL docs; if it isn't, an
exception is raised with a message.

Tested since 2016.  Smoke test made for current git build.
Stage 1
Greg Jung (aka maynardGK)
gvjung@gmail.com
