### PR TITLE
Container methods: "Equals" and "IsContained"

### DIFF
--- a/src/basic_fun_jmg.cpp
+++ b/src/basic_fun_jmg.cpp
@@ -39,6 +39,8 @@ namespace lib {
 
   using namespace std;
   using namespace antlr;
+  SizeT HASH_count( DStructGDL* oStructGDL);
+  SizeT LIST_count( DStructGDL* oStructGDL);
  
   BaseGDL* isa_fun( EnvT* e) 
   {
@@ -448,11 +450,11 @@ namespace lib {
 
 		if( desc->IsParent("LIST"))
 		  {
-		    isObjectContainer = true;
+				isObjectContainer = true; nEl = LIST_count(oStructGDL);
 		  }
 		if( desc->IsParent("HASH"))
 		  {
-		    isObjectContainer = true;
+				isObjectContainer = true; nEl = HASH_count(oStructGDL);
 		  }
 	      }
 	  }

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -19,7 +19,7 @@
 ; alist[3] = fltarr(8) generates an error.  
 *  
 **********
-*	April 4 2016: Greg Jung 
+*   April 4 2016: Greg Jung 
 *   - fully implement TOARRAY, including DIMENSION and NO_COPY keywords.
 *   -  list.MOVE, list.SWAP methods.
 *   - [ and ] overloads revised to accomodate in-place array access to hashes
@@ -41,7 +41,7 @@
 * Also
 * #define MAKE_LONGGDL(X, XLong) 
 * Used to get a guarded long from parameter X, possibly converted.
-* GDL_HASH_STRUCT() 			\
+* GDL_HASH_STRUCT()             \
 * GDL_HASHTABLEENTRY()
 * For access to a hash embedded in a list.
 * This is a stage1 list.cpp, so most of the new functionality is NOT
@@ -58,49 +58,49 @@
  ***************************************************************************/
 // These macros are used in the new container-related routines
 
-#define GDL_CONTAINER_STRUCT()			\
+#define GDL_CONTAINER_STRUCT()          \
   static unsigned GDLContainerVersionTag = \
-		structDesc::GDL_CONTAINER->TagIndex( "GDLCONTAINERVERSION"); \
-  static unsigned pHeadTag = structDesc::GDL_CONTAINER->TagIndex( "PHEAD");	\
-  static unsigned pTailTag = structDesc::GDL_CONTAINER->TagIndex( "PTAIL");	\
+        structDesc::GDL_CONTAINER->TagIndex( "GDLCONTAINERVERSION"); \
+  static unsigned pHeadTag = structDesc::GDL_CONTAINER->TagIndex( "PHEAD"); \
+  static unsigned pTailTag = structDesc::GDL_CONTAINER->TagIndex( "PTAIL"); \
   static unsigned nListTag = structDesc::GDL_CONTAINER->TagIndex( "NLIST");
 
-#define GDL_LIST_STRUCT()			\
+#define GDL_LIST_STRUCT()           \
   static unsigned GDLContainerVersionTag = \
-		structDesc::GDL_CONTAINER->TagIndex( "GDLCONTAINERVERSION"); \
-  static unsigned pHeadTag = structDesc::LIST->TagIndex( "PHEAD");	\
-  static unsigned pTailTag = structDesc::LIST->TagIndex( "PTAIL");	\
+        structDesc::GDL_CONTAINER->TagIndex( "GDLCONTAINERVERSION"); \
+  static unsigned pHeadTag = structDesc::LIST->TagIndex( "PHEAD");  \
+  static unsigned pTailTag = structDesc::LIST->TagIndex( "PTAIL");  \
   static unsigned nListTag = structDesc::LIST->TagIndex( "NLIST");
 
-#define	GDL_CONTAINER_NODE()			\
-    static unsigned pNextTag = structDesc::GDL_CONTAINER_NODE->TagIndex( "PNEXT");	\
+#define GDL_CONTAINER_NODE()            \
+    static unsigned pNextTag = structDesc::GDL_CONTAINER_NODE->TagIndex( "PNEXT");  \
     static unsigned pDataTag = structDesc::GDL_CONTAINER_NODE->TagIndex( "PDATA");
 
-#define GDL_HASH_STRUCT() 			\
-    static unsigned TableBitsTag = structDesc::HASH->TagIndex( "TABLE_BITS");	\
-    static unsigned pTableTag = structDesc::HASH->TagIndex( "TABLE_DATA");	\
-    static unsigned TableSizeTag = structDesc::HASH->TagIndex( "TABLE_SIZE");	\
+#define GDL_HASH_STRUCT()           \
+    static unsigned TableBitsTag = structDesc::HASH->TagIndex( "TABLE_BITS");   \
+    static unsigned pTableTag = structDesc::HASH->TagIndex( "TABLE_DATA");  \
+    static unsigned TableSizeTag = structDesc::HASH->TagIndex( "TABLE_SIZE");   \
     static unsigned TableCountTag = structDesc::HASH->TagIndex( "TABLE_COUNT");
 
-#define GDL_HASHTABLEENTRY()			\
+#define GDL_HASHTABLEENTRY()            \
     static unsigned pKeyTag = structDesc::GDL_HASHTABLEENTRY->TagIndex( "PKEY"); \
     static unsigned pValueTag = structDesc::GDL_HASHTABLEENTRY->TagIndex( "PVALUE");
 
 #define MAKE_LONGGDL(X, XLong) \
-		DLongGDL* XLong=0; \
-		Guard<DLongGDL> XLongGuard; \
-		if( X != 0) \
-		  if( X->Type() == GDL_LONG) \
-			XLong = static_cast<DLongGDL*>( X); \
-		  else  { \
-			try{ \
-			  XLong = static_cast<DLongGDL*>( X->Convert2( GDL_LONG, BaseGDL::COPY)); \
-				} \
-				catch( GDLException& ex) { \
-				  ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage()); \
-				} \
-			XLongGuard.Init( XLong); \
-		  }
+        DLongGDL* XLong=0; \
+        Guard<DLongGDL> XLongGuard; \
+        if( X != 0) \
+          if( X->Type() == GDL_LONG) \
+            XLong = static_cast<DLongGDL*>( X); \
+          else  { \
+            try{ \
+              XLong = static_cast<DLongGDL*>( X->Convert2( GDL_LONG, BaseGDL::COPY)); \
+                } \
+                catch( GDLException& ex) { \
+                  ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage()); \
+                } \
+            XLongGuard.Init( XLong); \
+          }
 
 #include "includefirst.hpp"
 
@@ -113,18 +113,18 @@
 
   
 static bool trace_me(false);
-static bool doIncDec(true);	// In order to experiment with IncRef and DecRef
+static bool doIncDec(true); // In order to experiment with IncRef and DecRef
 
 namespace lib {
-//	bool trace_arg();
+//  bool trace_arg();
 
-	
+    
   bool array_equal_bool( BaseGDL* p0, BaseGDL* p1,
-			bool notypeconv=false, bool not_equal=false,
-			bool quiet=true);
+            bool notypeconv=false, bool not_equal=false,
+            bool quiet=true);
  
   void help_item( std::ostream& os,
-		  BaseGDL* par, DString parString, bool doIndentation);
+          BaseGDL* par, DString parString, bool doIndentation);
   void help_struct( std::ostream& os,  BaseGDL* par, int indent , bool debug );
 }
   template< typename IndexT>
@@ -150,11 +150,11 @@ namespace lib {
     SizeT  h2Ix = 0;
     for( i=0; (h1Ix < h1N) && (h2Ix < h2N); ++i) 
       {
-	// the actual comparisson
-	if( h1[h1Ix] < h2[h2Ix]) 
-	  hhS[ i] = h2[ h2Ix++];
-	else
-	  hhS[ i] = h1[ h1Ix++];
+    // the actual comparisson
+    if( h1[h1Ix] < h2[h2Ix]) 
+      hhS[ i] = h2[ h2Ix++];
+    else
+      hhS[ i] = h1[ h1Ix++];
       }
     for(; h1Ix < h1N; ++i) hhS[ i] = h1[ h1Ix++];
     for(; h2Ix < h2N; ++i) hhS[ i] = h2[ h2Ix++];
@@ -190,17 +190,17 @@ namespace lib {
     catch( GDLInterpreter::HeapException& hEx)
     {
       if( e == NULL)
-			throw GDLException( "LIST container node ID <"
-							+i2s(actP)+"> not found.");
+            throw GDLException( "LIST container node ID <"
+                            +i2s(actP)+"> not found.");
       ThrowFromInternalUDSub( e, "LIST container node ID <"
-							+i2s(actP)+"> not found.");      
+                            +i2s(actP)+"> not found.");      
     }
     if( actPHeap == NULL || actPHeap->Type() != GDL_STRUCT)
       {
-	if( e == NULL)
-	  throw GDLException( "LIST node must be a STRUCT.");
-	else
-	  ThrowFromInternalUDSub( e, "LIST node must be a STRUCT.");
+    if( e == NULL)
+      throw GDLException( "LIST node must be a STRUCT.");
+    else
+      ThrowFromInternalUDSub( e, "LIST node must be a STRUCT.");
       }
     DStructGDL* actPStruct = static_cast<DStructGDL*>( actPHeap);
 
@@ -209,28 +209,28 @@ namespace lib {
 
 static BaseGDL* GetNodeData(DPtr &Node) 
 {
-	GDL_CONTAINER_NODE()
+    GDL_CONTAINER_NODE()
 
-	DStructGDL* act = GetLISTStruct( NULL, Node);
-	DPtr ptrX = (*static_cast<DPtrGDL*>(act->GetTag( pDataTag, 0)))[0];
-	Node = (*static_cast<DPtrGDL*>(act->GetTag( pNextTag, 0)))[0];
+    DStructGDL* act = GetLISTStruct( NULL, Node);
+    DPtr ptrX = (*static_cast<DPtrGDL*>(act->GetTag( pDataTag, 0)))[0];
+    Node = (*static_cast<DPtrGDL*>(act->GetTag( pNextTag, 0)))[0];
     BaseGDL* result = new BaseGDL( );
     Guard<BaseGDL> resultGuard( result);
-	result =  BaseGDL::interpreter->GetHeap( ptrX);
-	if( result == NULL) result = NullGDL::GetSingleInstance();
-//	if(trace_me) lib::help_item(std::cout, result, " from GetNodeData", false);
+    result =  BaseGDL::interpreter->GetHeap( ptrX);
+    if( result == NULL) result = NullGDL::GetSingleInstance();
+//  if(trace_me) lib::help_item(std::cout, result, " from GetNodeData", false);
     resultGuard.Release();
     return result;
 }
 
   void FreeLISTNode( EnvUDT* e, DPtr pRemoveNode, bool deleteData = true)
   {
-	  
-	GDL_CONTAINER_NODE()
+      
+    GDL_CONTAINER_NODE()
     
     DStructGDL* removeNode = GetLISTStruct( e, pRemoveNode);
     
-    DPtr pData = (*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];	      
+    DPtr pData = (*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];          
     
     if( deleteData)
       BaseGDL::interpreter->FreeHeap( pData); // delete
@@ -242,12 +242,12 @@ static BaseGDL* GetNodeData(DPtr &Node)
       
     BaseGDL::interpreter->FreeHeap( pRemoveNode); // delete
 
-	return;
+    return;
   }
 
   DPtr GetLISTNode( EnvUDT* e, DStructGDL* self, DLong targetIx)
   {
-	  
+      
     GDL_LIST_STRUCT()
     GDL_CONTAINER_NODE()
   
@@ -261,9 +261,9 @@ static BaseGDL* GetNodeData(DPtr &Node)
       actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
       for( SizeT elIx = 0; elIx < targetIx; ++elIx)
       {
-	DStructGDL* actPStruct = GetLISTStruct(e, actP);
+    DStructGDL* actPStruct = GetLISTStruct(e, actP);
 
-	actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+    actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
       }
     }
     return actP;
@@ -313,15 +313,15 @@ static BaseGDL* GetNodeData(DPtr &Node)
   
   // for HEAP_GC
   void EnvBaseT::AddLIST( DPtrListT& ptrAccessible,
-			  DPtrListT& objAccessible, DStructGDL* listStruct)
+              DPtrListT& objAccessible, DStructGDL* listStruct)
   {
-	  
+      
     GDL_LIST_STRUCT()
     GDL_CONTAINER_NODE()
     
     DStructGDL* self = listStruct;
 
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
   
 //     vector<DPtr> listElementsID;
 //     listElementsID.reserve( nList);
@@ -329,122 +329,122 @@ static BaseGDL* GetNodeData(DPtr &Node)
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-	// no recursion here
-	// PNEXT is handled within this loop instead
+    // no recursion here
+    // PNEXT is handled within this loop instead
         ptrAccessible.insert( actP);
 
-	DStructGDL* actPStruct = GetLISTStruct(NULL, actP);
+    DStructGDL* actPStruct = GetLISTStruct(NULL, actP);
 
-	DPtr actPData = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pDataTag, 0)))[0];
+    DPtr actPData = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pDataTag, 0)))[0];
 
-	// the LIST is corrupted if this check fails,
-	// but we quietly ignore it, as this is only about heap consistency
-	if( actPData != 0 && interpreter->PtrValid( actPData))
-	{
-	  ptrAccessible.insert( actPData);
-	  Add( ptrAccessible, objAccessible, interpreter->GetHeap( actPData));
-	}
-	
-	actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+    // the LIST is corrupted if this check fails,
+    // but we quietly ignore it, as this is only about heap consistency
+    if( actPData != 0 && interpreter->PtrValid( actPData))
+    {
+      ptrAccessible.insert( actPData);
+      Add( ptrAccessible, objAccessible, interpreter->GetHeap( actPData));
+    }
+    
+    actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
       }    
   }
 
   void LISTCleanup( EnvUDT* e, DStructGDL* self)
   {
-		GDL_CONTAINER_NODE()
-		GDL_LIST_STRUCT()
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+        GDL_CONTAINER_NODE()
+        GDL_LIST_STRUCT()
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
   
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
     // swipe head and tail pointer
     (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 0;
-    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;	      
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;         
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-	DStructGDL* actPStruct = GetLISTStruct(e, actP);
+    DStructGDL* actPStruct = GetLISTStruct(e, actP);
 
-	DPtr actPNext = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
-		
-	// the key here: break the chain
-	(*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0] = 0;
+    DPtr actPNext = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+        
+    // the key here: break the chain
+    (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0] = 0;
 //==//
-	DPtr pData = (*static_cast<DPtrGDL*>(actPStruct ->GetTag( pDataTag, 0)))[0];
-	if(doIncDec) {
-		BaseGDL* data = BaseGDL::interpreter->GetHeapNoThrow( pData);
-		if( data == NULL || data == NullGDL::GetSingleInstance())
-		 ;
-		else if( (data->Type() == GDL_PTR) &&
-			e->Interpreter()->PtrValid( pData))  e->Interpreter()->DecRef( pData);
-		else if( (data->Type() == GDL_OBJ) && 
-			e->Interpreter()->ObjValid( pData)) e->Interpreter()->DecRefObj( pData);
-		else e->Interpreter()->FreeHeap( pData);
-		}
-	
+    DPtr pData = (*static_cast<DPtrGDL*>(actPStruct ->GetTag( pDataTag, 0)))[0];
+    if(doIncDec) {
+        BaseGDL* data = BaseGDL::interpreter->GetHeapNoThrow( pData);
+        if( data == NULL || data == NullGDL::GetSingleInstance())
+         ;
+        else if( (data->Type() == GDL_PTR) &&
+            e->Interpreter()->PtrValid( pData))  e->Interpreter()->DecRef( pData);
+        else if( (data->Type() == GDL_OBJ) && 
+            e->Interpreter()->ObjValid( pData)) e->Interpreter()->DecRefObj( pData);
+        else e->Interpreter()->FreeHeap( pData);
+        }
+    
 //==//
-	GDLInterpreter::FreeHeap( actP); // deletes also PDATA
-	
-	actP = actPNext;
+    GDLInterpreter::FreeHeap( actP); // deletes also PDATA
+    
+    actP = actPNext;
       }    
-    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 0;	      
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 0;        
   }
 
   void CONTAINERCleanup( EnvUDT* e, DStructGDL* self)
   {
-	GDL_CONTAINER_STRUCT()
-	GDL_CONTAINER_NODE()
-	enum {POINTERS=1, OBJECTS};
+    GDL_CONTAINER_STRUCT()
+    GDL_CONTAINER_NODE()
+    enum {POINTERS=1, OBJECTS};
 
-	DInt GDLContainerVersion = 
-	   (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
-	bool isPtr = (GDLContainerVersion == POINTERS);
+    DInt GDLContainerVersion = 
+       (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
+    bool isPtr = (GDLContainerVersion == POINTERS);
 
     DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];
     if( nList == 0) return;
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
     if( actP == 0) ThrowFromInternalUDSub( e,
-			 " Invalid Node reference at tail end of container");
+             " Invalid Node reference at tail end of container");
   
     // swipe head and tail pointer, reset nlist.
     (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 0;
-    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;	      
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;         
     (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 0;    
-  	if( trace_me) std::cout << " Top of deallocation loop: " ;
+    if( trace_me) std::cout << " Top of deallocation loop: " ;
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-  	if( trace_me) std::printf(" #%llu %llu:",elIx,actP);
-//		DStructGDL* Node = GetLISTStruct(e, actP);
-		BaseGDL* actPHeap;
-		try {
-		  actPHeap = BaseGDL::interpreter->GetHeap( actP);
-		}
-		catch( GDLInterpreter::HeapException& hEx)
-		{
-	//      ThrowFromInternalUDSub( e, " container node ID <"
-	//							+i2s(actP)+"> not found.");
-			std::cout << "Container::cleanup -  container node ID <"
-								+i2s(actP)+"> not found."
-			 << " Returning w/o error " << std::endl;
-			return;
-		}
-		if( actPHeap == NULL || actPHeap->Type() != GDL_STRUCT)
-			  ThrowFromInternalUDSub( e, "container node must be a STRUCT.");
+    if( trace_me) std::printf(" #%llu %llu:",elIx,actP);
+//      DStructGDL* Node = GetLISTStruct(e, actP);
+        BaseGDL* actPHeap;
+        try {
+          actPHeap = BaseGDL::interpreter->GetHeap( actP);
+        }
+        catch( GDLInterpreter::HeapException& hEx)
+        {
+    //      ThrowFromInternalUDSub( e, " container node ID <"
+    //                          +i2s(actP)+"> not found.");
+            std::cout << "Container::cleanup -  container node ID <"
+                                +i2s(actP)+"> not found."
+             << " Returning w/o error " << std::endl;
+            return;
+        }
+        if( actPHeap == NULL || actPHeap->Type() != GDL_STRUCT)
+              ThrowFromInternalUDSub( e, "container node must be a STRUCT.");
 
-		DStructGDL* Node = static_cast<DStructGDL*>( actPHeap);
+        DStructGDL* Node = static_cast<DStructGDL*>( actPHeap);
 
-		DPtr pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-		DPtr pData = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];
-  	if( trace_me) std::printf("pData=%llu.",pData);
-		if(doIncDec) {
-				if( isPtr && e->Interpreter()->PtrValid( pData)) 
-					 e->Interpreter()->DecRef( pData);
-				else if(!isPtr && e->Interpreter()->ObjValid( pData))
-					 e->Interpreter()->DecRefObj( pData);
-		}
+        DPtr pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+        DPtr pData = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];
+    if( trace_me) std::printf("pData=%llu.",pData);
+        if(doIncDec) {
+                if( isPtr && e->Interpreter()->PtrValid( pData)) 
+                     e->Interpreter()->DecRef( pData);
+                else if(!isPtr && e->Interpreter()->ObjValid( pData))
+                     e->Interpreter()->DecRefObj( pData);
+        }
 
-			// prevent cleanup due to ref-counting  
-			(*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = 0;      
-		BaseGDL::interpreter->FreeHeap( actP);
-		actP = pNext;
+            // prevent cleanup due to ref-counting  
+            (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = 0;      
+        BaseGDL::interpreter->FreeHeap( actP);
+        actP = pNext;
       }  
       if(trace_me) std::cout << std::endl;  
   }
@@ -453,89 +453,89 @@ namespace lib {
 BaseGDL* list_rightextraction( EnvUDT* e, BaseGDL* theref, int iprm  );
 
 void list_insertion( BaseGDL* theref, BaseGDL* rVal,
-			ArrayIndexListT* ixList)
-{		// This routine is simply copied from the new list.cpp
-	DType destTy = theref->Type();
+            ArrayIndexListT* ixList)
+{       // This routine is simply copied from the new list.cpp
+    DType destTy = theref->Type();
     ixList->SetVariable( theref);
-	dimension dim = ixList->GetDim();
-	if( rVal->Type() != destTy) 
-		rVal = rVal->Convert2( destTy, BaseGDL::COPY);
+    dimension dim = ixList->GetDim();
+    if( rVal->Type() != destTy) 
+        rVal = rVal->Convert2( destTy, BaseGDL::COPY);
   switch( destTy)
     {
     case GDL_BYTE:
       { Data_<SpDByte>* dest=static_cast<Data_<SpDByte>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break;}
+        dest->AssignAt( rVal, ixList);
+        break;}
 
     case GDL_INT:
       { Data_<SpDInt>* dest=static_cast<Data_<SpDInt>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break;}
+        dest->AssignAt( rVal, ixList);
+        break;}
 
     case GDL_UINT:
       { Data_<SpDUInt>* dest=static_cast<Data_<SpDUInt>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	 break; }
+        dest->AssignAt( rVal, ixList);
+         break; }
 
     case GDL_LONG:
       { Data_<SpDLong>* dest=static_cast<Data_<SpDLong>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_ULONG:
       { Data_<SpDULong>* dest=static_cast<Data_<SpDULong>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_LONG64:
       { Data_<SpDLong64>* dest=static_cast<Data_<SpDLong64>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_ULONG64:
       { Data_<SpDULong64>* dest=static_cast<Data_<SpDULong64>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_FLOAT: 
       { Data_<SpDFloat>* dest=static_cast<Data_<SpDFloat>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-	break; }
+        dest->AssignAt( rVal, ixList);
+    break; }
 
     case GDL_DOUBLE: 
       { Data_<SpDDouble>* dest=static_cast<Data_<SpDDouble>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_STRING: 
       { Data_<SpDString>* dest=static_cast<Data_<SpDString>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_COMPLEX: 
       { Data_<SpDComplex>* dest=static_cast<Data_<SpDComplex>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_COMPLEXDBL: 
       { Data_<SpDComplexDbl>* dest=
-	  static_cast<Data_<SpDComplexDbl>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break; }
+      static_cast<Data_<SpDComplexDbl>* >(theref);
+        dest->AssignAt( rVal, ixList);
+        break; }
 
     case GDL_STRUCT:
       { DStructGDL* dest=static_cast<DStructGDL* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break;}
+        dest->AssignAt( rVal, ixList);
+        break;}
 
     case GDL_PTR:
       { Data_<SpDPtr>* dest=static_cast<Data_<SpDPtr>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break;}
+        dest->AssignAt( rVal, ixList);
+        break;}
     case GDL_OBJ:
       { Data_<SpDObj>* dest=static_cast<Data_<SpDObj>* >(theref);
-      	dest->AssignAt( rVal, ixList);
-      	break;}
+        dest->AssignAt( rVal, ixList);
+        break;}
 
     }
     return;
@@ -543,105 +543,105 @@ void list_insertion( BaseGDL* theref, BaseGDL* rVal,
 
 BaseGDL* list_extraction( BaseGDL* theref, ArrayIndexListT* ixList)
 {
-	DType destTy = theref->Type();
+    DType destTy = theref->Type();
     ixList->SetVariable( theref);
-	dimension dim = ixList->GetDim();
+    dimension dim = ixList->GetDim();
   switch( destTy)
     {
     case GDL_BYTE:
       {Data_<SpDByte>* dest=new Data_<SpDByte>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest) ;}
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest) ;}
     case GDL_INT:
       {Data_<SpDInt>* dest=new Data_<SpDInt>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest) ;}
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest) ;}
 
     case GDL_UINT:
       {Data_<SpDUInt>* dest=new Data_<SpDUInt>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	 return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+         return static_cast<BaseGDL*>(dest); }
 
     case GDL_LONG:
       {Data_<SpDLong>* dest=new Data_<SpDLong>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_ULONG:
       {Data_<SpDULong>* dest=new Data_<SpDULong>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_LONG64:
       {Data_<SpDLong64>* dest=new Data_<SpDLong64>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_ULONG64:
       {Data_<SpDULong64>* dest=new Data_<SpDULong64>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_FLOAT: 
       {Data_<SpDFloat>* dest=new Data_<SpDFloat>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);  return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);  return static_cast<BaseGDL*>(dest); }
 
     case GDL_DOUBLE: 
       {Data_<SpDDouble>* dest=new Data_<SpDDouble>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_STRING: 
       {Data_<SpDString>* dest=new Data_<SpDString>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_COMPLEX: 
       {Data_<SpDComplex>* dest=new Data_<SpDComplex>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
 
     case GDL_COMPLEXDBL: 
       {Data_<SpDComplexDbl>* dest=
-	  new Data_<SpDComplexDbl>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest); }
-      	
+      new Data_<SpDComplexDbl>( dim, BaseGDL::NOZERO);
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest); }
+        
     case GDL_PTR:
       {Data_<SpDPtr>* dest=new Data_<SpDPtr>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest) ;}
-      	
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest) ;}
+        
     case GDL_OBJ:
       {Data_<SpDObj>* dest=new Data_<SpDObj>( dim, BaseGDL::NOZERO);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest) ;}
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest) ;}
 
     case GDL_STRUCT:
       {DStructGDL* dest=new DStructGDL((static_cast<DStructGDL* >(theref))->Desc(), dim);
-      	dest->InsertAt( 0, theref, ixList);
-      	return static_cast<BaseGDL*>(dest) ;}
-      	    }
+        dest->InsertAt( 0, theref, ixList);
+        return static_cast<BaseGDL*>(dest) ;}
+            }
     //  Guard<BaseGDL> resultGuard( result);
 }
   
   void list__cleanup( EnvUDT* e)
   {
     DStructGDL* self = GetOBJ( e->GetKW( 0), e);
- 	if( trace_me) std::cout << " List::CLEANUP" << std::endl; 
+    if( trace_me) std::cout << " List::CLEANUP" << std::endl; 
     LISTCleanup( e, self);
   }
 
   BaseGDL* LIST___OverloadIsTrue( EnvUDT* e)
   {
     SizeT nParam = e->NParam(1); // SELF
-	
+    
     DStructGDL* self = GetOBJ( e->GetKW( 0), e);
 
     // here static is fine
     static unsigned nListTag = structDesc::LIST->TagIndex( "NLIST");
 
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
   
     if( nList == 0)
       return new DByteGDL(0);
@@ -698,7 +698,7 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
   if( r == NULL)
   {
     if( leftStruct == NULL)
-      ThrowFromInternalUDSub( e, "At least one parameter must be a LIST.");      	
+      ThrowFromInternalUDSub( e, "At least one parameter must be a LIST.");         
     r = NullGDL::GetSingleInstance();
   }
   if( r->Type() == GDL_OBJ)
@@ -716,7 +716,7 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
   
   if( rightStruct == NULL && leftStruct == NULL)
   {
-      ThrowFromInternalUDSub( e, "At least one parameter must be a LIST.");      	      
+      ThrowFromInternalUDSub( e, "At least one parameter must be a LIST.");               
   }
   
   if( leftStruct == NULL)
@@ -739,10 +739,10 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       nListRight = (*static_cast<DLongGDL*>(rightStruct->GetTag( nListTag, 0)))[0];
       if( nListRight == 0)
       {
-	if( nListLeft == 0)
-	  return new DByteGDL(1);
-	else
-	  return new DByteGDL(0);
+    if( nListLeft == 0)
+      return new DByteGDL(1);
+    else
+      return new DByteGDL(0);
       }
   }
   assert( rightStruct == NULL || nListRight > 0);
@@ -771,48 +771,48 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       if( dataL == NULL || dataL == NullGDL::GetSingleInstance())
       {
         if( dataR == NULL || dataR == NullGDL::GetSingleInstance())
-	  (*result)[ i] = 1;
+      (*result)[ i] = 1;
       }
       else if( dataR != NULL && dataR != NullGDL::GetSingleInstance())
       {
-	if( dataL->EqType(dataR))
-	{
-	  BaseGDL* eqRes = dataL->EqOp( dataR);
-	  if( eqRes->Type() != GDL_BYTE)
-	  {
-	    Guard<BaseGDL> eqResGuardTmp( eqRes);
-	    eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
-	    eqResGuardTmp.Release();
-	  }
-	  Guard<BaseGDL> eqResGuard( eqRes);
-	  DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
-	  SizeT c = 0;
-	  for( c=0; c<eqResByte->N_Elements(); ++c)
-	    if( !((*eqResByte)[ c]))
-	      break;
-	  if( c == eqResByte->N_Elements())
-	    (*result)[ i] = 1;	  
-	}
-	else
-	{
-	  BaseGDL* rConvert = dataR->Convert2(dataL->Type(),BaseGDL::COPY);
-	  Guard<BaseGDL> rCovertGuard( rConvert);
-	  BaseGDL* eqRes = dataL->EqOp( rConvert);
-	  if( eqRes->Type() != GDL_BYTE)
-	  {
-	    Guard<BaseGDL> eqResGuardTmp( eqRes);
-	    eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
-	    eqResGuardTmp.Release();
-	  }
-	  Guard<BaseGDL> eqResGuard( eqRes);
-	  DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
-	  SizeT c = 0;
-	  for( c=0; c<eqResByte->N_Elements(); ++c)
-	    if( !((*eqResByte)[ c]))
-	      break;
-	  if( c == eqResByte->N_Elements())
-	    (*result)[ i] = 1;	  
-	}
+    if( dataL->EqType(dataR))
+    {
+      BaseGDL* eqRes = dataL->EqOp( dataR);
+      if( eqRes->Type() != GDL_BYTE)
+      {
+        Guard<BaseGDL> eqResGuardTmp( eqRes);
+        eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
+        eqResGuardTmp.Release();
+      }
+      Guard<BaseGDL> eqResGuard( eqRes);
+      DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
+      SizeT c = 0;
+      for( c=0; c<eqResByte->N_Elements(); ++c)
+        if( !((*eqResByte)[ c]))
+          break;
+      if( c == eqResByte->N_Elements())
+        (*result)[ i] = 1;    
+    }
+    else
+    {
+      BaseGDL* rConvert = dataR->Convert2(dataL->Type(),BaseGDL::COPY);
+      Guard<BaseGDL> rCovertGuard( rConvert);
+      BaseGDL* eqRes = dataL->EqOp( rConvert);
+      if( eqRes->Type() != GDL_BYTE)
+      {
+        Guard<BaseGDL> eqResGuardTmp( eqRes);
+        eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
+        eqResGuardTmp.Release();
+      }
+      Guard<BaseGDL> eqResGuard( eqRes);
+      DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
+      SizeT c = 0;
+      for( c=0; c<eqResByte->N_Elements(); ++c)
+        if( !((*eqResByte)[ c]))
+          break;
+      if( c == eqResByte->N_Elements())
+        (*result)[ i] = 1;    
+    }
       }
       // advance to next node
       pActLNode = (*static_cast<DPtrGDL*>(actLNode->GetTag( pNextTag, 0)))[0];
@@ -837,65 +837,65 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       if( dataL == NULL || dataL == NullGDL::GetSingleInstance())
       {
         if( dataR == NULL || dataR == NullGDL::GetSingleInstance())
-	  (*result)[ i] = 1;
+      (*result)[ i] = 1;
       }
       else if( dataR != NULL && dataR != NullGDL::GetSingleInstance())
       {
-	if( dataL->EqType(dataR))
-	{
-	  BaseGDL* eqRes = dataL->EqOp( dataR);
-	  if( eqRes->Type() != GDL_BYTE)
-	  {
-	    Guard<BaseGDL> eqResGuardTmp( eqRes);
-	    eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
-	    eqResGuardTmp.Release();
-	  }
-	  Guard<BaseGDL> eqResGuard( eqRes);
-	  DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
-	  SizeT c = 0;
-	  for( c=0; c<eqResByte->N_Elements(); ++c)
-	    if( !((*eqResByte)[ c]))
-	      break;
-	  if( c == eqResByte->N_Elements())
-	    (*result)[ i] = 1;	  
-	}
-	else
-	{
-	  
-	  BaseGDL* eqRes = NULL;
+    if( dataL->EqType(dataR))
+    {
+      BaseGDL* eqRes = dataL->EqOp( dataR);
+      if( eqRes->Type() != GDL_BYTE)
+      {
+        Guard<BaseGDL> eqResGuardTmp( eqRes);
+        eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
+        eqResGuardTmp.Release();
+      }
+      Guard<BaseGDL> eqResGuard( eqRes);
+      DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
+      SizeT c = 0;
+      for( c=0; c<eqResByte->N_Elements(); ++c)
+        if( !((*eqResByte)[ c]))
+          break;
+      if( c == eqResByte->N_Elements())
+        (*result)[ i] = 1;    
+    }
+    else
+    {
+      
+      BaseGDL* eqRes = NULL;
 
-	  DType aTy=dataL->Type();
-	  DType bTy=dataR->Type();
-	  if( DTypeOrder[aTy] > DTypeOrder[bTy])
-	    {
-	      // convert b to a
-	      BaseGDL* rConvert = dataR->Convert2(dataL->Type(),BaseGDL::COPY);
-	      Guard<BaseGDL> rConvertGuard(rConvert);
-	      eqRes = dataL->EqOp( rConvert);
-	    }
-	  else
-	    {
-	      // convert a to b
-	      BaseGDL* lConvert = dataL->Convert2(dataR->Type(),BaseGDL::COPY);
-	      Guard<BaseGDL> lConvertGuard(lConvert);
-	      eqRes = dataR->EqOp( lConvert);
-	    }
-	  	  
-	  if( eqRes->Type() != GDL_BYTE)
-	  {
-	    Guard<BaseGDL> eqResGuardTmp( eqRes);
-	    eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
-	    eqResGuardTmp.Release();
-	  }
-	  Guard<BaseGDL> eqResGuard( eqRes);
-	  DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
-	  SizeT c = 0;
-	  for( c=0; c<eqResByte->N_Elements(); ++c)
-	    if( !((*eqResByte)[ c]))
-	      break;
-	  if( c == eqResByte->N_Elements())
-	    (*result)[ i] = 1;	  
-	}
+      DType aTy=dataL->Type();
+      DType bTy=dataR->Type();
+      if( DTypeOrder[aTy] > DTypeOrder[bTy])
+        {
+          // convert b to a
+          BaseGDL* rConvert = dataR->Convert2(dataL->Type(),BaseGDL::COPY);
+          Guard<BaseGDL> rConvertGuard(rConvert);
+          eqRes = dataL->EqOp( rConvert);
+        }
+      else
+        {
+          // convert a to b
+          BaseGDL* lConvert = dataL->Convert2(dataR->Type(),BaseGDL::COPY);
+          Guard<BaseGDL> lConvertGuard(lConvert);
+          eqRes = dataR->EqOp( lConvert);
+        }
+          
+      if( eqRes->Type() != GDL_BYTE)
+      {
+        Guard<BaseGDL> eqResGuardTmp( eqRes);
+        eqRes = eqRes->Convert2( GDL_BYTE, BaseGDL::CONVERT);
+        eqResGuardTmp.Release();
+      }
+      Guard<BaseGDL> eqResGuard( eqRes);
+      DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
+      SizeT c = 0;
+      for( c=0; c<eqResByte->N_Elements(); ++c)
+        if( !((*eqResByte)[ c]))
+          break;
+      if( c == eqResByte->N_Elements())
+        (*result)[ i] = 1;    
+    }
       }
       // advance to next node
       pActLNode = (*static_cast<DPtrGDL*>(actLNode->GetTag( pNextTag, 0)))[0];
@@ -983,7 +983,7 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       DPtr pData = (*static_cast<DPtrGDL*>(actNode->GetTag( pDataTag, 0)))[0];
       BaseGDL* data = BaseGDL::interpreter->GetHeap( pData);
       if( data != NULL) 
-	data = data->Dup();
+    data = data->Dup();
 
       DPtr dID = e->Interpreter()->NewHeap(1,data);
       
@@ -992,21 +992,21 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = dID;
       
       if( cStructLast != NULL)
-	(*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+    (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
       else
       { // 1st element
-	(*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;         
       }
-	    
+        
       cStructLast = cStruct;
       
       if( (i+1) == nListLeft && nListRight > 0)
-	pActNode = GetLISTNode( e, rightStruct, 0);
+    pActNode = GetLISTNode( e, rightStruct, 0);
       else
-	pActNode = (*static_cast<DPtrGDL*>(actNode->GetTag( pNextTag, 0)))[0];
+    pActNode = (*static_cast<DPtrGDL*>(actNode->GetTag( pNextTag, 0)))[0];
     }
     
-    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;	      
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;         
     (*static_cast<DLongGDL*>( listStruct->GetTag( nListTag, 0)))[0] = nListLeft+nListRight;      
 
     newObjGuard.Release();
@@ -1078,47 +1078,47 @@ BaseGDL* LIST___OverloadBracketsRightSide( EnvUDT* e)
     {
       BaseGDL* parX = e->GetKW( p + 2); // implicit SELF, ISRANGE, par1..par8
       if( parX == NULL)
-	ThrowFromInternalUDSub( e, "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
+    ThrowFromInternalUDSub( e, "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
 
       DLong isRangeX = (*isRangeLong)[p];
       if( isRangeX != 0 && isRangeX != 1)
       {
-	ThrowFromInternalUDSub( e, "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
+    ThrowFromInternalUDSub( e, "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
       }
       if( isRangeX == 1)
       {
-	if( parX->N_Elements() != 3)
-	{
-	  ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " + e->Caller()->GetString(e->GetKW( p + 2)));
-	}
-	DLongGDL* parXLong;
-	Guard<DLongGDL> parXLongGuard;
-	if( parX->Type() != GDL_LONG)
-	{
-	  try{
-	    parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
-	    parXLongGuard.Reset( parXLong);
-	  }
-	  catch( GDLException& ex)
-	  {
-	    ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-	  }
-	}
-	else
-	{
-	  parXLong = static_cast<DLongGDL*>( parX);
-	}
-	// negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
-	ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
+    if( parX->N_Elements() != 3)
+    {
+      ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " + e->Caller()->GetString(e->GetKW( p + 2)));
+    }
+    DLongGDL* parXLong;
+    Guard<DLongGDL> parXLongGuard;
+    if( parX->Type() != GDL_LONG)
+    {
+      try{
+        parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
+        parXLongGuard.Reset( parXLong);
+      }
+      catch( GDLException& ex)
+      {
+        ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+      }
+    }
+    else
+    {
+      parXLong = static_cast<DLongGDL*>( parX);
+    }
+    // negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
+    ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
       }
       else // non-range
       {
-	// ATTENTION: These two grab c1 (all others don't)
-	// a bit unclean, but for maximum efficiency
-	if( parX->Rank() == 0)
-	  ixList.push_back( new CArrayIndexScalar( parX->Dup()));
-	else
-	  ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
+    // ATTENTION: These two grab c1 (all others don't)
+    // a bit unclean, but for maximum efficiency
+    if( parX->Rank() == 0)
+      ixList.push_back( new CArrayIndexScalar( parX->Dup()));
+    else
+      ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
       }
     } // for
   }
@@ -1194,13 +1194,13 @@ BaseGDL* LIST___OverloadBracketsRightSide( EnvUDT* e)
       (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
     else
     { // 1st element
-      (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
+      (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;       
     }
           
     cStructLast = cStruct;
   }
   
-  (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;	      
+  (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;       
   (*static_cast<DLongGDL*>( listStruct->GetTag( nListTag, 0)))[0] = allIx->size();      
 
   newObjGuard.Release();
@@ -1284,55 +1284,55 @@ void LIST___OverloadBracketsLeftSide( EnvUDT* e)
     {
       BaseGDL* parX = e->GetKW( p + 4); // implicit SELF, ISRANGE, par1..par8
       if( parX == NULL)
-	ThrowFromInternalUDSub( e, "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
+    ThrowFromInternalUDSub( e, "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
 
       DLong isRangeX = (*isRangeLong)[p];
       if( isRangeX != 0 && isRangeX != 1)
       {
-	ThrowFromInternalUDSub( e, "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
+    ThrowFromInternalUDSub( e, "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
       }
       if( isRangeX == 1)
       {
-	if( parX->N_Elements() != 3)
-	{
-	  ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " + e->Caller()->GetString(e->GetKW( p + 2)));
-	}
-	DLongGDL* parXLong;
-	Guard<DLongGDL> parXLongGuard;
-	if( parX->Type() != GDL_LONG)
-	{
-	  try{
-	    parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
-	    parXLongGuard.Reset( parXLong);
-	  }
-	  catch( GDLException& ex)
-	  {
-	    ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-	  }
-	}
-	else
-	{
-	  parXLong = static_cast<DLongGDL*>( parX);
-	}
-	// negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
-	ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
+    if( parX->N_Elements() != 3)
+    {
+      ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " + e->Caller()->GetString(e->GetKW( p + 2)));
+    }
+    DLongGDL* parXLong;
+    Guard<DLongGDL> parXLongGuard;
+    if( parX->Type() != GDL_LONG)
+    {
+      try{
+        parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
+        parXLongGuard.Reset( parXLong);
+      }
+      catch( GDLException& ex)
+      {
+        ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+      }
+    }
+    else
+    {
+      parXLong = static_cast<DLongGDL*>( parX);
+    }
+    // negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
+    ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
       }
       else // non-range
       {
-	// ATTENTION: These two grab c1 (all others don't)
-	// a bit unclean, but for maximum efficiency
-	if( parX->Rank() == 0)
-	  ixList.push_back( new CArrayIndexScalar( parX->Dup()));
-	else
-	  ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
+    // ATTENTION: These two grab c1 (all others don't)
+    // a bit unclean, but for maximum efficiency
+    if( parX->Rank() == 0)
+      ixList.push_back( new CArrayIndexScalar( parX->Dup()));
+    else
+      ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
       }
     } // for
   }
   catch( GDLException& ex)
   {
     ixList.Destruct(); // ixList is not valid afterwards, but as we throw this is ok
-	// throw ex; -<< gives a codacy error.
-	ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+    // throw ex; -<< gives a codacy error.
+    ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
   }
   
   SizeT listSize = (*static_cast<DLongGDL*>(self->GetTag( nListTag, 0)))[0];
@@ -1399,23 +1399,23 @@ void LIST___OverloadBracketsLeftSide( EnvUDT* e)
 
 
 template< typename DTypeGDL>
-BaseGDL* LIST__ToArray( EnvUDT* e, 	dimension& newdim)
+BaseGDL* LIST__ToArray( EnvUDT* e,  dimension& newdim)
 {
 //
 // "resultype" == DtypeGDL::t
 //
     GDL_LIST_STRUCT()
-	GDL_CONTAINER_NODE()
-	if(trace_me) std::cout << " ToArray.";	
+    GDL_CONTAINER_NODE()
+    if(trace_me) std::cout << " ToArray.";  
     static int kwTYPEIx = e->GetKeywordIx("TYPE");
     static int kwSELFIx = kwTYPEIx + 1;
     static int kwMISSINGIx = e->GetKeywordIx("MISSING"); 
     static int kwDIMENSIONIx = e->GetKeywordIx("DIMENSION");
     static int kwNO_COPYIx = e->GetKeywordIx("NO_COPY");
- 	static int kwTRANSPOSEIx = e->GetKeywordIx("TRANSPOSE");
+    static int kwTRANSPOSEIx = e->GetKeywordIx("TRANSPOSE");
 
-	DTypeGDL* missingT = NULL;
-	Guard<DTypeGDL> missingTGuard;
+    DTypeGDL* missingT = NULL;
+    Guard<DTypeGDL> missingTGuard;
 /*
  * DIMENSION
  Set this keyword to the dimension over which to concatenate the arrays contained within the list.
@@ -1429,7 +1429,7 @@ Note: If the DIMENSION keyword is specified, the MISSING and TRANSPOSE keywords 
 */
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
 
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
     DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
     DPtr pNext = pTail;
 
@@ -1437,96 +1437,96 @@ Note: If the DIMENSION keyword is specified, the MISSING and TRANSPOSE keywords 
     BaseGDL* missingKW = (dimensionKW != 0)? 0:e->GetKW( kwMISSINGIx);
     BaseGDL* transposeKW = (dimensionKW != 0)? 0:e->GetKW( kwTRANSPOSEIx);
 
-	SizeT dimkw=0;
+    SizeT dimkw=0;
     MAKE_LONGGDL(dimensionKW, dimkwLong)
     if(dimensionKW != 0) dimkw = (*dimkwLong)[0];
 
-	SizeT Rank = newdim.Rank();
-	SizeT Stride = newdim.Stride(Rank-1);
-	if(dimkw > 0) Stride = newdim.Stride(dimkw-1);
+    SizeT Rank = newdim.Rank();
+    SizeT Stride = newdim.Stride(Rank-1);
+    if(dimkw > 0) Stride = newdim.Stride(dimkw-1);
 
-	if(missingKW != 0 && missingKW->Rank() != 0 &&
-				(Stride != missingKW->N_Elements()) )
-				ThrowFromInternalUDSub( e, " 'missing' keyword array does not match elements' structure");
+    if(missingKW != 0 && missingKW->Rank() != 0 &&
+                (Stride != missingKW->N_Elements()) )
+                ThrowFromInternalUDSub( e, " 'missing' keyword array does not match elements' structure");
 
-	DTypeGDL* result = new DTypeGDL( newdim, BaseGDL::NOZERO);
-	Guard<DTypeGDL> resultGuard( result);
+    DTypeGDL* result = new DTypeGDL( newdim, BaseGDL::NOZERO);
+    Guard<DTypeGDL> resultGuard( result);
     bool transposekw = (transposeKW != 0) || (dimensionKW != 0) ;
-	if(trace_me) {
-		std::cout << " newdim stride 0...Rank-1 = " << Rank-1 << ": " ;	
-		for (int i=0; i < Rank; i++) std::cout << "["<<i<<"]= "
-		  << newdim.Stride(i) << ". ";
-		  std::cout<< std::endl;
-		std::cout << " Transpose? " << transposekw << std::endl;
-	}
+    if(trace_me) {
+        std::cout << " newdim stride 0...Rank-1 = " << Rank-1 << ": " ; 
+        for (int i=0; i < Rank; i++) std::cout << "["<<i<<"]= "
+          << newdim.Stride(i) << ". ";
+          std::cout<< std::endl;
+        std::cout << " Transpose? " << transposekw << std::endl;
+    }
 
-	SizeT Toffset = 0; // A counter for the sandbox 
-	
-	SizeT catrankIx = (dimkw ==0) ? RankIx(newdim.Rank()) : dimkw-1 ;
+    SizeT Toffset = 0; // A counter for the sandbox 
+    
+    SizeT catrankIx = (dimkw ==0) ? RankIx(newdim.Rank()) : dimkw-1 ;
 
-	pNext = pTail;
-	SizeT inlist = 0;
-	for( SizeT i =0; i <nList; ++i )
-	{
-		DStructGDL* Node = GetLISTStruct(NULL, pNext);    
-		BaseGDL* data = BaseGDL::interpreter->GetHeap(
-						(*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0]);
-		pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];     		  
+    pNext = pTail;
+    SizeT inlist = 0;
+    for( SizeT i =0; i <nList; ++i )
+    {
+        DStructGDL* Node = GetLISTStruct(NULL, pNext);    
+        BaseGDL* data = BaseGDL::interpreter->GetHeap(
+                        (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0]);
+        pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];             
 
-		if( data == 0 ||
-					data == NullGDL::GetSingleInstance())
-		{ 
-		  if(missingKW == 0 ||
-				missingKW == NullGDL::GetSingleInstance()) continue;
-		  if( missingT == 0)
-		  {
-			missingT = new DTypeGDL( dimension(Stride) , BaseGDL::NOZERO);
-			missingTGuard.Init( missingT);
-			BaseGDL* fill = missingKW->Convert2( result->Type() ,BaseGDL::COPY);
-			missingT->AssignAt( fill, NULL, 0);
-		  }
-		  result->InsertAt( Stride*inlist , missingT, NULL);
-		   ++inlist;		  continue;
+        if( data == 0 ||
+                    data == NullGDL::GetSingleInstance())
+        { 
+          if(missingKW == 0 ||
+                missingKW == NullGDL::GetSingleInstance()) continue;
+          if( missingT == 0)
+          {
+            missingT = new DTypeGDL( dimension(Stride) , BaseGDL::NOZERO);
+            missingTGuard.Init( missingT);
+            BaseGDL* fill = missingKW->Convert2( result->Type() ,BaseGDL::COPY);
+            missingT->AssignAt( fill, NULL, 0);
+          }
+          result->InsertAt( Stride*inlist , missingT, NULL);
+           ++inlist;          continue;
 
-		} else {
-		DTypeGDL* src = static_cast<DTypeGDL*>(data);
-		DType theType = data->Type();
-//		if( ( theType == resultType) || !ConvertableType( theType) ) continue;
-		if( data->Type() != DTypeGDL::t )
-			src = static_cast<DTypeGDL*>(data->Convert2( DTypeGDL::t , BaseGDL::COPY));
+        } else {
+        DTypeGDL* src = static_cast<DTypeGDL*>(data);
+        DType theType = data->Type();
+//      if( ( theType == resultType) || !ConvertableType( theType) ) continue;
+        if( data->Type() != DTypeGDL::t )
+            src = static_cast<DTypeGDL*>(data->Convert2( DTypeGDL::t , BaseGDL::COPY));
 // inlist will be incremented in CatInsert and gaps, strides are all good.
-		result->CatInsert(src, catrankIx, inlist);
-		
-		} // ( data == NULL)
-	} // for i <nList; ++i
+        result->CatInsert(src, catrankIx, inlist);
+        
+        } // ( data == NULL)
+    } // for i <nList; ++i
 
-	if( e->KeywordSet( kwNO_COPYIx)) LISTCleanup( e, self); // For NO_COPY keyword
+    if( e->KeywordSet( kwNO_COPYIx)) LISTCleanup( e, self); // For NO_COPY keyword
 
   resultGuard.Release();
   if( transposekw)   return result;
   else { // The result is composed (via CatInsert) in transposed form.
-	     // If keyword TRANSPOSE not set, need to transpose back.
-		DUInt* perm = new DUInt[Rank];
-		ArrayGuard<DUInt> perm_guard( perm);
-		perm[0] = Rank - 1;
-		for( SizeT i=1; i< Rank; ++i) perm[i] = i-1;
-		return result->Transpose( perm);
-	}
+         // If keyword TRANSPOSE not set, need to transpose back.
+        DUInt* perm = new DUInt[Rank];
+        ArrayGuard<DUInt> perm_guard( perm);
+        perm[0] = Rank - 1;
+        for( SizeT i=1; i< Rank; ++i) perm[i] = i-1;
+        return result->Transpose( perm);
+    }
 }
 #if 0
 // currently a void, Standard GDLobject help provided in gdlhelp.
 void list__help( EnvUDT* e)
   {
-	  
+      
     GDL_LIST_STRUCT()
     GDL_CONTAINER_NODE()
     
     static int kwMAXITEMIx = e->GetKeywordIx("MAXITEM");
     static int kwSELFIx = kwMAXITEMIx + 1;
 
-		trace_me = false; // lib::trace_arg();
+        trace_me = false; // lib::trace_arg();
     SizeT nParam = e->NParam(1); // SELF
-	
+    
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
 
     if(trace_me) std::cout << " list.help():";
@@ -1534,7 +1534,7 @@ void list__help( EnvUDT* e)
 #endif
 BaseGDL* list__toarray( EnvUDT* e)
   {
-	  
+      
     GDL_LIST_STRUCT()
     GDL_CONTAINER_NODE()
     
@@ -1543,14 +1543,14 @@ BaseGDL* list__toarray( EnvUDT* e)
     static int kwMISSINGIx = e->GetKeywordIx("MISSING"); 
     static int kwDIMENSIONIx = e->GetKeywordIx("DIMENSION");
     static int kwNO_COPYIx = e->GetKeywordIx("NO_COPY");
- 	static int kwTRANSPOSEIx = e->GetKeywordIx("TRANSPOSE");
+    static int kwTRANSPOSEIx = e->GetKeywordIx("TRANSPOSE");
     static int kwPROMOTE_TYPEIx = e->GetKeywordIx("PROMOTE_TYPE");
 
     
 
-		trace_me = false; // lib::trace_arg();
+        trace_me = false; // lib::trace_arg();
     SizeT nParam = e->NParam(1); // SELF
-	
+    
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
 
     if(trace_me) std::cout << " list.toarray():";
@@ -1559,7 +1559,7 @@ BaseGDL* list__toarray( EnvUDT* e)
    DStructDesc* listDesc = structDesc::LIST;
 
 
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
   
     if( nList == 0)
       return NullGDL::GetSingleInstance();
@@ -1569,212 +1569,212 @@ BaseGDL* list__toarray( EnvUDT* e)
     int inlist = 0;
     BaseGDL* data;
       do {
-		DStructGDL* Node = GetLISTStruct(e, pNext);
-		DPtr Ptr = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];   
-		data = BaseGDL::interpreter->GetHeap( Ptr);
-		pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-	} while ( data == NULL and ++inlist != nList );
-	if( data == NULL ) 
-	   ThrowFromInternalUDSub( e, " no data in list to make array");   	   
+        DStructGDL* Node = GetLISTStruct(e, pNext);
+        DPtr Ptr = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];   
+        data = BaseGDL::interpreter->GetHeap( Ptr);
+        pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+    } while ( data == NULL and ++inlist != nList );
+    if( data == NULL ) 
+       ThrowFromInternalUDSub( e, " no data in list to make array");       
 
     BaseGDL* typeKW = e->GetKW( kwTYPEIx);
     BaseGDL* promote_typeKW = e->GetKW( kwPROMOTE_TYPEIx);
-	bool promote_type = e->KeywordSet(kwPROMOTE_TYPEIx);
+    bool promote_type = e->KeywordSet(kwPROMOTE_TYPEIx);
 
     BaseGDL* dimensionKW = e->GetKW( kwDIMENSIONIx);
     BaseGDL* missingKW = (dimensionKW != NULL)? NULL:e->GetKW( kwMISSINGIx);
-	Guard<BaseGDL> missingKWGuard(missingKW);
-	
-//	    value_guard.Reset(value);//e->Guard( value);
+    Guard<BaseGDL> missingKWGuard(missingKW);
+    
+//      value_guard.Reset(value);//e->Guard( value);
     DType resultType = GDL_UNDEF;
     if( typeKW == NULL)
     {
-	  if( missingKW != NULL)
-		resultType = missingKW->Type();
+      if( missingKW != NULL)
+        resultType = missingKW->Type();
       else
-		resultType = data->Type();
+        resultType = data->Type();
     }
     else
     {
-	  promote_type = false;
+      promote_type = false;
       if( typeKW->Type() == GDL_STRING)
       {
-		DString typeStr = StrUpCase( (*static_cast<DStringGDL*>(typeKW))[0]);
-			 if( SpDByte().TypeStr() == typeStr) resultType = GDL_BYTE;
-		else if( SpDInt().TypeStr() == typeStr) resultType = GDL_INT;
-		else if( SpDLong().TypeStr() == typeStr) resultType = GDL_LONG;
-		else if( SpDFloat().TypeStr() == typeStr) resultType = GDL_FLOAT;
-		else if( SpDDouble().TypeStr() == typeStr) resultType = GDL_DOUBLE;
-		else if( SpDComplex().TypeStr() == typeStr) resultType = GDL_COMPLEX;
-		else if( SpDString().TypeStr() == typeStr) resultType = GDL_STRING;
-		else if( SpDComplexDbl().TypeStr() == typeStr) resultType = GDL_COMPLEXDBL;
-		else if( SpDUInt().TypeStr() == typeStr) resultType = GDL_UINT;
-		else if( SpDULong().TypeStr() == typeStr) resultType = GDL_ULONG;
-		else if( SpDLong64().TypeStr() == typeStr) resultType = GDL_LONG64;
-		else if( SpDULong64().TypeStr() == typeStr) resultType = GDL_ULONG64;
-		else 
-		  ThrowFromInternalUDSub( e, "Unknown or unable to convert to type " + typeStr);      	
+        DString typeStr = StrUpCase( (*static_cast<DStringGDL*>(typeKW))[0]);
+             if( SpDByte().TypeStr() == typeStr) resultType = GDL_BYTE;
+        else if( SpDInt().TypeStr() == typeStr) resultType = GDL_INT;
+        else if( SpDLong().TypeStr() == typeStr) resultType = GDL_LONG;
+        else if( SpDFloat().TypeStr() == typeStr) resultType = GDL_FLOAT;
+        else if( SpDDouble().TypeStr() == typeStr) resultType = GDL_DOUBLE;
+        else if( SpDComplex().TypeStr() == typeStr) resultType = GDL_COMPLEX;
+        else if( SpDString().TypeStr() == typeStr) resultType = GDL_STRING;
+        else if( SpDComplexDbl().TypeStr() == typeStr) resultType = GDL_COMPLEXDBL;
+        else if( SpDUInt().TypeStr() == typeStr) resultType = GDL_UINT;
+        else if( SpDULong().TypeStr() == typeStr) resultType = GDL_ULONG;
+        else if( SpDLong64().TypeStr() == typeStr) resultType = GDL_LONG64;
+        else if( SpDULong64().TypeStr() == typeStr) resultType = GDL_ULONG64;
+        else 
+          ThrowFromInternalUDSub( e, "Unknown or unable to convert to type " + typeStr);        
       }
       else
       {
-		
-//		MAKE_LONGGDL(typeKW, typeCodeKW)
-		DLongGDL* typeCodeKW;
-		Guard<DLongGDL> typeCodeGuard;
-		if( typeKW->Type() == GDL_LONG)
-		{
-		  typeCodeKW = static_cast<DLongGDL*>(typeKW);
-		}
-		else
-		{
-		  try{
-			typeCodeKW = static_cast<DLongGDL*>(typeKW->Convert2(GDL_LONG,BaseGDL::COPY));
-			typeCodeGuard.Init(typeCodeKW);
-		  }
-		  catch( GDLException& ex)
-		  {
-			ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-		  }
-		}  //		MAKE_LONGGDL(typeKW, typeCodeKW)
+        
+//      MAKE_LONGGDL(typeKW, typeCodeKW)
+        DLongGDL* typeCodeKW;
+        Guard<DLongGDL> typeCodeGuard;
+        if( typeKW->Type() == GDL_LONG)
+        {
+          typeCodeKW = static_cast<DLongGDL*>(typeKW);
+        }
+        else
+        {
+          try{
+            typeCodeKW = static_cast<DLongGDL*>(typeKW->Convert2(GDL_LONG,BaseGDL::COPY));
+            typeCodeGuard.Init(typeCodeKW);
+          }
+          catch( GDLException& ex)
+          {
+            ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+          }
+        }  //       MAKE_LONGGDL(typeKW, typeCodeKW)
 
-		DLong typeCode = (*typeCodeKW)[0];
-		if( typeCode < GDL_BYTE || typeCode > GDL_ULONG64)
-		  ThrowFromInternalUDSub( e, "Illegal value for TYPE: " + i2s(typeCode));      	
-		resultType = static_cast<DType>(typeCode);  
-	   }
+        DLong typeCode = (*typeCodeKW)[0];
+        if( typeCode < GDL_BYTE || typeCode > GDL_ULONG64)
+          ThrowFromInternalUDSub( e, "Illegal value for TYPE: " + i2s(typeCode));       
+        resultType = static_cast<DType>(typeCode);  
+       }
     }
-	if( resultType == GDL_UNDEF)
-		ThrowFromInternalUDSub( e, "Result type is UNDEF. Please report."); 
-	DLong dimkw=0;
+    if( resultType == GDL_UNDEF)
+        ThrowFromInternalUDSub( e, "Result type is UNDEF. Please report."); 
+    DLong dimkw=0;
     MAKE_LONGGDL(dimensionKW, dimkwLong)
     if(dimensionKW != NULL) dimkw = (*dimkwLong)[0];
     if(dimkw > 8) ThrowFromInternalUDSub( e, 
-			" DIMENSION keyword can only go up to 8" );
-	SizeT nel0 = data->N_Elements();
-	dimension refdim(data->Dim());
-	if( dimkw == refdim.Rank() +1) refdim << 1; // one-time deal
-	SizeT Rank0 = refdim.Rank();
-	SizeT Rank0Ix = RankIx(Rank0);
-	if( dimkw > Rank0) 	ThrowFromInternalUDSub( e, 
-			" DIMENSION keyword exceeds plausible rank of first element" );
+            " DIMENSION keyword can only go up to 8" );
+    SizeT nel0 = data->N_Elements();
+    dimension refdim(data->Dim());
+    if( dimkw == refdim.Rank() +1) refdim << 1; // one-time deal
+    SizeT Rank0 = refdim.Rank();
+    SizeT Rank0Ix = RankIx(Rank0);
+    if( dimkw > Rank0)  ThrowFromInternalUDSub( e, 
+            " DIMENSION keyword exceeds plausible rank of first element" );
 
-	SizeT newSize = 0;
-	pNext = pTail;
+    SizeT newSize = 0;
+    pNext = pTail;
 
-	for( SizeT inlist=0; inlist<nList; ++inlist)
-	{
+    for( SizeT inlist=0; inlist<nList; ++inlist)
+    {
       DStructGDL* Node = GetLISTStruct(NULL, pNext);  
       data = BaseGDL::interpreter->GetHeap(
-				(*static_cast<DPtrGDL*>( 
-				Node->GetTag( pDataTag, 0)))[0]);
-      pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];     		  
+                (*static_cast<DPtrGDL*>( 
+                Node->GetTag( pDataTag, 0)))[0]);
+      pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];               
 
-		if( data == NULL) {
-			if( dimkw > 0 || missingKW == NULL) continue; // will be quietly bypassed.
-			++newSize;
-			continue;
-		}
+        if( data == NULL) {
+            if( dimkw > 0 || missingKW == NULL) continue; // will be quietly bypassed.
+            ++newSize;
+            continue;
+        }
 
       if(Rank0 != 0)
       {
-		dimension thedim(data->Dim());
-		if( thedim.Rank() != Rank0 ) {  // kick with one exception
-		  if(dimkw == 0 ) ThrowFromInternalUDSub( e, 
-			" all elements must be Rank "+i2s( (long) Rank0) );
-		  if( !((dimkw == Rank0) and
-			( thedim.Rank() == Rank0-1)) ) ThrowFromInternalUDSub( e, 
-			" all elements must be Rank "+i2s( (long) Rank0) );
-		  thedim << 1;
-		}
-		for(int i=0; i < Rank0; ++i)
-		  {
-			if(trace_me) std::cout << thedim[i];
-			if( dimkw == (i+1)) continue;
-			if(thedim[i] != refdim[i])
-				ThrowFromInternalUDSub(e, " dimensions dont agree "
-				+i2s(i+1)+" List item #"+i2s(inlist)+"\n "
-				+i2s(thedim[i]) +" # "+i2s(refdim[i]));
-			}
-			if( dimkw > 0) newSize += thedim[dimkw-1];
-			else ++newSize;
-		} 
+        dimension thedim(data->Dim());
+        if( thedim.Rank() != Rank0 ) {  // kick with one exception
+          if(dimkw == 0 ) ThrowFromInternalUDSub( e, 
+            " all elements must be Rank "+i2s( (long) Rank0) );
+          if( !((dimkw == Rank0) and
+            ( thedim.Rank() == Rank0-1)) ) ThrowFromInternalUDSub( e, 
+            " all elements must be Rank "+i2s( (long) Rank0) );
+          thedim << 1;
+        }
+        for(int i=0; i < Rank0; ++i)
+          {
+            if(trace_me) std::cout << thedim[i];
+            if( dimkw == (i+1)) continue;
+            if(thedim[i] != refdim[i])
+                ThrowFromInternalUDSub(e, " dimensions dont agree "
+                +i2s(i+1)+" List item #"+i2s(inlist)+"\n "
+                +i2s(thedim[i]) +" # "+i2s(refdim[i]));
+            }
+            if( dimkw > 0) newSize += thedim[dimkw-1];
+            else ++newSize;
+        } 
 // 1-d arrays an mix with scalars by defining array[10] = array[1,10]
-		else  // (Rank0Ix != 0)
-		{
-			if( (data->N_Elements() != nel0) && (dimkw != 1) ) 
-				ThrowFromInternalUDSub(e, " 1-d Sizes don't agree "
-				+i2s(nel0)+" List item #"+i2s(inlist));
-			else newSize += data->N_Elements();
-		}
-// Dimensionality seems ok. Now check for type.		
-		DType theType = data->Type();
-		if( ( theType == resultType) || !ConvertableType( theType) ) continue;
-		if( promote_type ) 
-		{ 
-		  if( theType == GDL_STRING) resultType = GDL_STRING;
-		  if( NumericType( theType) && (resultType != GDL_STRING)) 
-			{
-			if ( theType == GDL_COMPLEXDBL) resultType = GDL_COMPLEXDBL;
-			else if (resultType == GDL_COMPLEXDBL) continue;
-			else if (( theType == GDL_COMPLEX) && (resultType == GDL_DOUBLE)
-			  || ( theType == GDL_DOUBLE) && (resultType == GDL_COMPLEX) )
-				resultType = GDL_COMPLEXDBL;
-			else if (resultType == GDL_COMPLEX ) continue;
-			else if (theType == GDL_DOUBLE ) resultType = GDL_DOUBLE;
-			else if (theType == GDL_COMPLEX ) resultType = GDL_COMPLEX;
-			else if ( 	( theType > resultType) && 
-				(DTypeOrder[ theType] >= DTypeOrder[ resultType]) ) resultType = theType;
-			  }
+        else  // (Rank0Ix != 0)
+        {
+            if( (data->N_Elements() != nel0) && (dimkw != 1) ) 
+                ThrowFromInternalUDSub(e, " 1-d Sizes don't agree "
+                +i2s(nel0)+" List item #"+i2s(inlist));
+            else newSize += data->N_Elements();
+        }
+// Dimensionality seems ok. Now check for type.     
+        DType theType = data->Type();
+        if( ( theType == resultType) || !ConvertableType( theType) ) continue;
+        if( promote_type ) 
+        { 
+          if( theType == GDL_STRING) resultType = GDL_STRING;
+          if( NumericType( theType) && (resultType != GDL_STRING)) 
+            {
+            if ( theType == GDL_COMPLEXDBL) resultType = GDL_COMPLEXDBL;
+            else if (resultType == GDL_COMPLEXDBL) continue;
+            else if (( theType == GDL_COMPLEX) && (resultType == GDL_DOUBLE)
+              || ( theType == GDL_DOUBLE) && (resultType == GDL_COMPLEX) )
+                resultType = GDL_COMPLEXDBL;
+            else if (resultType == GDL_COMPLEX ) continue;
+            else if (theType == GDL_DOUBLE ) resultType = GDL_DOUBLE;
+            else if (theType == GDL_COMPLEX ) resultType = GDL_COMPLEX;
+            else if (   ( theType > resultType) && 
+                (DTypeOrder[ theType] >= DTypeOrder[ resultType]) ) resultType = theType;
+              }
 
-		}
-	  }
-  	dimension newdim = refdim;
-  	
-	if( dimkw > 0) {
-		newdim.SetOneDim( dimkw-1, newSize);
-	} else {
-		newdim << newSize;
-	}
+        }
+      }
+    dimension newdim = refdim;
+    
+    if( dimkw > 0) {
+        newdim.SetOneDim( dimkw-1, newSize);
+    } else {
+        newdim << newSize;
+    }
 
-	SizeT catrankIx = (dimkw ==0) ? RankIx(newdim.Rank()) : dimkw-1 ;
+    SizeT catrankIx = (dimkw ==0) ? RankIx(newdim.Rank()) : dimkw-1 ;
     if(trace_me)
-		std::cout <<" catrankIx, newdim.Rank()"<< catrankIx<<newdim.Rank()
-		 <<" Resulttype:"<<resultType<<" newdim:" << newdim << std::endl;
+        std::cout <<" catrankIx, newdim.Rank()"<< catrankIx<<newdim.Rank()
+         <<" Resulttype:"<<resultType<<" newdim:" << newdim << std::endl;
   {
     try{
-	     if( resultType == GDL_BYTE)
-	       return LIST__ToArray<DByteGDL>( e, newdim);       
-	else if( resultType == GDL_INT)
-	       return LIST__ToArray<DIntGDL>( e, newdim);
-	else if( resultType == GDL_LONG)
-	       return LIST__ToArray<DLongGDL>( e, newdim);
-	else if( resultType == GDL_FLOAT)
-	       return LIST__ToArray<DFloatGDL>( e, newdim);
-	else if( resultType == GDL_DOUBLE)
-	       return LIST__ToArray<DDoubleGDL>( e, newdim);
-	else if( resultType == GDL_COMPLEX)
-	       return LIST__ToArray<DComplexGDL>( e, newdim);
-	else if( resultType == GDL_STRING)
-	       return LIST__ToArray<DStringGDL>( e, newdim);
-	else if( resultType == GDL_COMPLEXDBL)
-	       return LIST__ToArray<DComplexDblGDL>( e, newdim);
-	else if( resultType == GDL_UINT)
-	       return LIST__ToArray<DUIntGDL>( e, newdim);
-	else if( resultType == GDL_ULONG)
-	       return LIST__ToArray<DULongGDL>( e, newdim);
-	else if( resultType == GDL_LONG64)
-	       return LIST__ToArray<DLong64GDL>( e, newdim);
-	else if( resultType == GDL_ULONG64)
-	       return LIST__ToArray<DULong64GDL>( e, newdim);
-	else if( resultType == GDL_STRUCT)
-	       throw GDLException( " unable to extract arrays of GDL_STRUCT");
-	else 
-	  throw GDLException( "Unknown or unable to convert to type code: " + i2s(resultType));      	
+         if( resultType == GDL_BYTE)
+           return LIST__ToArray<DByteGDL>( e, newdim);       
+    else if( resultType == GDL_INT)
+           return LIST__ToArray<DIntGDL>( e, newdim);
+    else if( resultType == GDL_LONG)
+           return LIST__ToArray<DLongGDL>( e, newdim);
+    else if( resultType == GDL_FLOAT)
+           return LIST__ToArray<DFloatGDL>( e, newdim);
+    else if( resultType == GDL_DOUBLE)
+           return LIST__ToArray<DDoubleGDL>( e, newdim);
+    else if( resultType == GDL_COMPLEX)
+           return LIST__ToArray<DComplexGDL>( e, newdim);
+    else if( resultType == GDL_STRING)
+           return LIST__ToArray<DStringGDL>( e, newdim);
+    else if( resultType == GDL_COMPLEXDBL)
+           return LIST__ToArray<DComplexDblGDL>( e, newdim);
+    else if( resultType == GDL_UINT)
+           return LIST__ToArray<DUIntGDL>( e, newdim);
+    else if( resultType == GDL_ULONG)
+           return LIST__ToArray<DULongGDL>( e, newdim);
+    else if( resultType == GDL_LONG64)
+           return LIST__ToArray<DLong64GDL>( e, newdim);
+    else if( resultType == GDL_ULONG64)
+           return LIST__ToArray<DULong64GDL>( e, newdim);
+    else if( resultType == GDL_STRUCT)
+           throw GDLException( " unable to extract arrays of GDL_STRUCT");
+    else 
+      throw GDLException( "Unknown or unable to convert to type code: " + i2s(resultType));         
       
     }
     catch( GDLException& ex)
       {
-	ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+    ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
       }
     assert(false);
     return NULL;
@@ -1784,12 +1784,12 @@ BaseGDL* list__toarray( EnvUDT* e)
 
 BaseGDL* list__isempty( EnvUDT* e)
 {
-	  
+      
     GDL_LIST_STRUCT()
-    	
+        
   static int kwSELFIx = 0;
   DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
-  DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+  DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];        
 
   if (nList > 0) return new DByteGDL(0); else return new DByteGDL(1);
 }
@@ -1797,7 +1797,7 @@ BaseGDL* list__isempty( EnvUDT* e)
 SizeT LIST_count( DStructGDL* list)
 {// straight through, no checks
   static unsigned nListTag = structDesc::LIST->TagIndex( "NLIST");
-    return (*static_cast<DLongGDL*>( list->GetTag( nListTag, 0)))[0];	      
+    return (*static_cast<DLongGDL*>( list->GetTag( nListTag, 0)))[0];         
 
 }
 BaseGDL* list__count( EnvUDT* e)
@@ -1807,44 +1807,44 @@ BaseGDL* list__count( EnvUDT* e)
    
 //    DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
     SizeT nParam = e->NParam(1);
-	if( nParam == 1)
-		return new DLongGDL( LIST_count( GetOBJ( e->GetKW( kwSELFIx), e)));
-	// nParam > 1:
- 	BaseGDL* r = e->GetKW( kwVALUEIx);   
-	DObjGDL* selfObj = static_cast<DObjGDL*>(e->GetKW( kwSELFIx));
+    if( nParam == 1)
+        return new DLongGDL( LIST_count( GetOBJ( e->GetKW( kwSELFIx), e)));
+    // nParam > 1:
+    BaseGDL* r = e->GetKW( kwVALUEIx);   
+    DObjGDL* selfObj = static_cast<DObjGDL*>(e->GetKW( kwSELFIx));
 
-	DByteGDL* result = static_cast<DByteGDL*>(selfObj->EqOp( r));
+    DByteGDL* result = static_cast<DByteGDL*>(selfObj->EqOp( r));
 
-	Guard<DByteGDL> newObjGuard( result);
-	DLong nList = 0;
-	for( SizeT i=0; i<result->N_Elements(); ++i)
-				if( (*result)[i] != 0) 	  ++nList;
-	return new DLongGDL( nList);
+    Guard<DByteGDL> newObjGuard( result);
+    DLong nList = 0;
+    for( SizeT i=0; i<result->N_Elements(); ++i)
+                if( (*result)[i] != 0)    ++nList;
+    return new DLongGDL( nList);
 }
   
 void list__move( EnvUDT* e)
 {
   
-	  GDL_LIST_STRUCT()
-	  GDL_CONTAINER_NODE()
+      GDL_LIST_STRUCT()
+      GDL_CONTAINER_NODE()
 
     SizeT nParam = e->NParam(3); // minimum SELF, SOURCE, DESTINATION
-	
+    
     static int kwSELFIx = 0; // no keywords
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
     trace_me = false; // trace_arg();
 
     DLong index1, index2;
-	// (allowing negative index references)
-	e->AssureLongScalarPar( 1, index1); if(index1 < 0) index1 += nList;
-	e->AssureLongScalarPar( 2, index2); if(index2 < 0) index2 += nList;
-	
-	if( index1 >= nList or index2 >= nList
-		or  index1 < 0 or index2 < 0) 	
-		ThrowFromInternalUDSub( e," index out of range - listsize=: "
-				+i2s(nList)+" indeces: "+i2s(index1)+","+i2s(index2));
-		
+    // (allowing negative index references)
+    e->AssureLongScalarPar( 1, index1); if(index1 < 0) index1 += nList;
+    e->AssureLongScalarPar( 2, index2); if(index2 < 0) index2 += nList;
+    
+    if( index1 >= nList or index2 >= nList
+        or  index1 < 0 or index2 < 0)   
+        ThrowFromInternalUDSub( e," index out of range - listsize=: "
+                +i2s(nList)+" indeces: "+i2s(index1)+","+i2s(index2));
+        
     DStructDesc* selfDesc= self->Desc();
     DStructDesc* containerDesc=structDesc::GDL_CONTAINER_NODE;
     assert( selfDesc != NULL && selfDesc->NTags() > 0);
@@ -1852,99 +1852,99 @@ void list__move( EnvUDT* e)
 
     DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
     DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
-    DPtr pTail = (*Tail)[0];	DPtr pHead = (*Head)[0];
-	if(trace_me or ((index1 ==0) and (index2==0))) 
-	{
-		DPtr p0 = (*Tail)[0];
-		std::printf(" list: TAIL=%llu", p0);
-		for( int i=0; i < nList ; i++) 
-		{	DStructGDL* Node=GetLISTStruct(NULL, p0);
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			DPtr pdata = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];
-			std::printf("->%llu<%llu>:", p0, pdata);}
-		std::printf("->HEAD= %llu (list.move:%d,%d) \n",  pHead, index1, index2);
-	}
-	if(index1 == index2) return; 		// trivial case
+    DPtr pTail = (*Tail)[0];    DPtr pHead = (*Head)[0];
+    if(trace_me or ((index1 ==0) and (index2==0))) 
+    {
+        DPtr p0 = (*Tail)[0];
+        std::printf(" list: TAIL=%llu", p0);
+        for( int i=0; i < nList ; i++) 
+        {   DStructGDL* Node=GetLISTStruct(NULL, p0);
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            DPtr pdata = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];
+            std::printf("->%llu<%llu>:", p0, pdata);}
+        std::printf("->HEAD= %llu (list.move:%d,%d) \n",  pHead, index1, index2);
+    }
+    if(index1 == index2) return;        // trivial case
 
-	DPtr ptrg, predptr;
-	DPtr p0 = pTail;
-	DStructGDL* Node = GetLISTStruct(NULL, p0);
-	DStructGDL* predNode = Node;
-	if(index2 < index1)
-		for( int i=0; i < index1 ; i++) 
-		{	if(i == index2-1) ptrg = p0;
-			predptr = p0;
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			predNode = Node;
-			Node = GetLISTStruct(NULL, p0);
-		} else
-		for( int i=0; i < index1 ; i++)
-		{
-			predptr = p0;
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			predNode = Node;
-			Node = GetLISTStruct(NULL, p0);
-		}
+    DPtr ptrg, predptr;
+    DPtr p0 = pTail;
+    DStructGDL* Node = GetLISTStruct(NULL, p0);
+    DStructGDL* predNode = Node;
+    if(index2 < index1)
+        for( int i=0; i < index1 ; i++) 
+        {   if(i == index2-1) ptrg = p0;
+            predptr = p0;
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            predNode = Node;
+            Node = GetLISTStruct(NULL, p0);
+        } else
+        for( int i=0; i < index1 ; i++)
+        {
+            predptr = p0;
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            predNode = Node;
+            Node = GetLISTStruct(NULL, p0);
+        }
 
-	DPtr psrc = p0;
-	DPtrGDL* ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
-	
-	if(index1 == 0) 
-		(*Tail)[0] = (*ptrnxt)[0];
-	else if( index1 == nList-1)
-	{
-		(*Head)[0] = predptr;
-		(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 0;			
-	}
-	else
-		(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
-			(*ptrnxt)[0];
-	(*ptrnxt)[0] = 0;
-	
-	if( index2 == 0)
-	{
-		(*Tail)[0] = psrc;
-		(*ptrnxt)[0] = pTail;
-	}
-	else if( index2 == nList-1)
-	{
-		Node = GetLISTStruct(NULL, (*Head)[0]);
-		(*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = psrc;
-		(*Head)[0] = psrc;
-	}
-	else {
-		if( index1 == 0) p0 =(*Tail)[0];
-		else if(index2 > index1) p0 = 
-			(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0];
-		else p0 = ptrg;
+    DPtr psrc = p0;
+    DPtrGDL* ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
+    
+    if(index1 == 0) 
+        (*Tail)[0] = (*ptrnxt)[0];
+    else if( index1 == nList-1)
+    {
+        (*Head)[0] = predptr;
+        (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 0;           
+    }
+    else
+        (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
+            (*ptrnxt)[0];
+    (*ptrnxt)[0] = 0;
+    
+    if( index2 == 0)
+    {
+        (*Tail)[0] = psrc;
+        (*ptrnxt)[0] = pTail;
+    }
+    else if( index2 == nList-1)
+    {
+        Node = GetLISTStruct(NULL, (*Head)[0]);
+        (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = psrc;
+        (*Head)[0] = psrc;
+    }
+    else {
+        if( index1 == 0) p0 =(*Tail)[0];
+        else if(index2 > index1) p0 = 
+            (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0];
+        else p0 = ptrg;
 
-		for(int i = index1; i < index2 - 1 ; i++) {
-			Node = GetLISTStruct(NULL, p0);
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-		}
-		Node = GetLISTStruct(NULL, p0);
-		ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
+        for(int i = index1; i < index2 - 1 ; i++) {
+            Node = GetLISTStruct(NULL, p0);
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+        }
+        Node = GetLISTStruct(NULL, p0);
+        ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
 
-		p0 = (*ptrnxt)[0];
-		(*ptrnxt)[0] = psrc;
-		Node = GetLISTStruct(NULL, psrc);
-		(*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = p0;
-	}
-	
-	if(trace_me) 
-	{	p0 = (*Tail)[0];
-		std::printf(" from list.move   : TAIL=%llu" , p0);
-		for( int i=0; i < nList ; i++) 
-		{
-			DStructGDL* Node=GetLISTStruct(NULL, p0);
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			std::printf("->%llu", p0);
-		}
-		p0 = (*Head)[0];
-		std::printf(" : HEAD= %llu \n",  p0);
-	}
+        p0 = (*ptrnxt)[0];
+        (*ptrnxt)[0] = psrc;
+        Node = GetLISTStruct(NULL, psrc);
+        (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = p0;
+    }
+    
+    if(trace_me) 
+    {   p0 = (*Tail)[0];
+        std::printf(" from list.move   : TAIL=%llu" , p0);
+        for( int i=0; i < nList ; i++) 
+        {
+            DStructGDL* Node=GetLISTStruct(NULL, p0);
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            std::printf("->%llu", p0);
+        }
+        p0 = (*Head)[0];
+        std::printf(" : HEAD= %llu \n",  p0);
+    }
 
-	return; // victorious
+    return; // victorious
 }
 
 void list__swap( EnvUDT* e)
@@ -1953,25 +1953,25 @@ void list__swap( EnvUDT* e)
   GDL_LIST_STRUCT()
   GDL_CONTAINER_NODE()
 
-//		trace_me = false; // lib::trace_arg();
-	if(trace_me) std::printf(" list__swap ");
+//      trace_me = false; // lib::trace_arg();
+    if(trace_me) std::printf(" list__swap ");
      SizeT nParam = e->NParam(3); // minimum SELF, INDEX1, INDEX2
     
     static int kwSELFIx = 0; // no keywords
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
     
     DLong index1, index2;
-	e->AssureLongScalarPar( 1, index1);
-	e->AssureLongScalarPar( 2,  index2);
-	if(index1 < 0 or index1 >= nList)
-		ThrowFromInternalUDSub( e," index1 out of range: "+i2s(index1));
-	if(index2 < 0 or index2 >= nList)
-		ThrowFromInternalUDSub( e," index2 out of range: "+i2s(index2));
+    e->AssureLongScalarPar( 1, index1);
+    e->AssureLongScalarPar( 2,  index2);
+    if(index1 < 0 or index1 >= nList)
+        ThrowFromInternalUDSub( e," index1 out of range: "+i2s(index1));
+    if(index2 < 0 or index2 >= nList)
+        ThrowFromInternalUDSub( e," index2 out of range: "+i2s(index2));
 
-	if(index1 < index2) {
-		DLong swap = index1; index1 = index2; index2 = swap;
-	} else if(index1 == index2) return;
+    if(index1 < index2) {
+        DLong swap = index1; index1 = index2; index2 = swap;
+    } else if(index1 == index2) return;
 
 // define the standard LIST struct = listDesc:
    DStructDesc* listDesc = structDesc::LIST;
@@ -1979,61 +1979,61 @@ void list__swap( EnvUDT* e)
 
     DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
     DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
-	DStructGDL* Node = NULL;
-	DStructGDL* predNsrc = Node;
-	DStructGDL* Ntrg;
-	DStructGDL* predNtrg;
-	DPtr pNext, ptrg, psrc;
+    DStructGDL* Node = NULL;
+    DStructGDL* predNsrc = Node;
+    DStructGDL* Ntrg;
+    DStructGDL* predNtrg;
+    DPtr pNext, ptrg, psrc;
 //--- .     ....    index2 ,,,,,               ... index1
 //     tail[0]>      ptrg  ..... predsrc->pNext .. psrc
-//  predtrg->pNext	                                      
-	DPtr p0 = (*Tail)[0];
-	Node = GetLISTStruct(NULL, p0);
-	for( int i=0; i < index1 ; i++) 
-	{   if(i == index2) { ptrg = p0; predNtrg=predNsrc; Ntrg=Node;}
-		p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-		predNsrc = Node;
-		Node = GetLISTStruct(NULL, p0);
-	}
-	psrc=p0;
-	DStructGDL* Nsrc = Node;
-	if(trace_me) {
-		std::printf(" ptrg %llu -> %llu , psrc %llu-> %llu ",
-			 ptrg,(*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0],
-			 psrc,(*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0]);
-		std::printf(" : Tail=%llu Head=%llu list.swap:%d,%d \n",
-					(*Tail)[0], (*Head)[0], index1, index2);
-	}
+//  predtrg->pNext                                        
+    DPtr p0 = (*Tail)[0];
+    Node = GetLISTStruct(NULL, p0);
+    for( int i=0; i < index1 ; i++) 
+    {   if(i == index2) { ptrg = p0; predNtrg=predNsrc; Ntrg=Node;}
+        p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+        predNsrc = Node;
+        Node = GetLISTStruct(NULL, p0);
+    }
+    psrc=p0;
+    DStructGDL* Nsrc = Node;
+    if(trace_me) {
+        std::printf(" ptrg %llu -> %llu , psrc %llu-> %llu ",
+             ptrg,(*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0],
+             psrc,(*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0]);
+        std::printf(" : Tail=%llu Head=%llu list.swap:%d,%d \n",
+                    (*Tail)[0], (*Head)[0], index1, index2);
+    }
 
 // swap contents of pNextTag
-	DPtr swap = (*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0];
-	if(swap == psrc) {
-		swap = ptrg; // correction for swapping adjacent nodes.
-		predNsrc = Nsrc;
-	}
+    DPtr swap = (*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0];
+    if(swap == psrc) {
+        swap = ptrg; // correction for swapping adjacent nodes.
+        predNsrc = Nsrc;
+    }
 
-	(*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0] =
-		(*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0];
+    (*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0] =
+        (*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0];
 
-	(*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0] = swap;
-	
-	if( index1 == nList-1)
-	{
-		(*Head)[0] = ptrg;
-		(*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0] = 0;			
-	}
-	
-	(*static_cast<DPtrGDL*>( predNsrc->GetTag( pNextTag, 0)))[0] = ptrg;
-		
-	if(index2 == 0)
-		(*Tail)[0] = psrc;
-	 else
-	 {
-		(*static_cast<DPtrGDL*>( predNtrg->GetTag( pNextTag, 0)))[0] = psrc;
-		}
+    (*static_cast<DPtrGDL*>( Nsrc->GetTag( pNextTag, 0)))[0] = swap;
+    
+    if( index1 == nList-1)
+    {
+        (*Head)[0] = ptrg;
+        (*static_cast<DPtrGDL*>( Ntrg->GetTag( pNextTag, 0)))[0] = 0;           
+    }
+    
+    (*static_cast<DPtrGDL*>( predNsrc->GetTag( pNextTag, 0)))[0] = ptrg;
+        
+    if(index2 == 0)
+        (*Tail)[0] = psrc;
+     else
+     {
+        (*static_cast<DPtrGDL*>( predNtrg->GetTag( pNextTag, 0)))[0] = psrc;
+        }
 //--- .     ....    index2 ,,,,,               ... index1
 //     tail[0]>      psrc  ..... predsrc->pNext .. ptrg
-	return;
+    return;
 }
 
   BaseGDL* list__where( EnvUDT* e)
@@ -2063,27 +2063,27 @@ void list__swap( EnvUDT* e)
     
     if( e->KeywordPresent( kwNCOMPLEMENTIx)) // NCOMPLEMENT
     {
-	e->SetKW( kwNCOMPLEMENTIx, new DLongGDL( nEl - count));
+    e->SetKW( kwNCOMPLEMENTIx, new DLongGDL( nEl - count));
     }
     if( e->KeywordPresent( kwCOUNTIx)) // COUNT
     {
-	e->SetKW( kwCOUNTIx, new DLongGDL( count));
+    e->SetKW( kwCOUNTIx, new DLongGDL( count));
     }
     if( e->KeywordPresent( kwCOMPLEMENTIx)) // COMPLEMENT
     {
         SizeT nCount = nEl - count;
-	if( nCount == 0)
-	{
-	  e->SetKW( kwCOMPLEMENTIx, NullGDL::GetSingleInstance());
-	}
-	else
-	{
-	  DLongGDL* cIxList = new DLongGDL( dimension( &nCount, 1), BaseGDL::NOZERO);	  
-	  SizeT cIx = nEl;
-	  for( SizeT i=0; i<nCount; ++i)
-	      (*cIxList)[ i] = ixList[ --cIx];
-	  e->SetKW( kwCOMPLEMENTIx, cIxList);
-	}
+    if( nCount == 0)
+    {
+      e->SetKW( kwCOMPLEMENTIx, NullGDL::GetSingleInstance());
+    }
+    else
+    {
+      DLongGDL* cIxList = new DLongGDL( dimension( &nCount, 1), BaseGDL::NOZERO);     
+      SizeT cIx = nEl;
+      for( SizeT i=0; i<nCount; ++i)
+          (*cIxList)[ i] = ixList[ --cIx];
+      e->SetKW( kwCOMPLEMENTIx, cIxList);
+    }
     }
     
     if( count == 0)
@@ -2157,7 +2157,7 @@ void list__swap( EnvUDT* e)
     }
   }
 
-  DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+  DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];        
   
   if( nList == 0)
     ThrowFromInternalUDSub( e, "LIST is empty.");
@@ -2183,20 +2183,20 @@ void list__swap( EnvUDT* e)
   {
     if( indexLong->N_Elements() == 1)
     {
-	removePos = (*indexLong)[0];
-	if( removePos < 0)
-	  removePos += nList;
-	if( removePos < 0)
-	  ThrowFromInternalUDSub( e, "Index too small.");
-	if( removePos >= nList)
-	  ThrowFromInternalUDSub( e, "Index out of range.");  
+    removePos = (*indexLong)[0];
+    if( removePos < 0)
+      removePos += nList;
+    if( removePos < 0)
+      ThrowFromInternalUDSub( e, "Index too small.");
+    if( removePos >= nList)
+      ThrowFromInternalUDSub( e, "Index out of range.");  
     }
   }
   
   if( indexLong == NULL || removePos == nList-1) // remove head
   {
 
-    DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];	      
+    DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];        
     
     DStructGDL* headNode = GetLISTStruct(e, pHead);  
     
@@ -2233,7 +2233,7 @@ void list__swap( EnvUDT* e)
   if( removePos == 0) // remove tail
   {
     // implicit: nList > 1
-    DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];	      
+    DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];        
     
     DStructGDL* tailNode = GetLISTStruct(e, pTail);  
     
@@ -2274,7 +2274,7 @@ void list__swap( EnvUDT* e)
     BaseGDL* data = BaseGDL::interpreter->GetHeap( pData);
 
     (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
-	(*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
+    (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
     
     (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
 
@@ -2307,12 +2307,12 @@ void list__swap( EnvUDT* e)
     {
       DLong actIx = (*indexLong)[ i];
       if( actIx < 0)
-	actIx += nList;
+    actIx += nList;
       if( actIx < 0)
-	ThrowFromInternalUDSub( e, "Index too small.");
+    ThrowFromInternalUDSub( e, "Index too small.");
       if( actIx >= nList)
-	ThrowFromInternalUDSub( e, "Index out of range.");
-	
+    ThrowFromInternalUDSub( e, "Index out of range.");
+    
       
       DPtr pActNode = GetLISTNode( e, self, actIx);
       DStructGDL* actNode = GetLISTStruct( e, pActNode);   
@@ -2320,7 +2320,7 @@ void list__swap( EnvUDT* e)
       DPtr pData = (*static_cast<DPtrGDL*>(actNode->GetTag( pDataTag, 0)))[0];
       BaseGDL* data = BaseGDL::interpreter->GetHeap( pData);
       if( data != NULL) 
-	data = data->Dup();
+    data = data->Dup();
       DPtr dID = e->Interpreter()->NewHeap(1,data);
       
       cStruct = new DStructGDL( structDesc::GDL_CONTAINER_NODE, dimension());
@@ -2328,16 +2328,16 @@ void list__swap( EnvUDT* e)
       (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = dID;
       
       if( cStructLast != NULL)
-	(*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+    (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
       else
       { // 1st element
-	(*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;         
       }
-	    
+        
       cStructLast = cStruct;
     }
     
-    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;	      
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;         
     (*static_cast<DLongGDL*>( listStruct->GetTag( nListTag, 0)))[0] = indexN_Elements;      
   } // if( asFunction)
   
@@ -2351,8 +2351,8 @@ void list__swap( EnvUDT* e)
   DLong *hh = static_cast<DLong*>(indexLong->DataAddr());
 // massage the indeces so that < 0 are back in range
   for( DLong i=0; i < indexN_Elements; ++i)
-	    if( hh[i] < 0) hh[i] += nList;
-// This needed for the tail->head removall.	  
+        if( hh[i] < 0) hh[i] += nList;
+// This needed for the tail->head removall.   
   DLong* h1 = new DLong[ indexN_Elements/2];
   DLong* h2 = new DLong[ (indexN_Elements+1)/2];
   // call the sort routine
@@ -2360,22 +2360,22 @@ void list__swap( EnvUDT* e)
   delete[] h1;
   delete[] h2;
 // See notes on doomed code block since 2018-May  
-	DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
-	DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
-	if(trace_me) 
-	{	DPtr p0 = (*Tail)[0];
-		std::printf(" tracing list.remove : TAIL=%llu", p0);
-		for( int i=0; i < nList ; i++) 
-		{	DStructGDL* Node=GetLISTStruct(NULL, p0);
-			p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			std::printf("->%llu", p0);}
-		std::printf(" : HEAD= %llu (incoming) \n",  (*Head)[0]);
-	}
+    DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
+    DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
+    if(trace_me) 
+    {   DPtr p0 = (*Tail)[0];
+        std::printf(" tracing list.remove : TAIL=%llu", p0);
+        for( int i=0; i < nList ; i++) 
+        {   DStructGDL* Node=GetLISTStruct(NULL, p0);
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            std::printf("->%llu", p0);}
+        std::printf(" : HEAD= %llu (incoming) \n",  (*Head)[0]);
+    }
   if(trace_me) {
-	  std::cout << "list.Remove() "+i2s(indexN_Elements)+" indeces ";
-	    for( DLong i=0; i < indexN_Elements; ++i)
-			std::cout << hh[ indexN_Elements - i - 1] <<": ";
-	  std::cout << std::endl;
+      std::cout << "list.Remove() "+i2s(indexN_Elements)+" indeces ";
+        for( DLong i=0; i < indexN_Elements; ++i)
+            std::cout << hh[ indexN_Elements - i - 1] <<": ";
+      std::cout << std::endl;
   }
   SizeT nListStart = nList;
   DLong prvfetch = -1; // repeated indeces need to be skipped!!
@@ -2383,64 +2383,64 @@ void list__swap( EnvUDT* e)
 // alternative one-way removal.
 
     DPtr pTail = (*Tail)[0];
-	DPtr predptr;
-	DPtr p0 = pTail;
-	DLong inlist = 0;
-	DStructGDL* Node;
-	DStructGDL* predNode;
-	for( DLong i=0; i < indexN_Elements; ++i)
-	  { 		// get the next index targetted for removal.  
-		DLong removeIndex = hh[ indexN_Elements - i - 1];
-		if( removeIndex < 0)
-		  ThrowFromInternalUDSub( e, "Index too small:"+i2s(removeIndex) );
-		if( removeIndex >= nListStart)
-		  ThrowFromInternalUDSub( e, "Index out of range: "+i2s(removeIndex) );
-		if( removeIndex == prvfetch) continue; // (ignore repeats)
+    DPtr predptr;
+    DPtr p0 = pTail;
+    DLong inlist = 0;
+    DStructGDL* Node;
+    DStructGDL* predNode;
+    for( DLong i=0; i < indexN_Elements; ++i)
+      {         // get the next index targetted for removal.  
+        DLong removeIndex = hh[ indexN_Elements - i - 1];
+        if( removeIndex < 0)
+          ThrowFromInternalUDSub( e, "Index too small:"+i2s(removeIndex) );
+        if( removeIndex >= nListStart)
+          ThrowFromInternalUDSub( e, "Index out of range: "+i2s(removeIndex) );
+        if( removeIndex == prvfetch) continue; // (ignore repeats)
 
-//	  if(trace_me)  std::cout << i2s(removeIndex) << " p0="<<p0<<" " ;
-		
-			assert( nList >= 1);
-		Node = GetLISTStruct(NULL, p0);
+//    if(trace_me)  std::cout << i2s(removeIndex) << " p0="<<p0<<" " ;
+        
+            assert( nList >= 1);
+        Node = GetLISTStruct(NULL, p0);
 
-		for( DLong j=0; j < removeIndex - prvfetch - 1; j++) 
-		{	inlist++;
-			predptr = p0;
-//			if(trace_me)  std::cout <<" ^" << p0;
-	  		p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			predNode = Node;
-			Node = GetLISTStruct(NULL, p0);
-		}
-		DPtrGDL* ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
+        for( DLong j=0; j < removeIndex - prvfetch - 1; j++) 
+        {   inlist++;
+            predptr = p0;
+//          if(trace_me)  std::cout <<" ^" << p0;
+            p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            predNode = Node;
+            Node = GetLISTStruct(NULL, p0);
+        }
+        DPtrGDL* ptrnxt = static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0));
 
-		if(inlist == 0) {
+        if(inlist == 0) {
 
-			(*Tail)[0] = (*ptrnxt)[0];
+            (*Tail)[0] = (*ptrnxt)[0];
 
-		} 
-		else if( inlist == nList -1 )
-		{   
-			(*Head)[0] = predptr;
-			(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 0;
-		}
-		else
-			(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
-				(*ptrnxt)[0];
+        } 
+        else if( inlist == nList -1 )
+        {   
+            (*Head)[0] = predptr;
+            (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 0;
+        }
+        else
+            (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
+                (*ptrnxt)[0];
    
-		DPtr Ptr = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];	      
-		BaseGDL::interpreter->FreeHeap( Ptr);
-/*				if(trace_me) {
-						std::printf(" pdata=%llu", Ptr);
-					std::printf(" pTail=%llu",(*Tail)[0]);
-					std::printf(" ptrnxt=%llu", (*ptrnxt)[0]);} */
+        DPtr Ptr = (*static_cast<DPtrGDL*>( Node->GetTag( pDataTag, 0)))[0];          
+        BaseGDL::interpreter->FreeHeap( Ptr);
+/*              if(trace_me) {
+                        std::printf(" pdata=%llu", Ptr);
+                    std::printf(" pTail=%llu",(*Tail)[0]);
+                    std::printf(" ptrnxt=%llu", (*ptrnxt)[0]);} */
 
-		DPtr pNext = (*ptrnxt)[0];  // delete p0 from heap
-		(*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = 0;  
-		BaseGDL::interpreter->FreeHeap( p0);
-		p0 = pNext;			// & get ready for next item.
+        DPtr pNext = (*ptrnxt)[0];  // delete p0 from heap
+        (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0] = 0;  
+        BaseGDL::interpreter->FreeHeap( p0);
+        p0 = pNext;         // & get ready for next item.
 
-		(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = --nList;
-		prvfetch = removeIndex;
-	}
+        (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = --nList;
+        prvfetch = removeIndex;
+    }
 #elif 1
 // doomed code block: was bookended by #elif 0 ... #endif
 // old way (works,but traverses list for each deletion.)
@@ -2460,27 +2460,27 @@ void list__swap( EnvUDT* e)
     {
 //     std::cout << " Removing index: nList-1" << std::endl;
 
-      DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];	      
+      DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];          
       
       DStructGDL* headNode = GetLISTStruct(e, pHead);  
       
       if( nList == 1)
       {
-	(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;    
-	(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 0;    
-	(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 0;
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 0;    
+    (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 0;    
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 0;
       }
       else if( nList == 2)
       {
-	(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 
-	(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];    
-	(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 1;
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = 
+    (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];    
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 1;
       }
       else // nList > 2
       {
-	DPtr pPredHead = GetLISTNode( e, self, nList-2);
-	(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = pPredHead;    
-	(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
+    DPtr pPredHead = GetLISTNode( e, self, nList-2);
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = pPredHead;    
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
       }
       
       // prevent (ref-count) cleanup of next node 
@@ -2491,21 +2491,21 @@ void list__swap( EnvUDT* e)
     }
     else if( removeIndex == 0) // remove tail
     { // implicit: nList > 1
-      DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];	      
+      DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];          
       
       DStructGDL* tailNode = GetLISTStruct(e, pTail);  
       
       if( nList == 2)
       {
-	(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 
-	(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];    
-	(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 1;
+    (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];    
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = 1;
       }
       else // nList > 2
       {
-	(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 
-	(*static_cast<DPtrGDL*>( tailNode->GetTag( pNextTag, 0)))[0];        
-	(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
+    (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = 
+    (*static_cast<DPtrGDL*>( tailNode->GetTag( pNextTag, 0)))[0];        
+    (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
       }
 
       // prevent (ref-count) cleanup of next node 
@@ -2523,7 +2523,7 @@ void list__swap( EnvUDT* e)
       DStructGDL* removeNode = GetLISTStruct( e, pRemoveNode);   
 
       (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = 
-	  (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
+      (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
 
       // prevent (ref-count) cleanup of next node 
       (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0] = 0;
@@ -2537,19 +2537,19 @@ void list__swap( EnvUDT* e)
     prvfetch = removeIndex;
   }  // end of doomed code block.
 #endif
-	if(trace_me) 
-			{
-				std::cout<< std::endl; 
-	DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
-	DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
-					DPtr p0 = (*Tail)[0];
-				std::printf(" tracing: TAIL=%llu", p0);
-				for( int i=0; i < nList-1 ; i++) 
-				{	DStructGDL* Node=GetLISTStruct(NULL, p0);
-					p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-					std::printf("->%llu", p0);}
-				std::printf(" : HEAD= %llu (outgoing) \n",  (*Head)[0]);
-			}
+    if(trace_me) 
+            {
+                std::cout<< std::endl; 
+    DPtrGDL* Tail = static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0));
+    DPtrGDL* Head = static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0));
+                    DPtr p0 = (*Tail)[0];
+                std::printf(" tracing: TAIL=%llu", p0);
+                for( int i=0; i < nList-1 ; i++) 
+                {   DStructGDL* Node=GetLISTStruct(NULL, p0);
+                    p0 = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+                    std::printf("->%llu", p0);}
+                std::printf(" : HEAD= %llu (outgoing) \n",  (*Head)[0]);
+            }
 
   
   newObjGuard.Release();
@@ -2565,11 +2565,11 @@ void list__swap( EnvUDT* e)
 
     DStructGDL* self = GetOBJ( e->GetKW( 0), e);
   
-	  
+      
     GDL_LIST_STRUCT()
     GDL_CONTAINER_NODE()
     
-    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
 
     if( nList <= 1) // no change for empty or one-element
       return;
@@ -2578,29 +2578,29 @@ void list__swap( EnvUDT* e)
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-	DStructGDL* actPStruct = GetLISTStruct(e, actP);
+    DStructGDL* actPStruct = GetLISTStruct(e, actP);
 
-	DPtr actPNext = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+    DPtr actPNext = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
 
-	(*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0] = actPrevP;
-	
-	actPrevP = actP;
-	
-	actP = actPNext;
+    (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0] = actPrevP;
+    
+    actPrevP = actP;
+    
+    actP = actPNext;
       }
 
     // swap head and tail pointer
     DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
     (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] =  
-    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];	      
-    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = pTail;	      
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];         
+    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = pTail;         
   }
 
 
  BaseGDL* list__init( EnvUDT* e) {
 
-//	if( trace_me) std::cout << " List Init!" << std::endl;
-	return new DByteGDL(1); // if we reach here, defaul is to return 'TRUE'
+//  if( trace_me) std::cout << " List Init!" << std::endl;
+    return new DByteGDL(1); // if we reach here, defaul is to return 'TRUE'
  }
 // list__get and list__add are shared by the LIST oand the GDL_CONTAINER objects. 
 // "bool listmode" adapts LIST::GET to GDL (NOT an IDL feature, useful for debug)
@@ -2614,50 +2614,50 @@ void list__swap( EnvUDT* e)
   
   GDL_LIST_STRUCT()
   GDL_CONTAINER_NODE()
-	enum { POINTERS=1, OBJECTS};
+    enum { POINTERS=1, OBJECTS};
   SizeT nParam = e->NParam(1);
 
-		trace_me = false;//trace_arg();
-	static int kwALLIx = e->GetKeywordIx("ALL");
-	static int kwISAIx = e->GetKeywordIx("ISA");
-	static int kwNULLIx = e->GetKeywordIx("NULL");
-	static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
-	static int kwCOUNTIx = e->GetKeywordIx("COUNT");
-	static int kwSELFIx = kwALLIx + 1;
-	DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
+        trace_me = false;//trace_arg();
+    static int kwALLIx = e->GetKeywordIx("ALL");
+    static int kwISAIx = e->GetKeywordIx("ISA");
+    static int kwNULLIx = e->GetKeywordIx("NULL");
+    static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
+    static int kwCOUNTIx = e->GetKeywordIx("COUNT");
+    static int kwSELFIx = kwALLIx + 1;
+    DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
 
 // IDL_CONTAINER began as an object container and was later extended to
 // include Heap variable pointers.  Both cases are handled with the same
 // GDL_CONTAINER link-list, as for LIST.
   DStructDesc* selfDesc= self->Desc();
   bool listmode = ( selfDesc == structDesc::LIST);
-	if(trace_me) {
-	  if(listmode) std::printf(" list__get -nprm= %llu ", nParam);
-		else std::printf(" container::get -nprm= %llu ", nParam);
-	}
+    if(trace_me) {
+      if(listmode) std::printf(" list__get -nprm= %llu ", nParam);
+        else std::printf(" container::get -nprm= %llu ", nParam);
+    }
 
-	DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
-	bool nullKW = e->KeywordSet(kwNULLIx);
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
+    bool nullKW = e->KeywordSet(kwNULLIx);
 
-	if( nList == 0)	{
-		if(nullKW) return NullGDL::GetSingleInstance();
-		else return new DLongGDL(-1);
-	}
-	DInt GDLContainerVersion =
-		(*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
-	bool isPtr = (GDLContainerVersion == POINTERS) or listmode;
-	bool allKW = e->KeywordSet(kwALLIx);
+    if( nList == 0) {
+        if(nullKW) return NullGDL::GetSingleInstance();
+        else return new DLongGDL(-1);
+    }
+    DInt GDLContainerVersion =
+        (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
+    bool isPtr = (GDLContainerVersion == POINTERS) or listmode;
+    bool allKW = e->KeywordSet(kwALLIx);
     BaseGDL* isaKW = NULL;
     if( allKW) {
-		isaKW = e->GetKW( kwISAIx);
-		if( isPtr && isaKW != NULL) {
-			if(nullKW) return NullGDL::GetSingleInstance();
-		else return new DLongGDL(-1);
-	}
-	}
+        isaKW = e->GetKW( kwISAIx);
+        if( isPtr && isaKW != NULL) {
+            if(nullKW) return NullGDL::GetSingleInstance();
+        else return new DLongGDL(-1);
+    }
+    }
     BaseGDL** countKW = NULL;
     if( e->GetKW( kwCOUNTIx) != NULL) countKW = &e->GetKW( kwCOUNTIx);
-	
+    
 // 
 // an IDL_CONTAINER is supposed to be only of one type or another:
 // either it is holding objects or it is holding heapvar pointers.
@@ -2666,157 +2666,160 @@ void list__swap( EnvUDT* e)
 // the data item(s) in the list.
 //
 
-	BaseGDL* index = e->GetKW(kwPOSITIONIx);
-	MAKE_LONGGDL(index, indexLong)
+    BaseGDL* index = e->GetKW(kwPOSITIONIx);
+    MAKE_LONGGDL(index, indexLong)
 
-	if( indexLong == NULL) indexLong = new DLongGDL(0);
+    if( indexLong == NULL) indexLong = new DLongGDL(0);
 
-		std::vector<DString> testisa;
-	if( isaKW != NULL) {
-			if( isaKW->Type() != GDL_STRING)
-					 ThrowFromInternalUDSub( e,
-					  "Object Classes can be referenced only with names (strings)");
-		for(SizeT i=0; i < isaKW->N_Elements(); ++i)
-				testisa.push_back(StrUpCase( (*static_cast<DStringGDL*>( isaKW))[i]));
-			}
-	
-	DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
-	DPtr pNext = pTail;
-	DStructGDL* Node = GetLISTStruct(e, pTail);
-	BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
-	DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
+        std::vector<DString> testisa;
+    if( isaKW != NULL) {
+            if( isaKW->Type() != GDL_STRING)
+                     ThrowFromInternalUDSub( e,
+                      "Object Classes can be referenced only with names (strings)");
+        for(SizeT i=0; i < isaKW->N_Elements(); ++i)
+                testisa.push_back(StrUpCase( (*static_cast<DStringGDL*>( isaKW))[i]));
+            }
+    
+    DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
+    DPtr pNext = pTail;
+    DStructGDL* Node = GetLISTStruct(e, pTail);
+    BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
+    DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
     DObj ObjID = static_cast<DObj>(pointer);
 
-	if(trace_me and !listmode) {
-		if(isPtr) std::printf(" Tail.pDataTag: %llu \n", pointer);
-		else std::printf(" Tail.pDataTag (OBJ): %llu \n", ObjID);
-	}
+    if(trace_me and !listmode) {
+        if(isPtr) std::printf(" Tail.pDataTag: %llu \n", pointer);
+        else std::printf(" Tail.pDataTag (OBJ): %llu \n", ObjID);
+    }
 
-	std::vector<DPtr> pointers;
-  	if(allKW) {
-		int inlist = 0;
-		do {
-			if(pNext == 0) 
-				 ThrowFromInternalUDSub( e,	  "Invalid container node");			
-			DStructGDL* Node = GetLISTStruct(e, pNext);
-			BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
-			DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
-			DObj ObjID = static_cast<DObj>(pointer);
-			if(isPtr && e->Interpreter()->PtrValid( pointer)) {
-					pointers.push_back( pointer);
-					if(trace_me) std::printf(" (ptr)++: %d %llu",inlist,  pointer);	
-				}
+    std::vector<DPtr> pointers;
+    if(allKW) {
+        int inlist = 0;
+        do {
+            if(pNext == 0) 
+                 ThrowFromInternalUDSub( e,   "Invalid container node");            
+            DStructGDL* Node = GetLISTStruct(e, pNext);
+            BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
+            DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
+            DObj ObjID = static_cast<DObj>(pointer);
+            if(isPtr && e->Interpreter()->PtrValid( pointer)) {
+                    pointers.push_back( pointer);
+                    if(trace_me) std::printf(" (ptr)++: %d %llu",inlist,  pointer); 
+                }
 
-			else if(!isPtr && e->Interpreter()->ObjValid( ObjID)) {
-					bool accept = true;
-				if( isaKW != NULL) {
-							accept = false;
-					DStructGDL* oStruct = e->GetObjHeap( ObjID);
-					for(SizeT i =0; i < testisa.size(); ++i)
-									if( oStruct->Desc()->IsParent( testisa[i]))
-									  { accept = true; break;}
-						}
-				if(accept) {
-					pointers.push_back( ObjID);
-					if(trace_me) std::printf(" (obj)++: %d %llu",inlist,  ObjID);	
-					}
+            else if(!isPtr && e->Interpreter()->ObjValid( ObjID)) {
+                    bool accept = true;
+                if( isaKW != NULL) {
+                            accept = false;
+                    DStructGDL* oStruct = e->GetObjHeap( ObjID);
+                    for(SizeT i =0; i < testisa.size(); ++i)
+                                    if( oStruct->Desc()->IsParent( testisa[i]))
+                                      { accept = true; break;}
+                        }
+                if(accept) {
+                    pointers.push_back( ObjID);
+                    if(trace_me) std::printf(" (obj)++: %d %llu",inlist,  ObjID);   
+                    }
 
-			} else
-				if(trace_me) std::printf(" invalid: %d %llu", inlist,  pointer);
+            } else
+                if(trace_me) std::printf(" invalid: %d %llu", inlist,  pointer);
 
-			pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-			if(trace_me) std::printf(" pNext:%llu",  pNext);
-		} while ( ++inlist != nList );
+            pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+            if(trace_me) std::printf(" pNext:%llu",  pNext);
+        } while ( ++inlist != nList );
 
-		if(countKW != NULL) *countKW = new DLongGDL(pointers.size());
-		if(pointers.size() == 0){
-			if(nullKW) return NullGDL::GetSingleInstance();
-			else return new DLongGDL(-1);
-		}
+        if(countKW != NULL) *countKW = new DLongGDL(pointers.size());
+        if(pointers.size() == 0){
+            if(nullKW) return NullGDL::GetSingleInstance();
+            else return new DLongGDL(-1);
+        }
 
-	}  else  {	// allKW
+    }  else  {  // allKW
     
-		if( index == NULL) {
-			if(trace_me) std::printf(" 1-shot %llu\n" ,  pointer);	
+        if( index == NULL) {
+            if(trace_me) std::printf(" 1-shot %llu\n" ,  pointer);  
 
-			if(isPtr && e->Interpreter()->PtrValid( pointer)) {
-				if(doIncDec) e->Interpreter()->IncRef( pointer);
-				if(countKW != NULL) *countKW = new DLongGDL(1);
-				return new DPtrGDL( pointer);
-			}
-			else if(!isPtr && e->Interpreter()->ObjValid( ObjID)) {
-				if(doIncDec) e->Interpreter()->IncRefObj( ObjID);
-			if(countKW != NULL) *countKW = new DLongGDL(1);
-				return new DObjGDL( ObjID);
-			} else {
-				if(countKW != NULL) *countKW = new DLongGDL(0);
-				if(nullKW) return NullGDL::GetSingleInstance();
-				else return new DLongGDL(-1);
-			}
-			}
+            if(isPtr && e->Interpreter()->PtrValid( pointer)) {
+                if(doIncDec) e->Interpreter()->IncRef( pointer);
+                if(countKW != NULL) *countKW = new DLongGDL(1);
+                return new DPtrGDL( pointer);
+            }
+            else if(!isPtr && e->Interpreter()->ObjValid( ObjID)) {
+                if(doIncDec) e->Interpreter()->IncRefObj( ObjID);
+            if(countKW != NULL) *countKW = new DLongGDL(1);
+                return new DObjGDL( ObjID);
+            } else {
+                if(countKW != NULL) *countKW = new DLongGDL(0);
+                if(nullKW) return NullGDL::GetSingleInstance();
+                else return new DLongGDL(-1);
+            }
+            }
 
-		int inlist = 0;
-		SizeT nEl = indexLong->N_Elements();
-		do {
-			if(pNext == 0) 
-				 ThrowFromInternalUDSub( e,	  "Invalid container node");			
-			DStructGDL* Node = GetLISTStruct(e, pNext);
-			BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
-			DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
-			DObj ObjID = static_cast<DObj>(pointer);
-			if( (isPtr && e->Interpreter()->PtrValid( pointer)) ||
-				(!isPtr && e->Interpreter()->ObjValid( ObjID))  ) {
-			  for( SizeT i=0; i < nEl; ++i)
-					if(inlist == (*indexLong)[i]) 
-						 pointers.push_back( pointer);
+        int inlist = 0;
+        SizeT nEl = indexLong->N_Elements();
+        do {
+            if(pNext == 0) 
+                 ThrowFromInternalUDSub( e,   "Invalid container node");            
+            DStructGDL* Node = GetLISTStruct(e, pNext);
+            BaseGDL* NodePtr = Node->GetTag( pDataTag, 0);
+            DPtr pointer = (*static_cast<DPtrGDL*>( NodePtr))[0];
+            DObj ObjID = static_cast<DObj>(pointer);
+            if( (isPtr && e->Interpreter()->PtrValid( pointer)) ||
+                (!isPtr && e->Interpreter()->ObjValid( ObjID))  ) {
+              for( SizeT i=0; i < nEl; ++i) {
+                  int ix = (*indexLong)[i];
+                  if (ix < 0) ix += nList;
+                  if(inlist == ix) 
+                     pointers.push_back( pointer);
+                     }
 
-			} else if(trace_me)
-					std::printf(" invalid: %d %llu", inlist,  pointer);
-			if(trace_me) std::printf(" pNext:%llu",  pNext);
-				pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
-		} while ( ++inlist != nList );
-		if(trace_me) std::cout << std::endl;
+            } else if(trace_me)
+                    std::printf(" invalid: %d %llu", inlist,  pointer);
+            if(trace_me) std::printf(" pNext:%llu",  pNext);
+                pNext = (*static_cast<DPtrGDL*>( Node->GetTag( pNextTag, 0)))[0];
+        } while ( ++inlist != nList );
+        if(trace_me) std::cout << std::endl;
 
-	}
-	SizeT nfetch = pointers.size();
-	if(countKW != NULL) *countKW = new DLongGDL(nfetch);
-	if(nfetch == 0) {
-		if(nullKW) return NullGDL::GetSingleInstance();
-		else return new DLongGDL(-1);
-	}
-	if(trace_me) printf(" fetch: #%llu isPtr? %d",nfetch,isPtr);
-    if( isPtr)	
+    }
+    SizeT nfetch = pointers.size();
+    if(countKW != NULL) *countKW = new DLongGDL(nfetch);
+    if(nfetch == 0) {
+        if(nullKW) return NullGDL::GetSingleInstance();
+        else return new DLongGDL(-1);
+    }
+    if(trace_me) printf(" fetch: #%llu isPtr? %d",nfetch,isPtr);
+    if( isPtr)  
     {
-		if( nfetch ==1) {
-			if(doIncDec) e->Interpreter()->IncRef(pointers[0]);
-			return new DPtrGDL(pointers[0]);
-		}
-		DPtrGDL* ret;
-		ret = new DPtrGDL( dimension(nfetch));
-		Guard<DPtrGDL> retGuard( ret);
-		for(SizeT i=0; i < nfetch; ++i) {
-		if(doIncDec) e->Interpreter()->IncRef(pointers[i]);
-					(*ret)[i] = pointers[i];
-				}
-		retGuard.Release();
-		return ret;
-	}
-	else 
-	{
-		if( nfetch ==1) {
-			if(doIncDec) e->Interpreter()->IncRefObj(static_cast<DObj>(pointers[0]));
-			return new DObjGDL(static_cast<DObj>(pointers[0]));
-		}
-		DObjGDL* ret;
-		ret = new DObjGDL( dimension(nfetch));
-		Guard<DObjGDL> retGuard( ret);
-		for(SizeT i=0; i < nfetch; ++i) {
-		if(doIncDec) e->Interpreter()->IncRefObj( static_cast<DObj>(pointers[i]));
-					(*ret)[i] = static_cast<DObj>(pointers[i]);
-				}
-		retGuard.Release();
-		return ret;
-	}
+        if( nfetch ==1) {
+            if(doIncDec) e->Interpreter()->IncRef(pointers[0]);
+            return new DPtrGDL(pointers[0]);
+        }
+        DPtrGDL* ret;
+        ret = new DPtrGDL( dimension(nfetch));
+        Guard<DPtrGDL> retGuard( ret);
+        for(SizeT i=0; i < nfetch; ++i) {
+        if(doIncDec) e->Interpreter()->IncRef(pointers[i]);
+                    (*ret)[i] = pointers[i];
+                }
+        retGuard.Release();
+        return ret;
+    }
+    else 
+    {
+        if( nfetch ==1) {
+            if(doIncDec) e->Interpreter()->IncRefObj(static_cast<DObj>(pointers[0]));
+            return new DObjGDL(static_cast<DObj>(pointers[0]));
+        }
+        DObjGDL* ret;
+        ret = new DObjGDL( dimension(nfetch));
+        Guard<DObjGDL> retGuard( ret);
+        for(SizeT i=0; i < nfetch; ++i) {
+        if(doIncDec) e->Interpreter()->IncRefObj( static_cast<DObj>(pointers[i]));
+                    (*ret)[i] = static_cast<DObj>(pointers[i]);
+                }
+        retGuard.Release();
+        return ret;
+    }
 }
   
   void list__add( EnvUDT* e)
@@ -2830,64 +2833,64 @@ void list__swap( EnvUDT* e)
   GDL_CONTAINER_NODE()
 
 
-//		trace_me = false; //lib::trace_arg();
+//      trace_me = false; //lib::trace_arg();
   
-	static int kwEXTRACTIx = e->GetKeywordIx("EXTRACT");
-	static int kwNO_COPYIx = e->GetKeywordIx("NO_COPY");
-	static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
-	static int kwSELFIx = kwEXTRACTIx + 1;
-	static int kwVALUEIx = kwSELFIx+1;
-	static int kwINDEXIx = kwSELFIx+2;
+    static int kwEXTRACTIx = e->GetKeywordIx("EXTRACT");
+    static int kwNO_COPYIx = e->GetKeywordIx("NO_COPY");
+    static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
+    static int kwSELFIx = kwEXTRACTIx + 1;
+    static int kwVALUEIx = kwSELFIx+1;
+    static int kwINDEXIx = kwSELFIx+2;
   
-	SizeT nParam = e->NParam(1);
+    SizeT nParam = e->NParam(1);
 
-	DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
+    DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
   DStructDesc* containerDesc=structDesc::GDL_CONTAINER_NODE;
-	DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
-	DInt GDLContainerVersion = 0;
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
+    DInt GDLContainerVersion = 0;
 
-	DStructDesc* selfDesc= self->Desc();
-	bool listmode = ( selfDesc == structDesc::LIST);
+    DStructDesc* selfDesc= self->Desc();
+    bool listmode = ( selfDesc == structDesc::LIST);
 
   BaseGDL* value = NULL;
-	DType valType;
+    DType valType;
   if( nParam >= 2)
     value = e->GetKW(kwVALUEIx);
-	bool isvalscalar = false;
-	if( value == NULL || value == NullGDL::GetSingleInstance()) 
-		isvalscalar = true;
-	else {
-		if( value->StrictScalar() ) isvalscalar = true;
-		valType = value->Type();
-	}
+    bool isvalscalar = false;
+    if( value == NULL || value == NullGDL::GetSingleInstance()) 
+        isvalscalar = true;
+    else {
+        if( value->StrictScalar() ) isvalscalar = true;
+        valType = value->Type();
+    }
 
-	DLong listSize;
+    DLong listSize;
     DStructGDL* ListHead;   
-	bool isvallist = false;
-	bool kwEXTRACT = false;
-	bool kwNO_COPY = false;
-	BaseGDL* index = NULL;
-	if(listmode) {
-		if( nParam >= 3)  index = e->GetKW(kwINDEXIx);
-		if (e->KeywordSet(kwEXTRACTIx)) kwEXTRACT = true;
-		if (e->KeywordSet(kwNO_COPYIx)) kwNO_COPY = true;
-		if (e->KeywordPresent(kwPOSITIONIx))  
-			 ThrowFromInternalUDSub( e, "list::add - POSITION cannot be used");
-		if( isvalscalar && kwEXTRACT && valType == GDL_OBJ) {
-			DObj p=(*static_cast<DObjGDL*>( value))[0];
-			if(p != 0) {
-				ListHead = GetOBJ( value, e);
-				DStructDesc* desc = ListHead->Desc();
-				isvallist = desc->IsParent("LIST");
-			}
-		}
-	} else {
- 		if (e->KeywordPresent(kwPOSITIONIx))  index = e->GetKW( kwPOSITIONIx);
-		if (e->KeywordSet(kwEXTRACTIx)) 
-			 ThrowFromInternalUDSub( e, " EXTRACT cannot be used");
-		if (e->KeywordSet(kwNO_COPYIx)) 
-			 ThrowFromInternalUDSub( e, " NOCOPY cannot be used");
-	}
+    bool isvallist = false;
+    bool kwEXTRACT = false;
+    bool kwNO_COPY = false;
+    BaseGDL* index = NULL;
+    if(listmode) {
+        if( nParam >= 3)  index = e->GetKW(kwINDEXIx);
+        if (e->KeywordSet(kwEXTRACTIx)) kwEXTRACT = true;
+        if (e->KeywordSet(kwNO_COPYIx)) kwNO_COPY = true;
+        if (e->KeywordPresent(kwPOSITIONIx))  
+             ThrowFromInternalUDSub( e, "list::add - POSITION cannot be used");
+        if( isvalscalar && kwEXTRACT && valType == GDL_OBJ) {
+            DObj p=(*static_cast<DObjGDL*>( value))[0];
+            if(p != 0) {
+                ListHead = GetOBJ( value, e);
+                DStructDesc* desc = ListHead->Desc();
+                isvallist = desc->IsParent("LIST");
+            }
+        }
+    } else {
+        if (e->KeywordPresent(kwPOSITIONIx))  index = e->GetKW( kwPOSITIONIx);
+        if (e->KeywordSet(kwEXTRACTIx)) 
+             ThrowFromInternalUDSub( e, " EXTRACT cannot be used");
+        if (e->KeywordSet(kwNO_COPYIx)) 
+             ThrowFromInternalUDSub( e, " NOCOPY cannot be used");
+    }
 
   MAKE_LONGGDL(index, indexLong)
 
@@ -2900,7 +2903,7 @@ void list__swap( EnvUDT* e)
     if( insertPos < 0)
       ThrowFromInternalUDSub( e, "INDEX out of range ("+i2s(insertPos)+" (<0))");
     if( insertPos > nList)
-      ThrowFromInternalUDSub( e, "INDEX out of range ("+i2s(insertPos)+" (>"+i2s(nList)+"))");	
+      ThrowFromInternalUDSub( e, "INDEX out of range ("+i2s(insertPos)+" (>"+i2s(nList)+"))");  
   }
 // InsertPos: 0-nList, or -1 (equiv nList)
 //
@@ -2909,10 +2912,10 @@ void list__swap( EnvUDT* e)
 //    VALUE may be singular (chain has one member) or need extraction.
 //    process may involve NO_COPY
 // 2. Attach chain to the list at insertPos
-	if(trace_me) {
-	  if(listmode) std::printf(" list__add ");
-		else std::printf(" container::add ");
-	}
+    if(trace_me) {
+      if(listmode) std::printf(" list__add ");
+        else std::printf(" container::add ");
+    }
 
     DStructGDL* cStruct = NULL;
     DPtr cID = 0;
@@ -2922,142 +2925,142 @@ void list__swap( EnvUDT* e)
     if( kwEXTRACT && value != NULL)
     {
       DStructGDL* cStructLast = NULL;
-		DPtr valNode;
-		DPtr pID;
-		valueN_Elements = value->N_Elements();
-		
-		if(trace_me) 
-		  std::printf(" (kwEXTRACT && value != NULL) #: %llu" , valueN_Elements ); 
+        DPtr valNode;
+        DPtr pID;
+        valueN_Elements = value->N_Elements();
+        
+        if(trace_me) 
+          std::printf(" (kwEXTRACT && value != NULL) #: %llu" , valueN_Elements ); 
       if(isvallist) {
-		   valueN_Elements = 
-				(*static_cast<DLongGDL*>(ListHead->GetTag( nListTag, 0)))[0];
-			valNode = GetLISTNode(e, ListHead, 0);
-		}
+           valueN_Elements = 
+                (*static_cast<DLongGDL*>(ListHead->GetTag( nListTag, 0)))[0];
+            valNode = GetLISTNode(e, ListHead, 0);
+        }
 
       for( SizeT eIx=0; eIx<valueN_Elements; ++eIx)
       {
-		// create place for "value"[eIx]
-		if(isvallist) 
-			pID = e->Interpreter()->NewHeap(1,GetNodeData(valNode)->Dup());
-		else if(valType != GDL_PTR or isvalscalar )
-	pID = e->Interpreter()->NewHeap(1,value->NewIx(eIx));
-		else { // when a ptrarr is added & extracted, make ptrarr(1)
-			DPtrGDL* pHeap = new DPtrGDL( dimension(1));
-			(*pHeap)[0] = (*static_cast<DPtrGDL*>(value))[eIx];
-			pID = e->Interpreter()->NewHeap(1, 	pHeap);
-			}
-		if(trace_me) 
-		  std::printf(" (%llu)", pID);		
-		// container to accomodate the data
-	cStruct= new DStructGDL( containerDesc, dimension());
-		// attach pID to cstruct (as data)
-	(*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
-	
-		 // create pointer for cstruct cID
-	cID = e->Interpreter()->NewHeap(1,cStruct);
-		// assign pointer cID
-	if( cStructLast != NULL)
-	  (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
-	else
-	  firstID = cID;	      
-	
-	cStructLast = cStruct;
+        // create place for "value"[eIx]
+        if(isvallist) 
+            pID = e->Interpreter()->NewHeap(1,GetNodeData(valNode)->Dup());
+        else if(valType != GDL_PTR or isvalscalar )
+    pID = e->Interpreter()->NewHeap(1,value->NewIx(eIx));
+        else { // when a ptrarr is added & extracted, make ptrarr(1)
+            DPtrGDL* pHeap = new DPtrGDL( dimension(1));
+            (*pHeap)[0] = (*static_cast<DPtrGDL*>(value))[eIx];
+            pID = e->Interpreter()->NewHeap(1,  pHeap);
+            }
+        if(trace_me) 
+          std::printf(" (%llu)", pID);      
+        // container to accomodate the data
+    cStruct= new DStructGDL( containerDesc, dimension());
+        // attach pID to cstruct (as data)
+    (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
+    
+         // create pointer for cstruct cID
+    cID = e->Interpreter()->NewHeap(1,cStruct);
+        // assign pointer cID
+    if( cStructLast != NULL)
+      (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+    else
+      firstID = cID;          
+    
+    cStructLast = cStruct;
       }
       }
     else if( !listmode)     {
-	  if(valType != GDL_PTR and valType != GDL_OBJ)
-		 ThrowFromInternalUDSub( e, " Must be pointers or Objects");
+      if(valType != GDL_PTR and valType != GDL_OBJ)
+         ThrowFromInternalUDSub( e, " Must be pointers or Objects");
       DStructGDL* cStructLast = NULL;
       valueN_Elements = value->N_Elements();
 // because objects do not get another pointer
-	  GDLContainerVersion = (valType == GDL_PTR) ? 1 : 2;
+      GDLContainerVersion = (valType == GDL_PTR) ? 1 : 2;
       if(nList == 0)
-		  (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0]
-					= GDLContainerVersion;
-	  else if( GDLContainerVersion !=
-			(*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0])
-				ThrowFromInternalUDSub( e, 
-					" Mixed pointers/Objects attempted");
-	  for( SizeT eIx=0; eIx<valueN_Elements; ++eIx)
+          (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0]
+                    = GDLContainerVersion;
+      else if( GDLContainerVersion !=
+            (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0])
+                ThrowFromInternalUDSub( e, 
+                    " Mixed pointers/Objects attempted");
+      for( SizeT eIx=0; eIx<valueN_Elements; ++eIx)
       {
-		cStruct= new DStructGDL( containerDesc, dimension());
-		cID = e->Interpreter()->NewHeap(1,cStruct);
-		if( cStructLast != NULL)
-		  (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+        cStruct= new DStructGDL( containerDesc, dimension());
+        cID = e->Interpreter()->NewHeap(1,cStruct);
+        if( cStructLast != NULL)
+          (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
       else
-		  firstID = cID;
-// Container::ADD. IncRef(pID) // IncRefObj calls are essential, so no option offered.     				
-		if(valType == GDL_PTR) {      				
-			DPtr pID = (*static_cast<DPtrGDL*>(value))[eIx];
-			e->Interpreter()->IncRef(pID);
-			if(trace_me)   std::printf(" (%llu)", pID);		
-			(*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
-		} else {
-			DObj ID = (*static_cast<DObjGDL*>(value))[eIx];
-			e->Interpreter()->IncRefObj(ID);
-			if(trace_me)   std::printf(" (%llu)", ID);		
-			(*static_cast<DObjGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = ID;
+          firstID = cID;
+// Container::ADD. IncRef(pID) // IncRefObj calls are essential, so no option offered.                  
+        if(valType == GDL_PTR) {                    
+            DPtr pID = (*static_cast<DPtrGDL*>(value))[eIx];
+            e->Interpreter()->IncRef(pID);
+            if(trace_me)   std::printf(" (%llu)", pID);     
+            (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
+        } else {
+            DObj ID = (*static_cast<DObjGDL*>(value))[eIx];
+            e->Interpreter()->IncRefObj(ID);
+            if(trace_me)   std::printf(" (%llu)", ID);      
+            (*static_cast<DObjGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = ID;
       }
-		cStructLast = cStruct;
+        cStructLast = cStruct;
     }
-	}	else { // kwEXTRACT && value != NULL ... !listmode
-		DPtr pID;
+    }   else { // kwEXTRACT && value != NULL ... !listmode
+        DPtr pID;
       if( value == NULL || kwNO_COPY)
-	pID = e->Interpreter()->NewHeap(1,value);
+    pID = e->Interpreter()->NewHeap(1,value);
       else
-	pID = e->Interpreter()->NewHeap(1,value->Dup());
+    pID = e->Interpreter()->NewHeap(1,value->Dup());
 
-		valueN_Elements = 1;
+        valueN_Elements = 1;
       // pID properly set (ptr to data)
       cStruct= new DStructGDL( containerDesc, dimension());
       (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
       cID = e->Interpreter()->NewHeap(1,cStruct);
-		if(trace_me) std::printf(" cID %llu",cID); 
-		firstID = cID;
+        if(trace_me) std::printf(" cID %llu",cID); 
+        firstID = cID;
      }  // kwEXTRACT && value != NULL
 
 
-	  if( kwNO_COPY)
-	  {
-		bool stolen = e->StealLocalKW( kwVALUEIx);
-		if( !stolen) e->GetKW(kwVALUEIx) = NULL;
-		 GDLDelete(value);
-	  }
+      if( kwNO_COPY)
+      {
+        bool stolen = e->StealLocalKW( kwVALUEIx);
+        if( !stolen) e->GetKW(kwVALUEIx) = NULL;
+         GDLDelete(value);
+      }
 
-		if(trace_me) std::printf(" nList %d \n",nList); 
+        if(trace_me) std::printf(" nList %d \n",nList); 
       
       if( nList == 0) // empty LIST
       {
-		(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = firstID;
-		(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = cID;	      	
+        (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = firstID;
+        (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = cID;         
       }
       else if( insertPos == -1 || insertPos == nList) // head
       {
-		DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];	      
-	DStructGDL* headNode = GetLISTStruct( e, pHead);  
-	
-		(*static_cast<DPtrGDL*>( headNode->GetTag( pNextTag, 0)))[0] = firstID;
-		(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = cID;	      
+        DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];        
+    DStructGDL* headNode = GetLISTStruct( e, pHead);  
+    
+        (*static_cast<DPtrGDL*>( headNode->GetTag( pNextTag, 0)))[0] = firstID;
+        (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = cID;       
       }
       else if( insertPos == 0) // tail
       {
-		DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];	      
-	
-	(*static_cast<DPtrGDL*>( cStruct->GetTag( pNextTag, 0)))[0] = pTail;
-		(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = firstID;	      
+        DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];        
+    
+    (*static_cast<DPtrGDL*>( cStruct->GetTag( pNextTag, 0)))[0] = pTail;
+        (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = firstID;       
       }
       else
       {
-	DPtr pPredNode = GetLISTNode( e, self, insertPos-1);
-	DStructGDL* predNode = GetLISTStruct( e, pPredNode);   
+    DPtr pPredNode = GetLISTNode( e, self, insertPos-1);
+    DStructGDL* predNode = GetLISTStruct( e, pPredNode);   
 
-	(*static_cast<DPtrGDL*>( cStruct->GetTag( pNextTag, 0)))[0] = 
-	(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0];
-		(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = firstID;
+    (*static_cast<DPtrGDL*>( cStruct->GetTag( pNextTag, 0)))[0] = 
+    (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0];
+        (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = firstID;
     }
       
       (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] =
-					nList+valueN_Elements;
+                    nList+valueN_Elements;
   }
   
   
@@ -3081,7 +3084,7 @@ void list__swap( EnvUDT* e)
     {
       listLength = (*lengthKW)[0];
       if( listLength < 0)
-	listLength = 0;
+    listLength = 0;
     }
     
     DInterpreter* ip = e->Interpreter();
@@ -3108,123 +3111,123 @@ void list__swap( EnvUDT* e)
     SizeT added = 0;
     DStructGDL* cStruct = NULL;
     DPtr cID = 0;
-    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;         
     if( nParam > 0 || listLength > 0)
     {
       DStructGDL* cStructLast = NULL;
       for( SizeT pIx=0; pIx<nParam; ++pIx)
       {
-	BaseGDL* p = e->GetPar(pIx);
-	
-	if( kwEXTRACT && p != NULL && p->N_Elements() > 1)
-	{
-	  for( SizeT eIx=0; eIx<p->N_Elements(); ++eIx)
-	  {
-	    DPtr pID;
-
-//	    pID = ip->NewHeap(1,p->NewIx(eIx)); // sets ref count to 1
-		if(p->Type() != GDL_PTR or (p->StrictScalar()) ){
-			pID = ip->NewHeap(1,p->NewIx(eIx));
-		} else { 				// when a ptrarr is added & extracted, make ptrarr(1)
-			DPtrGDL* pHeap = new DPtrGDL( dimension(1));
-			(*pHeap)[0] = (*static_cast<DPtrGDL*>(p))[eIx];
-			pID = ip->NewHeap(1, // scalar PTRs are treated different in [, ].
-					pHeap);
-		}
-	    
-	    cStruct= new DStructGDL( containerDesc, dimension());
+    BaseGDL* p = e->GetPar(pIx);
     
-	    (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
-	    
-	    cID = ip->NewHeap(1,cStruct); // sets ref count to 1
+    if( kwEXTRACT && p != NULL && p->N_Elements() > 1)
+    {
+      for( SizeT eIx=0; eIx<p->N_Elements(); ++eIx)
+      {
+        DPtr pID;
 
-	    if( cStructLast != NULL)
-	      (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
-	    else
-	    { // 1st element
-	      (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
-	    }
-	    
-	    cStructLast = cStruct;
+//      pID = ip->NewHeap(1,p->NewIx(eIx)); // sets ref count to 1
+        if(p->Type() != GDL_PTR or (p->StrictScalar()) ){
+            pID = ip->NewHeap(1,p->NewIx(eIx));
+        } else {                // when a ptrarr is added & extracted, make ptrarr(1)
+            DPtrGDL* pHeap = new DPtrGDL( dimension(1));
+            (*pHeap)[0] = (*static_cast<DPtrGDL*>(p))[eIx];
+            pID = ip->NewHeap(1, // scalar PTRs are treated different in [, ].
+                    pHeap);
+        }
+        
+        cStruct= new DStructGDL( containerDesc, dimension());
+    
+        (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
+        
+        cID = ip->NewHeap(1,cStruct); // sets ref count to 1
 
-	    if( ++added == listLength)
-	      break;	    
-	  }
-	  if( kwNO_COPY)
-	  {
-	    bool stolen = e->StealLocalPar( pIx);
-	    if( !stolen) e->GetPar(pIx) = NULL;
-	    GDLDelete(p);
-	  }
-	  assert( added > 0);
-	  if( added == listLength)
-	    break;	    
-	}
-	else
-	{
-	  SizeT pID;
+        if( cStructLast != NULL)
+          (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+        else
+        { // 1st element
+          (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;       
+        }
+        
+        cStructLast = cStruct;
 
-	  if( p == NULL || kwNO_COPY)
-	  {
-	    pID = ip->NewHeap(1,p); // sets ref count
-	    bool stolen = e->StealLocalPar( pIx);
-	    if( !stolen) e->GetPar(pIx) = NULL;
-	  }
-	  else
-	  {
-	    pID = ip->NewHeap(1,p->Dup());
-	  }
+        if( ++added == listLength)
+          break;        
+      }
+      if( kwNO_COPY)
+      {
+        bool stolen = e->StealLocalPar( pIx);
+        if( !stolen) e->GetPar(pIx) = NULL;
+        GDLDelete(p);
+      }
+      assert( added > 0);
+      if( added == listLength)
+        break;      
+    }
+    else
+    {
+      SizeT pID;
+
+      if( p == NULL || kwNO_COPY)
+      {
+        pID = ip->NewHeap(1,p); // sets ref count
+        bool stolen = e->StealLocalPar( pIx);
+        if( !stolen) e->GetPar(pIx) = NULL;
+      }
+      else
+      {
+        pID = ip->NewHeap(1,p->Dup());
+      }
   
-	  cStruct= new DStructGDL( containerDesc, dimension());
+      cStruct= new DStructGDL( containerDesc, dimension());
   
-	  (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
-	  
-	  cID = ip->NewHeap(1,cStruct); // sets ref count
+      (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
+      
+      cID = ip->NewHeap(1,cStruct); // sets ref count
 
-	  if( cStructLast != NULL)
-	    (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
-	  else
-	  { // 1st element
-	    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
-	  }
-	  
-	  cStructLast = cStruct;
+      if( cStructLast != NULL)
+        (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+      else
+      { // 1st element
+        (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;         
+      }
+      
+      cStructLast = cStruct;
 
-	  if( ++added == listLength)
-	    break;	    
-	}
+      if( ++added == listLength)
+        break;      
+    }
       }
       if( listLength != 0 && added < listLength)
       {
-	for( ; added<listLength; ++added)
-	{
-	  DPtr pID;
+    for( ; added<listLength; ++added)
+    {
+      DPtr pID;
 
-	  pID = ip->NewHeap(1,NULL);
-	  
-	  cStruct= new DStructGDL( containerDesc, dimension());
+      pID = ip->NewHeap(1,NULL);
+      
+      cStruct= new DStructGDL( containerDesc, dimension());
   
-	  (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
-	  
-	  cID = ip->NewHeap(1,cStruct);
+      (*static_cast<DPtrGDL*>( cStruct->GetTag( pDataTag, 0)))[0] = pID;
+      
+      cID = ip->NewHeap(1,cStruct);
 
-	  if( cStructLast != NULL)
-	    (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
-	  else
-	  { // 1st element
-	    (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;	      
-	  }
-	  
-	  cStructLast = cStruct;
-	}
+      if( cStructLast != NULL)
+        (*static_cast<DPtrGDL*>( cStructLast->GetTag( pNextTag, 0)))[0] = cID;
+      else
+      { // 1st element
+        (*static_cast<DPtrGDL*>( listStruct->GetTag( pTailTag, 0)))[0] = cID;         
+      }
+      
+      cStructLast = cStruct;
+    }
       }
     }
 
 //     if( cStruct != NULL)
 //       (*static_cast<DPtrGDL*>( cStruct->GetTag( pNextTag, 0)))[0] = 0;
-	    
-    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;	      
-    (*static_cast<DLongGDL*>( listStruct->GetTag( nListTag, 0)))[0] = added;	      
+        
+    (*static_cast<DPtrGDL*>( listStruct->GetTag( pHeadTag, 0)))[0] = cID;         
+    (*static_cast<DLongGDL*>( listStruct->GetTag( nListTag, 0)))[0] = added;          
 
     newObjGuard.Release();
     return newObj;
@@ -3232,75 +3235,75 @@ void list__swap( EnvUDT* e)
   
  BaseGDL* container__init( EnvUDT* e) {
 // container is parented by GDL_OBJECT which can handle INIT:
-	return new DByteGDL(1); // if we reach here, defaul is to return 'TRUE'
+    return new DByteGDL(1); // if we reach here, defaul is to return 'TRUE'
  }
 
   void container__cleanup( EnvUDT* e)
   {
     DStructGDL* self = GetOBJ( e->GetKW( 0), e);
-  	if( trace_me) std::cout << " CONTAINER::CLEANUP:" ;
+    if( trace_me) std::cout << " CONTAINER::CLEANUP:" ;
     CONTAINERCleanup( e, self);
-		}
+        }
   
   BaseGDL* container__iscontained( EnvUDT* e)
   {
     GDL_CONTAINER_STRUCT()
     GDL_CONTAINER_NODE()
-	static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
+    static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
     static int kwSELFIx = kwPOSITIONIx + 1; // no keywords
     static int kwVALUEIx = kwSELFIx + 1;
 // Keyword
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
-	DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];  
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];  
     if( nList == 0)
       return NullGDL::GetSingleInstance();
-	SizeT nParam = e->NParam(1);
-	BaseGDL* values = e->GetKW( kwVALUEIx);
-	if( nParam == 0 or values== 0) return NullGDL::GetSingleInstance();
-	DInt GDLContainerVersion = 
-  		  (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
-	if(	GDLContainerVersion == 0)
-			ThrowFromInternalUDSub( e,
-			 " only pointers or objects shall be placed in such containers");
-	if( GDLContainerVersion == 1 and values->Type() != GDL_PTR)
-			ThrowFromInternalUDSub( e,
-			 " only pointers can be found in this container");
-	if( GDLContainerVersion == 2 and values->Type() != GDL_OBJ)
-			ThrowFromInternalUDSub( e,
-			 " only objects can be found in this container");
-	
+    SizeT nParam = e->NParam(1);
+    BaseGDL* values = e->GetKW( kwVALUEIx);
+    if( nParam == 0 or values== 0) return NullGDL::GetSingleInstance();
+    DInt GDLContainerVersion = 
+          (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
+    if( GDLContainerVersion == 0)
+            ThrowFromInternalUDSub( e,
+             " only pointers or objects shall be placed in such containers");
+    if( GDLContainerVersion == 1 and values->Type() != GDL_PTR)
+            ThrowFromInternalUDSub( e,
+             " only pointers can be found in this container");
+    if( GDLContainerVersion == 2 and values->Type() != GDL_OBJ)
+            ThrowFromInternalUDSub( e,
+             " only objects can be found in this container");
+    
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
-	if( ! BaseGDL::interpreter->PtrValid(actP)) // 
-				return NullGDL::GetSingleInstance();
+    if( ! BaseGDL::interpreter->PtrValid(actP)) // 
+                return NullGDL::GetSingleInstance();
     DLongGDL* pos = new DLongGDL( dimension(values->N_Elements()) );
     Guard<DLongGDL> posGuard( pos);
-	
+    
     DByteGDL* result = new DByteGDL( dimension(nList));
     Guard<DByteGDL> resultGuard( result);
     
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-		DStructGDL* actPStruct = GetLISTStruct(e, actP);
+        DStructGDL* actPStruct = GetLISTStruct(e, actP);
 
-		DPtr Ptr = (*static_cast<DPtrGDL*>(actPStruct->GetTag( pDataTag, 0)))[0];
-		for( SizeT k=0; k < values->N_Elements(); k++ ) 
-			if( Ptr == (*static_cast<DPtrGDL*>(values))[k] ) {
-				(*result)[k] = 1;
-				(*pos)[k] = elIx;
-				break;
-			}
-		actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+        DPtr Ptr = (*static_cast<DPtrGDL*>(actPStruct->GetTag( pDataTag, 0)))[0];
+        for( SizeT k=0; k < values->N_Elements(); k++ ) 
+            if( Ptr == (*static_cast<DPtrGDL*>(values))[k] ) {
+                (*result)[k] = 1;
+                (*pos)[k] = elIx;
+                break;
+            }
+        actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
       }
-	for( SizeT k=0; k < values->N_Elements(); k++ ) 
-			if( (*result)[k] == 0 ) (*pos)[k] = -1;
+    for( SizeT k=0; k < values->N_Elements(); k++ ) 
+            if( (*result)[k] == 0 ) (*pos)[k] = -1;
     if( e->KeywordPresent( kwPOSITIONIx)) {
-		BaseGDL** posKW = &e->GetKW( kwPOSITIONIx);
-		posGuard.Release();
-		*posKW = pos;
-		}
+        BaseGDL** posKW = &e->GetKW( kwPOSITIONIx);
+        posGuard.Release();
+        *posKW = pos;
+        }
     resultGuard.Release();
-	if(!values->StrictScalar()) return result;
-	else return new DByteGDL( (*result)[0]);
+    if(!values->StrictScalar()) return result;
+    else return new DByteGDL( (*result)[0]);
 }
   BaseGDL* container__equals( EnvUDT* e)
   {
@@ -3310,33 +3313,33 @@ void list__swap( EnvUDT* e)
     static int kwVALUEIx = 1;
 // no Keywords
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
-	DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];  
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];  
     if( nList == 0)
       return NullGDL::GetSingleInstance();
-	SizeT nParam = e->NParam(1);
-	BaseGDL* value = e->GetKW( kwVALUEIx);
-	if( nParam == 0 or value== 0) return NullGDL::GetSingleInstance();
+    SizeT nParam = e->NParam(1);
+    BaseGDL* value = e->GetKW( kwVALUEIx);
+    if( nParam == 0 or value== 0) return NullGDL::GetSingleInstance();
     DByteGDL* result = new DByteGDL( dimension(nList));
     Guard<DByteGDL> resultGuard( result);
-	DInt GDLContainerVersion = 
-  		  (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
-	if(	GDLContainerVersion != 1) // should be throwing exception here
-			ThrowFromInternalUDSub( e, " only containers of pointers are allowed");
+    DInt GDLContainerVersion = 
+          (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
+    if( GDLContainerVersion != 1) // should be throwing exception here
+            ThrowFromInternalUDSub( e, " only containers of pointers are allowed");
     DPtr actP = (*static_cast<DPtrGDL*>(self->GetTag( pTailTag, 0)))[0];
-	if( ! BaseGDL::interpreter->PtrValid(actP)) // 
-				return NullGDL::GetSingleInstance();
+    if( ! BaseGDL::interpreter->PtrValid(actP)) // 
+                return NullGDL::GetSingleInstance();
 
     for( SizeT elIx = 0; elIx < nList; ++elIx)
       {
-		DStructGDL* actPStruct = GetLISTStruct(e, actP);
+        DStructGDL* actPStruct = GetLISTStruct(e, actP);
 
-		DPtr Ptr = (*static_cast<DPtrGDL*>(actPStruct->GetTag( pDataTag, 0)))[0];
-		BaseGDL* data = BaseGDL::interpreter->GetHeapNoThrow( Ptr);
-		if( data == NULL || data == NullGDL::GetSingleInstance())
-			(*result)[elIx] = 0;
+        DPtr Ptr = (*static_cast<DPtrGDL*>(actPStruct->GetTag( pDataTag, 0)))[0];
+        BaseGDL* data = BaseGDL::interpreter->GetHeapNoThrow( Ptr);
+        if( data == NULL || data == NullGDL::GetSingleInstance())
+            (*result)[elIx] = 0;
         else (*result)[elIx] = lib::array_equal_bool(data, value) ? 1 : 0;
 
-		actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
+        actP = (*static_cast<DPtrGDL*>( actPStruct->GetTag( pNextTag, 0)))[0];
       }    
     resultGuard.Release();
     return result;
@@ -3346,141 +3349,141 @@ void list__swap( EnvUDT* e)
 
     GDL_CONTAINER_STRUCT()
     GDL_CONTAINER_NODE()
-	enum { POINTERS=1, OBJECTS};
+    enum { POINTERS=1, OBJECTS};
     SizeT nParam = e->NParam(1);
 
   // sALL, POSITION are keyword.
-	static int kwALLIx = e->GetKeywordIx("ALL");
-	static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
-	static int kwSELFIx = kwALLIx + 1;
+    static int kwALLIx = e->GetKeywordIx("ALL");
+    static int kwPOSITIONIx = e->GetKeywordIx("POSITION");
+    static int kwSELFIx = kwALLIx + 1;
 
 
     DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
 
-	DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];	      
+    DLong nList = (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0];          
 // Is this correct behavior? Not from the LIST example.
-//	if( nList == 0) ThrowFromInternalUDSub( e, "Container is empty.");
-	if(nList == 0) return;
+//  if( nList == 0) ThrowFromInternalUDSub( e, "Container is empty.");
+    if(nList == 0) return;
 
-	DInt GDLContainerVersion =
-		(*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
-	DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
-	  
-	bool isPtr = (GDLContainerVersion == POINTERS);
-	bool allKW = e->KeywordSet(kwALLIx);
-	if(allKW) {
-		CONTAINERCleanup(e, self);
+    DInt GDLContainerVersion =
+        (*static_cast<DIntGDL*>( self->GetTag( GDLContainerVersionTag, 0)))[0];
+    DPtr pTail = (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0];
+      
+    bool isPtr = (GDLContainerVersion == POINTERS);
+    bool allKW = e->KeywordSet(kwALLIx);
+    if(allKW) {
+        CONTAINERCleanup(e, self);
 
-	  return;
-	  }
+      return;
+      }
   
-	if( nParam == 2) {
-		static int kwVALUEIx = kwSELFIx + 1;
-		BaseGDL* value =  e->GetKW(kwVALUEIx);
-		if( value == NULL) return;
-		DType valType = value->Type();
-		if( valType != GDL_PTR and isPtr)
-			ThrowFromInternalUDSub( e, " Heapvars not pointers");
-		else 
-		if(	valType != GDL_OBJ and !isPtr)
-			ThrowFromInternalUDSub( e, " Heapvars not Objects");
-		DPtr pNext = pTail;
-		DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] ;
-		DPtr predPtr = 0;
-		DLong newnList = nList;
+    if( nParam == 2) {
+        static int kwVALUEIx = kwSELFIx + 1;
+        BaseGDL* value =  e->GetKW(kwVALUEIx);
+        if( value == NULL) return;
+        DType valType = value->Type();
+        if( valType != GDL_PTR and isPtr)
+            ThrowFromInternalUDSub( e, " Heapvars not pointers");
+        else 
+        if( valType != GDL_OBJ and !isPtr)
+            ThrowFromInternalUDSub( e, " Heapvars not Objects");
+        DPtr pNext = pTail;
+        DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] ;
+        DPtr predPtr = 0;
+        DLong newnList = nList;
         SizeT valueN_Elements = value->N_Elements();
-		for (SizeT k=0; k < nList; ++k) {
-			DPtr pRemove=pNext;
-			DStructGDL* removeNode = GetLISTStruct( e, pRemove);
-			pNext = (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
-			DPtr pData = (*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];
-			bool release = false;
-			for (SizeT eIx=0; eIx < valueN_Elements; ++eIx) {
-				DPtr valtest = (*static_cast<DPtrGDL*>(value))[eIx];
-				if( pData == valtest) {release = true; break;}
-			}
-			if( release) {
-				if(doIncDec) {
-					if( isPtr && e->Interpreter()->PtrValid( pData)) 
-						 e->Interpreter()->DecRef( pData);
-				else if(!isPtr && e->Interpreter()->ObjValid( pData))
-						 e->Interpreter()->DecRefObj( pData);
-//					else std::cout << " removing an invalid obj/ptr " << std::endl;
-					}
-				(*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0] = 0;      
-				e->Interpreter()->FreeHeap( pRemove);
+        for (SizeT k=0; k < nList; ++k) {
+            DPtr pRemove=pNext;
+            DStructGDL* removeNode = GetLISTStruct( e, pRemove);
+            pNext = (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
+            DPtr pData = (*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];
+            bool release = false;
+            for (SizeT eIx=0; eIx < valueN_Elements; ++eIx) {
+                DPtr valtest = (*static_cast<DPtrGDL*>(value))[eIx];
+                if( pData == valtest) {release = true; break;}
+            }
+            if( release) {
+                if(doIncDec) {
+                    if( isPtr && e->Interpreter()->PtrValid( pData)) 
+                         e->Interpreter()->DecRef( pData);
+                else if(!isPtr && e->Interpreter()->ObjValid( pData))
+                         e->Interpreter()->DecRefObj( pData);
+//                  else std::cout << " removing an invalid obj/ptr " << std::endl;
+                    }
+                (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0] = 0;      
+                e->Interpreter()->FreeHeap( pRemove);
 //====  Now patch up the container for the hole we created.
-				--newnList;
-				if( predPtr == 0)
-					(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = pNext;
-				else {
-					DStructGDL* predNode =  GetLISTStruct( e, predPtr);
-					(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = pNext;
-				}
-				if( pRemove == pHead)
-					(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = predPtr;
-			} else {  // release
-				predPtr = pRemove;
-			}	
+                --newnList;
+                if( predPtr == 0)
+                    (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = pNext;
+                else {
+                    DStructGDL* predNode =  GetLISTStruct( e, predPtr);
+                    (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = pNext;
+                }
+                if( pRemove == pHead)
+                    (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = predPtr;
+            } else {  // release
+                predPtr = pRemove;
+            }   
     }
-		(*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = newnList;
-		return;
-	}
+        (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = newnList;
+        return;
+    }
   
-	BaseGDL* index = NULL;
-	if( e->KeywordPresent(kwPOSITIONIx))  index = e->GetKW(kwPOSITIONIx);
+    BaseGDL* index = NULL;
+    if( e->KeywordPresent(kwPOSITIONIx))  index = e->GetKW(kwPOSITIONIx);
 
-	MAKE_LONGGDL(index, indexLong)
+    MAKE_LONGGDL(index, indexLong)
 
   DLong removePos = -1;
-	if( indexLong != NULL)	{
-		if( indexLong->N_Elements() == 1) {
-	removePos = (*indexLong)[0];
-	if( removePos < 0)
-	  removePos += nList;
-			if( (removePos < 0) or ( removePos >= nList) )
-	  ThrowFromInternalUDSub( e, "Index out of range.");  
+    if( indexLong != NULL)  {
+        if( indexLong->N_Elements() == 1) {
+    removePos = (*indexLong)[0];
+    if( removePos < 0)
+      removePos += nList;
+            if( (removePos < 0) or ( removePos >= nList) )
+      ThrowFromInternalUDSub( e, "Index out of range.");  
     }
   }
-	if(trace_me) std::printf(" c-r.remove: %d ",removePos);
+    if(trace_me) std::printf(" c-r.remove: %d ",removePos);
   
 
-	DPtr pNext = pTail;
-    DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];	      
-	DPtr predPtr = 0;
-	for (SizeT k=0; k < nList; ++k) {
-		DPtr pRemove=pNext;
-		DStructGDL* removeNode = GetLISTStruct( e, pRemove);
-		bool release = (k == removePos);
-		pNext = (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
-		if( release) {
-			DPtr pData = 
-				(*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];
-			if(doIncDec) {
-				if( isPtr && e->Interpreter()->PtrValid( pData)) 
-					 e->Interpreter()->DecRef( pData);
-			else if(!isPtr && e->Interpreter()->ObjValid( pData))
-					 e->Interpreter()->DecRefObj( pData);
-//				else std::cout << " removing an invalid obj/ptr " << std::endl;
-				}
+    DPtr pNext = pTail;
+    DPtr pHead = (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0];        
+    DPtr predPtr = 0;
+    for (SizeT k=0; k < nList; ++k) {
+        DPtr pRemove=pNext;
+        DStructGDL* removeNode = GetLISTStruct( e, pRemove);
+        bool release = (k == removePos);
+        pNext = (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0];
+        if( release) {
+            DPtr pData = 
+                (*static_cast<DPtrGDL*>( removeNode->GetTag( pDataTag, 0)))[0];
+            if(doIncDec) {
+                if( isPtr && e->Interpreter()->PtrValid( pData)) 
+                     e->Interpreter()->DecRef( pData);
+            else if(!isPtr && e->Interpreter()->ObjValid( pData))
+                     e->Interpreter()->DecRefObj( pData);
+//              else std::cout << " removing an invalid obj/ptr " << std::endl;
+                }
 
-			(*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0] = 0;      
-			e->Interpreter()->HeapErase( pRemove);
-			if( predPtr == 0)
-				(*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = pNext;
-			else {
-				DStructGDL* predNode = GetLISTStruct( e, predPtr);
-				(*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = pNext;
+            (*static_cast<DPtrGDL*>( removeNode->GetTag( pNextTag, 0)))[0] = 0;      
+            e->Interpreter()->HeapErase( pRemove);
+            if( predPtr == 0)
+                (*static_cast<DPtrGDL*>( self->GetTag( pTailTag, 0)))[0] = pNext;
+            else {
+                DStructGDL* predNode = GetLISTStruct( e, predPtr);
+                (*static_cast<DPtrGDL*>( predNode->GetTag( pNextTag, 0)))[0] = pNext;
     }
-			if( pRemove == pHead)
-				(*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = predPtr;
+            if( pRemove == pHead)
+                (*static_cast<DPtrGDL*>( self->GetTag( pHeadTag, 0)))[0] = predPtr;
       (*static_cast<DLongGDL*>( self->GetTag( nListTag, 0)))[0] = nList - 1;
-			break;
+            break;
     }
-		predPtr = pRemove;
-		if( trace_me) std::printf(" %llu ", k);
+        predPtr = pRemove;
+        if( trace_me) std::printf(" %llu ", k);
   }
-	if(trace_me) std::cout << std::endl;
+    if(trace_me) std::cout << std::endl;
     return;
 }
 

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -95,9 +95,9 @@ BaseGDL* _GDL_OBJECT_OverloadIsTrue( EnvUDT* e)
   return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
 }
 BaseGDL* _GDL_OBJECT_Init( EnvUDT* e)
-{	  
-//	std::cout << " gdl_OBJECT_Init!" << std::endl;
-	return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
+{     
+//  std::cout << " gdl_OBJECT_Init!" << std::endl;
+    return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
 }
 void _GDL_OBJECT_OverloadBracketsLeftSide( EnvUDT* e)
 {
@@ -162,7 +162,7 @@ BaseGDL* _GDL_OBJECT_OverloadBracketsRightSide( EnvUDT* e)
     try{
       isRangeLong = static_cast<DLongGDL*>( isRange->Convert2( GDL_LONG, BaseGDL::COPY));
     }
-		catch( GDLException& ex) {
+        catch( GDLException& ex) {
       ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
     }
     isRangeLongGuard.Reset( isRangeLong);
@@ -175,41 +175,41 @@ BaseGDL* _GDL_OBJECT_OverloadBracketsRightSide( EnvUDT* e)
     {
       BaseGDL* parX = e->GetKW( p + 2); // implicit SELF, ISRANGE, par1..par8
       if( parX == NULL)
-			ThrowFromInternalUDSub( e,
-			 "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
+            ThrowFromInternalUDSub( e,
+             "Parameter is undefined: "  + e->Caller()->GetString(e->GetKW( p + 2)));
       DLong isRangeX = (*isRangeLong)[p];
       if( isRangeX != 0 && isRangeX != 1)
-			ThrowFromInternalUDSub( e,
-			 "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
+            ThrowFromInternalUDSub( e,
+             "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
       if( isRangeX == 1)
       {
-	if( parX->N_Elements() != 3)
-			ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " +
-							e->Caller()->GetString(e->GetKW( p + 2)));
-	Guard<DLongGDL> parXLongGuard;
-	DLongGDL* parXLong;
-		  if( parX->Type() == GDL_LONG)
-			parXLong = static_cast<DLongGDL*>( parX);
-		  else  {
-	  try{
-	    parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
-	  }
-				catch( GDLException& ex) {
-	    ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-	  }
-			parXLongGuard.Reset( parXLong);
-	}
-	// negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
-	ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
+    if( parX->N_Elements() != 3)
+            ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " +
+                            e->Caller()->GetString(e->GetKW( p + 2)));
+    Guard<DLongGDL> parXLongGuard;
+    DLongGDL* parXLong;
+          if( parX->Type() == GDL_LONG)
+            parXLong = static_cast<DLongGDL*>( parX);
+          else  {
+      try{
+        parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
+      }
+                catch( GDLException& ex) {
+        ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
+      }
+            parXLongGuard.Reset( parXLong);
+    }
+    // negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
+    ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
       }
       else // non-range
       {
-	// ATTENTION: These two grab c1 (all others don't)
-	// a bit unclean, but for maximum efficiency
-	if( parX->Rank() == 0)
-	  ixList.push_back( new CArrayIndexScalar( parX->Dup()));
-	else
-	  ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
+    // ATTENTION: These two grab c1 (all others don't)
+    // a bit unclean, but for maximum efficiency
+    if( parX->Rank() == 0)
+      ixList.push_back( new CArrayIndexScalar( parX->Dup()));
+    else
+      ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
       }
     } // for
   }
@@ -250,7 +250,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp( EnvUDT* e)
   ULong rEl=right->N_Elements();
   ULong nEl=left->N_Elements();
   //   if( nEl == 0)
-  // 	 nEl=N_Elements();
+  //     nEl=N_Elements();
   assert( rEl);
   assert( nEl);
   //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
@@ -262,57 +262,57 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp( EnvUDT* e)
     {
       res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
       if( nEl == 1)
-	{
-	  (*res)[0] = (s == (*left)[0]);
-	  return res;
-	}
+    {
+      (*res)[0] = (s == (*left)[0]);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*left)[i] == s);
-	}    }
+      for( OMPInt i=0; i < nEl; ++i)
+        (*res)[i] = ((*left)[i] == s);
+    }    }
   else if( left->StrictScalar(s)) 
     {
       res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
       if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == s);
-	  return res;
-	}
+    {
+      (*res)[0] = ((*right)[0] == s);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == s);
-	}    }
+      for( OMPInt i=0; i < rEl; ++i)
+        (*res)[i] = ((*right)[i] == s);
+    }    }
   else if( rEl < nEl) 
     {
       res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*left)[i]);
-	}    }
+      for( OMPInt i=0; i < rEl; ++i)
+        (*res)[i] = ((*right)[i] == (*left)[i]);
+    }    }
   else // ( rEl >= nEl)
     {
       res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
       if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == (*left)[0]);
-	  return res;
-	}
+    {
+      (*res)[0] = ((*right)[0] == (*left)[0]);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*left)[i]);
-	}    }
+      for( OMPInt i=0; i < nEl; ++i)
+        (*res)[i] = ((*right)[i] == (*left)[i]);
+    }    }
   return res;
 }
 
@@ -338,7 +338,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp( EnvUDT* e)
   ULong rEl=right->N_Elements();
   ULong nEl=left->N_Elements();
   //   if( nEl == 0)
-  // 	 nEl=N_Elements();
+  //     nEl=N_Elements();
   assert( rEl);
   assert( nEl);
   //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
@@ -350,57 +350,57 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp( EnvUDT* e)
     {
       res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
       if( nEl == 1)
-	{
-	  (*res)[0] = (s != (*left)[0]);
-	  return res;
-	}
+    {
+      (*res)[0] = (s != (*left)[0]);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*left)[i] != s);
-	}    }
+      for( OMPInt i=0; i < nEl; ++i)
+        (*res)[i] = ((*left)[i] != s);
+    }    }
   else if( left->StrictScalar(s)) 
     {
       res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
       if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != s);
-	  return res;
-	}
+    {
+      (*res)[0] = ((*right)[0] != s);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != s);
-	}    }
+      for( OMPInt i=0; i < rEl; ++i)
+        (*res)[i] = ((*right)[i] != s);
+    }    }
   else if( rEl < nEl) 
     {
       res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*left)[i]);
-	}    }
+      for( OMPInt i=0; i < rEl; ++i)
+        (*res)[i] = ((*right)[i] != (*left)[i]);
+    }    }
   else // ( rEl >= nEl)
     {
       res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
       if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != (*left)[0]);
-	  return res;
-	}
+    {
+      (*res)[0] = ((*right)[0] != (*left)[0]);
+      return res;
+    }
       TRACEOMP( __FILE__, __LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
+    {
 #pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*left)[i]);
-	}    }
+      for( OMPInt i=0; i < nEl; ++i)
+        (*res)[i] = ((*right)[i] != (*left)[i]);
+    }    }
   return res;
 }
 
@@ -595,7 +595,7 @@ void SetupOverloadSubroutines()
   DPro *DProLIST__CLEANUP = new DPro("CLEANUP","LIST",INTERNAL_LIBRARY_STR);
   treePro = new WRAPPED_PRONode( lib::list__cleanup);
   DProLIST__CLEANUP->SetTree( treePro);
-	  listDesc->ProList().push_back(DProLIST__CLEANUP);
+      listDesc->ProList().push_back(DProLIST__CLEANUP);
 // LIST::MOVE
   DPro *DProLIST__MOVE = new DPro("MOVE","LIST",INTERNAL_LIBRARY_STR);
   DProLIST__MOVE->AddPar("SOURCE")->AddPar("DESTINATION");
@@ -764,8 +764,7 @@ void SetupOverloadSubroutines()
   hashDesc->FunList().push_back(DFunHASH__WHERE);
  
  // GDL_CONTAINER - references list procedures because, we can.
-// GDL_CONTAINER::GET() - Not present in list.
-  // res=GDL_CONTAINER.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
+// res=GDL_CONTAINER.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
   DFun* DFunlist = new DFun("GET","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
   DFunlist->AddKey("ALL","ALL")->AddKey("ISA","ISA")->AddKey("NULL","NULL");
   DFunlist->AddKey("COUNT","COUNT");
@@ -804,9 +803,6 @@ void SetupOverloadSubroutines()
   gdlContainerDesc->ProList().push_back(DProlist);
   #endif
 // GDL_CONTAINER::CLEANUP
-// 
-//*2017-Dec-23 GVJ Omit this routine and see if GDL takes care of things.
-// 2018-May revert
   DProlist = new DPro("CLEANUP","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
   treePro = new WRAPPED_PRONode( lib::container__cleanup);
   DProlist->SetTree( treePro);
@@ -829,13 +825,13 @@ void SetupOverloadSubroutines()
   DFunlist = new DFun("EQUALS","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
   treeFun = new WRAPPED_FUNNode( lib::container__equals);
   DFunlist->SetTree( treeFun);
-  listDesc->FunList().push_back( DFunlist);
+  gdlContainerDesc->FunList().push_back( DFunlist);
 // GDL_CONTAINER::ISCONTAINED()
   DFunlist = new DFun("ISCONTAINED","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
   DFunlist->AddKey("POSITION","POSITION");
   DFunlist->AddPar("VALUE");
   treeFun = new WRAPPED_FUNNode( lib::container__iscontained);
   DFunlist->SetTree( treeFun);
-  listDesc->FunList().push_back( DFunlist);
+  gdlContainerDesc->FunList().push_back( DFunlist);
   
 }

--- a/testsuite/test_container.pro
+++ b/testsuite/test_container.pro
@@ -4,11 +4,9 @@
 ; 
 PRO ObjTEST::Cleanup, prm1, prm2, prm3
   COMPILE_OPT IDL2 ,HIDDEN
-  ; Call our superclass Cleanup method
-  ; self->IDL_Object::Cleanup ; (there is no GDL_OBJECT::cleanup)
 
 nprm = N_PARAMS()
-print,' ObjTEST::Cleanup, #params=',nprm
+if nprm gt 0 then print,' ObjTEST::Cleanup, #params=',nprm
 ;
 END
  
@@ -33,9 +31,9 @@ track.ref = heap_refcount(obj)
 return
 end
 ;
-	pro TEST_CONTAINER, help=help, verbose=verbose, short=short, $
+   pro TEST_CONTAINER, help=help, verbose=verbose, short=short, $
                no_exit=no_exit, test=test
-;verbose=1
+; verbose=1
 ;
 if KEYWORD_SET(help) then begin
    print, 'pro TEST_CONTAINER, help=help, verbose=verbose, short=short, $'
@@ -61,9 +59,9 @@ if(oc.count() ne 0) then MYMESS, nb_errors,txt
 objtest=obj_new('OBJTEST')
 
 for k=5,6 do pc.add,ptr_new(indgen(k))
-	ptrall = ptr_valid()
-	ptrv = ptr_valid(1+indgen(3))
-	ptrpc = ptrall[indgen(3)]
+    ptrall = ptr_valid()
+    ptrv = ptr_valid(1+indgen(3))
+    ptrpc = ptrall[indgen(3)]
 for k=5,6 do oc.add,objtest
 
 if KEYWORD_SET(test) then STOP,' stop 0',ptrv
@@ -80,15 +78,15 @@ txt=' pointers contained in pc at ppall=PTRARR(2)'
 
 ; Our prototype structure:
 lifecycle = { name: "", status: "unused", class: "LIST", ref: fix(0)} 
-	ppall = pc.get(/all)
-	hash_ppref = hash("pc",heap_refcount(pc),"ppall=pc.get(/all)",heap_refcount(ppall))
+    ppall = pc.get(/all)
+    hash_ppref = hash("pc",heap_refcount(pc),"ppall=pc.get(/all)",heap_refcount(ppall))
 
-	hrppall = heap_refcount(ppall)
-	if keyword_set(verbose) then $
-		print,' heap_refcount of extracted pointers:',hrppall[0]
+    hrppall = heap_refcount(ppall)
+    if keyword_set(verbose) then $
+        print,' heap_refcount of extracted pointers:',hrppall[0]
 ;  Checkpoint:
-;	 ::add called for all three types. 
-;		get() called once for ALL pointers in pc.
+;    ::add called for all three types. 
+;       get() called once for ALL pointers in pc.
 
 txt=' pp1 = pc.get(posit=1)'
 
@@ -101,9 +99,9 @@ ppnew = pc.get(/all)
 if ~array_equal(heap_refcount(ppnew), heap_refcount(ppall)) then $
               MYMESS, nb_errors," ppnew=pc.get(/all) not right'
 
-	ptrall = ptr_valid()
-	ptrv = ptr_valid(1+indgen(3))
-	ptrpc = ptrall[indgen(3)]
+    ptrall = ptr_valid()
+    ptrv = ptr_valid(1+indgen(3))
+    ptrpc = ptrall[indgen(3)]
 pc.remove,pp1
 
 if ~array_equal(heap_refcount(ppnew), heap_refcount(ppall)) then $
@@ -113,7 +111,7 @@ if KEYWORD_SET(test) then STOP,' stop 1: testing ::GET(/ALL,POSITION)'
 ; 
 heap_free,ppall
 if keyword_set(verbose) then message,/continue,$
-	" pointers of PC are invalid but still retrievable pc.count()=",pc.count()
+    " pointers of PC are invalid but still retrievable pc.count()=",pc.count()
 
 txt = ' create 4 objects from compiled-in {OBJTEST} testobj OBJARR(4)'
 
@@ -123,12 +121,12 @@ for k=0,3 do testobj[k] = obj_new('OBJTEST')
 
 txt = ' just kill oc and restart it - too heavy for now.
 
-;	collect the lists in OC, and remove them
-	LOC = oc.get(isa='LIST',/all) & 	oc.remove,lc
+;   collect the lists in OC, and remove them
+    LOC = oc.get(isa='LIST',/all) &     oc.remove,lc
 ; Notice we have used ::GET and ::REMOVE methods
 
-	oc.add,pc		; add the pointer container (ppall, pp1)
-	oc.add,testobj[0]
+    oc.add,pc       ; add the pointer container (ppall, pp1)
+    oc.add,testobj[0]
 
 ; Our prototype structure:
 lifecycle = { name: "", ID: obj_new(), status: "unused", class: "LIST", ref: fix(0)} 
@@ -144,46 +142,44 @@ LOC[1]=testobj[0]
 ; LOC is OBJARR[2] containing two 'objtest' objects.
 ; lout is another list all by itself
 ; memorialize their status:
-	lchist = replicate(lifecycle,5)
-	lchist.name = ["lc0", "lc1", "loc[0]", "loc[1]", "lout"]
-	lchist.status = "BORN"
-	lchist[0:1].ref = heap_refcount([lc0,lc1])
-	lchist[2:3].ref = heap_refcount(loc)
-	lchist[4].ref = heap_refcount(lout)
-	lchist.ID = [lc0, lc1, loc, lout]
+    lchist = replicate(lifecycle,5)
+    lchist.name = ["lc0", "lc1", "loc[0]", "loc[1]", "lout"]
+    lchist.status = "BORN"
+    lchist[0:1].ref = heap_refcount([lc0,lc1])
+    lchist[2:3].ref = heap_refcount(loc)
+    lchist[4].ref = heap_refcount(lout)
+    lchist.ID = [lc0, lc1, loc, lout]
 if keyword_set(verbose) then $
-	print,format='(A8, 5(A6,4x),/,8x,10(4x,I6))',"  BORN",lchist.name,lchist.ref
-hrclc = heap_refcount(lc) 	; a list containing two lists.
-	oc.add,lc[0]
-	oc.add,testobj[1]
-	oc.add,lc[1]
-	oc.add,testobj[2]
+    print,format='(A8, 5(A6,4x),/,8x,10(4x,I6))',"  BORN",lchist.name,lchist.ref
+hrclc = heap_refcount(lc)   ; a list containing two lists.
+    oc.add,lc[0]
+    oc.add,testobj[1]
+    oc.add,lc[1]
+    oc.add,testobj[2]
 if heap_refcount(lc) ne hrclc then $
-	mymess, nb_errors," lc reference count was incremented incorrectly"
+    mymess, nb_errors," lc reference count was incremented incorrectly"
 ;
-	oc.add,list(["gdl1","gdl2"])
-	oc.add,testobj[3]
+    oc.add,list(["gdl1","gdl2"])
+    oc.add,testobj[3]
 
 txt = ' Container OC is stuffed. pc, {testobj}/{list}'
 
 ; lists are objects with overloaded bracket properties
 ;
 numoc = oc.count()
-	oc.add,lc & numoc++;
-	if oc.count() ne numoc then $  ;	Check it one last time.
-		MYMESS, nb_errors,' object container count is off'
-	if heap_refcount(lc)-hrclc ne 1 then $
-	mymess, nb_errors," lc reference count was not incremented correctly"
-	hrclccont = intarr(2)
-	for k=0,1 do hrclccont[k] = heap_refcount(lc[k])
+    oc.add,lc & numoc++;
+    if oc.count() ne numoc then $  ;    Check it one last time.
+        MYMESS, nb_errors,' object container count is off'
+    if heap_refcount(lc)-hrclc ne 1 then $
+    mymess, nb_errors," lc reference count was not incremented correctly"
+    hrclccont = intarr(2)
+    for k=0,1 do hrclccont[k] = heap_refcount(lc[k])
 ;
 ; take the two lists contained in LC and put them into an OBJARR(2)(=lca)
 lca = objarr(2) & lca[0] = lc[0] & lca[1]=lc[1]
-	oc.add,lca
-	if oc.count() ne numoc+2 then $
-		MYMESS, nb_errors,' object container count is off'
-;	if ~array_equal(heap_refcount(lca)-hrclccont,2) then $
-;		MYMESS, nb_errors," lca reference count was not incremented correctly"
+    oc.add,lca
+    if oc.count() ne numoc+2 then $
+        MYMESS, nb_errors,' object container count is off'
 
 octest=oc.get(/all,isa='OBJTEST')
 oclist = oc.get(/all,isa='LIST')
@@ -192,23 +188,15 @@ ocpc = oc.get(/all,isa='IDL_CONTAINER')
 if KEYWORD_SET(test) then STOP,' stop 2: '+txt
 ;
 ocall=oc.get(/all) & hrcoc=heap_refcount(ocall)
-	oc.remove,/all
-;	if ~array_equal(hrcoc - heap_refcount(ocall),1) then $
-;		 MYMESS, nb_errors, " refcount for removed objects didn't decrement correctly"
-	hrctest = heap_refcount(octest) & oc.add,octest
-	hrclist = heap_refcount(oclist) & oc.add,oclist
-	hrccont = heap_refcount(occont) & oc.add,occont
-;	if ~array_equal(heap_refcount(octest) - hrctest,1) then $
-;		 MYMESS, nb_errors, " refcount didn't decrement correctly (OCTEST)"
-;	if ~array_equal(heap_refcount(occont) - hrccont,1) then $
-;		 MYMESS, nb_errors, " refcount didn't decrement correctly (OCCONT)"
-;	if ~array_equal(heap_refcount(oclist) - hrclist,1) then $
-;		 MYMESS, nb_errors, " refcount didn't decrement correctly (OCLIST)"
+    oc.remove,/all
+    hrctest = heap_refcount(octest) & oc.add,octest
+    hrclist = heap_refcount(oclist) & oc.add,oclist
+    hrccont = heap_refcount(occont) & oc.add,occont
 
 txt = ' OC has beem unloaded (.remove,/all) and reloaded (octest, oclist, occont) '
 
 ocall=oc.get(/all)
-;			if ~is_compiled_in then oc.add,ocpc
+;           if ~is_compiled_in then oc.add,ocpc
 ;
 ;  try to stuff pointers into oc, generating an error:
 ;
@@ -216,11 +204,67 @@ catch, ocerr
 if ocerr ne 0 then $
   catch,/cancel $
   else $
-	oc.add,ppall	; error message "Mixed pointers/Objects attempted"
+    oc.add,ppall    ; error message "Mixed pointers/Objects attempted"
 if(ocerr eq 0) then MYMESS, nb_errors,' no error is an error' $
 else  if KEYWORD_SET(verbose) then print,!error_state.msg
 
 oc.remove,/all
+
+ocid = obj_valid(octest,/get_heap) & oc.add,octest
+ocid = [ocid,obj_valid(oclist,/get_heap)] & oc.add,oclist
+chk = obj_valid(oc.get(/all),/get_heap)
+if n_elements(chk) lt 5 then $
+        MYMESS, nb_errors,' testing CONTAINER::MOVE not enough room ...'
+if ~array_equal(chk, ocid) then $
+        MYMESS, nb_errors,' testing CONTAINER::MOVE not starting well ...'
+movea = [2,4] & moveb = [0,4]
+ltrack = list(chk,/extract)
+im = movea & oc.move,im[0],im[1] & ltrack.move,im[0],im[1]
+im = moveb & oc.move,im[0],im[1] & ltrack.move,im[0],im[1]
+listmove = ltrack.toarray()
+chk = obj_valid(oc.get(/all),/get_heap)
+if ~array_equal(chk, listmove) then $
+        MYMESS, nb_errors," testing CONTAINER::MOVE wasn't tracked by LIST::MOVE ..."
+p = IDL_Container()
+; Add pointers to 100 random numbers between 0 and 9.
+FOR i=0,99 DO p.Add, PTR_NEW(FIX(RANDOMU(seed)*10))
+ 
+; Locate which items are equal to the value 5.
+match = p.Equals(5)
+jj=WHERE(match,n5)
+if n5 eq 0 then $
+  MYMESS, nb_errors,' testing CONTAINER::EQUALS unlikely ...'
+;
+; reset p
+;
+p.remove,/all
+FOR i=0,99 DO p.Add, PTR_NEW(indgen(1+FIX(RANDOMU(seed)*10)))
+ndgen = indgen(1+FIX(RANDOMU(seed)*10))
+jj=where(p.equals(ndgen),n6)
+szchk = size(ndgen)
+for k=0,n6-1 do begin
+  if ~array_equal(szchk,size(*(p.get(position=jj[k]))) ) then $
+  MYMESS, nb_errors,' testing CONTAINER::EQUALS unlikely ...'
+  endfor
+; Now get an array of positions
+ppgen = p.get(position=jj-100)
+for k=0,n6-1 do begin
+  if ~array_equal(szchk,size(*ppgen[k]) ) then $
+  MYMESS, nb_errors,' testing CONTAINER::EQUALS unlikely ...'
+  endfor
+;
+; reset p
+;
+p.remove,/all
+FOR i=0,99 DO p.Add, PTR_NEW(indgen(1+FIX(RANDOMU(seed)*10)))
+ndgen = indgen(1+FIX(RANDOMU(seed)*10))
+jj=where(p.equals(ndgen),n6)
+for k=0,n6-1 do p.move,jj[k]-100,0
+jj=where(p.equals(ndgen),n6)
+itest = where(jj ne indgen(n6),n0)
+if n0 ne 0 then $
+  MYMESS, nb_errors,' testing CONTAINER::MOVE failed ...'
+
 ;
 
 if KEYWORD_SET(verbose) then print,' heap_refcount(oc):',heap_refcount(oc)
@@ -228,7 +272,7 @@ if KEYWORD_SET(verbose) then print,' heap_refcount(oc):',heap_refcount(oc)
 ;
 BANNER_FOR_TESTSUITE, 'TEST_CONTAINER', nb_errors, short=short
 ;
-;	if (nb_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;   if (nb_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
 ;
 if KEYWORD_SET(test) then STOP,' final stop'
 ;


### PR DESCRIPTION
container::Equals and :IsContained() didn't make it because of a typo in overload.
 Fix negative indeces access for container::get(position=jj).

test_container expanded to include ::get, ::move, and ::equals methods.

Greg Jung
gvjung@gmail.com