### PR TITLE
Enable save/restore of arrays of equivalent byte size > 2Gbytes (needs 64 bits internal pointers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@
 
 # tested with 2.4 and doesn't seem to run.
 # SA: 2.6 supports simplified if constructs, e.g. endif()
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
+cmake_policy(SET CMP0026 OLD) # LOCATION property
+set(CMAKE_CXX_STANDARD 98)
 
 project(GDL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,7 @@
 
 # tested with 2.4 and doesn't seem to run.
 # SA: 2.6 supports simplified if constructs, e.g. endif()
-cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
-cmake_policy(SET CMP0026 OLD) # LOCATION property
-set(CMAKE_CXX_STANDARD 98)
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 
 project(GDL)
 

--- a/src/saverestore.cpp
+++ b/src/saverestore.cpp
@@ -279,7 +279,6 @@ namespace lib {
     int32_t arrstart;
     int32_t UnknownLong;
     if (!xdr_int32_t(xdrs, &arrstart)) return NULL;
-    cerr<<arrstart<<endl;
     if (arrstart != 8 && arrstart !=18) //'10'o and '22'o
     {
       cerr << "array is not a array! abort." << endl;


### PR DESCRIPTION
Tested, works. Tests imply files > 2Go, not for the fait of heart. 