### PR TITLE
Added support for START and INCREMENT keywords in INDGEN functions

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -791,24 +791,25 @@ namespace lib {
   BaseGDL* bindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DByteGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
     /* }
        catch( GDLException& ex)
        {
        e->Throw( "BINDGEN: "+ex.getMessage());
        }
     */ }
-  // keywords not supported yet
   BaseGDL* indgen( EnvT* e)
   {
     dimension dim;
-
-    // Defaulting to GDL_INT
+    DDouble off = 0, inc = 1;
     DType type = GDL_INT;
 
     static int kwIx1 = e->KeywordIx("BYTE");
@@ -858,23 +859,26 @@ namespace lib {
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+
     switch(type)
       {
-      case GDL_INT:        return new DIntGDL(dim, BaseGDL::INDGEN);
-      case GDL_BYTE:       return new DByteGDL(dim, BaseGDL::INDGEN);
-      case GDL_COMPLEX:    return new DComplexGDL(dim, BaseGDL::INDGEN);
-      case GDL_COMPLEXDBL: return new DComplexDblGDL(dim, BaseGDL::INDGEN);
-      case GDL_DOUBLE:     return new DDoubleGDL(dim, BaseGDL::INDGEN);
-      case GDL_FLOAT:      return new DFloatGDL(dim, BaseGDL::INDGEN);
-      case GDL_LONG64:     return new DLong64GDL(dim, BaseGDL::INDGEN);
-      case GDL_LONG:       return new DLongGDL(dim, BaseGDL::INDGEN);
+      case GDL_INT:        return new DIntGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_BYTE:       return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_COMPLEX:    return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_COMPLEXDBL: return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_DOUBLE:     return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_FLOAT:      return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_LONG64:     return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_LONG:       return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
       case GDL_STRING: {
-	DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN);
+	DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
 	return iGen->Convert2(GDL_STRING);
       }
-      case GDL_UINT:       return new DUIntGDL(dim, BaseGDL::INDGEN);
-      case GDL_ULONG64:    return new DULong64GDL(dim, BaseGDL::INDGEN);
-      case GDL_ULONG:      return new DULongGDL(dim, BaseGDL::INDGEN);
+      case GDL_UINT:       return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_ULONG64:    return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      case GDL_ULONG:      return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
       default:
 	e->Throw( "Invalid type code specified.");
 	break;
@@ -891,12 +895,15 @@ namespace lib {
   BaseGDL* uindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DUIntGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
     /* }
        catch( GDLException& ex)
        {
@@ -906,12 +913,15 @@ namespace lib {
   BaseGDL* sindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
     return iGen->Convert2( GDL_STRING);
     /*    }
 	  catch( GDLException& ex)
@@ -922,9 +932,15 @@ namespace lib {
   BaseGDL* lindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
-    return new DLongGDL(dim, BaseGDL::INDGEN);
+    if (dim[0] == 0)
+      throw GDLException( "Array dimensions must be greater than 0");
+
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
     /*    }
 	  catch( GDLException& ex)
 	  {
@@ -934,12 +950,15 @@ namespace lib {
   BaseGDL* ulindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DULongGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
     /*    }
 	  catch( GDLException& ex)
 	  {
@@ -949,12 +968,15 @@ namespace lib {
   BaseGDL* l64indgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DLong64GDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
     /*  }
 	catch( GDLException& ex)
 	{
@@ -964,12 +986,15 @@ namespace lib {
   BaseGDL* ul64indgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DULong64GDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
     /*   }
 	 catch( GDLException& ex)
 	 {
@@ -979,12 +1004,15 @@ namespace lib {
   BaseGDL* findgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DFloatGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
     /*  }
 	catch( GDLException& ex)
 	{
@@ -994,12 +1022,15 @@ namespace lib {
   BaseGDL* dindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DDoubleGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
     /*  }
 	catch( GDLException& ex)
 	{
@@ -1009,12 +1040,15 @@ namespace lib {
   BaseGDL* cindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DComplexGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
     /*  }
 	catch( GDLException& ex)
 	{
@@ -1024,12 +1058,15 @@ namespace lib {
   BaseGDL* dcindgen( EnvT* e)
   {
     dimension dim;
+    DDouble off = 0, inc = 1;
     //     try{
     arr( e, dim); 
     if (dim[0] == 0)
       throw GDLException( "Array dimensions must be greater than 0");
 
-    return new DComplexDblGDL(dim, BaseGDL::INDGEN);
+    e->AssureDoubleScalarKWIfPresent("START", off);
+    e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
+    return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
     /*  }
 	catch( GDLException& ex)
 	{

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -386,7 +386,7 @@ template<> Data_<SpDObj>::Data_( const Ty* p, const SizeT nEl):
 // template<class Sp> Data_<Sp>::Data_(const Data_& d_): 
 // Sp(d_.dim), dd(d_.dd) {}
 
-template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT):
+template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble off, DDouble inc):
   Sp( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
 {
   this->dim.Purge();
@@ -400,12 +400,12 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT)
 	// #pragma omp for
 	for( SizeT i=0; i<sz; i++)
 	  {
-	    (*this)[i]=i;//val;
+	    (*this)[i]=off+i*inc;
 	  }
 	// 	  val += 1; // no increment operator for floats
       }
   }
-  if (iT == BaseGDL::ZERO) {
+  else if (iT == BaseGDL::ZERO) {
     SizeT sz = dd.size();
 #pragma omp parallel if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
     {
@@ -484,7 +484,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT)
 // string, ptr, obj (cannot be INDGEN, 
 // need not to be zeroed if all intialized later)
 // struct (as a separate class) as well
-template<> Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT):
+template<> Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble):
   SpDString(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
 {
   dim.Purge();
@@ -492,7 +492,7 @@ template<> Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT):
   if( iT == BaseGDL::INDGEN)
     throw GDLException("DStringGDL(dim,InitType=INDGEN) called.");
 }
-template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT):
+template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DDouble, DDouble):
   SpDPtr(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
 {
   dim.Purge();
@@ -514,7 +514,7 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT):
       // 	}
     }
 }
-template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT):
+template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble):
   SpDObj(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
 {
   dim.Purge();

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -124,7 +124,8 @@ static	void operator delete( void *ptr);
   Data_(const Ty& d_);
 
   // new array, no zero or indgen
-  Data_(const dimension& dim_,  BaseGDL::InitType iT);
+  Data_(const dimension& dim_,  BaseGDL::InitType iT,
+        DDouble start = 0, DDouble increment = 1);
   
   // new array, zero fields
   Data_(const dimension& dim_);

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -355,19 +355,21 @@ void LibInit()
   
   const string indKey[]={"TYPE","BYTE","COMPLEX","DCOMPLEX",
 			 "DOUBLE","FLOAT","L64","LONG",
-			 "STRING","UINT","UL64","ULONG",KLISTEND};
-  new DLibFunRetNew(lib::bindgen,string("BINDGEN"),MAXRANK,NULL,NULL,true);
+			 "STRING","UINT","UL64","ULONG",
+			 "START", "INCREMENT", KLISTEND};
+  const string xindKey[]={"START", "INCREMENT", KLISTEND};
+  new DLibFunRetNew(lib::bindgen,string("BINDGEN"),MAXRANK,xindKey,NULL,true);
   new DLibFunRetNew(lib::indgen,string("INDGEN"),MAXRANK,indKey,NULL,true);
-  new DLibFunRetNew(lib::uindgen,string("UINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::sindgen,string("SINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::lindgen,string("LINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::ulindgen,string("ULINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::l64indgen,string("L64INDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::findgen,string("FINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::dindgen,string("DINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::cindgen,string("CINDGEN"),MAXRANK,NULL,NULL,true);
-  new DLibFunRetNew(lib::dcindgen,string("DCINDGEN"),MAXRANK,NULL,NULL,true);
+  new DLibFunRetNew(lib::uindgen,string("UINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::sindgen,string("SINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::lindgen,string("LINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::ulindgen,string("ULINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::l64indgen,string("L64INDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::findgen,string("FINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::dindgen,string("DINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::cindgen,string("CINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::dcindgen,string("DCINDGEN"),MAXRANK,xindKey,NULL,true);
 
   new DLibFunRetNew(lib::n_elements,string("N_ELEMENTS"),1,NULL,NULL,true,1);
 

--- a/src/specializations.hpp
+++ b/src/specializations.hpp
@@ -378,11 +378,11 @@ void* Data_<SpDString>::DataAddr();//SizeT);*/
 /*template<>
 Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT);*/
 template<>
-Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT);
+Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble);
 template<>
-Data_<SpDPtr>::Data_(const dimension& dim_, BaseGDL::InitType iT);
+Data_<SpDPtr>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble);
 template<>
-Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT);
+Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble);
 
 template<>  SizeT Data_<SpDString>::NBytes() const;
 // template<>  SizeT Data_<SpDObj>::NBytes() const;

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -125,6 +125,7 @@ TESTS = \
   test_idl_validname.pro \
   test_idlneturl.pro \
   test_image_statistics.pro \
+  test_indgen.pro \
   test_interpol.pro \
   test_interpolate.pro \
   test_isa.pro \

--- a/testsuite/test_indgen.pro
+++ b/testsuite/test_indgen.pro
@@ -1,0 +1,62 @@
+;
+; Testing *INDGEN family with keywords
+;
+
+pro test_indgen, test=test, no_exit=no_exit
+
+  nerr=0
+
+  ; Type specialised functions 
+  if typename(bindgen(5)) ne "BYTE" then ADD_ERROR, nerr, 'BINDGEN does not yield a BYTE array'
+  if typename(cindgen(5)) ne "COMPLEX" then ADD_ERROR, nerr, 'CINDGEN does not yield a COMPLEX array'
+  if typename(dcindgen(5)) ne "DCOMPLEX" then ADD_ERROR, nerr, 'DCINDGEN does not yield a DCOMPLEX array'
+  if typename(dindgen(5)) ne "DOUBLE" then ADD_ERROR, nerr, 'DINDGEN does not yield a DOUBLE array'
+  if typename(findgen(5)) ne "FLOAT" then ADD_ERROR, nerr, 'FINDGEN does not yield a FLOAT array'
+  if typename(indgen(5)) ne "INT" then ADD_ERROR, nerr, 'INDGEN does not yield an INT array'
+  if typename(lindgen(5)) ne "LONG" then ADD_ERROR, nerr, 'LINDGEN does not yield a LONG array'
+  if typename(l64indgen(5)) ne "LONG64" then ADD_ERROR, nerr, 'L64INDGEN does not yield a LONG64 array'
+  if typename(sindgen(5)) ne "STRING" then ADD_ERROR, nerr, 'SINDGEN does not yield a STRING array'
+  if typename(uindgen(5)) ne "UINT" then ADD_ERROR, nerr, 'UINDGEN does not yield an UINT array'
+  if typename(ulindgen(5)) ne "ULONG" then ADD_ERROR, nerr, 'ULINDGEN does not yield an ULONG array'
+  if typename(ul64indgen(5)) ne "ULONG64" then ADD_ERROR, nerr, 'UL64INDGEN does not yield an ULONG64 array'
+
+  ; INDGEN with explicit type keywords
+  if typename(indgen(5, /BYTE)) ne "BYTE" then ADD_ERROR, nerr, 'INDGEN(/BYTE) does not yield a BYTE array'
+  if typename(indgen(5, /COMPLEX)) ne "COMPLEX" then ADD_ERROR, nerr, 'INDGEN(/COMPLEX) does not yield a COMPLEX array'
+  if typename(indgen(5, /DCOMPLEX)) ne "DCOMPLEX" then ADD_ERROR, nerr, 'INDGEN(/DCOMPLEX) does not yield a DCOMPLEX array'
+  if typename(indgen(5, /DOUBLE)) ne "DOUBLE" then ADD_ERROR, nerr, 'INDGEN(/DOUBLE) does not yield a DOUBLE array'
+  if typename(indgen(5, /FLOAT)) ne "FLOAT" then ADD_ERROR, nerr, 'INDGEN(/FLOAT) does not yield a FLOAT array'
+  if typename(indgen(5, /L64)) ne "LONG64" then ADD_ERROR, nerr, 'INDGEN(/L64) does not yield a LONG64 array'
+  if typename(indgen(5, /LONG)) ne "LONG" then ADD_ERROR, nerr, 'INDGEN(/LONG) does not yield a LONG array'
+  if typename(indgen(5, /STRING)) ne "STRING" then ADD_ERROR, nerr, 'INDGEN(/STRING) does not yield a STRING array'
+  if typename(indgen(5, /UINT)) ne "UINT" then ADD_ERROR, nerr, 'INDGEN(/UINT) does not yield an UINT array'
+  if typename(indgen(5, /UL64)) ne "ULONG64" then ADD_ERROR, nerr, 'INDGEN(/UL64) does not yield an ULONG64 array'
+  if typename(indgen(5, /ULONG)) ne "ULONG" then ADD_ERROR, nerr, 'INDGEN(/ULONG) does not yield an ULONG array'
+
+  ; Check correct number of elements in 1-dimensional arrays
+  if size(bindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'BINDGEN(5) does not yield a 5-element array'
+  if size(cindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'CINDGEN(5) does not yield a 5-element array'
+  if size(dcindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'DCINDGEN(5) does not yield a 5-element array'
+  if size(dindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'DINDGEN(5) does not yield a 5-element array'
+  if size(findgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'FINDGEN(5) does not yield a 5-element array'
+  if size(indgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'INDGEN(5) does not yield a 5-element array'
+  if size(lindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'LINDGEN(5) does not yield a 5-element array'
+  if size(l64indgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'L64INDGEN(5) does not yield a 5-element array'
+  if size(sindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'SINDGEN(5) does not yield a 5-element array'
+  if size(uindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'UINDGEN(5) does not yield a 5-element array'
+  if size(ulindgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'ULINDGEN(5) does not yield a 5-element array'
+  if size(ul64indgen(5), /N_ELEMENTS) ne 5 then ADD_ERROR, nerr, 'UL64INDGEN(5) does not yield a 5-element array'
+
+  ; Various IDL 8.2.1 START and IDL 8.3 INCREMENT tests
+  if not array_equal(indgen(6, start=5, increment=0.5), [5,5,6,6,7,7]) then ADD_ERROR, nerr, 'INDGEN(START=5, INCREMENT=0.5) yields wrong result' 
+  if not array_equal(findgen(6, start=5, increment=0.5), [5.0,5.5,6.0,6.5,7.0,7.5]) then ADD_ERROR, nerr, 'FINDGEN(START=5, INCREMENT=0.5) yields wrong result'
+  if not array_equal(bindgen(6, start=5, increment=4), [5,9,13,17,21,25]) then ADD_ERROR, nerr, 'BINDGEN(START=5, INCREMENT=4) yields wrong result'
+  if not array_equal(uindgen(2, start=2018), [2018, 2019]) then ADD_ERROR, nerr, 'UINDGEN(START=2018) yields wrong result'
+
+  BANNER_FOR_TESTSUITE, 'test_indgen', nerr
+
+  if nerr gt 0 and ~keyword_set(no_exit) then exit, status=1
+  if keyword_set(test) then stop
+
+end
+


### PR DESCRIPTION
Partly solves #89 by adding support for START and INCREMENT keywords to all INDGEN functions.
Will create a separate PR after adding these keywords to MAKE_ARRAY as well.

START and INCREMENT were added in IDL 8.2.1 and 8.3 respectively.

Hope this is useful. I am new to GDL hacking, so comments are welcome and appreciated.
I would love to write tests, but I lack experience with IDL and have no IDL licence,
so for now I have just verified the results based on the examples found on this page:
https://www.harrisgeospatial.com/docs/Creating_Arrays.html