### PR TITLE
patch for size(): n_elements(<list>)

### DIFF
--- a/src/basic_fun_jmg.cpp
+++ b/src/basic_fun_jmg.cpp
@@ -39,6 +39,8 @@ namespace lib {
 
   using namespace std;
   using namespace antlr;
+  SizeT HASH_count( DStructGDL* oStructGDL);
+  SizeT LIST_count( DStructGDL* oStructGDL);
  
   BaseGDL* isa_fun( EnvT* e) 
   {
@@ -448,11 +450,11 @@ namespace lib {
 
 		if( desc->IsParent("LIST"))
 		  {
-		    isObjectContainer = true;
+				isObjectContainer = true; nEl = LIST_count(oStructGDL);
 		  }
 		if( desc->IsParent("HASH"))
 		  {
-		    isObjectContainer = true;
+				isObjectContainer = true; nEl = HASH_count(oStructGDL);
 		  }
 	      }
 	  }


### PR DESCRIPTION
  For l a list or hash, it is IDL convention that n_elements() return, for scalar lists or hashes, the count of the object instead of the actual # of elements in the variable passed. This was
implemented in n_elements but was neglected in size();

GDL> l=list(indgen(5),/ex)
GDL> print,n_elements(l)
           5
GDL> print,size(l)
           1           5          11           5
GDL> l=list(indgen(5),/ex) & l2=replicate(l,2)
GDL> print,size(l2)
           1           2          11           2
GDL> help,l,l2
L               LIST      <ID=1  N_ELEMENTS=5>
L2              OBJREF    = Array[2]