### PR TITLE
basic_pro branch code update.

### DIFF
--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -333,18 +333,15 @@ namespace lib {
   void obj_destroy(EnvT* e) {
     StackGuard<EnvStackT> guard(e->Interpreter()->CallStack());
 
-      int n_Param=e->NParam();
-      if( n_Param == 0) return;
+	int n_Param=e->NParam();
+	if( n_Param == 0) return;
+	BaseGDL*& par=e->GetPar( 0);
+	if( par == NULL or par->Type() != GDL_OBJ) return;
+	DObjGDL* op= static_cast<DObjGDL*>(par);
 
-//	  for( SizeT ipar=0; ipar<n_Param; ipar++) { // Only one at a time
-		BaseGDL*& par=e->GetPar( 0);
-		if( par == NULL or
-			par->Type() != GDL_OBJ) continue;
-		DObjGDL* op= static_cast<DObjGDL*>(par);
     SizeT nEl = op->N_Elements();
-		for( SizeT i=0; i<nEl; i++)	
+	for( SizeT i=0; i<nEl; i++)	
 			e->ObjCleanup( (*op)[i]);
-  //  } remaining args are for processing in ObjCleanup
   }
 
   void call_procedure(EnvT* e) {

--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -58,7 +58,7 @@
 namespace lib {
 
   using namespace std;
-
+	DString GetCWD(); // From file.cpp
   // control !CPU settings
 
   void cpu(EnvT* e) {
@@ -1594,9 +1594,10 @@ namespace lib {
     }
     *pos = ptr;
   }
-
-  DWORD launch_cmd(BOOL hide, BOOL nowait, LPWSTR cmd, LPWSTR title = NULL, DWORD *pid = NULL,
-    vector<DString> *ds_outs = NULL, vector<DString> *ds_errs = NULL) {
+static DWORD launch_cmd(BOOL hide, BOOL nowait,
+                     const char * cmd, const char * title = NULL, DWORD *pid = NULL,
+		     vector<DString> *ds_outs = NULL, vector<DString> *ds_errs = NULL)
+    {
     DWORD status;
     CHAR outbuf[BUFSIZE];
     CHAR errbuf[BUFSIZE];
@@ -1604,6 +1605,15 @@ namespace lib {
     STARTUPINFOW si = {0,};
     PROCESS_INFORMATION pi = {0,};
 
+      WCHAR w_cmd[1000];
+      MultiByteToWideChar(CP_UTF8, 0, cmd, -1, w_cmd, 1000);
+      WCHAR w_title[100];
+      if( title != NULL)
+              MultiByteToWideChar(CP_UTF8, 0, title, -1, w_title, 100);
+      WCHAR w_cwd[MAX_PATH];
+	DString cwd = lib::GetCWD();
+             MultiByteToWideChar(CP_UTF8, 0, cwd.c_str(), -1, w_cwd, MAX_PATH);
+	
     SECURITY_ATTRIBUTES saAttr;
 
     saAttr.nLength = sizeof (SECURITY_ATTRIBUTES);
@@ -1617,9 +1627,9 @@ namespace lib {
 
     si.cb = sizeof (si);
     if (title == NULL)
-      si.lpTitle = cmd;
+        si.lpTitle = (wchar_t *) L"GDL spawned process";
     else
-      si.lpTitle = title;
+        si.lpTitle = w_title;
     int debug = 0;
 
     if (hide) {
@@ -1641,7 +1651,9 @@ namespace lib {
       }
       si.dwFlags |= STARTF_USESTDHANDLES;
       if (debug) std::printf(" CreateProcess: ");
-      CreateProcessW(NULL, cmd, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi);
+        CreateProcessW(NULL, w_cmd, NULL, NULL, TRUE,
+						 0, NULL, w_cwd,	// start from wherever we happen to be 
+								&si, &pi);
       if (pid != NULL) *pid = pi.dwProcessId;
       DWORD progress;
 
@@ -1683,8 +1695,13 @@ namespace lib {
       } else
         std::printf(" error from CreateProcess: progress = 0x%x \n", progress);
 
-    } else {
-      CreateProcessW(NULL, cmd, NULL, NULL, FALSE, CREATE_NEW_CONSOLE, NULL, NULL, &si, &pi);
+      }
+      else
+	{
+          CreateProcessW(NULL, w_cmd, NULL, NULL, FALSE,
+                        CREATE_NEW_CONSOLE, 
+                        NULL, w_cwd,	// start from wherever we happen to be 
+								&si, &pi);
       if (pid != NULL) *pid = pi.dwProcessId;
       if (!nowait) WaitForSingleObject(pi.hProcess, INFINITE);
       GetExitCodeProcess(pi.hProcess, &status);
@@ -1739,8 +1756,10 @@ namespace lib {
        */
     }
 
-    if (nParam == 0) {
-      DWORD status = launch_cmd(hideKeyword, nowaitKeyword, (LPWSTR) L"cmd", (LPWSTR) L"Command Prompt");
+      if (nParam == 0)
+	{
+          DWORD status = launch_cmd(hideKeyword, nowaitKeyword,
+                              "cmd", " (GDL-Spawned) Command Prompt");
       if (countKeyword)
         e->SetKW(countIx, new DLongGDL(0));
       if (exit_statusKeyword)
@@ -1761,20 +1780,17 @@ namespace lib {
       ds_cmd = cmd;
     else
       ds_cmd = "cmd /c " + cmd;
-
-    WCHAR w_cmd[255];
-    MultiByteToWideChar(CP_ACP, 0, ds_cmd.c_str(), ds_cmd.length(), w_cmd, 255);
-
     vector<DString> ds_outs;
     vector<DString> ds_errs;
     int status;
     DWORD pid;
     if (nParam == 1)
-      status = launch_cmd(hideKeyword, nowaitKeyword, w_cmd, NULL, &pid);
+        status = launch_cmd(hideKeyword, nowaitKeyword, ds_cmd.c_str(), NULL, &pid);
     else if (nParam == 2) {
-      status = launch_cmd(hideKeyword, nowaitKeyword, w_cmd, NULL, &pid, &ds_outs);
-    } else if (nParam == 3) {
-      status = launch_cmd(hideKeyword, nowaitKeyword, w_cmd, NULL, &pid, &ds_outs, &ds_errs);
+        status = launch_cmd(hideKeyword, nowaitKeyword, ds_cmd.c_str(), NULL, &pid, &ds_outs);
+      }
+      else if (nParam == 3) {
+        status = launch_cmd(hideKeyword, nowaitKeyword, ds_cmd.c_str(), NULL, &pid, &ds_outs, &ds_errs);
     }
 
     if (pidKeyword)

--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -337,7 +337,7 @@ namespace lib {
       if( n_Param == 0) return;
 
 //	  for( SizeT ipar=0; ipar<n_Param; ipar++) { // Only one at a time
-		BaseGDL*& par=e->GetPar( ipar);
+		BaseGDL*& par=e->GetPar( 0);
 		if( par == NULL or
 			par->Type() != GDL_OBJ) continue;
 		DObjGDL* op= static_cast<DObjGDL*>(par);

--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -336,7 +336,7 @@ namespace lib {
       int n_Param=e->NParam();
       if( n_Param == 0) return;
 
-	  for( SizeT ipar=0; ipar<n_Param; ipar++) {
+//	  for( SizeT ipar=0; ipar<n_Param; ipar++) { // Only one at a time
 		BaseGDL*& par=e->GetPar( ipar);
 		if( par == NULL or
 			par->Type() != GDL_OBJ) continue;
@@ -344,7 +344,7 @@ namespace lib {
     SizeT nEl = op->N_Elements();
 		for( SizeT i=0; i<nEl; i++)	
 			e->ObjCleanup( (*op)[i]);
-    }
+  //  } remaining args are for processing in ObjCleanup
   }
 
   void call_procedure(EnvT* e) {

--- a/testsuite/test_bug_708.pro
+++ b/testsuite/test_bug_708.pro
@@ -1,0 +1,6 @@
+pro test_bug_708
+; example given for bug 708: Unhandled exception
+ab = ptr_new(fltarr(12))
+cmp = {a:ab, b:ab}
+heap_free, cmp
+end

--- a/testsuite/test_obj_destroy.pro
+++ b/testsuite/test_obj_destroy.pro
@@ -7,5 +7,5 @@ pps[1] = ptr_new(mlist)
 rcbeg = heap_refcount(pps)
 obj_destroy,llist,mlist
 rcend = heap_refcount(pps)
-if(obj_valid(llist) or obj_valid(mlist)) then exit 1
+if (obj_valid(llist) or obj_valid(mlist)) then exit, status=1
 end

--- a/testsuite/test_obj_destroy.pro
+++ b/testsuite/test_obj_destroy.pro
@@ -1,0 +1,11 @@
+pro test_obj_destroy
+llist = list(fltarr(4),"hello",2.)
+mlist = list(!gdl, "goodbye",findgen(3,4))
+pps=ptrarr(2)
+pps[0] = ptr_new(llist)
+pps[1] = ptr_new(mlist)
+rcbeg = heap_refcount(pps)
+obj_destroy,llist,mlist
+rcend = heap_refcount(pps)
+if(obj_valid(llist) or obj_valid(mlist)) then exit 1
+end

--- a/testsuite/test_obj_destroy.pro
+++ b/testsuite/test_obj_destroy.pro
@@ -1,12 +1,42 @@
-pro test_obj_destroy
+;
+;
+ 
+PRO ObjTEST::Cleanup, prm1, prm2, prm3
+  COMPILE_OPT IDL2 ,HIDDEN
+  ; Call our superclass Cleanup method
+  ; self->IDL_Object::Cleanup ; (there is no GDL_OBJECT::cleanup)
+
+nprm = N_PARAMS()
+print,' ObjTEST::Cleanup, #params=',nprm
+;
+END
+ 
+PRO ObjTEST__define
+  COMPILE_OPT IDL2 ,HIDDEN
+  void = {ObjTEST, $
+  inherits IDL_Object, $ ; superclass
+  center: [0d, 0d], $ ; two-element array
+  radius: 0d}  ; scalar value
+END
+;
+;
+pro test_obj_destroy, test=test, verbose=verbose
+;
 llist = list(fltarr(4),"hello",2.)
 mlist = list(!gdl, "goodbye",findgen(3,4))
 pps=ptrarr(2)
 pps[0] = ptr_new(llist)
 pps[1] = ptr_new(mlist)
 rcbeg = heap_refcount(pps)
+
 obj_destroy,llist
 obj_destroy,mlist
+
 rcend = heap_refcount(pps)
 if (obj_valid(llist) or obj_valid(mlist)) then exit, status=1
+
+obTEST= obj_new('ObjTEST')
+obj_destroy,obTEST,pps,2.
+if obj_valid(obTEST) then exit, status=1 else print,'Success!'
+
 end

--- a/testsuite/test_obj_destroy.pro
+++ b/testsuite/test_obj_destroy.pro
@@ -5,7 +5,8 @@ pps=ptrarr(2)
 pps[0] = ptr_new(llist)
 pps[1] = ptr_new(mlist)
 rcbeg = heap_refcount(pps)
-obj_destroy,llist,mlist
+obj_destroy,llist
+obj_destroy,mlist
 rcend = heap_refcount(pps)
 if (obj_valid(llist) or obj_valid(mlist)) then exit, status=1
 end


### PR DESCRIPTION
  These are changes to basic_fun to cleanup the code and to
 advance GDL functionality.

  OBJ_DESTROY is updated and its previous shortcomings should be gone.

  bug 708 indicated an interpreter error when certain conditions came up.
  Now, more robust checks are made that avoids coding with try ... catch exception throwing.
  test_bug_708.pro is provided  to verify healthy results for at least this situation.

  In HEAP_GC, if there are no heap values remaining in either the pointer or the object heaps,  GDLInterpreter::ResetHeap() is called, which will also reset the numbering of the pointer and object indices.

  Other modifications to basic_pro are pending in other pull requests:
The delvar-rnew branch brings in the DELVAR main-level command
The Windows SPAWN command is improved with the code provided in the file_etc PR.

Greg Jung (maynardGK)
gvjung@gmail.com