### PR TITLE
 Restore src/pro/cw_bgroup.pro and revise testsuite/demo_widgets.pro

### DIFF
--- a/src/pro/cw_bgroup.pro
+++ b/src/pro/cw_bgroup.pro
@@ -1,0 +1,214 @@
+; part of GNU Data Language - GDL 
+;-------------------------------------------------------------
+;+
+; NAME:
+;       CW_BGROUP
+; PURPOSE:
+;       Create a compound checkbox, radiobox or regular button group
+;
+; CATEGORY:
+;       GUI widgets
+;
+; CALLING SEQUENCE:
+; widgetID = CW_BGROUP(ParentID, ButtonNames, $
+;                    BUTTON_UVALUE=button_uvalue, COLUMN=column, EVENT_FUNCT=event_funct,$
+;                    EXCLUSIVE=exclusive,NONEXCLUSIVE=nonexclusive,SPACE=space,$
+;                    XPAD=xpad, YPAD=ypad, FONT=font, FRAME=frame, IDS=ids,$
+;                    LABEL_LEFT=label_left, LABEL_TOP=label_top, MAP=map, NO_RELEASE=no_release,$
+;                    RETURN_ID=return_id, RETURN_INDEX=return_index, RETURN_NAME=return_name,$
+;                    ROW=row, SCROLL=scroll, SET_VALUE=sel_value, TAB_MODE=tab_mode,$
+;                    X_SCROLL_SIZE=x_scroll_size, Y_SCROLL_SIZE=y_scroll_size,$
+;                    SET_VALUE=set_value, UNAME=uname, UVALUE=uvalue, XOFFSET=xoffset,$
+;                    XSIZE=xsize, YOFFSET=yoffset, YSIZE=ysize)
+;
+; INPUTS:
+;
+; KEYWORD PARAMETERS:
+;
+; OUTPUTS:
+;       widgetID = widget ID of compound widget
+;
+; MODIFICATION HISTORY:
+; 	written 2013-10-29 by Marc Schellens (Initial import)
+;
+;-
+; LICENCE:
+; Copyright (C) 2013
+; This program is free software; you can redistribute it and/or modify  
+; it under the terms of the GNU General Public License as published by  
+; the Free Software Foundation; either version 2 of the License, or     
+; (at your option) any later version.                                   
+;
+;
+function CW_BGROUP_EVENT,ev
+  widget_control,ev.handler,GET_UVALUE=state1
+  if size(state1,/TYPE) ne 8 then begin ;; no STRUCT?
+     ;; if no struct, uvalue is the UVALUE holder's ID
+     widget_control,state1,GET_UVALUE=state
+  endif else begin
+     state = state1
+  endelse
+  widget_control,ev.id,GET_UVALUE=index  
+  if ev.select ne 0 then begin
+     state.lastButton = index
+  endif
+  if state.exclusiveMode eq 0 then begin
+  endif
+  if state.exclusiveMode eq 1 then begin
+  endif
+  if state.exclusiveMode eq 2 then begin
+     state.buttonState[index] = ev.select
+  endif
+
+  widget_control,ev.handler,SET_UVALUE=state
+
+  if state.noRelease ne 0 and ev.select eq 0 then return,0
+
+  retEv = { ID:state.topBaseID, $
+            TOP:ev.top,$
+            HANDLER:0L,$
+            SELECT:ev.select, $
+            VALUE:state.rArray[index] }
+  return,retEv
+end
+
+function CW_BGROUP_GETV,id
+  bbase = widget_info(id,/CHILD)
+  widget_control,bbase,GET_UVALUE=state
+  if state.exclusiveMode eq 0 then begin
+     message,"CW_BGROUP: Unable to get plain button group value."
+  endif
+  if state.exclusiveMode eq 1 then begin
+     return,state.rArray[state.lastButton]
+  endif
+  return,state.buttonState
+end
+
+pro CW_BGROUP_SETV,id,value
+  bbase = widget_info(id,/CHILD)
+  widget_control,bbase,GET_UVALUE=state
+
+  if state.exclusiveMode eq 0 then begin
+     message,"CW_BGROUP: Unable to set plain button group value."
+     return
+  endif
+
+  if state.exclusiveMode eq 1 then begin
+     state.lastButton = value
+     widget_control,state.buttonID[value],SET_BUTTON=1
+     widget_control,bbase,SET_UVALUE=state
+     return
+  endif
+
+  for b=0,N_ELEMENTS(value)-1 do begin
+     state.buttonState[b] = value[b]
+     widget_control,state.buttonID[b],SET_BUTTON=value[b]
+  endfor
+  widget_control,bbase,SET_UVALUE=state
+end
+
+function CW_BGROUP,parentID, buttonNames, $
+                   BUTTON_UVALUE=button_uvalue, COLUMN=column, EVENT_FUNCT=event_funct,$
+                   EXCLUSIVE=exclusive,NONEXCLUSIVE=nonexclusive,SPACE=space,$
+                   XPAD=xpad, YPAD=ypad, FONT=font, FRAME=frame, IDS=ids,$
+                   LABEL_LEFT=label_left, LABEL_TOP=label_top, MAP=map, NO_RELEASE=no_release,$
+                   RETURN_ID=return_id, RETURN_INDEX=return_index, RETURN_NAME=return_name,$
+                   ROW=row, SCROLL=scroll, SET_VALUE=set_value, TAB_MODE=tab_mode,$
+                   X_SCROLL_SIZE=x_scroll_size, Y_SCROLL_SIZE=y_scroll_size,$
+                   UNAME=uname, UVALUE=uvalue, XOFFSET=xoffset,$
+                   XSIZE=xsize, YOFFSET=yoffset, YSIZE=ysize
+
+  nButtons = N_ELEMENTS(buttonNames)
+  if nButtons eq 0 then begin
+     MESSAGE,"CW_BGROUP: 2nd parameter (button names) not valid."
+     return,0
+  endif
+
+  if N_ELEMENTS( button_uvalue) gt 0 then begin
+     if N_ELEMENTS( button_uvalue) ne nButtons then begin
+        MESSAGE,"CW_BGROUP: BUTTON_UVALUE mut contain one element for each button."
+        return,0
+     endif
+  endif
+
+  exclusiveMode = 0
+  if keyword_set(exclusive) then begin
+     if keyword_set(nonexclusive) then begin
+        MESSAGE,"CW_BGROUP: Conficting keywords: [NON]EXCLUSIVE."
+        return,0
+     endif
+     exclusiveMode = 1
+  endif
+  if keyword_set(nonexclusive) then begin
+     exclusiveMode = 2
+  endif
+
+  widgetID = widget_base(parentID,/COL,MAP=map,UNAME=uname,UVALUE=uvalue,$
+                         FUNC_GET_VALUE='CW_BGROUP_GETV', PRO_SET_VALUE='CW_BGROUP_SETV', $
+                         EVENT_FUNC=event_funct,$
+                         XSIZE=xsize,YSIZE=ysize)
+  uValueHolder = 0
+  if N_ELEMENTS(label_top) ne 0 then begin
+     label = widget_label( widgetID, VALUE=label_top)
+     uValueHolder = label
+  endif
+  
+  if uValueHolder eq 0 then begin
+     baseID = widget_base(widgetID,EXCLUSIVE=exclusive,NONEXCLUSIVE=nonexclusive,$
+                          COLUMN=column,ROW=row, EVENT_FUNC="CW_BGROUP_EVENT")
+     uValueHolder = baseID
+  endif else begin
+     baseID = widget_base(widgetID,EXCLUSIVE=exclusive,NONEXCLUSIVE=nonexclusive,$
+                          COLUMN=column,ROW=row, EVENT_FUNC="CW_BGROUP_EVENT",UVALUE=label)
+  endelse
+
+  ids = lonarr(nButtons)
+
+;; if N_ELEMENTS( button_uvalue) gt 0 then begin
+  for b=0,nButtons-1 do begin
+
+     ids[b]=widget_button(baseID,VALUE=buttonNames[b],UVALUE=b)
+  endfor
+;; endif else begin
+;;    for b=0,nButtons-1 do begin
+
+;;       ids[b]=widget_button(baseID,VALUE=buttonNames[b])
+;;    endfor
+;; endelse
+
+  rMode = -1 
+  if N_ELEMENTS( button_uvalue) gt 0 then begin
+     rMode = 1                  ; button_uvalue (overrides)
+     rArray = button_uvalue
+;     help,1,rArray
+  endif else begin
+     if keyword_set( return_name) then begin
+        rMode = 3
+        rArray = buttonNames
+;        help,3,rArray
+     endif else if keyword_set( return_id) then begin
+        rMode = 4
+        rArray = ids
+;        help,4,rArray
+     endif else begin
+        ;; default -> return index
+        rMode = 2
+        rArray = lindgen( nButtons)
+;        help,2,rArray
+     endelse
+  endelse
+
+  internalUValue = {rArray:rArray,$
+                    exclusiveMode: exclusiveMode,$
+                    buttonID: ids,$
+                    buttonState: intarr(nButtons),$
+                    lastButton: 0,$
+                    noRelease: keyword_set(no_release),$
+                    buttonBase: baseID,$
+                    topBaseID: widgetID }
+  widget_control,uValueHolder,SET_UVALUE=internalUValue
+
+  if N_ELEMENTS(set_value) ne 0 then CW_BGROUP_SETV, widgetID, set_value
+
+  return,widgetID
+end

--- a/testsuite/demo_widgets.pro
+++ b/testsuite/demo_widgets.pro
@@ -63,20 +63,21 @@ help,ev,/str
   endif
 end
 
-pro demo_widgets,table,help=help,nocanvas=nocanvas,notree=notree,block=block
+pro demo_widgets,table,help=help,nocanvas=nocanvas,notree=notree,block=block, test=test
 common mycount,count
+
 count=0
 if ~keyword_set(block) then block=0
 if keyword_set(help) then begin
-print,"useage: test_widgets[,table][,/help][,/nocanvas][,/notree]"
-print,"Will display some examples of currently available widgets"
-print,"if table is passed as argument and is a structure, tab 3 will show the"
-print,"elements of the structure as buttons in a scrolled panel"
-print,"options: /nocanvas removes the widget_draw"
-print,"/notree remove the tree widget"
+	print,"useage: test_widgets[,table][,/help][,/nocanvas][,/notree]"
+	print,"Will display some examples of currently available widgets"
+	print,"if table is passed as argument and is a structure, tab 3 will show the"
+	print,"elements of the structure as buttons in a scrolled panel"
+	print,"options: /nocanvas removes the widget_draw"
+	print,"/notree remove the tree widget"
 
-return
-endif
+	return
+	endif
 
 ev = {vEv,type:'',pos:[0,0]}
 ;Create a base widget. 
@@ -85,27 +86,28 @@ base = WIDGET_BASE(MBAR=mbar,title="gdl widget examples",event_pro='event_in_bas
 menu = widget_button(mbar,VALUE="Menu")
 ex = widget_button(menu,VALUE="Exit",EVENT_PRO="exit_gui")
 siz= widget_button(menu,VALUE="Resize (error)",EVENT_PRO="resize_gui")
+
 ;buttons as menu buttons
-        fileID = Widget_Button(mbar, Value='Complicated Menu')
-        saveID = Widget_Button(fileID, Value='submenu 1', /MENU)
-        button = Widget_Button(saveID, Value='entry 1', UNAME='POSTSCRIPT')
-        button = Widget_Button(saveID, Value='entry 2', UNAME='PDF')
-        raster = Widget_Button(saveID, Value='submenu 2', /MENU)
-        
-        button = Widget_Button(raster, Value='BMP', UNAME='RASTER_BMP')
-        button = Widget_Button(raster, Value='GIF', UNAME='RASTER_GIF')
-        button = Widget_Button(raster, Value='JPEG', UNAME='RASTER_JPEG')
-        button = Widget_Button(raster, Value='PNG', UNAME='RASTER_PNG')
-        button = Widget_Button(raster, Value='TIFF', UNAME='RASTER_TIFF')
-        imraster = Widget_Button(saveID, Value='submenu 3', /MENU)
-        button = Widget_Button(imraster, Value='BMP', UNAME='IMAGEMAGICK_BMP')
-        button = Widget_Button(imraster, Value='GIF', UNAME='IMAGEMAGICK_GIF')
-        button = Widget_Button(imraster, Value='JPEG', UNAME='IMAGEMAGICK_JPEG')
-        button = Widget_Button(imraster, Value='PNG', UNAME='IMAGEMAGICK_PNG')
-        button = Widget_Button(imraster, Value='TIFF', UNAME='IMAGEMAGICK_TIFF')
-        button = Widget_Button(fileID, Value='entry 3', /Separator, UNAME='SAVECOMMANDS')
-        button = Widget_Button(fileID, Value='entry 4', UNAME='RESTORECOMMANDS')
-        button = Widget_Button(fileID, Value='entry 5', /Separator, UNAME='QUIT')
+fileID = Widget_Button(mbar, Value='Complicated Menu')
+saveID = Widget_Button(fileID, Value='submenu 1', /MENU)
+button = Widget_Button(saveID, Value='entry 1', UNAME='POSTSCRIPT')
+button = Widget_Button(saveID, Value='entry 2', UNAME='PDF')
+raster = Widget_Button(saveID, Value='submenu 2', /MENU)
+
+button = Widget_Button(raster, Value='BMP', UNAME='RASTER_BMP')
+button = Widget_Button(raster, Value='GIF', UNAME='RASTER_GIF')
+button = Widget_Button(raster, Value='JPEG', UNAME='RASTER_JPEG')
+button = Widget_Button(raster, Value='PNG', UNAME='RASTER_PNG')
+button = Widget_Button(raster, Value='TIFF', UNAME='RASTER_TIFF')
+imraster = Widget_Button(saveID, Value='submenu 3', /MENU)
+button = Widget_Button(imraster, Value='BMP', UNAME='IMAGEMAGICK_BMP')
+button = Widget_Button(imraster, Value='GIF', UNAME='IMAGEMAGICK_GIF')
+button = Widget_Button(imraster, Value='JPEG', UNAME='IMAGEMAGICK_JPEG')
+button = Widget_Button(imraster, Value='PNG', UNAME='IMAGEMAGICK_PNG')
+button = Widget_Button(imraster, Value='TIFF', UNAME='IMAGEMAGICK_TIFF')
+button = Widget_Button(fileID, Value='entry 3', /Separator, UNAME='SAVECOMMANDS')
+button = Widget_Button(fileID, Value='entry 4', UNAME='RESTORECOMMANDS')
+button = Widget_Button(fileID, Value='entry 5', /Separator, UNAME='QUIT')
 
 
 ;tab = widget_base(base,/col); 
@@ -233,17 +235,21 @@ if ~keyword_set(notree) then begin
   racine = widget_tree(tab7)
   wtRoot = widget_tree(racine, VALUE='GDL', /folder, /draggable, /drop_events)
   feuille_11 = WIDGET_TREE(wtRoot, VALUE='is', $
-    UVALUE='LEAF')
+    UVALUE={vEv,'LEAF',[0,0]})
   branche_12 = WIDGET_TREE(wtRoot, VALUE='...', $
     /FOLDER, /EXPANDED)
   feuille_121 = WIDGET_TREE(branche_12, VALUE='with', $
-    UVALUE='LEAF')
+    UVALUE={vEv,'LEAF',[0,0]})
+
   feuille_122 = WIDGET_TREE(branche_12, VALUE='a lot of', $
-    UVALUE='LEAF')
+    UVALUE={vEv,'LEAF',[0,0]})
+
   feuille_13 = WIDGET_TREE(wtRoot, VALUE='widgets', $
-    UVALUE='LEAF')
+    UVALUE={vEv,'LEAF',[0,0]})
+
   feuille_14 = WIDGET_TREE(wtRoot, VALUE='now', $
-    UVALUE='LEAF')
+    UVALUE={vEv,'LEAF',[0,0]})
+
 end
 ; overwrite buttons;
    for iRow=0,nRows-1 do widget_control,fileButtons(iRow) , set_value="Y"
@@ -258,24 +264,49 @@ widget_control,base,notify_realize='i_am_realized'
 ;Realize the widgets. 
 WIDGET_CONTROL, /REALIZE, base 
  
-;Obtain the window index. 
 if ~keyword_set(nocanvas) then begin
-print,"Draw widgets:",draw,draw2
- WIDGET_CONTROL, draw, GET_VALUE = index 
-  WIDGET_CONTROL, draw2, GET_VALUE = index2 
+	;Obtain the window index. 
+	index =0  & index2 = 1
+	print,"Draw widgets:",draw,draw2
+	WIDGET_CONTROL, draw, GET_VALUE = index 
+	WIDGET_CONTROL, draw2, GET_VALUE = index2 
+; 
+;  Accomodate the "NO_WIDGET_DRAW" crowd:
+;
+; 0 <= index,index2 < 32
 
+	if (!d.name eq "WIN") or (!d.name eq "X") $
+			and (index lt 32) and (index2 lt 32) then begin
+		device,window_state=wcheck
+		if wcheck[index] eq 0  then window,index
+		if wcheck[index2] eq 0  then window,index2
+		 endif
 ;Set the new widget to be the current graphics window 
- print,"window indexes",index,index2
- file='Saturn.jpg'
- image=read_image(file)
- WSET,index
- plot,findgen(100)
- tv,image,10,10,/data,/true
+;
+if keyword_set(test) then stop,' checked graphics windows.',index,index2
+;
+	file='Saturn.jpg'
+	image=read_image(file_which(file))
+	; for window index 32 or greater we cannot call WINDOW to create but
+	; it may be "closed and unavailable" when WX is not the plot device.
 
- WSET, index2 
- f=findgen(1000)/100.
- contour,cos(dist(100,100)/10.)
+	CATCH,wset_error
+	if wset_error eq 0 then WSET,index else $
+		message,/contin," can't plot to, or image on, the draw widget"
+		CATCH,/CANCEL
+		
+	plot,findgen(100)
+	tv,image,10,10,/data,/true
+	if wset_error ne 0 then wait,2
+	
+	CATCH,wset_error
+	if wset_error eq 0 then WSET,index2 else $
+		message,/contin," can't plot to, or image on, the draw widget"
+		CATCH,/CANCEL
+	
+	f=findgen(1000)/100.
+	contour,cos(dist(100,100)/10.)
 
-end
+	endif
 xmanager,"demo_widgets",base,cleanup="cleanup_xmanager",no_block=~block
 end


### PR DESCRIPTION
  In some manner the compound widget procedure CW_BGROUP was lost to the GDL
distribution; the last time it appeared was in 2014 during 0.9.5. Bring this back
to the pro/ subdirectory with a small correction.
 A modified testsuite/demo_widgets.pro is tested to run with or without a viable widget/plot cohension. It will also function under the programming given with the NO_WIDGET_DRAW option.

Greg Jung
gvjung@gmail.com