### PR TITLE
Use std::isinf, avoid ambiguous providers

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -111,6 +111,7 @@ namespace lib {
   std::vector<char*> command_line_args;
 
   //  using namespace std;
+  using std::isinf;
   using std::isnan;
   using namespace antlr;
 


### PR DESCRIPTION
This avoids the following error on EL7 (gcc 4.8.5):
```
/export/home/orion/fedora/gdl/gdl-0.9.8/src/basic_fun.cpp:6653:46: error: call of overloaded 'isinf(DDouble&)' is ambiguous
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
                                              ^
/export/home/orion/fedora/gdl/gdl-0.9.8/src/basic_fun.cpp:6653:46: note: candidates are:
In file included from /usr/include/features.h:375:0,
                 from /usr/include/limits.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/limits.h:168,
                 from /usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/limits.h:34,
                 from /usr/include/python2.7/Python.h:19,
                 from /export/home/orion/fedora/gdl/gdl-0.9.8/src/includefirst.hpp:51,
                 from /export/home/orion/fedora/gdl/gdl-0.9.8/src/basic_fun.cpp:26:
/usr/include/bits/mathcalls.h:202:1: note: int isinf(double)
 __MATHDECL_1 (int,isinf,, (_Mdouble_ __value)) __attribute__ ((__const__));
 ^
In file included from /usr/include/c++/4.8.2/complex:44:0,
                 from /usr/include/eigen3/Eigen/Core:28,
                 from /export/home/orion/fedora/gdl/gdl-0.9.8/src/includefirst.hpp:62,
                 from /export/home/orion/fedora/gdl/gdl-0.9.8/src/basic_fun.cpp:26:
/usr/include/c++/4.8.2/cmath:608:3: note: constexpr bool std::isinf(long double)
   isinf(long double __x)
   ^
/usr/include/c++/4.8.2/cmath:604:3: note: constexpr bool std::isinf(double)
   isinf(double __x)
   ^
/usr/include/c++/4.8.2/cmath:600:3: note: constexpr bool std::isinf(float)
   isinf(float __x)
   ^
```