### PR TITLE
Added libgeotiff subdir used in some distros

### DIFF
--- a/CMakeModules/FindGeoTIFF.cmake
+++ b/CMakeModules/FindGeoTIFF.cmake
@@ -2,7 +2,7 @@
 # -----------
 # Find the GeoTIFF library (libgeotiff)
 
-find_path(GEOTIFF_INCLUDE_DIR geotiff.h PATH_SUFFIXES geotiff)
+find_path(GEOTIFF_INCLUDE_DIR geotiff.h PATH_SUFFIXES geotiff libgeotiff)
 find_library(GEOTIFF_LIBRARY NAMES geotiff libgeotiff)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GeoTIFF DEFAULT_MSG GEOTIFF_INCLUDE_DIR GEOTIFF_LIBRARY)


### PR DESCRIPTION
As reported by @opoplawski, in some distributions libgeotiff is found under the libgeotiff sub-directory.