### PR TITLE
libtiff implementation improvements

### DIFF
--- a/src/dstructfactory.cxx
+++ b/src/dstructfactory.cxx
@@ -30,6 +30,9 @@ DStructFactory::~DStructFactory()
 
 DStructGDL* DStructFactory::Create()
 {
+    if(vals_.empty())
+        return nullptr;
+
     auto res = new DStructGDL(desc_, dimension());
     for(auto& pair : vals_) {
         res->InitTag(pair.first, *pair.second);

--- a/src/tiff.cxx
+++ b/src/tiff.cxx
@@ -240,7 +240,9 @@ namespace lib
                 auto img = static_cast<T*>(image);
                 auto ptr = reinterpret_cast<typename T::Ty*>(img->DataAddr());
                 auto dim = img->Dim();
-                memcpy(ptr + (y * dim[0] + x), buf, bytes);
+                auto w = dim[dim.Rank() - 2];
+                auto c = dim.Rank() > 2 ? dim[0] : 1;
+                memcpy(ptr + (y * w + x) * c, buf, bytes);
             };
         }
 
@@ -276,7 +278,7 @@ namespace lib
             }
 
             char *buffer = nullptr, *start;
-            ptrdiff_t sampOff = (dir.samplesPerPixel * (dir.bitsPerSample >= 8 ? (dir.bitsPerSample / 8) : 1));
+            ptrdiff_t sampOff = (c * (dir.bitsPerSample >= 8 ? (dir.bitsPerSample / 8) : 1));
 
             // Scanline-based images
             if(!TIFFIsTiled(tiff_)) {

--- a/src/tiff.cxx
+++ b/src/tiff.cxx
@@ -343,7 +343,7 @@ namespace lib
         }
 
         #ifdef USE_GEOTIFF
-        DStructGDL* Handler::CreateGeoStruct(tdir_t index) const
+        BaseGDL* Handler::CreateGeoStructOrZero(tdir_t index) const
         {
             if(!tiff_ || !TIFFSetDirectory(tiff_, index))
                 return nullptr;
@@ -451,7 +451,10 @@ namespace lib
             if(GetGeoKey(VerticalUnitsGeoKey, gk))
                 gtif.Add<DIntGDL>("VERTICALUNITSGEOKEY", *gk.value.i);
 
-            return gtif.Create();
+            if(auto geoStruct = gtif.Create())
+	        return geoStruct;
+
+            return new DLongGDL(0);
         }
 
         bool Handler::GetGeoKey(geokey_t key, GeoKey& res) const
@@ -538,7 +541,7 @@ namespace lib
             #ifdef USE_GEOTIFF
             static int gtifIx = e->KeywordIx("GEOTIFF");
             if(e->KeywordPresent(gtifIx)) {
-                e->SetKW(gtifIx, tiff.CreateGeoStruct(imageIndex));
+                e->SetKW(gtifIx, tiff.CreateGeoStructOrZero(imageIndex));
             }
             #endif
 
@@ -651,7 +654,7 @@ namespace lib
             #ifdef USE_GEOTIFF
             static int gtifIx = e->KeywordIx("GEOTIFF");
             if(e->KeywordPresent(gtifIx)) {
-                e->SetKW(gtifIx, tiff.CreateGeoStruct(imageIndex));
+                e->SetKW(gtifIx, tiff.CreateGeoStructOrZero(imageIndex));
             }
             #endif
 

--- a/src/tiff.hxx
+++ b/src/tiff.hxx
@@ -182,7 +182,7 @@ namespace lib
             }
 
             #ifdef USE_GEOTIFF
-            DStructGDL* CreateGeoStruct(tdir_t) const;
+            BaseGDL*    CreateGeoStructOrZero(tdir_t) const;
             bool        GetGeoKey(geokey_t, GeoKey&) const;
             #endif
 


### PR DESCRIPTION
Dereferencing the geotiff structure returned from QUERY_TIFF/READ_TIFF used on non-geotagged TIFF images resulted in a segfault because of empty values. This patch fixes this problem by returning a scalar zero instead of an empty structure, similar to IDL:

>  If no GeoTIFF information is present in the file, the returned variable is set to a scalar zero.

Also, the colour and orientation problem mentioned in https://github.com/gnudatalanguage/gdl/pull/375#issuecomment-398881741 should now be fixed.
