### PR TITLE
WIP: adding IMPLIED_PRINT

### DIFF
--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -136,6 +136,11 @@ std::ostream& BaseGDL::ToStream(std::ostream& o, SizeT width,
 {
   throw GDLException("BaseGDL::ToStream(...) called.");
 }
+std::ostream& BaseGDL::ToStreamImplied(std::ostream& o, SizeT width, 
+				SizeT* actPosPtr )
+{
+  throw GDLException("BaseGDL::ToStreamImplied(...) called.");
+}
 std::istream& BaseGDL::FromStream(std::istream& i)
 {
   i >> *this;

--- a/src/basegdl.hpp
+++ b/src/basegdl.hpp
@@ -508,6 +508,8 @@ public:
 
   virtual std::ostream& ToStream(std::ostream& o, SizeT width = 0, 
 			    SizeT* actPosPtr = NULL);
+  virtual std::ostream& ToStreamImplied(std::ostream& o, SizeT width = 0, 
+			    SizeT* actPosPtr = NULL);
   virtual std::istream& FromStream(std::istream& i);
 
   virtual bool Greater(SizeT i1, SizeT i2) const; // comp 2 elements

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -204,6 +204,8 @@ static	void operator delete( void *ptr);
 
   std::ostream& ToStream(std::ostream& o, SizeT width = 0, 
 			 SizeT* actPosPtr = NULL);
+  std::ostream& ToStreamImplied(std::ostream& o, SizeT width = 0, 
+			 SizeT* actPosPtr = NULL);
   std::istream& FromStream(std::istream& i);
  
   // used by the interpreter

--- a/src/default_io.cpp
+++ b/src/default_io.cpp
@@ -1016,7 +1016,7 @@ template<>
 ostream& Data_<SpDDouble>::ToStream(ostream& o, SizeT w, SizeT* actPosPtr) 
 {
   const int prec = 8;
-  const int width = 15;
+  const int width = 16;
 
   SizeT nElem=N_Elements();
   if( nElem == 0)

--- a/src/default_io.cpp
+++ b/src/default_io.cpp
@@ -1016,7 +1016,7 @@ template<>
 ostream& Data_<SpDDouble>::ToStream(ostream& o, SizeT w, SizeT* actPosPtr) 
 {
   const int prec = 8;
-  const int width = 16;
+  const int width = 15;
 
   SizeT nElem=N_Elements();
   if( nElem == 0)
@@ -1334,13 +1334,14 @@ ostream& DStructGDL::ToStream(ostream& o, SizeT w, SizeT* actPosPtr)
 	  if( actEl->Type() == GDL_STRING)
 	    o << CheckNL( w, actPosPtr, 1) << " ";
 	    
+      o << std::endl <<this->Desc()->TagName(tIx);
 	  bool isArr = (actEl->Dim().Rank() != 0);
 
 	  if( isArr && arrOut && *actPosPtr != 0)
 	    InsNL( o, actPosPtr);
 
 	  actEl->ToStream( o, w, actPosPtr);
-	  
+
 	  if( isArr)
 	    {
 	      arrOut = true;
@@ -1357,6 +1358,7 @@ ostream& DStructGDL::ToStream(ostream& o, SizeT w, SizeT* actPosPtr)
       if( actEl->Type() == GDL_STRING)
 	o << CheckNL( w, actPosPtr, 1) << " ";
       
+      o << std::endl << this->Desc()->TagName(nTags-1);
       actEl->ToStream( o, w, actPosPtr);
 
       o << CheckNL( w, actPosPtr, 1) << "}";
@@ -1388,6 +1390,796 @@ ostream& DStructGDL::ToStreamRaw( ostream& o) {
   }
   return o;
 }
+
+// the default output functions for IMPLIED_PRINT
+template<class Sp> 
+ostream& Data_<Sp>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 8) << setw(8) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem / this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 8) << setw(8) << (*this)[eIx++];
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 8) << setw(8) << (*this)[eIx++];
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// Long
+template<> 
+ostream& Data_<SpDLong>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem / this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[eIx++];
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[eIx++];
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// ULong
+template<> 
+ostream& Data_<SpDULong>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[eIx++];
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 12) << setw(12) << (*this)[eIx++];
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// Long64
+template<> 
+ostream& Data_<SpDLong64>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[eIx++];
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[eIx++];
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// ULong64
+template<> 
+ostream& Data_<SpDULong64>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[eIx++];
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 22) << setw(22) << (*this)[eIx++];
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+template<> 
+ostream& Data_<SpDPtr>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << left;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 15);
+      HeapVarString( o, (*this)[0]);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	  {
+	    o << CheckNL( w, actPosPtr, 15);
+	    HeapVarString( o, (*this)[eIx++]);
+	  }
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+      {
+	o << CheckNL( w, actPosPtr, 15);
+	HeapVarString( o, (*this)[eIx++]);
+      }
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+template<> 
+ostream& Data_<SpDObj>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  static bool recursive = false;
+  if( this->StrictScalar() && !recursive)
+  {
+    DObj s = dd[0]; // is StrictScalar()
+    if( s != 0)  // no overloads for null object
+    {
+      DStructGDL* oStructGDL= GDLInterpreter::GetObjHeapNoThrow( s);
+      if( oStructGDL != NULL) // if object not valid -> default behaviour
+      {  
+	DStructDesc* desc = oStructGDL->Desc();
+
+	if( desc->IsParent("LIST"))
+	{
+	  recursive = true;
+	  try{
+	    LIST__ToStream(oStructGDL,o,w,actPosPtr);
+	    recursive = false;
+	  } catch( ...)
+	  {
+	    recursive = false;
+	    throw;
+	  }
+	  
+	  return o;
+	}
+	if( desc->IsParent("HASH"))
+	{
+	  recursive = true;
+	  try{
+	    HASH__ToStream(oStructGDL,o,w,actPosPtr);
+	    recursive = false;
+	  } catch( ...)
+	  {
+	    recursive = false;
+	    throw;
+	  }
+	  
+	  return o;
+	}
+      }
+    }
+  }
+
+  SizeT nElem=this->Size();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << left;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 15);
+      ObjHeapVarString( o, (*this)[0]);
+//       o << CheckNL( w, actPosPtr, 15) << "<ObjHeapVar" << (*this)[0] << ">";
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	  {
+	    o << CheckNL( w, actPosPtr, 15);
+	    ObjHeapVarString( o, (*this)[eIx++]);
+// 	    o << CheckNL( w, actPosPtr, 15) << "<ObjHeapVar" << (*this)[eIx++] << ">";
+	  }
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+      {
+	o << CheckNL( w, actPosPtr, 15);
+	ObjHeapVarString( o, (*this)[eIx++]);
+// 	o << CheckNL( w, actPosPtr, 15) << "<ObjHeapVar" << (*this)[eIx++] << ">";
+      }
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+// float
+template<> 
+ostream& Data_<SpDFloat>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  const int prec = 8;
+  const int width = 16;
+
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, width); 
+      OutAuto( o, (*this)[0], width, prec, 0);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    {
+	      o << CheckNL( w, actPosPtr, width);
+	      OutAuto( o, (*this)[eIx++], width, prec, 0);
+	    }
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	{
+	  o << CheckNL( w, actPosPtr, width); 
+	  OutAuto( o, (*this)[eIx++], width, prec, 0);
+	}
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+// double
+template<> 
+ostream& Data_<SpDDouble>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  const int prec = 16;
+  const int width = 25;
+
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, width); 
+      OutAuto( o, (*this)[0], width, prec, 0);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    {
+	      o << CheckNL( w, actPosPtr, width); 
+	      OutAuto( o, (*this)[eIx++], width, prec, 0);
+	    }
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	{
+	  o << CheckNL( w, actPosPtr, width); 
+	  OutAuto( o, (*this)[eIx++], width, prec, 0);
+	}
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+template<> 
+ostream& Data_<SpDComplex>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  const int prec = 6;
+  const int width = 13;
+  const char fill = ' ';
+
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplex>( (*this)[0], width, prec, fill);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplex>( (*this)[eIx++], width, prec, fill);
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplex>( (*this)[eIx++], width, prec, fill);
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+template<> 
+ostream& Data_<SpDComplexDbl>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  const int prec = 8;
+  const int width = 16;
+  const char fill = ' ';
+
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplexDbl>( (*this)[0], width, prec, fill);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplexDbl>( (*this)[eIx++], width, prec, fill);
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, 2*width+3) << AsComplex< DComplexDbl>( (*this)[eIx++], width, prec, fill);
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// byte (c++ does output as characters)
+template<> 
+ostream& Data_<SpDByte>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  const int width = 4;
+
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << right;
+
+  if( this->dim.Rank() == 0)
+    {
+      o << CheckNL( w, actPosPtr, width) << setw(width) << static_cast<int>((*this)[0]);
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=0; i1<d1; i1++)
+	{
+	  for( SizeT i0=0; i0<d0; i0++)
+	    o << CheckNL( w, actPosPtr, width) << setw(width) << static_cast<int>((*this)[eIx++]);
+	  InsNL( o, actPosPtr);
+	}
+      InsNL( o, actPosPtr);
+    }
+
+  // last block (no '\n' at the end)
+  for( SizeT i1=0; i1<d1; i1++)
+    {
+      for( SizeT i0=0; i0<d0; i0++)
+	o << CheckNL( w, actPosPtr, width) << setw(width) << static_cast<int>((*this)[eIx++]);
+      //      if( (i1+1) < d1) InsNL( o, actPosPtr);
+      InsNL( o, actPosPtr);
+    }
+  return o;
+}
+
+// strings
+template<> 
+ostream& Data_<SpDString>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  bool someCharacterSeen=false;
+  SizeT nElem=N_Elements();
+  if( nElem == 0)
+    throw GDLException("Variable is undefined.");
+
+  o << left;
+
+  SizeT length;
+  if( this->dim.Rank() == 0)
+    {
+      length = (*this)[0].length();
+      o << CheckNL( w, actPosPtr, length) << (*this)[0];
+      return o;
+    }
+
+  SizeT nLoop=nElem/this->dim.Stride(2);
+  SizeT eIx=0; // linear counter
+  SizeT d0=this->Dim(0); 
+  SizeT d1=this->Dim(1);
+
+  // d0 cannot be 0
+  if( d1 == 0) d1 = 1;
+
+  for( SizeT l=1; l<nLoop; l++)
+    {
+      for( SizeT i1=1; i1<d1; i1++)
+	{
+	  for( SizeT i0=1; i0<d0; i0++)
+	    {
+	      length = (*this)[eIx].length() + 1;
+	      if( length > 1)
+		o << CheckNL( w, actPosPtr, length) << (*this)[eIx++] << " ";
+	      else eIx++;
+	    }
+	  length = (*this)[eIx].length();
+	  if( length > 0)
+	    o << CheckNL( w, actPosPtr, length) << (*this)[eIx++]; 
+	  else eIx++;
+	  InsNL( o, actPosPtr);
+	}
+
+      for( SizeT i0=1; i0<d0; i0++)
+	{
+	  length = (*this)[eIx].length() + 1;
+	  if( length > 1)
+	    o << CheckNL( w, actPosPtr, length) << (*this)[eIx++] << " ";
+	  else eIx++;
+	}
+      length = (*this)[eIx].length();
+      if( length > 0)
+		o << CheckNL( w, actPosPtr, length) << (*this)[eIx++]; 
+      else eIx++;
+      InsNL( o, actPosPtr);
+      
+      InsNL( o, actPosPtr);
+    }
+
+  for ( SizeT i1 = 1; i1 < d1; i1++ ) {
+    someCharacterSeen=false;
+    for ( SizeT i0 = 1; i0 < d0; i0++ ) {
+	  length = (*this)[eIx].length() + 1;
+      if( length > 1)  someCharacterSeen=true;
+      // for array output a space should be inserted e.g. a=strarr(9)&a[8]=':'&a[0]='>'&aa=[[a],[a]]&print,aa
+      // actually, blanks are inserted only between the first non-null character and the last non-null character. 
+      //see a=strarr(9)&a[6]=':'&a[1]='>'&aa=[[a],[a]]&print,aa
+      if (someCharacterSeen) o << CheckNL( w, actPosPtr, length ) << (*this)[eIx++] << " ";
+      else eIx++;
+	}
+      length = (*this)[eIx].length();
+      if( length > 0)
+		o << CheckNL( w, actPosPtr, length) << (*this)[eIx++]; 
+      else eIx++;
+      InsNL( o, actPosPtr);
+    }
+  someCharacterSeen=false;
+  for ( SizeT i0 = 1; i0 < d0; i0++ ) {
+      length = (*this)[eIx].length() + 1;
+    // for array output a space should be inserted e.g. a=strarr(9)&a[8]=':'&a[0]='>'&aa=[[a],[a]]&print,aa
+    // actually, blanks are inserted only between the first non-null character and the last non-null character. 
+    //see a=strarr(9)&a[6]=':'&a[1]='>'&aa=[[a],[a]]&print,aa
+    if( length > 1)  someCharacterSeen=true;
+    if (someCharacterSeen) o << CheckNL( w, actPosPtr, length ) << (*this)[eIx++] << " ";
+    else eIx++;
+    }
+  length = (*this)[eIx].length();
+  if( length > 0)
+    o << CheckNL( w, actPosPtr, length) << (*this)[eIx++];
+  else eIx++;
+  InsNL( o, actPosPtr);
+  
+  return o;
+}
+
+ostream& DStructGDL::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
+{
+  // avoid checking actPosPtr
+  SizeT dummyPos = 0;
+  if( actPosPtr == NULL) actPosPtr = &dummyPos;
+
+  SizeT nTags = NTags();
+  SizeT nEl   = N_Elements();
+  
+  bool arrOut = false; // remember if an array was already put out
+
+  for( SizeT e=0; e<nEl; ++e)
+    {
+      o << CheckNL( w, actPosPtr, 2) << "{";
+      for( SizeT tIx=0; tIx<nTags-1; ++tIx)
+	{
+	  BaseGDL* actEl = GetTag( tIx, e);
+
+	  assert( actEl != NULL);
+// 	  if( actEl == NULL)
+// 	    throw 
+// 	      GDLException("Internal error: Output of UNDEF struct element.");
+	  if( actEl->Type() == GDL_STRING)
+	    o << CheckNL( w, actPosPtr, 1) << " ";
+	    
+      o << std::endl <<this->Desc()->TagName(tIx);
+	  bool isArr = (actEl->Dim().Rank() != 0);
+
+	  if( isArr && arrOut && *actPosPtr != 0)
+	    InsNL( o, actPosPtr);
+
+	  actEl->ToStream( o, w, actPosPtr);
+
+	  if( isArr)
+	    {
+	      arrOut = true;
+	      if( *actPosPtr != 0)
+		InsNL( o, actPosPtr);
+	    }
+	}
+
+      BaseGDL* actEl = GetTag( nTags-1, e);
+      assert( actEl != NULL);
+//    if( actEl == NULL)
+//      throw 
+//        GDLException("Internal error: Output of UNDEF struct element.");
+      if( actEl->Type() == GDL_STRING)
+	o << CheckNL( w, actPosPtr, 1) << " ";
+      
+      o << std::endl << this->Desc()->TagName(nTags-1);
+      actEl->ToStream( o, w, actPosPtr);
+
+      o << CheckNL( w, actPosPtr, 1) << "}";
+    }
+  return o;
+}
+
 //this is the routined used by IDL as per the documentation.
 bool_t xdr_complex( XDR *xdrs, DComplex *p)  
 { 

--- a/src/default_io.cpp
+++ b/src/default_io.cpp
@@ -1829,7 +1829,7 @@ ostream& Data_<SpDFloat>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr)
 template<> 
 ostream& Data_<SpDDouble>::ToStreamImplied(ostream& o, SizeT w, SizeT* actPosPtr) 
 {
-  const int prec = 16;
+  const int prec = 17;
   const int width = 25;
 
   SizeT nElem=N_Elements();

--- a/src/dstructgdl.hpp
+++ b/src/dstructgdl.hpp
@@ -419,6 +419,7 @@ public:
   friend std::istream& operator>>(std::istream& i, DStructGDL& data_);
   
   std::ostream& ToStream(std::ostream& o, SizeT width = 0, SizeT* actPosPtr = NULL);
+  std::ostream& ToStreamImplied(std::ostream& o, SizeT width = 0, SizeT* actPosPtr = NULL);
   //  std::ostream& ToStream(std::ostream& o)
   //  { o << *this; return o;}
   std::ostream& ToStreamRaw(std::ostream& o);

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -174,12 +174,14 @@ namespace lib {
       catch ( antlr::ANTLRException& ex)  {
 	    e->Throw( ex.getMessage());
        }
+;
 	  }
 	}
       }
     //else // default-format output. can be implied print (to be written: FIXME)
       {
 	int nParam = e->NParam();
+	int IMPLIED = e->KeywordIx("IMPLIED_PRINT");
 
 	if( nParam == parOffset) 
 	  {
@@ -203,7 +205,10 @@ namespace lib {
 	      e->Throw("Variable is undefined: "+e->GetParString( i));
             if (lastParScalar && anyArrayBefore && par->Rank() != 0) (*os) << endl; // e.g. print,[1],1,[1] 
             anyArrayBefore |= par->Rank() != 0;
-	    par->ToStream( *os, width, &actPos);
+		if (e->GetKW(IMPLIED))
+	    	par->ToStreamImplied( *os, width, &actPos);
+		else
+	    	par->ToStream( *os, width, &actPos);
 // debug	  
 // 		(*os) << flush;
 	  }

--- a/src/specializations.hpp
+++ b/src/specializations.hpp
@@ -534,6 +534,26 @@ template<>
 std::ostream& Data_<SpDByte>::ToStream(std::ostream& o, SizeT w, SizeT* actPosPtr); 
 template<>  
 std::ostream& Data_<SpDString>::ToStream(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDLong>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDULong>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDPtr>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDObj>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDFloat>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDDouble>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDComplex>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDComplexDbl>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDByte>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
+template<>  
+std::ostream& Data_<SpDString>::ToStreamImplied(std::ostream& o, SizeT w, SizeT* actPosPtr); 
 template<> 
 std::ostream& Data_<SpDString>::Write( std::ostream& os, bool swapEndian, 
 				       bool compress, XDR *xdrs);


### PR DESCRIPTION
I'm currently trying to implement the IMPLIED_PRINT (see http://www.harrisgeospatial.com/docs/ImpliedPrint.html)

I don't really know what is the "cleanest" way to implement it.
I implemented the IMPLIED_PRINT behavior for Float and Double in this PR :
```
GDL> print, !dpi
       3.1415927
GDL> !dpi
       3.1415926535897931
GDL> print, 3.1
      3.10000
GDL> 3.1
       3.0999999

IDL> print, !dpi
       3.1415927
IDL> !dpi
       3.1415926535897931
IDL> print, 3.1
      3.10000
IDL> 3.1
       3.0999999
```

Some variables, such as the Structures are more complex to implement and I had some questions about the way I should implement the IMPLIED_PRINT option.

Note that the print function use  ToStream() to format and print a variable, and the ToStream() parameters do not have the EnvT* e variable in it.

1) Adding a ToStreamImplied function for every type :
    It adds a lot of lines in the default_io file, and in some cases (Float and Double for exemple) it adds a lot of duplicate code. (This is what I did in this PR)
2) Adding the Envt *e variable in ToStream prototype :
    It adds an arg to ToStream but we will have less duplicate code in some functions. It might also complexifie some cases (Such as structure) with some special cases added.
3) Adding binary flags, which kinda act like adding the Envt *e, but it also add some const var, and it's never good adding too many

Feel free to askquestions and to discuss the implementention ideas :)