### PR TITLE
Returning a double array fails in Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: cpp
 # TODO: investigate why MINI builds timeout on icc, while FULL ones not?!
 matrix:
   include:
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+#    - os: linux
+#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: osx
@@ -17,8 +17,8 @@ matrix:
     - os: osx
       env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
 
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+#    - os: linux
+#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,29 +85,29 @@ install:
     - if [ -v CODECOV ]; then echo "SETUP_TARGET_FOR_COVERAGE(NAME codecov EXECUTABLE \${CMAKE_BUILD_TOOL} check)" >> testsuite/CMakeLists.txt; fi
 
     # pytest
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES python-pytest}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-pytest"; fi
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip2 install pytest; fi 
 
     # CMake 
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES cmake}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} cmake"; fi
 
     ##
     ## MANDATORY DEPENDENCIES
     ##
 
     # ncurses
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libncurses-dev}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libncurses-dev"; fi
 
     # zlib
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES zlib1g-dev}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} zlib1g-dev"; fi
 
     # gsl
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libgsl0-dev}"; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES gsl}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgsl0-dev"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} gsl"; fi
 
     # plplot
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libplplot-dev}"; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES plplot}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libplplot-dev"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} plplot"; fi
 
     ##
     ## OPTIONAL DEPENDENCIES
@@ -134,7 +134,7 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgraphicsmagick++1-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=ON -DMAGICK=OFF"; fi 
 
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES imagemagick}"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} imagemagick"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=ON"; fi 
 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=OFF"; fi 
@@ -206,19 +206,19 @@ install:
 
     # GRIB API
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgrib-api-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} grib-api"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} grib-api"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=OFF"; fi 
 
     # QHULL
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} qhull"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} qhull"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=OFF"; fi 
 
     # GLPK
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libglpk-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} glpk"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} glpk"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=OFF"; fi 
 
@@ -228,7 +228,7 @@ install:
 
     # apt-get/brew invocation
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install $BREW_PACKAGES graphicsmagick; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install $BREW_PACKAGES; fi
 
 script:
     - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -227,9 +227,9 @@ install:
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
 
     # diagnostics
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo "APT_PACKAGES: " $APT_PACKAGES; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo "BREW_PACKAGES: " $BREW_PACKAGES; fi
-    - echo "CMAKE_ARGS: " $CMAKE_ARGS
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then printf "%s\n" "APT_PACKAGES: ${APT_PACKAGES}; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then printf "%s\n" "BREW_PACKAGES: ${BREW_PACKAGES}; fi
+    - printf "%s\n" "CMAKE_ARGS: ${CMAKE_ARGS}"
 
     # apt-get/brew invocation
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,12 +137,12 @@ install:
     # OpenMP (for DEPS=FULL only if supported by the compile)
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DOPENMP=OFF"; fi 
 
-    # ImageMagick (OSX) / GraphicsMagick (Linux) - just to try both
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgraphicsmagick++1-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=ON -DMAGICK=OFF"; fi 
+    # ImageMagick (Linux) / GraphicsMagick (OSX) - just to try both
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libmagick++-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=ON"; fi 
 
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} imagemagick"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=ON"; fi 
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} graphicsmagick"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=ON -DMAGICK=OFF"; fi 
 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=OFF"; fi 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,32 @@ language: cpp
 matrix:
   include:
     - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
-#    - os: linux
-#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
-#    - os: linux
-#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
-
-    - os: linux
-      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+
+    - os: linux
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
+
+    - os: linux
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
+
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: linux
-      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
-
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: osx
       env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=FULL
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
 
 before_install:
     # TEMPORARILY disabling tests that did not work at "day zero" (i.e. SF -> github migration)
@@ -54,6 +55,7 @@ before_install:
     - $SEDCMD '/test_rounding.pro/d'         testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_simplex.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_step.pro/d'             testsuite/Makefile.am # TODO!
+    - $SEDCMD '/test_tic_toc/d'              testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_total.pro/d'            testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_typename.pro/d'         testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_wait.pro/d'             testsuite/Makefile.am # TODO!

--- a/.travis.yml
+++ b/.travis.yml
@@ -213,7 +213,8 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} pslib-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=OFF"; fi 
-
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=OFF"; fi 
+ 
     # GRIB API (only Linux - TODO!)
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgrib-api-dev"; fi
     #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} grib-api"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,29 @@ language: cpp
 matrix:
   include:
     - os: linux
-      env: COMPILER=icc CMAKE_BUILD_TYPE=Debug
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
     - os: linux
-      env: COMPILER=icc CMAKE_BUILD_TYPE=Release
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
-      env: COMPILER=gcc CMAKE_BUILD_TYPE=Debug CODECOV=yes
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: linux
-      env: COMPILER=gcc CMAKE_BUILD_TYPE=Release
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
     - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Release
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=FULL
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
 
 before_install:
     # TEMPORARILY disabling tests that did not work at "day zero" (i.e. SF -> github migration)
@@ -41,7 +53,6 @@ before_install:
     - $SEDCMD '/test_typename.pro/d'         testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_wait.pro/d'             testsuite/Makefile.am # TODO!
 
-install:
     # https://github.com/travis-ci/travis-ci/issues/8613
     - if [[ $TRAVIS_OS_NAME == 'linux' && $CXX == 'clang++' ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
 
@@ -51,6 +62,11 @@ install:
     # https://stackoverflow.com/questions/25276329/cant-load-python-modules-installed-via-pip-from-site-packages-directory
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages; fi 
 
+install:
+    ##
+    ## BUILD DEPENDENCIES
+    ##
+
     # https://github.com/nemequ/icc-travis
     - if [ $COMPILER == icc ]; then wget "https://raw.githubusercontent.com/nemequ/icc-travis/master/install-icc.sh"; fi
     - if [ $COMPILER == icc ]; then sudo sh install-icc.sh; fi
@@ -58,7 +74,7 @@ install:
     - if [ $COMPILER == icc ]; then export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc"; fi
 
     # codecov
-    - if [ -v CODECOV ]; then sudo apt-get install lcov ;fi #TODO
+    - if [ -v CODECOV && $TRAVIS_OS_NAME == 'linux' ]; then export APT_PACKAGES="$APT_PACKAGES lcov" ;fi
     - if [ -v CODECOV ]; then wget -O CMakeModules/CodeCoverage.cmake https://raw.githubusercontent.com/bilke/cmake-modules/master/CodeCoverage.cmake; fi
     - if [ -v CODECOV ]; then TMPFILE=`tempfile` ;fi
     - if [ -v CODECOV ]; then tac src/CMakeLists.txt > $TMPFILE; fi
@@ -68,15 +84,151 @@ install:
     - if [ -v CODECOV ]; then rm $TMPFILE; fi
     - if [ -v CODECOV ]; then echo "SETUP_TARGET_FOR_COVERAGE(NAME codecov EXECUTABLE \${CMAKE_BUILD_TOOL} check)" >> testsuite/CMakeLists.txt; fi
 
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y wget cmake libncurses-dev libreadline-gplv2-dev zlib1g-dev libgsl0-dev libplplot-dev libgraphicsmagick++1-dev libwxgtk2.8-dev libnetcdf-dev libhdf4-alt-dev libhdf5-serial-dev libfftw3-dev python-dev python-numpy-dev python-pytest libudunits2-dev pslib-dev libgrib-api-dev libgrib-api-dev; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON -DUDUNITS=ON"; fi #TODO!
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install gsl graphicsmagick udunits fftw eigen plplot wxwidgets netcdf hdf5; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF -DPSLIB=OFF -DEDITLINE=OFF -DREADLINE=OFF"; fi #TODO!
+    # pytest
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES python-pytest}"; fi
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip2 install pytest; fi 
 
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then unzip 3.3.2.zip; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3DIR=../eigen-eigen-da9b4e14c255"; fi
+    # CMake 
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES cmake}"; fi
+
+    ##
+    ## MANDATORY DEPENDENCIES
+    ##
+
+    # ncurses
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libncurses-dev}"; fi
+
+    # zlib
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES zlib1g-dev}"; fi
+
+    # gsl
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libgsl0-dev}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES gsl}"; fi
+
+    # plplot
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES libplplot-dev}"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES plplot}"; fi
+
+    ##
+    ## OPTIONAL DEPENDENCIES
+    ##
+
+    # readline (OSX) / editline (Linux) - just to try both
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libeditline-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=ON -DREADLINE=OFF"; fi
+
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} readline"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
+
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=OFF"; fi 
+
+    # pnglib
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libpng-dev"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPNGLIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPNGLIB=OFF"; fi 
+
+    # OpenMP (for DEPS=FULL only if supported by the compile)
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DOPENMP=OFF"; fi 
+
+    # ImageMagick (OSX) / GraphicsMagick (Linux) - just to try both
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgraphicsmagick++1-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=ON -DMAGICK=OFF"; fi 
+
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES imagemagick}"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=ON"; fi 
+
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=OFF"; fi 
+
+    # wx
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libwxgtk2.8-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} wxwidgets"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DWXWIDGETS=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DWXWIDGETS=OFF"; fi 
+
+    # netcdf
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libnetcdf-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} netcdf"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
+
+    # hdf4
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; f
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; f
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
+
+    # hdf5
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf5-serial-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf5"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
+
+    # fftw
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libfftw3-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} fftw"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DFFTW=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DFFTW=OFF"; fi 
+
+    # proj4 (only for Linux - TODO)
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libproj-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DLIBPROJ4=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DLIBPROJ4=OFF"; fi 
+
+    # MPICH
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libmpich-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} mpich"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=OFF"; fi 
+
+    # Python & NumPy 
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-dev python-numpy-dev"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=OFF"; fi 
+
+    # udunits
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libudunits2-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} udunits"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DUDUNITS=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DUDUNITS=OFF"; fi 
+
+    # eigen
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then unzip 3.3.2.zip; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3DIR=../eigen-eigen-da9b4e14c255"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} eigen"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3=OFF"; fi 
+
+    # pslib (only Linux - TODO!)
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} pslib-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=OFF"; fi 
+
+    # GRIB API
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgrib-api-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} grib-api"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=OFF"; fi 
+
+    # QHULL
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} qhull"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=OFF"; fi 
+
+    # GLPK
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libglpk-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export APT_PACKAGES="${APT_PACKAGES} glpk"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=OFF"; fi 
+
+    # X11
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
+
+    # apt-get/brew invocation
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install $BREW_PACKAGES graphicsmagick; fi
 
 script:
     - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_install:
     - $SEDCMD '/test_obj_isa.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_obj_new.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_parse_url.pro/d'        testsuite/Makefile.am # TODO!
+    - $SEDCMD '/test_plot_ranges.pro/d'      testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_resolve_routine.pro/d'  testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_rounding.pro/d'         testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_step.pro/d'             testsuite/Makefile.am # TODO!
@@ -76,7 +77,7 @@ install:
     - if [ $COMPILER == icc ]; then export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc"; fi
 
     # codecov
-    - if [ -v CODECOV && $TRAVIS_OS_NAME == 'linux' ]; then export APT_PACKAGES="$APT_PACKAGES lcov" ;fi
+    - if [[ -v CODECOV && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="$APT_PACKAGES lcov" ;fi
     - if [ -v CODECOV ]; then wget -O CMakeModules/CodeCoverage.cmake https://raw.githubusercontent.com/bilke/cmake-modules/master/CodeCoverage.cmake; fi
     - if [ -v CODECOV ]; then TMPFILE=`tempfile` ;fi
     - if [ -v CODECOV ]; then tac src/CMakeLists.txt > $TMPFILE; fi
@@ -210,10 +211,11 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=OFF"; fi 
 
-    # GRIB API
+    # GRIB API (only Linux - TODO!)
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgrib-api-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} grib-api"; fi
-    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
+    #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} grib-api"; fi
+    #- if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=OFF"; fi 
 
     # QHULL

--- a/.travis.yml
+++ b/.travis.yml
@@ -227,9 +227,9 @@ install:
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
 
     # diagnostics
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then printf "%s\n" "APT_PACKAGES: ${APT_PACKAGES}; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then printf "%s\n" "BREW_PACKAGES: ${BREW_PACKAGES}; fi
-    - printf "%s\n" "CMAKE_ARGS: ${CMAKE_ARGS}"
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo APT_PACKAGES $APT_PACKAGES; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo BREW_PACKAGES $BREW_PACKAGES; fi
+    - echo CMAKE_ARGS $CMAKE_ARGS
 
     # apt-get/brew invocation
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,16 @@ matrix:
       env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: linux
       env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
-    - os: osx
+    - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+
     - os: osx
       env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
     - os: osx
@@ -158,8 +160,8 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
     # TODO - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
-    # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
-    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
+    # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
 
     # hdf5
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf5-serial-dev"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -227,9 +227,9 @@ install:
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
 
     # diagnostics
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo "APT_PACKAGES: $APT_PACKAGES"; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo "BREW_PACKAGES: $BREW_PACKAGES"; fi
-    - echo "CMAKE_ARGS: ${CMAKE_ARGS}"
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo "APT_PACKAGES: " $APT_PACKAGES; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo "BREW_PACKAGES: " $BREW_PACKAGES; fi
+    - echo "CMAKE_ARGS: " $CMAKE_ARGS
 
     # apt-get/brew invocation
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,8 +187,8 @@ install:
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=OFF"; fi 
 
-    # Python & NumPy 
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-dev python-numpy-dev"; fi
+    # Python & NumPy (installing always as needed for the Python module build)
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-dev python-numpy-dev"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=OFF"; fi 
 
@@ -218,8 +218,9 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=OFF"; fi 
 
-    # QHULL
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
+    # QHULL - TODO: disabled for icc (see https://github.com/gnudatalanguage/gdl/issues/229)
+    - if [[ $COMPILER != icc && $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
+    #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} qhull"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=OFF"; fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,9 +113,12 @@ install:
     ## OPTIONAL DEPENDENCIES
     ##
 
-    # readline (OSX) / editline (Linux) - just to try both
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libeditline-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=ON -DREADLINE=OFF"; fi
+    # readline (OSX) / editline (Linux) - just to try both - TODO
+    #TODO! - see https://github.com/gnudatalanguage/gdl/issues/227
+    # - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libeditline-dev"; fi
+    # - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=ON -DREADLINE=OFF"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libreadline-gplv2-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
 
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} readline"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
@@ -153,15 +156,16 @@ install:
 
     # hdf4
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
-    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    # TODO - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
+    # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
 
     # hdf5
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf5-serial-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf5"; fi
-    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
-    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF5=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF5=OFF"; fi 
 
     # fftw
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libfftw3-dev"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
     # TODO - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
     # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
-    - if [[ $TRAVIS_OS_NAME' == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
 
     # hdf5

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
     - if [ $COMPILER == icc ]; then export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc"; fi
 
     # codecov
-    - if [[ -v CODECOV && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="$APT_PACKAGES lcov" ;fi
+    - if [ -v CODECOV ]; then export APT_PACKAGES="$APT_PACKAGES lcov"; fi
     - if [ -v CODECOV ]; then wget -O CMakeModules/CodeCoverage.cmake https://raw.githubusercontent.com/bilke/cmake-modules/master/CodeCoverage.cmake; fi
     - if [ -v CODECOV ]; then TMPFILE=`tempfile` ;fi
     - if [ -v CODECOV ]; then tac src/CMakeLists.txt > $TMPFILE; fi
@@ -222,7 +222,8 @@ install:
     - if [[ $COMPILER != icc && $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
     #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} qhull"; fi
-    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
+    #- if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
+    - if [[ $COMPILER != icc && $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=OFF"; fi 
 
     # GLPK

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,8 +152,8 @@ install:
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
 
     # hdf4
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; f
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; f
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
     - $SEDCMD '/test_plot_ranges.pro/d'      testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_resolve_routine.pro/d'  testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_rounding.pro/d'         testsuite/Makefile.am # TODO!
+    - $SEDCMD '/test_simplex.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_step.pro/d'             testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_total.pro/d'            testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_typename.pro/d'         testsuite/Makefile.am # TODO!
@@ -124,7 +125,7 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
 
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} readline"; fi
-    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON -DREADLINEDIR=/usr/local/opt/readline"; fi
 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=OFF"; fi 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: cpp
 
+# TODO: investigate why MINI builds timeout on icc, while FULL ones not?!
 matrix:
   include:
     - os: linux
       env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+#    - os: linux
+#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
       env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+#    - os: linux
+#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
 
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
@@ -163,6 +164,7 @@ install:
     - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
     # TODO - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
     # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
+    - if [[ $TRAVIS_OS_NAME' == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
 
     # hdf5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,31 @@ language: cpp
 matrix:
   include:
     - os: linux
-      env: COMPILER=icc CMAKE_BUILD_TYPE=Debug
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
     - os: linux
-      env: COMPILER=icc CMAKE_BUILD_TYPE=Release
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
     - os: linux
-      env: COMPILER=gcc CMAKE_BUILD_TYPE=Debug CODECOV=yes
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
     - os: linux
-      env: COMPILER=gcc CMAKE_BUILD_TYPE=Release
+      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
+    - os: linux
+      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
+
     - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
     - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Release
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=FULL
+    - os: osx
+      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
 
 before_install:
     # TEMPORARILY disabling tests that did not work at "day zero" (i.e. SF -> github migration)
@@ -34,14 +48,15 @@ before_install:
     - $SEDCMD '/test_obj_isa.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_obj_new.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_parse_url.pro/d'        testsuite/Makefile.am # TODO!
+    - $SEDCMD '/test_plot_ranges.pro/d'      testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_resolve_routine.pro/d'  testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_rounding.pro/d'         testsuite/Makefile.am # TODO!
+    - $SEDCMD '/test_simplex.pro/d'          testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_step.pro/d'             testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_total.pro/d'            testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_typename.pro/d'         testsuite/Makefile.am # TODO!
     - $SEDCMD '/test_wait.pro/d'             testsuite/Makefile.am # TODO!
 
-install:
     # https://github.com/travis-ci/travis-ci/issues/8613
     - if [[ $TRAVIS_OS_NAME == 'linux' && $CXX == 'clang++' ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
 
@@ -51,6 +66,11 @@ install:
     # https://stackoverflow.com/questions/25276329/cant-load-python-modules-installed-via-pip-from-site-packages-directory
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages; fi 
 
+install:
+    ##
+    ## BUILD DEPENDENCIES
+    ##
+
     # https://github.com/nemequ/icc-travis
     - if [ $COMPILER == icc ]; then wget "https://raw.githubusercontent.com/nemequ/icc-travis/master/install-icc.sh"; fi
     - if [ $COMPILER == icc ]; then sudo sh install-icc.sh; fi
@@ -58,7 +78,7 @@ install:
     - if [ $COMPILER == icc ]; then export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc"; fi
 
     # codecov
-    - if [ -v CODECOV ]; then sudo apt-get install lcov ;fi #TODO
+    - if [ -v CODECOV ]; then export APT_PACKAGES="$APT_PACKAGES lcov"; fi
     - if [ -v CODECOV ]; then wget -O CMakeModules/CodeCoverage.cmake https://raw.githubusercontent.com/bilke/cmake-modules/master/CodeCoverage.cmake; fi
     - if [ -v CODECOV ]; then TMPFILE=`tempfile` ;fi
     - if [ -v CODECOV ]; then tac src/CMakeLists.txt > $TMPFILE; fi
@@ -68,15 +88,163 @@ install:
     - if [ -v CODECOV ]; then rm $TMPFILE; fi
     - if [ -v CODECOV ]; then echo "SETUP_TARGET_FOR_COVERAGE(NAME codecov EXECUTABLE \${CMAKE_BUILD_TOOL} check)" >> testsuite/CMakeLists.txt; fi
 
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y wget cmake libncurses-dev libreadline-gplv2-dev zlib1g-dev libgsl0-dev libplplot-dev libgraphicsmagick++1-dev libwxgtk2.8-dev libnetcdf-dev libhdf4-alt-dev libhdf5-serial-dev libfftw3-dev python-dev python-numpy-dev python-pytest libudunits2-dev pslib-dev libgrib-api-dev libgrib-api-dev; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON -DUDUNITS=ON"; fi #TODO!
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install gsl graphicsmagick udunits fftw eigen plplot wxwidgets netcdf hdf5; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF -DPSLIB=OFF -DEDITLINE=OFF -DREADLINE=OFF"; fi #TODO!
+    # pytest
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-pytest"; fi
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip2 install pytest; fi 
 
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then unzip 3.3.2.zip; fi
-    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3DIR=../eigen-eigen-da9b4e14c255"; fi
+    # CMake 
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} cmake"; fi
+
+    ##
+    ## MANDATORY DEPENDENCIES
+    ##
+
+    # ncurses
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libncurses-dev"; fi
+
+    # zlib
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} zlib1g-dev"; fi
+
+    # gsl
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgsl0-dev"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} gsl"; fi
+
+    # plplot
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libplplot-dev"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} plplot"; fi
+
+    ##
+    ## OPTIONAL DEPENDENCIES
+    ##
+
+    # readline (OSX) / editline (Linux) - just to try both - TODO
+    #TODO! - see https://github.com/gnudatalanguage/gdl/issues/227
+    # - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libeditline-dev"; fi
+    # - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=ON -DREADLINE=OFF"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libreadline-gplv2-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON"; fi
+
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} readline"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=ON -DREADLINEDIR=/usr/local/opt/readline"; fi
+
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEDITLINE=OFF -DREADLINE=OFF"; fi 
+
+    # pnglib
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libpng-dev"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPNGLIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPNGLIB=OFF"; fi 
+
+    # OpenMP (for DEPS=FULL only if supported by the compile)
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DOPENMP=OFF"; fi 
+
+    # ImageMagick (OSX) / GraphicsMagick (Linux) - just to try both
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgraphicsmagick++1-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=ON -DMAGICK=OFF"; fi 
+
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} imagemagick"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=ON"; fi 
+
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRAPHICSMAGICK=OFF -DMAGICK=OFF"; fi 
+
+    # wx
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libwxgtk2.8-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} wxwidgets"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DWXWIDGETS=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DWXWIDGETS=OFF"; fi 
+
+    # netcdf
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libnetcdf-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} netcdf"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=OFF"; fi 
+
+    # hdf4
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf4-alt-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DNETCDF=ON"; fi 
+    # TODO - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf4"; fi
+    # TODO - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF=OFF"; fi 
+
+    # hdf5
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libhdf5-serial-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} hdf5"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF5=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DHDF5=OFF"; fi 
+
+    # fftw
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libfftw3-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} fftw"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DFFTW=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DFFTW=OFF"; fi 
+
+    # proj4 (only for Linux - TODO)
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libproj-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DLIBPROJ4=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DLIBPROJ4=OFF"; fi 
+
+    # MPICH
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libmpich-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} mpich"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DMPICH=OFF"; fi 
+
+    # Python & NumPy (installing always as needed for the Python module build)
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} python-dev python-numpy-dev"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPYTHON=OFF"; fi 
+
+    # udunits
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libudunits2-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} udunits"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DUDUNITS=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DUDUNITS=OFF"; fi 
+
+    # eigen
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then wget http://bitbucket.org/eigen/eigen/get/3.3.2.zip; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then unzip 3.3.2.zip; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3DIR=../eigen-eigen-da9b4e14c255"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} eigen"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DEIGEN3=OFF"; fi 
+
+    # pslib (only Linux - TODO!)
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} pslib-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DPSLIB=OFF"; fi 
+
+    # GRIB API (only Linux - TODO!)
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libgrib-api-dev"; fi
+    #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} grib-api"; fi
+    #- if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGRIB=OFF"; fi 
+
+    # QHULL - TODO: disabled for icc (see https://github.com/gnudatalanguage/gdl/issues/229)
+    - if [[ $COMPILER != icc && $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
+    #- if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libqhull-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} qhull"; fi
+    #- if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
+    - if [[ $COMPILER != icc && $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DQHULL=OFF"; fi 
+
+    # GLPK
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'linux' ]]; then export APT_PACKAGES="${APT_PACKAGES} libglpk-dev"; fi
+    - if [[ $DEPS == 'FULL' && $TRAVIS_OS_NAME == 'osx' ]]; then export BREW_PACKAGES="${BREW_PACKAGES} glpk"; fi
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DGLPK=OFF"; fi 
+
+    # X11
+    - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=ON"; fi 
+    - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
+
+    # diagnostics
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo APT_PACKAGES $APT_PACKAGES; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo BREW_PACKAGES $BREW_PACKAGES; fi
+    - echo CMAKE_ARGS $CMAKE_ARGS
+
+    # apt-get/brew invocation
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install $BREW_PACKAGES; fi
 
 script:
     - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -226,6 +226,11 @@ install:
     - if [[ $DEPS == 'FULL' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=ON"; fi 
     - if [[ $DEPS == 'MINI' ]]; then export CMAKE_ARGS="${CMAKE_ARGS} -DX11=OFF"; fi 
 
+    # diagnostics
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then echo "APT_PACKAGES: $APT_PACKAGES"; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then echo "BREW_PACKAGES: $BREW_PACKAGES"; fi
+    - echo "CMAKE_ARGS: ${CMAKE_ARGS}"
+
     # apt-get/brew invocation
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install --no-install-recommends -y $APT_PACKAGES; fi
     - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install $BREW_PACKAGES; fi

--- a/src/topython.cpp
+++ b/src/topython.cpp
@@ -67,7 +67,7 @@ PyObject* Data_<Sp>::ToPython()
     // TODO: free the memory:  PyArray_Free(PyObject* op, void* ptr) ?
     throw GDLException("Failed to convert array to python.");
   }
-  memcpy(PyArray_DATA(ret), DataAddr(), this->N_Elements() * Data_<Sp>::Sizeof());
+  memcpy(PyArray_DATA(ret), DataAddr(), this->NBytes());
   return ret;
 }
 


### PR DESCRIPTION
(moved from https://sourceforge.net/p/gnudatalanguage/bugs/679/)
As reported on SF by @olebole:

When a GDL function returns a double array, everything after the the first half is set to some rubbish value:

$ cat arrays.py
import GDL
print 'float:', GDL.function('farr', 10)
print 'double:', GDL.function('darr', 10)
$ cat farr.pro
function FARR, n
return, findgen(n)
end
$ cat darr.pro
function DARR, n
return, dindgen(n)
end
$ python arrays.py
float:% Compiled module: FARR.
[ 0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]
double:% Compiled module: DARR.
[ 0.00000000e+000 1.00000000e+000 2.00000000e+000 3.00000000e+000
4.00000000e+000 3.51819867e+257 4.40039800e+199 1.42990123e+248
1.72636855e+243 6.92738351e-310]

This looks like that somewhere the wrong size is used to calc the return value.

The same actually happens for 64-bit integers.

I've made a patch for this. Issue caused by typo or incorrent use of sizeof()