### PR TITLE
 Patch to avoid accidental assert failures from EnvT::KeywordIx

### DIFF
--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -1168,10 +1168,12 @@ int EnvT::KeywordIx( const std::string& k)
   assert( pro != NULL);
   int val=pro->FindKey( k);
   if( val == -1) {		//  assert( val != -1);
-    cout << pro->ObjectName() << "  Key: " << k << endl;
-    cout << "Invalid Keyword lookup (EnvT::KeywordIx) ! " << endl
-		<< " Returning the wrong (but a valid) key index of zero" << endl;
-		val = 0;
+    cout << "Invalid Keyword lookup (EnvT::KeywordIx) ! "
+				" from "+pro->ObjectName() + "  Key: " + k << endl;
+//    cout << pro->ObjectName() << "  Key: " << k << endl;
+//		<< " Returning the wrong (but a valid) key index of zero" << endl;
+//		val = 0; // too lax - may allow most tests to pass
+	assert( val != -1);
 	}
   return val;
 }

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -1167,7 +1167,12 @@ int EnvT::KeywordIx( const std::string& k)
   //  cout << pro->ObjectName() << "  Key: " << k << endl;
   assert( pro != NULL);
   int val=pro->FindKey( k);
-  assert( val != -1);
+  if( val == -1) {		//  assert( val != -1);
+    cout << pro->ObjectName() << "  Key: " << k << endl;
+    cout << "Invalid Keyword lookup (EnvT::KeywordIx) ! " << endl
+		<< " Returning the wrong (but a valid) key index of zero" << endl;
+		val = 0;
+	}
   return val;
 }
 

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -1233,7 +1233,9 @@ BaseGDL*& EnvBaseT::GetParDefined(SizeT i)
   SizeT ix = i + pro->key.size();
 
   // cout << i << " -> " << ix << "  " << env.size() << "  env[ix] " << env[ix] << endl;
-  if( ix >= env.size() || env[ ix] == NULL || env[ ix] == NullGDL::GetSingleInstance())
+  if( ix >= env.size())
+    Throw("Incorrect number of arguments.");
+  if( env[ ix] == NULL || env[ ix] == NullGDL::GetSingleInstance())
     Throw("Variable is undefined: "+GetString( ix));
   return env[ ix];
 }
@@ -1355,7 +1357,7 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 				       pro->warnKey.end(),
 				       strAbbrefEq_k);
       if( wf == pro->warnKey.end()) 
-	Throw(  "Keyword parameter "+k+" not allowed in call "
+	Throw(  "Keyword parameter -"+k+"- not allowed in call "
 		"to: "+pro->Name());
       // 	throw GDLException(callingNode,
       // 			   "Keyword parameter "+k+" not allowed in call "
@@ -1384,7 +1386,7 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 					   pro->warnKey.end(),
 					   strAbbrefEq_k);
 	  if( wf == pro->warnKey.end()) 
-	    Throw( "Keyword parameter "+k+" not allowed in call "
+	    Throw( "Keyword parameter <"+k+"> not allowed in call "
 		   "to: "+pro->Name());
 	  /*	    throw GDLException(callingNode,
 	    "Keyword parameter "+k+" not allowed in call "
@@ -1416,10 +1418,12 @@ int EnvBaseT::GetKeywordIx( const std::string& k)
 
   // already set? -> Warning 
   // (move to Throw by AC on June 25, 2014, bug found by Levan.)
-  if( KeywordPresent(varIx)) // just a message in the original
-    {
-      Throw( "Duplicate keyword "+k+" in call to: "+pro->Name());
-    }
+// Removed G. Jung 2016:
+// mungs things up.  Could not determine 2014 bug.
+//  if( KeywordPresent(varIx)) // just a message in the original
+//    {
+//      Throw( "Duplicate keyword "+k+" in call to: "+pro->Name());
+//    }
 
   return varIx;
 }


### PR DESCRIPTION
Converts a hard exit/crash to a harmless diagnostic for new imperfect software. (see comments i n commit). Also removal of a modification from 2014 that was suppose to prevent duplicate keywords.

Greg Jung 
gvjung@gmail.com