### PR TITLE
 Returning a double array fails in Python

### DIFF
--- a/src/topython.cpp
+++ b/src/topython.cpp
@@ -67,7 +67,7 @@ PyObject* Data_<Sp>::ToPython()
     // TODO: free the memory:  PyArray_Free(PyObject* op, void* ptr) ?
     throw GDLException("Failed to convert array to python.");
   }
-  memcpy(PyArray_DATA(ret), DataAddr(), this->N_Elements() * Data_<Sp>::Sizeof());
+  memcpy(PyArray_DATA(ret), DataAddr(), this->NBytes());
   return ret;
 }
 


### PR DESCRIPTION
(moved from https://sourceforge.net/p/gnudatalanguage/bugs/679/)
As reported on SF by @olebole:

When a GDL function returns a double array, everything after the the first half is set to some rubbish value:

$ cat arrays.py
import GDL
print 'float:', GDL.function('farr', 10)
print 'double:', GDL.function('darr', 10)
$ cat farr.pro
function FARR, n
return, findgen(n)
end
$ cat darr.pro
function DARR, n
return, dindgen(n)
end
$ python arrays.py
float:% Compiled module: FARR.
[ 0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]
double:% Compiled module: DARR.
[ 0.00000000e+000 1.00000000e+000 2.00000000e+000 3.00000000e+000
4.00000000e+000 3.51819867e+257 4.40039800e+199 1.42990123e+248
1.72636855e+243 6.92738351e-310]

This looks like that somewhere the wrong size is used to calc the return value.

The same actually happens for 64-bit integers.

I've made a patch for this. Issue caused by typo or incorrent use of sizeof()