### PR TITLE
WIP: windows' appveyor build improvement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,10 +79,10 @@ install:
         tar zxf gsl-2.4.tar.gz
         c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
         cd C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
-        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
-        appveyor DownloadFile https://repo.msys2.org/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
-        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
-        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
         tar xf mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
         tar xf mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
         tar xf mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
@@ -90,15 +90,15 @@ install:
 
         # GNUWin32 (GNU Readline, Zlib, libPNG, PCRE)
         cd c:\projects\gdl\win32libs
-        #appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
+        appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libpng/1.2.37/libpng-1.2.37-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-lib.zip
-        #7z x readline-5.0-1-lib.zip
+        7z x readline-5.0-1-lib.zip
         7z x zlib-1.2.3-lib.zip
         7z x libpng-1.2.37-lib.zip
         7z x pcre-7.0-lib.zip
-        #appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-bin.zip
+        appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libpng/1.2.37/libpng-1.2.37-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-bin.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,10 +114,11 @@ before_build:
   
 build_script:
   - cd c:\projects\gdl\build
-  - copy c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin\wx* c:\projects\gdl\install\gdl\bin
   - set CMAKE_LIBRARY_PATH=c:\projects\gdl\win32libs\lib
   - set CMAKE_INCLUDE_PATH=c:\projects\gdl\win32libs\include
   - cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
+  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4 c:\projects\gdl\install\gdl\build
+  - sed -e 's;cblas;cblas -lgnurx;' -i  src/CMakeFiles/gdl.dir/linklibs.rsp
   - robocopy /move /e c:\projects\gdl\build c:\projects\gdl\install\gdl\build || exit 0
   #- mingw32-make -j4
   #- mingw32-make install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,8 @@ install:
         copy c:\projects\gdl\win32libs\wxWidgets-3.0.4\build\msw\gcc_mswudll\coredll_headerctrlg.o c:\projects\gdl\win32libs\wxWidgets-3.0.4\build\msw\gcc_mswudll\coredll_headerctrlgo
         mingw32-make SHELL=cmd -f makefile.gcc -j4 BUILD=release SHARED=1 USE_GUI=1 USE_XRC=0 USE_HTML=0 USE_WEBVIEW=0 USE_MEDIA=0 USE_AUI=0 USE_RIBBON=0 USE_PROPGRID=0 USE_RICHTEXT=0 USE_STC=0 USE_OPENGL=0 VENDOR=gdl DEBUG_FLAG=1
         $env:WXWIDGETS_ROOT="c:\projects\gdl\win32libs\wxWidgets-3.0.4"
+        #        cd C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
+
         
         # BSD-XDR
         cd c:\projects\gdl\win32libs
@@ -75,27 +77,31 @@ install:
         mingw32-make install
 
         # GSL
-        cd c:\projects\gdl\win32libs
-        appveyor DownloadFile http://ftpmirror.gnu.org/gsl/gsl-2.4.tar.gz
-        tar zxf gsl-2.4.tar.gz
-        c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
+        #cd c:\projects\gdl\win32libs
+        #appveyor DownloadFile http://ftpmirror.gnu.org/gsl/gsl-2.4.tar.gz
+        #tar zxf gsl-2.4.tar.gz
+        #c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
         cd C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-gsl-2.4-1-any.pkg.tar.xz
+        7z x mingw-w64-i686-gsl-2.4-1-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-pdcurses-3.6-2-any.pkg.tar.xz
+        7z x mingw-w64-i686-pdcurses-3.6-2-any.pkg.tar.xz
         appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
         appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
         appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
         appveyor DownloadFile https://repo.msys2.org/mingw/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
-        tar xf mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
-        tar xf mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
-        tar xf mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
-        tar xf mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
+        7z x mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
+        7z x mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
+        7z x mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
+        7z x mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
 
         # GNUWin32 (GNU Readline, Zlib, libPNG, PCRE)
         cd c:\projects\gdl\win32libs
-        appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
+        #appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libpng/1.2.37/libpng-1.2.37-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-lib.zip
-        7z x readline-5.0-1-lib.zip
+        #7z x readline-5.0-1-lib.zip
         7z x zlib-1.2.3-lib.zip
         7z x libpng-1.2.37-lib.zip
         7z x pcre-7.0-lib.zip
@@ -118,7 +124,7 @@ build_script:
   - set CMAKE_LIBRARY_PATH=c:\projects\gdl\win32libs\lib
   - set CMAKE_INCLUDE_PATH=c:\projects\gdl\win32libs\include
   - cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
-  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4 c:\projects\gdl\install\gdl\build
+  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4\lib\gcc_dll c:\projects\gdl\install\gdl\bin || exit 0
   - sed -e 's;cblas;cblas -lgnurx;' -i  src/CMakeFiles/gdl.dir/linklibs.rsp
   - robocopy /move /e c:\projects\gdl\build c:\projects\gdl\install\gdl\build || exit 0
   #- mingw32-make -j4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,9 +57,10 @@ install:
         cd c:\projects\gdl\win32libs
         appveyor DownloadFile http://downloads.sourceforge.net/project/plplot/plplot/5.13.0%20Source/plplot-5.13.0.tar.gz
         tar zxf plplot-5.13.0.tar.gz
+        # patches to drivers/wingcc.c, drivers/wingdi.c needed here
         md plplot-5.13.0/build
         cd plplot-5.13.0/build
-        cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE='-O3' -DCMAKE_INSTALL_PREFIX=c:\projects\gdl\win32libs -DOLD_WXWIDGETS:BOOL=ON -DENABLE_wxwidgets:BOOL=ON -DwxWidgets_LIB_DIR=$env:WXWIDGETS_ROOT\lib\gcc_dll -DwxWidgets_CONFIGURATION=mswu -DENABLE_MIX_CXX=ON
+        cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE='-O3' -DCMAKE_INSTALL_PREFIX=c:\projects\gdl\win32libs -DDEFAULT_NO_BINDINGS=ON -DENABLE_cxx=ON -DENABLE_wxwidgets=ON -DOLD_WXWIDGETS=ON -DwxWidgets_LIB_DIR=$env:WXWIDGETS_ROOT\lib\gcc_dll  -DDEFAULT_NO_CAIRO_DEVICES=ON -DDEFAULT_NO_QT_DEVICES=ON -DPLD_pdf=OFF -DPLD_psttf=OFF -DPLD_wingdi=ON
         mingw32-make -j4
         mingw32-make install
         
@@ -77,22 +78,31 @@ install:
         appveyor DownloadFile http://ftpmirror.gnu.org/gsl/gsl-2.4.tar.gz
         tar zxf gsl-2.4.tar.gz
         c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
-        
+        cd C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1
+        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
+        appveyor DownloadFile https://repo.msys2.org/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
+        tar xf mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
+        tar xf mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
+        tar xf mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
+        tar xf mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
+
         # GNUWin32 (GNU Readline, Zlib, libPNG, PCRE)
         cd c:\projects\gdl\win32libs
-        appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
+        #appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libpng/1.2.37/libpng-1.2.37-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-lib.zip
-        7z x readline-5.0-1-lib.zip
+        #7z x readline-5.0-1-lib.zip
         7z x zlib-1.2.3-lib.zip
         7z x libpng-1.2.37-lib.zip
         7z x pcre-7.0-lib.zip
-        appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-bin.zip
+        #appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libpng/1.2.37/libpng-1.2.37-bin.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-bin.zip
-        7z x readline-5.0-1-bin.zip -y
+        #7z x readline-5.0-1-bin.zip -y
         7z x zlib-1.2.3-bin.zip -y
         7z x libpng-1.2.37-bin.zip -y
         7z x pcre-7.0-bin.zip -y
@@ -104,15 +114,16 @@ before_build:
   
 build_script:
   - cd c:\projects\gdl\build
+  - copy c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin\wx* c:\projects\gdl\install\gdl\bin
   - set CMAKE_LIBRARY_PATH=c:\projects\gdl\win32libs\lib
   - set CMAKE_INCLUDE_PATH=c:\projects\gdl\win32libs\include
-  #- cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DCMAKE_CXX_FLAGS="-std=gnu++11" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
+  - cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
+  - robocopy /move /e c:\projects\gdl\build c:\projects\gdl\install\gdl\build || exit 0
   #- mingw32-make -j4
   #- mingw32-make install
 
 after_build:
   - robocopy /move /e c:\projects\gdl\win32libs\bin c:\projects\gdl\install\gdl\bin || exit 0
-  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin c:\projects\gdl\install\gdl\bin || exit 0
   - copy C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\*.dll c:\projects\gdl\install\gdl\bin
   - cd c:\projects\gdl\install
   - 7z a gdlwinlibs.zip gdl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,10 +79,6 @@ install:
         c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
         
         # GNUWin32 (GNU Readline, Zlib, libPNG, PCRE)
-#https://repo.msys2.org/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
-#https://repo.msys2.org/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
-#https://repo.msys2.org/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
-#https://repo.msys2.org/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
         cd c:\projects\gdl\win32libs
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,7 +112,7 @@ build_script:
 
 after_build:
   - robocopy /move /e c:\projects\gdl\win32libs\bin c:\projects\gdl\install\gdl\bin || exit 0
-  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin\wx*.dll c:\projects\gdl\install\gdl\bin || exit 0
+  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin c:\projects\gdl\install\gdl\bin || exit 0
   - copy C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\*.dll c:\projects\gdl\install\gdl\bin
   - cd c:\projects\gdl\install
   - 7z a gdlwinlibs.zip gdl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,6 +79,10 @@ install:
         c:\msys64\usr\bin\bash.exe -lc 'export PATH=$PATH:/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/bin && export LDFLAGS=-L/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/lib && export CPPFLAGS=-I/c/mingw-w64/i686-6.3.0-release-posix-dwarf-rt_v5-rev1/mingw32/i686-w64-mingw32/include && cd /c/projects/gdl/win32libs/gsl-2.4 && ./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --prefix /c/projects/gdl/win32libs && make -j4 && make install'
         
         # GNUWin32 (GNU Readline, Zlib, libPNG, PCRE)
+#https://repo.msys2.org/i686/mingw-w64-i686-ncurses-6.1.20180407-1-any.pkg.tar.xz
+#https://repo.msys2.org/i686/mingw64-64-i686-readline-6.3.008-1-any.pkg.tar.xz
+#https://repo.msys2.org/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz
+#https://repo.msys2.org/i686/mingw-w64-i686-termcap-1.3.1-3-any.pkg.tar.xz
         cd c:\projects\gdl\win32libs
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/readline/5.0-1/readline-5.0-1-lib.zip
         appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/zlib/1.2.3/zlib-1.2.3-lib.zip
@@ -98,7 +102,7 @@ install:
         7z x pcre-7.0-bin.zip -y
       }
   # - if %platform%==mingw64630x8664 set PATH=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw32\bin;%PATH%
-  # - if %platform%==mingw64630x8664 set PYTHON_ROOT=C:\Python27-x64
+  # - if %platform%==mingw64630x8664 set PYTHON_ROOT=C:\Python27-x64 - error - must be mingw32 python build
 before_build:
   - md c:\projects\gdl\build
   
@@ -112,6 +116,7 @@ build_script:
 
 after_build:
   - robocopy /move /e c:\projects\gdl\win32libs\bin c:\projects\gdl\install\gdl\bin || exit 0
+  - robocopy /move /e $env:WXWIDGETS_ROOT\bin\wx*.dll c:\projects\gdl\install\gdl\bin || exit 0
   - copy C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\*.dll c:\projects\gdl\install\gdl\bin
   - cd c:\projects\gdl\install
   - 7z a gdl_build.zip gdl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,8 @@ install:
         # patches to drivers/wingcc.c, drivers/wingdi.c needed here
         md plplot-5.13.0/build
         cd plplot-5.13.0/build
-        cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE='-O3' -DCMAKE_INSTALL_PREFIX=c:\projects\gdl\win32libs -DDEFAULT_NO_BINDINGS=ON -DENABLE_cxx=ON -DENABLE_wxwidgets=ON -DOLD_WXWIDGETS=ON -DwxWidgets_LIB_DIR=$env:WXWIDGETS_ROOT\lib\gcc_dll  -DDEFAULT_NO_CAIRO_DEVICES=ON -DDEFAULT_NO_QT_DEVICES=ON -DPLD_pdf=OFF -DPLD_psttf=OFF -DPLD_wingdi=ON
+        cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE='-O3' -DCMAKE_INSTALL_PREFIX=c:\projects\gdl\win32libs -DOLD_WXWIDGETS:BOOL=ON -DENABLE_wxwidgets:BOOL=ON -DwxWidgets_LIB_DIR=$env:WXWIDGETS_ROOT\lib\gcc_dll -DwxWidgets_CONFIGURATION=mswu -DENABLE_MIX_CXX=ON
+        #cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE='-O3' -DCMAKE_INSTALL_PREFIX=c:\projects\gdl\win32libs -DDEFAULT_NO_BINDINGS=ON -DENABLE_cxx=ON -DENABLE_wxwidgets=ON -DOLD_WXWIDGETS=ON -DwxWidgets_LIB_DIR=$env:WXWIDGETS_ROOT\lib\gcc_dll  -DDEFAULT_NO_CAIRO_DEVICES=ON -DDEFAULT_NO_QT_DEVICES=ON -DPLD_pdf=OFF -DPLD_psttf=OFF -DPLD_wingdi=ON
         mingw32-make -j4
         mingw32-make install
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,21 +106,21 @@ build_script:
   - cd c:\projects\gdl\build
   - set CMAKE_LIBRARY_PATH=c:\projects\gdl\win32libs\lib
   - set CMAKE_INCLUDE_PATH=c:\projects\gdl\win32libs\include
-  - cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DCMAKE_CXX_FLAGS="-std=gnu++11" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
-  - mingw32-make -j4
-  - mingw32-make install
+  #- cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" -DCMAKE_CXX_FLAGS="-std=gnu++11" -DWXWIDGETSDIR=%WXWIDGETS_ROOT% -DCMAKE_INSTALL_PREFIX:PATH=c:\projects\gdl\install\gdl -DGRAPHICSMAGICK=OFF -DMAGICK=OFF -DPSLIB=OFF -DNETCDF=OFF -DHDF=OFF -DHDF5=OFF -DFFTW=OFF -DGSHHS=OFF -DPYTHON=OFF
+  #- mingw32-make -j4
+  #- mingw32-make install
 
 after_build:
   - robocopy /move /e c:\projects\gdl\win32libs\bin c:\projects\gdl\install\gdl\bin || exit 0
-  - robocopy /move /e $env:WXWIDGETS_ROOT\bin\wx*.dll c:\projects\gdl\install\gdl\bin || exit 0
+  - robocopy /move /e c:\projects\gdl\win32libs\wxWidgets-3.0.4\bin\wx*.dll c:\projects\gdl\install\gdl\bin || exit 0
   - copy C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin\*.dll c:\projects\gdl\install\gdl\bin
   - cd c:\projects\gdl\install
-  - 7z a gdl_build.zip gdl
+  - 7z a gdlwinlibs.zip gdl
   # - ctest -C Release --output-on-failure
   # - python -c "import gdl; dir(gdl)"
 
 artifacts:
-  - path: install\gdl_build.zip
+  - path: install\gdlwinlibs.zip
     name: GDL
   
 deploy:


### PR DESCRIPTION
 To run the built program from a "raw" windows system, all shareable images need to be in the
home directory. \win32libs\bin did not have them all: wx are left to copy.  This first commit attempts that.

Later, the appropriate downloads from repo.msys2 should replace the outdated win32libs/ downloads.
Also, patches to wingcc.c and wingdi.c in plplot-xxx/drivers/ will help. 
 As a first step we will see if I can simply edit the appveyor.yml file to copy wx*.dll files into install/bin.