### PR TITLE
Help_pro refurbishment and code cleanup: part 1

### DIFF
--- a/src/basic_pro.hpp
+++ b/src/basic_pro.hpp
@@ -43,10 +43,11 @@ namespace lib {
 	void writeu(EnvT* e);
 	void readu(EnvT* e);
 
+  
 	// help_item is used by EnvT::HeapGC
 	void help_item(std::ostream& os,
 		BaseGDL* par, DString parString, bool doIndentation);
-	void help_pro(EnvT* e);
+  void help_struct( std::ostream& os,  BaseGDL* par, int indent , bool debug );
 	void exitgdl(EnvT* e);
 
 	// in print.cpp
@@ -92,8 +93,6 @@ namespace lib {
 	// the following by Alain Coulais
 	// (alaingdl @@ users.sourceforge.net)
 
-	// Sorry to put a Function with Procedure but I need it for HELP proc.
-	BaseGDL* recall_commands(EnvT* e);
 
 	void resolve_routine(EnvT* e);
 

--- a/src/gdlhelp.hpp
+++ b/src/gdlhelp.hpp
@@ -32,12 +32,11 @@ namespace lib {
   // (alaingdl @@ users.sourceforge.net)
   BaseGDL* recall_commands(EnvT* e);
 
-//  BaseGDL* routine_filepath( EnvT* e); this is in basic_fun
+// routine_filepath is housed in basic_fun.spp
+//  BaseGDL* routine_filepath( EnvT* e);
 
   void help_pro( EnvT* e);
 
-//  void delvar_pro( EnvT* e);
-//  void findvar_pro( EnvT* e);
 
   } // namespace
 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -26,6 +26,7 @@
 
 #include "basic_fun.hpp"
 #include "basic_pro.hpp"
+#include "gdlhelp.hpp"
 
 #include "list.hpp"
 #include "hash.hpp"
@@ -253,13 +254,14 @@ void LibInit()
   const string exitKey[]={"NO_CONFIRM","STATUS",KLISTEND};
   new DLibPro(lib::exitgdl,string("EXIT"),0,exitKey);
   
-  const string helpKey[]={"ALL_KEYS","BRIEF","FULL","CALLS","DEVICE","FUNCTIONS","HELP","INFO",
+  const string helpKey[]={"ALL_KEYS","BRIEF","FULL","CALLS",
+	           "DEBUG","DEVICE","FUNCTIONS","HEAP_VARIABLES","HELP","INFO","FILES",
 			  "INTERNAL_LIB_GDL","KEYS","LAST_MESSAGE","LIB","MEMORY","NAMES",
-			  "OUTPUT","PATH_CACHE","PREFERENCES","PROCEDURES",
+		"OBJECTS","OUTPUT","PATH_CACHE","PREFERENCES","PROCEDURES",
 			  "RECALL_COMMANDS","ROUTINES","SOURCE_FILES","STRUCTURES",
               "SYSTEM_VARIABLES","TRACEBACK", "COMMON","LEVEL", KLISTEND};
-  const string helpWarnKey[]={"BREAKPOINTS","DLM","FILES","HEAP_VARIABLES","MESSAGES",
-			      "OBJECTS","SHARED_MEMORY", KLISTEND};
+  const string helpWarnKey[]={"BREAKPOINTS","DLM", "MESSAGES",
+			      "SHARED_MEMORY", KLISTEND};
   new DLibPro(lib::help_pro,string("HELP"),-1,helpKey,helpWarnKey);
   
   //stub to avoid setting errors on pref_set. One may want to really write pref_set,

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -117,6 +117,7 @@ TESTS = \
   test_get_lun.pro \
   test_get_screen_size.pro \
   test_grib.pro \
+  test_help.pro \
   test_hist_2d.pro \
   test_hdf5.pro \
   test_idl8.pro \

--- a/testsuite/test_help.pro
+++ b/testsuite/test_help.pro
@@ -1,0 +1,39 @@
+; test_help: a prototype everything goes collection of compiled routines
+; and common blocks, and help calls.  If os_family ne "Windows" then
+; we can invoke another set of test routines via spawn and run: that hasn't worked for windows yet.
+pro holdacommon, a,b,outhelp=outhelp
+common acommon,  acom_a,acom_b
+help,acom_a,acom_b,out=outstrb
+acom_a=a
+acom_b=b
+help,acom_a,acom_b,out=outstre
+if (n_elements(outstrb) ne 0) then outhelp=[outstrb," ... then (holda) ...",outstre]
+return
+end
+pro holdbcommon, a,b,outhelp=outhelp
+common bcommon,  bcom_a,bcom_b
+help,bcom_a,bcom_b,out=outstrb
+bcom_a=a
+bcom_b=b
+help,bcom_a,bcom_b,out=outstre
+if (n_elements(outstrb) ne 0) then outhelp=[outstrb," ... then (holdb) ...",outstre]
+return
+end
+;
+; rudimentary beginnings of a test program
+;
+pro test_help
+holdacommon, findgen(2,3), fltarr(4), outhelp=stra
+holdbcommon, findgen(4,5), fltarr(6), outhelp=strb
+na = n_elements(stra)
+nb = n_elements(strb)
+if (na ne nb) or (na eq 0) then exit, status=1
+for k=0,na-1 do print,stra[k]
+;
+;	BANNER_FOR_TESTSUITE, 0
+help,/fun,/lib,name='str*',output=strfun
+nf=n_elements(strfun)
+print,' There are ',nf,' library functions that begin with "STR"'
+end
+
+


### PR DESCRIPTION
The help routine had been included with the basic_pro set of routines
and it grew to become the largest single routine with the most keywords.
It grew in increments and so is a challenge to decipher.
These changes put much of the formatting code in subroutines called from
help_pro, allowing the flow and logic of help_pro to be more approachable.
Some new features of help will  also be present:
help,/heap
COMMON, OBJECT, METHODS keywords.
Output=<variable> is implemented in many more places.
This is part 1, which is maybe 1/3 of the way finished to help_pro() which is
pretty much the same as it was.

gdlhelp
Greg Jung (aka maynardGK)
gvjung@gmail.com
