### PR TITLE
Added support for tirpc as replacement for SunRPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,22 @@ else(GSL_FOUND)
         "(suitable Fedora package: gsl-devel)")
 endif(GSL_FOUND)
 
+# RPC MANDATORY
+# -DRPCDIR=DIR
+set(CMAKE_PREFIX_PATH ${RPCDIR})
+find_package(RPC QUIET)
+set(HAVE_RPC ${RPC_FOUND})
+if(RPC_FOUND)
+	set(LIBRARIES ${LIBRARIES} ${RPC_LIBRARIES})
+	include_directories(${RPC_INCLUDE_DIR})
+else(RPC_FOUND)
+	message(FATAL_ERROR "RPC support is mandatory.\n"
+	"Note that SunRPC has been removed in glibc-2.26 and later, "
+	"while being optional in earlier versions. Consider using the "
+	"recommended and more modern libtirpc instead.\n"
+	"Use -DRPCDIR=DIR to specify the rpc directory tree.\n")
+endif(RPC_FOUND)
+
 if(WIN32 AND NOT CYGWIN)
 set(CMAKE_PREFIX_PATH ${XDRDIR})
 find_package(Xdr)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,46 +356,44 @@ else(GSL_FOUND)
         "(suitable Fedora package: gsl-devel)")
 endif(GSL_FOUND)
 
-# RPC MANDATORY
-# -DRPCDIR=DIR
-set(CMAKE_PREFIX_PATH ${RPCDIR})
-find_package(RPC QUIET)
-set(HAVE_RPC ${RPC_FOUND})
-if(RPC_FOUND)
-	set(LIBRARIES ${LIBRARIES} ${RPC_LIBRARIES})
-	include_directories(${RPC_INCLUDE_DIR})
-else(RPC_FOUND)
-	message(FATAL_ERROR "RPC support is mandatory.\n"
-	"Note that SunRPC has been removed in glibc-2.26 and later, "
-	"while being optional in earlier versions. Consider using the "
-	"recommended and more modern libtirpc instead.\n"
-	"Use -DRPCDIR=DIR to specify the rpc directory tree.\n")
-endif(RPC_FOUND)
+if(UNIX)
+	set(CMAKE_PREFIX_PATH ${RPCDIR})
+	find_package(RPC QUIET)
+	set(HAVE_RPC ${RPC_FOUND})
+	if(RPC_FOUND)
+		set(LIBRARIES ${LIBRARIES} ${RPC_LIBRARIES})
+		include_directories(${RPC_INCLUDE_DIR})
+	else(RPC_FOUND)
+		message(FATAL_ERROR "RPC support is mandatory.\n"
+		"Note that SunRPC has been removed in glibc-2.26 and later, "
+		"while being optional in earlier versions. Consider using the "
+		"recommended and more modern libtirpc instead.\n"
+		"Use -DRPCDIR=DIR to specify the rpc directory tree.\n")
+	endif(RPC_FOUND)
+elseif (WIN32 AND NOT CYGWIN)
+	set(CMAKE_PREFIX_PATH ${XDRDIR})
+	find_package(Xdr)
+	set(HAVE_LIBXDR ${XDR_FOUND})
+	if(XDR_FOUND)
+		set(LIBRARIES ${LIBRARIES} ${XDR_LIBRARY})
+		include_directories(${XDR_INCLUDE_DIR})
+	else(XDR_FOUND)
+		message(FATAL_ERROR "bsd-xdr library is required but was not found.\n"
+		"Use -DXDRDIR=DIR to specify the bsd-xdr directory tree.")
+	endif(XDR_FOUND)
 
-if(WIN32 AND NOT CYGWIN)
-set(CMAKE_PREFIX_PATH ${XDRDIR})
-find_package(Xdr)
-set(HAVE_LIBXDR ${XDR_FOUND})
-if(XDR_FOUND)
-	set(LIBRARIES ${LIBRARIES} ${XDR_LIBRARY})
-	include_directories(${XDR_INCLUDE_DIR})
-else(XDR_FOUND)
-	message(FATAL_ERROR "bsd-xdr library is required but was not found.\n"
-	"Use -DXDRDIR=DIR to specify the bsd-xdr directory tree.")
-endif(XDR_FOUND)
-
-set(CMAKE_PREFIX_PATH ${PCREDIR})
-find_package(PCRE)
-set(HAVE_LIBPCRE ${PCRE_FOUND})
-if(PCRE_FOUND)
-	set(LIBRARIES ${LIBRARIES} ${PCRE_LIBRARIES})
-	include_directories(${PCRE_INCLUDE_DIR})
-else(PCRE_FOUND)
-	message(FATAL_ERROR "pcre library is required but was not found.\n"
-	"Use -DPCREDIR=DIR to specify the pcre directory tree.")
-endif(PCRE_FOUND)
-LINK_LIBRARIES(shlwapi)
-endif(WIN32 AND NOT CYGWIN)
+	set(CMAKE_PREFIX_PATH ${PCREDIR})
+	find_package(PCRE)
+	set(HAVE_LIBPCRE ${PCRE_FOUND})
+	if(PCRE_FOUND)
+		set(LIBRARIES ${LIBRARIES} ${PCRE_LIBRARIES})
+		include_directories(${PCRE_INCLUDE_DIR})
+	else(PCRE_FOUND)
+		message(FATAL_ERROR "pcre library is required but was not found.\n"
+		"Use -DPCREDIR=DIR to specify the pcre directory tree.")
+	endif(PCRE_FOUND)
+	LINK_LIBRARIES(shlwapi)
+endif()
 
 # PLplot MANDATORY
 # -DOLDPLPLOT=ON|OFF

--- a/CMakeModules/FindRPC.cmake
+++ b/CMakeModules/FindRPC.cmake
@@ -1,0 +1,14 @@
+
+include(FindPackageHandleStandardArgs)
+find_path(RPC_INCLUDE_DIR NAMES "rpc/rpc.h" PATH_SUFFIXES "tirpc")
+
+if(RPC_INCLUDE_DIR MATCHES "/tirpc/?$")
+	find_library(RPC_LIBRARY NAMES tirpc)
+	set(RPC_LIBRARIES ${RPC_LIBRARY})
+	find_package_handle_standard_args(RPC DEFAULT_MSG RPC_INCLUDE_DIR RPC_LIBRARY RPC_LIBRARIES)
+else()
+	find_package_handle_standard_args(RPC DEFAULT_MSG RPC_INCLUDE_DIR)
+endif()
+
+mark_as_advanced(RPC_INCLUDE_DIR RPC_LIBRARY RPC_LIBRARIES)
+


### PR DESCRIPTION
After updating glibc, GDL suddenly failed linking due to missing xdr references.  Apparently, SunRPC has been removed from glibc since version **2.26**, so newer systems should rely on **tirpc** instead ([reference](https://fedoraproject.org/wiki/Changes/SunRPCRemoval)). SunRPC is *optional* in earlier glibc so the more modern and potentially faster tirpc is preferable anyway.

This patch merely adds the tirpc directory as a prefix during path lookup in cmake, and tries to link the relevant library if found.

Am I the only one who had this problem?

Sure, it worked fine until yesterday since I compiled glibc with rpc built-in, and this might be the case for most distributions, but still it seems like tirpc is preferred. I do not have any Windows or OSX box to test this patch on, but I suppose the CI tests will catch any errors. This fixed the linking errors on my Gentoo system without SunRPC and still builds fine on both newer and older Ubuntus, as well as on Arch at least.