### PR TITLE
test_resolve_routine should work with files in the current dir. too !

### DIFF
--- a/testsuite/test_resolve_routine.pro
+++ b/testsuite/test_resolve_routine.pro
@@ -8,6 +8,14 @@
 ; an opportunity to test also that no bugs or typo introduced
 ; in the PRO files ! (two discovered in testsuite files when tested !)
 ;
+; ---------------------------------------
+; Modifications history :
+;
+; - 2018-JUL-10 : AC. not ok when more than one file :(
+;
+; ---------------------------------------
+; 
+;
 pro TEST_ALL_TEST_ROUTINES, cumul_errors, filter=filter, test=test
 ;
 errors=0
@@ -20,7 +28,7 @@ name='test_resolve_routine'
 info=ROUTINE_INFO(name,/source)
 path=STRMID(info.path, 0, STRLEN(info.path)-(STRLEN(name)+4))
 ;
-if (files EQ '') then files=FILE_SEARCH(path+path_sep()+filter)
+if (files[0] EQ '') then files=FILE_SEARCH(path+path_sep()+filter)
 ;
 ; we need to remove "TEST_RESOLVE_ROUTINE" in the list
 ;
@@ -54,6 +62,7 @@ endfor
 ;
 if (N_ELEMENTS(pbs) GT 1) then begin
    pbs=pbs[1:*]
+   BANNER_FOR_TESTSUITE, 'TEST_ALL_TEST_ROUTINES', 0, /line
    for jj=0, N_ELEMENTS(pbs)-1 do print, 'Problem in : ', pbs[jj]
    print, 'Due to problem, will skip next test.'
 endif else begin
@@ -61,7 +70,7 @@ endif else begin
    resolve_routine,files,/either
 endelse
 ;
-BANNER_FOR_TESTSUITE, 'TEST_ALL_TEST_ROUTINES', errors, /short
+BANNER_FOR_TESTSUITE, 'TEST_ALL_TEST_ROUTINES', errors, /status
 ;
 ERRORS_CUMUL, cumul_errors, errors
 ;


### PR DESCRIPTION
my initial change was OK when the current dir. does no contain files (then we change the dir)
but it should also work when the current dir. does contain files !

NB: this code can be easily used to compile large set of *pro files (eg : idlastro, coyote & mpfit
packages !) calling : 

GDL> .r test_resolve_routine.pro
GDL> TEST_ALL_TEST_ROUTINES, filter='*pro'