### PR TITLE
add basic_benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ cmake_policy(SET CMP0026 OLD) # LOCATION property
 project(GDL)
 set(CMAKE_CXX_STANDARD 11)
 
+# advice by Orion, mandatory for FC 28
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # X.X.X git becomes release X.X.X+1
 set(VERSION "0.9.8 git")
 enable_testing()

--- a/src/initsysvar.cpp
+++ b/src/initsysvar.cpp
@@ -699,53 +699,55 @@ namespace SysVar
     DStructGDL*  ver = new DStructGDL( "!VERSION");
 #ifdef _WIN32
 #ifdef __MINGW32__
-	typedef void (WINAPI *GetNativeSystemInfoFunc)(LPSYSTEM_INFO);
-	HMODULE hModule = LoadLibraryW(L"kernel32.dll");
-	GetNativeSystemInfoFunc GetNativeSystemInfo =(GetNativeSystemInfoFunc) 
-            GetProcAddress(hModule, "GetNativeSystemInfo");
+    typedef void (WINAPI *GetNativeSystemInfoFunc)(LPSYSTEM_INFO);
+    HMODULE hModule = LoadLibraryW(L"kernel32.dll");
+    GetNativeSystemInfoFunc GetNativeSystemInfo =(GetNativeSystemInfoFunc) 
+      GetProcAddress(hModule, "GetNativeSystemInfo");
 #endif
-	const char* SysName = "Windows";
-	SYSTEM_INFO stInfo;
-	GetNativeSystemInfo( &stInfo );
-	DStringGDL *arch;
-	switch(stInfo.wProcessorArchitecture) {
-	case PROCESSOR_ARCHITECTURE_AMD64:
-		arch = new DStringGDL("x64");
-		break;
-	case PROCESSOR_ARCHITECTURE_INTEL:
-		arch = new DStringGDL("x86");
-		break;
-	case PROCESSOR_ARCHITECTURE_ARM:
-		arch = new DStringGDL("ARM");
-		break;
-	default:
-		arch = new DStringGDL("unknown");
-	}
-	ver->NewTag("ARCH", arch); 
-    ver->NewTag("OS", new DStringGDL(SysName));    
-    ver->NewTag("OS_FAMILY", new DStringGDL(SysName)); 
-    ver->NewTag("OS_NAME", new DStringGDL(SysName)); 
+    const char* SysName = "Windows";
+    SYSTEM_INFO stInfo;
+    GetNativeSystemInfo( &stInfo );
+    DStringGDL *arch;
+    switch(stInfo.wProcessorArchitecture) {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+      arch = new DStringGDL("x64");
+      break;
+    case PROCESSOR_ARCHITECTURE_INTEL:
+      arch = new DStringGDL("x86");
+      break;
+    case PROCESSOR_ARCHITECTURE_ARM:
+      arch = new DStringGDL("ARM");
+      break;
+    default:
+      arch = new DStringGDL("unknown");
+    }
+    ver->NewTag("ARCH", arch); 
+    ver->NewTag("OS", new DStringGDL(SysName));
+    ver->NewTag("OS_FAMILY", new DStringGDL(SysName));
+    ver->NewTag("OS_NAME", new DStringGDL(SysName));
 #else
     struct utsname uts;
     uname(&uts);
-    ver->NewTag("ARCH", new DStringGDL( uts.machine)); 
+    ver->NewTag("ARCH", new DStringGDL( uts.machine));
     const char *SysName=uts.sysname;
     if (strcmp(SysName,"Linux") ==0) SysName="linux";
     if (strcmp(SysName,"Darwin") ==0) SysName="darwin";
     ver->NewTag("OS", new DStringGDL(SysName));    //correct IDL order
-    ver->NewTag("OS_FAMILY", new DStringGDL( "unix")); 
-    ver->NewTag("OS_NAME", new DStringGDL(SysName)); 
+    ver->NewTag("OS_FAMILY", new DStringGDL( "unix"));
+    // AC 2018-sep-07
+    if (strcmp(SysName,"darwin") ==0) SysName="Mac OS X";
+    ver->NewTag("OS_NAME", new DStringGDL(SysName));
 #endif
 
     ver->NewTag("RELEASE", new DStringGDL( "8.2")); //we are at least 6.4
-    ver->NewTag("BUILD_DATE", new DStringGDL(BUILD_DATE)); 
-    ver->NewTag("MEMORY_BITS", new DIntGDL( sizeof(BaseGDL*)*8)); 
-    ver->NewTag("FILE_OFFSET_BITS", new DIntGDL( sizeof(SizeT)*8)); 
+    ver->NewTag("BUILD_DATE", new DStringGDL(BUILD_DATE));
+    ver->NewTag("MEMORY_BITS", new DIntGDL( sizeof(BaseGDL*)*8));
+    ver->NewTag("FILE_OFFSET_BITS", new DIntGDL( sizeof(SizeT)*8));
     DVar *v            = new DVar( "VERSION", ver);
     vIx                = sysVarList.size();
     sysVarList.push_back(v);
     sysVarRdOnlyList.push_back(v);
-    
+
     // !Mouse
     DStructGDL*  MouseData = new DStructGDL( "!MOUSE");
     MouseData->NewTag("X", new DLongGDL( 0));
@@ -768,14 +770,14 @@ namespace SysVar
 
     // !ERROR_STATE
     DStructGDL*  eStateData = new DStructGDL( "!ERROR_STATE");
-    eStateData->NewTag("NAME", new DStringGDL( "IDL_M_SUCCESS")); 
-    eStateData->NewTag("BLOCK", new DStringGDL( "IDL_MBLK_CORE")); 
-    eStateData->NewTag("CODE", new DLongGDL( 0)); 
+    eStateData->NewTag("NAME", new DStringGDL( "IDL_M_SUCCESS"));
+    eStateData->NewTag("BLOCK", new DStringGDL( "IDL_MBLK_CORE"));
+    eStateData->NewTag("CODE", new DLongGDL( 0));
     eStateData->NewTag("SYS_CODE", new DLongGDL( dimension( &dim2,one))); //idl 8
-    eStateData->NewTag("SYS_CODE_TYPE", new DStringGDL( "")); 
-    eStateData->NewTag("MSG", new DStringGDL( "")); 
-    eStateData->NewTag("SYS_MSG", new DStringGDL( "")); 
-    eStateData->NewTag("MSG_PREFIX", new DStringGDL( "% ")); 
+    eStateData->NewTag("SYS_CODE_TYPE", new DStringGDL( ""));
+    eStateData->NewTag("MSG", new DStringGDL( ""));
+    eStateData->NewTag("SYS_MSG", new DStringGDL( ""));
+    eStateData->NewTag("MSG_PREFIX", new DStringGDL( "% "));
     DVar *eState       = new DVar( "ERROR_STATE", eStateData);
     errorStateIx       = sysVarList.size();
     sysVarList.push_back(eState);

--- a/src/pro/utilities/color2color.pro
+++ b/src/pro/utilities/color2color.pro
@@ -1,0 +1,36 @@
+;
+; Alain C., 31 Aout 2017, at JSC during Harvey
+;
+; Goal : an easy way to use new !color fiels in classic plotting world 
+; plot, findgen(10), color=COLOR2COLOR(!color.red)
+;
+; bilateral conversion between :
+; hexidecimal 24-bit RGB color specification
+; and 3-byte !color specification (BYTE = Array[3])
+;
+; How to test :
+; 1: print, COLOR2COLOR(COLOR2COLOR(1193046))
+; 2: print, COLOR2COLOR(COLOR2COLOR(byte([12,34,56])))
+;
+function COLOR2COLOR, color_in, quiet=quiet, $
+                      help=help, test=test, verbose=verbose
+;
+; conversion from !color.field into 
+;
+if ARRAY_EQUAL(SIZE(color_in), [1,3,1,3]) then begin
+   color_out=color_in[2]*256L^2+color_in[1]*256L+color_in[0]
+endif else begin
+   color_out=BYTARR(3)
+   blue = color_in / (256L^2)
+   reste= color_in - blue* (256L^2)
+   green= reste / 256
+   red= reste -green*256
+   ;;
+   color_out[0]=BYTE(red)
+   color_out[1]=BYTE(green)
+   color_out[2]=BYTE(bleu)
+endelse
+;
+return, color_out
+;
+end

--- a/testsuite/benchmark/basic_benchmarks.pro
+++ b/testsuite/benchmark/basic_benchmarks.pro
@@ -1,0 +1,67 @@
+
+pro printb, str, flt, tab_name, tab_val
+vide='              '
+print, format='(A20, f7.2)', str+vide, flt
+;
+tmp=STRMID(STRMID(str,9),STRLEN(str), STRLEN(str)-9-2, /REV)
+tab_name=[tab_name, tmp]
+tab_val=[tab_val, flt]
+end
+
+pro basic_benchmarks, nbps=nbps, double=double, test=test, prefix=prefix
+;
+if ~KEYWORD_SET(nbps) then nbps=1e8
+tab_name=['']
+tab_val=[0.]
+;
+a=TIC()
+input=RANDOMU(1, nbps, double=double)
+printb, 'Time for RANDOMU : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=COS(input)
+printb, 'Time for COS : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=SIN(input)
+printb, 'Time for SIN : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=TAN(input)
+printb, 'Time for TAN : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=ALOG(input)
+printb, 'Time for ALOG : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=SQRT(input)
+printb, 'Time for SQRT : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=EXP(input)
+printb, 'Time for EXP : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=WHERE(input GT 0.5)
+printb, 'Time for WHERE : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=SORT(input[0:nbps/30])
+printb, 'Time for SORT (1/30) : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=FINITE(input)
+printb, 'Time for FINITE : ', TOC(a), tab_name, tab_val
+;
+a=TIC() & res=FIX(input)
+printb, 'Time for FIX : ', TOC(a), tab_name, tab_val
+;
+; save file ...
+;
+if ~KEYWORD_SET(prefix) then prefix=''
+filename=BENCHMARK_GENERATE_FILENAME('basic_bench'+prefix)
+cpuinfo=BENCHMARK_GENERATE_CPUINFO()
+DEFSYSV, '!GDL', exist=exist
+if exist then version=!gdl.release else version=!version.release
+;
+op_name=tab_name[1:*]
+op_val=tab_val[1:*]
+;
+SAVE, file=filename, nbps, op_name, op_val, cpuinfo, version
+print, 'writing file : ', filename
+;
+if KEYWORD_SET(test) then stop
+;
+end

--- a/testsuite/benchmark/basic_benchmarks_by_type.pro
+++ b/testsuite/benchmark/basic_benchmarks_by_type.pro
@@ -1,0 +1,44 @@
+
+pro printb, str, flt, tab
+vide='              '
+print, format='(A20, f7.2)', str+vide, flt
+tab=[tab, STRING(str), STRING(flt, format='(f7.2)')]
+end
+;
+pro BASIC_BENCHMARKS_BY_TYPE, nbps=nbps, double=double, test=test
+;
+if ~KEYWORD_SET(nbps) then nbps=1e8
+tab=['']
+;
+a=TIC()
+input=RANDOMU(1, nbps, double=double)
+printb, 'Time for RANDOMU : ', TOC(a), tab
+input=1000.*input-500
+;
+GIVE_LIST_NUMERIC, list_num_types, list_num_names
+;
+for ii=0, N_ELEMENTS(list_num_types)-1 do begin
+   mod_input=FIX(input, TYPE=list_num_types[ii])
+   if ISA(mod_input,/complex) then begin
+      print, 'Skip Complex'
+      continue
+   endif
+   a=TIC()
+   res=WHERE(mod_input EQ 0.5)
+;;   res=(mod_input EQ 0.5)
+   PRINTB, 'Time for WHERE and TYPE ='+list_num_names[ii]+' : ', TOC(a), tab
+endfor
+;
+; save file ...
+;
+tab=REFORM(tab[1:*],2, N_ELEMENTS(tab)/2)
+filename=BENCHMARK_GENERATE_FILENAME('bench_where_by_type')
+cpuinfo=BENCHMARK_GENERATE_CPUINFO()
+DEFSYSV, '!GDL', exist=exist
+if exist then version=!gdl.release else version=!version.release
+;
+SAVE, file=filename, tab, cpuinfo, version
+;
+if KEYWORD_SET(test) then stop
+;
+end

--- a/testsuite/benchmark/benchmark_compute_range.pro
+++ b/testsuite/benchmark/benchmark_compute_range.pro
@@ -21,7 +21,9 @@ end
 ; vectors of data. Extracting extremal ranges.
 ;
 pro BENCHMARK_COMPUTE_RANGE, liste_xdr_files, xrange, yrange, x_name, y_name, $
-                         xmax=xmax, ymax=ymax, verbose=verbose, test=test, debug=debug
+                             xmax=xmax, ymax=ymax, $
+                             xelems=xelems, yelems=yelems, $
+                             verbose=verbose, test=test, debug=debug
 ;
 xrange=[0.,0.]
 yrange=[0.,0.]
@@ -59,6 +61,8 @@ for ii=0, N_ELEMENTS(liste_xdr_files)-1 do begin
       endif  else update_flag=0
       ;;print,nbpy,  y_data
    endif
+   xelems=N_ELEMENTS(x_data)
+   yelems=N_ELEMENTS(y_data)
    ;;
    ;; do we still have one point ?!
    ;;

--- a/testsuite/benchmark/benchmark_file_search.pro
+++ b/testsuite/benchmark/benchmark_file_search.pro
@@ -1,6 +1,15 @@
 ;
 ; AC, August 7, 2017, under GPL v2+
 ;
+; ----------------------------------------------------
+; Modifications history :
+;
+; 2018-Sep-04 : AC. 
+; 1/ "filter" can be a liste
+; 2/ return liste='' if nothing found
+;
+; ----------------------------------------------- 
+;
 function BENCHMARK_FILE_SEARCH, filter, message, path=path, $
                             test=test, vervose=verbose, help=help
 ;
@@ -8,14 +17,24 @@ ON_ERROR, 2
 ;
 if N_PARAMS() NE 2 then MESSAGE, 'missing inputs parameters'
 ;
-if STRLEN(filter) EQ 0 then MESSAGE, 'filter input must be set'
-if STRLEN(message) EQ 0 then MESSAGE, 'message input must be set'
+if ~ISA(filter) then MESSAGE, 'filter input must be set'
+if ~ISA(message) then MESSAGE, 'message input must be set'
+;
 message='No '+STRUPCASE(message)+' test data found.'
 ;
 if KEYWORD_SET(path) then filter=path+PATH_SEP()+filter
 ;
 liste=FILE_SEARCH(filter, count=count)
-if (count EQ 0) then MESSAGE, message
+if (count EQ 0) then begin
+   MESSAGE, /continue, message
+   print, 'used filter(s) : ', filter
+   liste=''
+endif
+;
+if KEYWORD_SET(test) then begin
+   print, 'used filter(s) : ', filter
+   print, 'liste : ', liste
+endif
 ;
 if KEYWORD_SET(test) then STOP
 ;

--- a/testsuite/benchmark/benchmark_generate_cpuinfo.pro
+++ b/testsuite/benchmark/benchmark_generate_cpuinfo.pro
@@ -7,6 +7,8 @@
 ; -- bogomips   <<-- does not exist on OSX
 ; -- cpu MHz
 ;
+
+
 function BENCHMARK_GENERATE_CPUINFO, test=test, verbose=verbose, help=help
 ;
 if KEYWORD_SET(help) then begin
@@ -14,7 +16,7 @@ if KEYWORD_SET(help) then begin
    return, -1
 endif
 ;
-os_name=STRLOWCASE(!version.os_name)
+os_name=STRLOWCASE(!version.os)
 ;
 if (os_name EQ 'linux') then begin
    ;;
@@ -34,7 +36,7 @@ endif
 if (os_name EQ 'darwin') then begin
    ;;
    SPAWN, 'sysctl -n hw.cpufrequency', resu_Hz
-   resu_Mhz=resu_Hz*1.e6
+   resu_Mhz=resu_Hz/1.e6
    ;;
    ;; no known equivalent of BogoMIPS on OSX :(
    resu_bogo=-1

--- a/testsuite/benchmark/benchmark_graphic_style.pro
+++ b/testsuite/benchmark/benchmark_graphic_style.pro
@@ -3,22 +3,44 @@
 ;
 ; generic graphic style for Benchmarks plots
 ;
-pro BENCHMARK_GRAPHIC_STYLE, liste, colors, mypsym, myline, flags, languages, $
-                         verbose=verbose, test=test
+pro BENCHMARK_GRAPHIC_STYLE, liste, colors, mypsym, myline, flags, $
+                             languages, select=select, $
+                             verbose=verbose, test=test
 ;
-; GDL (green), IDL (red), FL (magenta)
-;
-languages=['GDL','IDL','FL']
-colors=['ff00'x,'ff'x,'ff00ff'x]
-;
-mypsym=[-2,-3,-4]
+mypsym=[-2,-1,-4]
 myline=[2,3,4]
-;
-; create flags for fields ...
-flags=STREGEX(liste,'_GDL_',/bool)
-flags=flags+STREGEX(liste,'_IDL_',/bool)*2
-flags=flags+STREGEX(liste,'_FL_',/bool)*3
-flags=flags-1
+;;colors=['ff00'x,'ff'x,'ff00ff'x]
+colors=[COLOR2COLOR(!color.green), $
+        COLOR2COLOR(!color.red), $
+        COLOR2COLOR(!color.magenta), $
+        COLOR2COLOR(!color.blue), $
+        COLOR2COLOR(!color.yellow), $
+        COLOR2COLOR(!color.orange)]
+;;
+if ~KEYWORD_SET(select) then begin
+   ;; GDL (green), IDL (red), FL (magenta)
+   languages=['GDL','IDL','FL']
+   colors=colors[0:2]
+   ;;
+   ;; create flags for fields ...
+   flags=STREGEX(liste,'_GDL_',/bool)
+   flags=flags+STREGEX(liste,'_IDL_',/bool)*2
+   flags=flags+STREGEX(liste,'_FL_',/bool)*3
+   flags=flags-1
+endif else begin
+   nbps=N_ELEMENTS(select)
+   languages=select
+   flags=REPLICATE(0, N_ELEMENTS(liste))
+   for ii=0, nbps-1 do begin
+      flags=flags+STREGEX(liste,select[ii],/bool)*(1+ii)        
+   endfor
+   flags=flags-1
+   ;;
+   if nbps GT N_ELEMENTS(colors) then begin
+      colors=[colors, colors]
+   endif
+   colors=colors[0:nbps-1]
+endelse
 ;
 if KEYWORD_SET(verbose) then begin
    print, 'Colors ? GDL : green, IDL : red, FL : magenta !'

--- a/testsuite/benchmark/benchmark_plot_cartouche.pro
+++ b/testsuite/benchmark/benchmark_plot_cartouche.pro
@@ -4,6 +4,11 @@
 ;
 ; Modification history :
 ;
+; * AC 2018-09-04 :
+;  - change of definition for Pos (before : xmin, xmax,
+;    ymin, ymax; now : xmin, ymin, xmax, ymax)
+;  - new keyword /Absolute
+;
 ; * AC 2017-08-07 : first public release
 ; - all the positionning is now done using /Normal
 ; - all the Xlog/Ylog mess is now processed easily
@@ -111,18 +116,20 @@ end
 ; -----------------------------------------
 ;
 pro BENCHMARK_PLOT_CARTOUCHE, messages, positions=positions, title=title, $
-                          colors_list=colors_list, $
-                          linestyle_list=linestyle_list, $
-                          psym_list=psym_list, epsilon_margin=epsilon_margin, $
-                          allow_extendscale=allow_extendscale, $
-                          ratio=ratio, box=box, _extra=_extra, $
-                          verbose=verbose, debug=debug, test=test, help=help
+                              colors_list=colors_list, $
+                              linestyle_list=linestyle_list, $
+                              psym_list=psym_list, $
+                              absolute=absolute, $
+                              epsilon_margin=epsilon_margin, $
+                              allow_extendscale=allow_extendscale, $
+                              ratio=ratio, box=box, _extra=_extra, $
+                              verbose=verbose, debug=debug, test=test, help=help
 ;
 mess=AC_SETMESSAGES('BENCHMARK_PLOT_CARTOUCHE')
 ;
 if (N_PARAMS() lt 1) then begin
-    print, mess.fatal+'missing mandatory "messages list" arguments'
-    help=1
+   print, mess.fatal+'missing mandatory "messages list" arguments'
+   help=1
 endif
 ;
 if KEYWORD_SET(help) then begin
@@ -131,7 +138,7 @@ if KEYWORD_SET(help) then begin
    print, '                linestyle_list=linestyle_list, $'
    print, '                psym_list=psym_list, epsilon_margin=epsilon_margin, $'
    print, '                allow_extendscale=allow_extendscale, $'
-   print, '                ratio=ratio, box=box, _extra=_extra, $'
+   print, '                ratio=ratio, box=box, _extra=_extra, absolute=absolute, $'
    print, '                verbose=verbose, debug=debug, test=test, help=help'
    print, ''
    return
@@ -233,72 +240,82 @@ if (N_ELEMENTS(positions) EQ 1) then begin
    xy_pos=[xmin,xmax,ymin,ymax]
    ;;
    set_normal=1
-   if KEYWORD_SET(debug) then print, xy_pos
 endif
 ;
-; ---------------------
 if (N_ELEMENTS(positions) EQ 4) then begin
-   ;;
-   ;; What are the limits on the plot ?
-   ;; managing Xlog and Ylog too :(
-   if (!x.type EQ 1) then begin
-      xdata_min=10^!x.crange[0]
-      xdata_max=10^!x.crange[1]
+   if KEYWORD_SET(absolute) then begin
+      PLOT, [0,1], [0,1],/nodata, /noerase, pos=positions, xstyle=5, ystyle=5
+      xmin=0.
+      xmax=1.
+      ymin=0.
+      ymax=1.
+      xy_pos=[xmin,xmax,ymin,ymax]
+      set_normal=0
    endif else begin
-      xdata_min=!x.crange[0]
-      xdata_max=!x.crange[1]
+      ;;
+      ;; What are the limits on the plot ?
+      ;; managing Xlog and Ylog too :(
+      if (!x.type EQ 1) then begin
+         xdata_min=10^!x.crange[0]
+         xdata_max=10^!x.crange[1]
+      endif else begin
+         xdata_min=!x.crange[0]
+         xdata_max=!x.crange[1]
+      endelse
+      ;; managing Ylog 
+      if (!y.type EQ 1) then begin
+         ydata_min=10^!y.crange[0]
+         ydata_max=10^!y.crange[1]
+      endif else begin
+         ydata_min=!y.crange[0]
+         ydata_max=!y.crange[1]
+      endelse
+      ;;
+      ;; managing X range
+      xmin=positions[0]
+      xmax=positions[2]
+      ;;
+      ;; checking X bondaries
+      if (xmin LT xdata_min) then begin
+         print, mess.warning+'X min position below Xmin scale ...'
+         if ~KEYWORD_SET(allow_extendscale) then xmin=xdata_min
+      endif
+      if (xmax GT xdata_max) then begin
+         print, mess.warning+'Y max position above Xmax scale ...'
+         if ~KEYWORD_SET(allow_extendscale) then xmax=xdata_max
+      endif
+      ;;
+      ;; managing Y range
+      ymin=positions[1]
+      ymax=positions[3]
+      ;; checking Y bondaries
+      if (ymin LT ydata_min) then begin
+         print, mess.warning+'Y min position below Ymin scale ...'
+         if ~KEYWORD_SET(allow_extendscale) then ymin=ydata_min
+      endif
+      if (ymax GT ydata_max) then begin
+         print, mess.warning+'Y max position above Ymax scale ...'
+         if ~KEYWORD_SET(allow_extendscale) then ymax=ydata_max
+      endif
+      ;;
+      xy_pos=[xmin,xmax,ymin,ymax]
+      ;;
+      ;; if KEYWORD_SET(debug) then print, !x.crange, !y.crange
+      ;; if KEYWORD_SET(debug) then print, xy_pos
+      ;;
+      ;; transforming in Normal coordinates the XY positions
+      xy_pos=RESCALE4CARTOUCHE(xy_pos, debug=debug)
+      ;;if KEYWORD_SET(debug) then print, 'revisited :', xy_pos
+      xmin=xy_pos[0]
+      xmax=xy_pos[1]
+      ymin=xy_pos[2]
+      ymax=xy_pos[3]
+      ;;
+      set_normal=1
    endelse
-   ;; managing Ylog 
-   if (!y.type EQ 1) then begin
-      ydata_min=10^!y.crange[0]
-      ydata_max=10^!y.crange[1]
-   endif else begin
-      ydata_min=!y.crange[0]
-      ydata_max=!y.crange[1]
-   endelse
-   ;;
-   ;; managing X range
-   xmin=positions[0]
-   xmax=positions[1]
-   ;;
-   ;; checking X bondaries
-   if (xmin LT xdata_min) then begin
-      print, mess.warning+'X min position below Xmin scale ...'
-      if ~KEYWORD_SET(allow_extendscale) then xmin=xdata_min
-   endif
-   if (xmax GT xdata_max) then begin
-      print, mess.warning+'Y max position above Xmax scale ...'
-      if ~KEYWORD_SET(allow_extendscale) then xmax=xdata_max
-   endif
-   ;;
-   ;; managing Y range
-   ymin=positions[2]
-   ymax=positions[3]
-   ;; checking Y bondaries
-   if (ymin LT ydata_min) then begin
-      print, mess.warning+'Y min position below Ymin scale ...'
-      if ~KEYWORD_SET(allow_extendscale) then ymin=ydata_min
-   endif
-   if (ymax GT ydata_max) then begin
-      print, mess.warning+'Y max position above Ymax scale ...'
-      if ~KEYWORD_SET(allow_extendscale) then ymax=ydata_max
-   endif
-   ;;
-   xy_pos=[xmin,xmax,ymin,ymax]
-   ;;
-   ;; if KEYWORD_SET(debug) then print, !x.crange, !y.crange
-   ;; if KEYWORD_SET(debug) then print, xy_pos
-   ;;
-   ;; transforming in Normal coordinates the XY positions
-   xy_pos=RESCALE4CARTOUCHE(xy_pos, debug=debug)
-   ;;if KEYWORD_SET(debug) then print, 'revisited :', xy_pos
-   xmin=xy_pos[0]
-   xmax=xy_pos[1]
-   ymin=xy_pos[2]
-   ymax=xy_pos[3]
-   ;;
-   set_normal=1
 endif
+;
+if KEYWORD_SET(debug) then print, xy_pos
 ;
 if N_ELEMENTS(ratio) EQ 0 then ratio=0.5
 ;
@@ -311,11 +328,11 @@ xdx=(xmax-xmin)/20.
 ;
 sysvar_modified=0
 if (SIZE(_extra))(0) GT 0 then begin
-    sysvar_modified=1
-    copy_p=!p
-    if IS_FIELD_IN_STRUCT(_extra, 'thick') then !p.thick=_extra.thick
-    if IS_FIELD_IN_STRUCT(_extra, 'charthick') then !p.charthick=_extra.charthick
-    if IS_FIELD_IN_STRUCT(_extra, 'charsize') then !p.charsize=_extra.charsize
+   sysvar_modified=1
+   copy_p=!p
+   if IS_FIELD_IN_STRUCT(_extra, 'thick') then !p.thick=_extra.thick
+   if IS_FIELD_IN_STRUCT(_extra, 'charthick') then !p.charthick=_extra.charthick
+   if IS_FIELD_IN_STRUCT(_extra, 'charsize') then !p.charsize=_extra.charsize
 endif
 ;
 ; il n'y a qu'un titre (a ce jour)
@@ -477,5 +494,24 @@ window, 2
 BENCHMARK_PLOT_CARTOUCHE_DEMO, /ylog
 window, 3
 BENCHMARK_PLOT_CARTOUCHE_DEMO, /xlog, /ylog
+;
+end
+;
+; -----------------------------------------------
+;
+pro BENCHMARK_PLOT_CARTOUCHE_DEMO_OUTSIDE
+;
+window, 0
+PLOT, findgen(1000)+1000, /nodata, pos=[0.05,0.05, 0.66, 0.9]
+;
+BENCHMARK_PLOT_CARTOUCHE, /box, REVERSE(FINDGEN(10)), $
+                          pos=[0.7,0.05, 0.95, 0.9], /absolute
+window, 2
+PLOT, findgen(1000)+1000, /nodata, pos=[0.25,0.05, 0.75, 0.9]
+;
+BENCHMARK_PLOT_CARTOUCHE, /box, REVERSE(FINDGEN(10)), $
+                          pos=[0.05,0.05, 0.2, 0.7], /absolute
+BENCHMARK_PLOT_CARTOUCHE, /box, REVERSE(FINDGEN(5)), $
+                          pos=[0.77,0.5, 0.98, 0.9], /absolute
 ;
 end

--- a/testsuite/benchmark/plot_basic_benchmarks.pro
+++ b/testsuite/benchmark/plot_basic_benchmarks.pro
@@ -1,0 +1,95 @@
+;
+; August 2018
+;
+pro PLOT_BASIC_BENCHMARKS, path=path, filter=filter, $
+                           select=select, $
+                           xrange=xrange, yrange=yrange, $
+                           xlog=xlog, ylog=ylog, $
+                           svg=svg, special=special, $
+                           help=help, test=test
+;
+if KEYWORD_SET(help) then begin
+    print, 'pro PLOT_BASIC_BENCHMARKS, path=path, filter=filter, $'
+    print, '                           xrange=xrange, yrange=yrange, $'
+    print, '                           xlog=xlog, ylog=ylog, $'
+    print, '                           svg=svg, $'
+    print, '                           help=help, test=test'
+    return
+endif
+;
+ON_ERROR, 2
+;
+CHECK_SAVE_RESTORE
+;
+if ~KEYWORD_SET(filter) then filter='bench_basic_*.xdr'
+;
+liste=BENCHMARK_FILE_SEARCH(filter, 'BASIC_BENCHMARKS', path=path)
+if N_ELEMENTS(liste) EQ 0 then begin
+   print, 'Used filter : ', filter
+   MESSAGE, 'No file found !'
+endif
+;
+BENCHMARK_SVG, svg=svg, /on, filename='bench_basic_bench.svg', infosvg=infosvg 
+;
+; not useful now, maybe later ...
+if KEYWORD_SET(xrange) then MESSAGE,/info, "keyword Xrange not effective !"
+if KEYWORD_SET(xlog) then MESSAGE,/info, "keyword Xrange not effective !"
+;
+;; Which ranges ? fake Xrange (we don't care)
+BENCHMARK_COMPUTE_RANGE, liste, xrange, yrange_new, 'op_val', 'op_val', $
+                         xelems=xelems, yelems=yelems
+if ~KEYWORD_SET(yrange) then yrange=yrange_new
+;
+; in fact, we overwrite xrange ...
+xval=INDGEN(xelems)+1
+xrange=[0, xelems+1]
+;
+DEVICE, decompose=1
+;
+BENCHMARK_GRAPHIC_STYLE, liste, colors, mypsym, myline, flags, languages, $
+                         select=select
+;
+PLOT, FINDGEN(10), /nodata, xstyle=4, /ystyle, ylog=ylog, $
+      xrange=xrange, yrange=yrange, $
+      xtitle='Operations', ytitle='time [s]', $
+      title='Basic Benchmark', pos=[0.05,0.05, 0.85, 0.9]
+;
+for ii=0, N_ELEMENTS(liste)-1 do begin
+   print, 'Restoring '+liste[ii]
+   RESTORE, liste[ii]
+   ;; ordering data stored in XDR files
+   jj=flags[ii]
+   if ii EQ 0 then $
+      AXIS, xtickname=['',op_name], xticks=N_ELEMENTS(op_name)+1
+   
+   my_line=myline[jj]
+   if KEYWORD_SET(special) and ii GT 0 then my_line=0
+
+   if jj GE 0 then begin
+      OPLOT, xval, op_val, psym=mypsym[jj], line=my_line, col=colors[jj]
+      OPLOT, xval, op_val, psym=-mypsym[jj], col=colors[jj]
+   endif
+   print, ii, jj, mypsym[jj], myline, colors[jj]
+endfor
+;
+; adding vertical lines separating the 4 cases
+;
+BENCHMARK_PLOT_CARTOUCHE, pos=[0.85,0.05,0.98,0.5], languages, /box, $
+                          colors=colors, lines=lines, /all, /absolute, $
+                          thick=1.5, title='Languages'
+
+if KEYWORD_SET(special) then begin
+   colors=[colors[0],colors[0]]
+   info=['git_11','git_19']
+   lines=[2,0]
+   BENCHMARK_PLOT_CARTOUCHE, pos=[0.85,0.55,0.98,0.95], info, /box, $
+                             colors=colors, lines=lines, /all, /absolute, $
+                             thick=1.5, title='Git version'
+endif
+;
+BENCHMARK_SVG, svg=svg, /off, infosvg=infosvg
+;
+if KEYWORD_SET(test) then STOP
+;
+end
+;

--- a/testsuite/benchmark/print_basic_benchmarks.pro
+++ b/testsuite/benchmark/print_basic_benchmarks.pro
@@ -1,0 +1,49 @@
+;
+; August 2018
+;
+pro PRINT_BASIC_BENCHMARKS, path=path, filter=filter, $
+                            xrange=xrange, yrange=yrange, $
+                            xlog=xlog, ylog=ylog, $
+                            svg=svg, $
+                            help=help, test=test
+;
+if KEYWORD_SET(help) then begin
+    print, 'pro PRINT_BASIC_BENCHMARKS, path=path, filter=filter, $'
+    print, '                            xrange=xrange, yrange=yrange, $'
+    print, '                            xlog=xlog, ylog=ylog, $'
+    print, '                            svg=svg, $'
+    print, '                            help=help, test=test'
+    return
+endif
+;
+ON_ERROR, 2
+;
+CHECK_SAVE_RESTORE
+;
+if ~KEYWORD_SET(filter) then filter='bench_basic_bench*.xdr'
+;
+liste=BENCHMARK_FILE_SEARCH(filter, 'BASIC_BENCHMARKS', path=path)
+if N_ELEMENTS(liste) EQ 0 then begin
+   print, 'Used filter : ', filter
+   MESSAGE, 'No file found !'
+endif
+;
+for ii=0, N_ELEMENTS(liste)-1 do begin
+   print, 'Restoring '+liste[ii]
+   RESTORE, liste[ii]
+   if ii EQ 0 then begin
+      tab=REPLICATE('',N_ELEMENTS(op_name)+1, N_ELEMENTS(liste)+1)
+      tab[*,0]=STRING(format='(A9)',['',op_name])
+   endif
+   tab[0,ii+1]=STRING(format='(A9)',version)
+   tab[1:*,ii+1]=STRING(format='(f9.2)', op_val)
+endfor
+;
+print, 'host :', (GET_LOGIN_INFO()).MACHINE_NAME
+print, 'nbps :', NBPS
+print, TRANSPOSE(tab)
+
+if KEYWORD_SET(test) then STOP
+;
+end
+;

--- a/testsuite/gdl_idl_fl.pro
+++ b/testsuite/gdl_idl_fl.pro
@@ -14,6 +14,8 @@
 ; Modifications history :
 ;
 ; 2018-Feb-05 : AC. Default return now UpperCase
+; 2018-Sep-06 : AC. new test for FL (mail from Lajos)
+;               using undocument trick in FL
 ;
 ; ----------------------------------------------------
 ;
@@ -32,7 +34,19 @@ if isGDL then suffix='gdl' else begin
    ;; This test is still OK in FL fl_0.79.41
    ;;
    DEFSYSV, '!slave', exists=isFL
-   if isFL then suffix='fl' else suffix='idl'
+   if isFL then begin
+      suffix='fl'
+   endif else begin
+      ;;  new way to detect FL 
+      ;; AC: FL trick : don't change next line !!!!
+      in_fl=0   ;#fl +1
+      ;; AC: FL trick : don't change previous line !!!!
+      if in_fl then begin
+         suffix='fl'
+      endif else begin
+         suffix='idl'
+      endelse
+   endelse
 endelse
 ;
 ; AC 2018-02-07 : we decided the default is now UpperCase


### PR DESCRIPTION
1/ a detail in CMakeLists.txt to fix compilation on FC28 (option -fPIC)
2/ a detail in initsysvar.cpp to have good !version.os_name on OSX (check by idl 8.5)
3/ adding a new utility (color2color())
4/ a new way to detect recent versions of FL
5/ few improvements in benchmark/
6/ two new procedures in benchmark/ : both can easily be extended : 
 - basic_benchmarks.pro is now only for 11 functions and two types (Float & Double). It will be easy to extend it (functions & type). It give the way to quick check in performances. Preliminary results in #456 
 - basic_benchmarks_by_type.pro is now only for WHERE() but with an EXECUTE() we will be able to test many functions
