### PR TITLE
case no display in get_screen_size

### DIFF
--- a/src/devicewin.cpp
+++ b/src/devicewin.cpp
@@ -447,6 +447,7 @@ DIntGDL* 	DeviceWIN::GetScreenSize(char *disp)
 	MaxXYSize(&xsize, &ysize);
 	DIntGDL* res;
 	res = new DIntGDL(2, BaseGDL::NOZERO);
+    std::cout << ">>HERE<<" << std::endl
 	(*res)[0] = xsize;
 	(*res)[1] = ysize;
 	return res;

--- a/src/devicewin.cpp
+++ b/src/devicewin.cpp
@@ -447,7 +447,6 @@ DIntGDL* 	DeviceWIN::GetScreenSize(char *disp)
 	MaxXYSize(&xsize, &ysize);
 	DIntGDL* res;
 	res = new DIntGDL(2, BaseGDL::NOZERO);
-    std::cout << ">>HERE<<" << std::endl
 	(*res)[0] = xsize;
 	(*res)[1] = ysize;
 	return res;

--- a/src/devicex.hpp
+++ b/src/devicex.hpp
@@ -255,14 +255,18 @@ public:
   
     DIntGDL* GetScreenSize(char* disp) { 
       Display* display = XOpenDisplay(disp);
-      if (display == NULL) ThrowGDLException("Cannot connect to X server");
       int screen_num, screen_width, screen_height;
-      screen_num = DefaultScreen(display);
-      screen_width = DisplayWidth(display, screen_num);
-      screen_height = DisplayHeight(display, screen_num);
-      XCloseDisplay(display);
-
       DIntGDL* res;
+
+      if (display == NULL) {
+         screen_width = 0;
+         screen_height = 0;
+      } else {
+         screen_num = DefaultScreen(display);
+         screen_width = DisplayWidth(display, screen_num);
+         screen_height = DisplayHeight(display, screen_num);
+         XCloseDisplay(display);
+      }
       res = new DIntGDL(2, BaseGDL::NOZERO);
       (*res)[0]= screen_width;
       (*res)[1]= screen_height;

--- a/src/plotting_misc.cpp
+++ b/src/plotting_misc.cpp
@@ -222,10 +222,7 @@ void tvlct( EnvT* e ) {
     //GD: DO NOT NEVER EVER TOUCH THIS WITHOUT TRIPLE THINKING.
     //ANY CHANGE MUST BE IN GetScreenSize() and GetScreenResolution() for a DERIVED CLASS.
     SizeT nParam=e->NParam();
-    SizeT authorized_nb_params=0;
-#ifdef HAVE_X  
-    authorized_nb_params=1;
-#endif
+    SizeT authorized_nb_params=1;
     if ( nParam > authorized_nb_params) e->Throw( "Incorrect number of arguments.");
     char *TheDisplay=NULL;
     


### PR DESCRIPTION
When no display is found, get_screen_size return a [0, 0] array instead of throwing an exception