### PR TITLE
change to finite complex

### DIFF
--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -319,8 +319,8 @@ namespace lib {
 	  {
 	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
 	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())==0 && kwSign > 0) (*res)[i]=1;
-	   else if ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==1 && kwSign < 0) (*res)[i]=1;
-	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())==1 && kwSign < 0) (*res)[i]=1;	 
+	   else if ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())!=0 && kwSign < 0) (*res)[i]=1;
+	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())!=0 && kwSign < 0) (*res)[i]=1;	 
 	  }
      } 
      return res;


### PR DESCRIPTION
TEST_FINITE_BASIC, type=6,/tes failed on a Ubuntu 4.4.0-121-generic and on Debian 4.9.88-1+deb9u1
The failed tests seems to be related to signbit()==1
changing it to signbit()!=0 made the tests pass 
(signbit is supposed to return a boolean and both implementation should be the same in theory, but it is not the case)
I don't have more information about the issue