### PR TITLE
Feature-complete DILATE and ERODE functions

### DIFF
--- a/src/libinit_ac.cpp
+++ b/src/libinit_ac.cpp
@@ -85,12 +85,20 @@ void LibInit_ac()
   new DLibFunRetNew(lib::sobel_fun,string("SOBEL"),1,helpKey);
   new DLibFunRetNew(lib::prewitt_fun,string("PREWITT"),1,helpKey);
 
+  /* NOTE: 2018-09-07 by rexso (remi.solaas at edinsights dot no)
+   *
+   * ERODE and DILATE currently implemented in IDL,
+   * available in pro/erode.pro and pro/dilate.pro
+   * with grayscale support. Uncomment when the C++
+   * implementation is complete.
+   *
   const string erodeKey[]={"HELP","GRAY","PRESERVE_TYPE","UINT","ULONG","VALUES",KLISTEND};
   new DLibFunRetNew(lib::erode_fun,string("ERODE"),5,erodeKey);
 
   const string dilateKey[]={"HELP","GRAY","PRESERVE_TYPE","UINT","ULONG","VALUES",
 			    "CONSTRAINED","BACKGROUND",KLISTEND};
   new DLibFunRetNew(lib::dilate_fun,string("DILATE"),5,dilateKey);
+  */
 
   const string matrix_multiplyKey[]={"ATRANSPOSE","BTRANSPOSE",KLISTEND};
   new DLibFunRetNew(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);

--- a/src/pro/dilate.pro
+++ b/src/pro/dilate.pro
@@ -1,0 +1,467 @@
+;
+;  GDL replacement to DILATE in IDL
+;  Bin Wu <bin.wu (at) edinsights.no>
+;  Aug. 2018
+;
+;  Arguments (from IDL): Image Structure X0 Y0 Z0
+;  Keywords (from IDL): 
+;  	BACKGROUND 
+;		Set this keyword to the pixel value that is to be considered the background when 
+;		dilation is being performed in constrained mode. The default value is 0.
+; 	CONSTRAINED (a boolean keyword)
+;		If this keyword is set and grayscale dilation has been selected, the dilation 
+;		algorithm will operate in constrained mode. In this mode, a pixel is set to the 
+;		value determined by normal grayscale dilation rules in the output image only if 
+;		the current value destination pixel value matches the BACKGROUND pixel value. Once 
+;		a pixel in the output image has been set to a value other than the BACKGROUND 
+;		value, it cannot change.
+;	GRAY (a boolean keyword)
+;		Set this keyword to perform grayscale, rather than binary, dilation. The nonzero 
+;		elements of the Structure parameter determine the shape of the structuring element 
+;		(neighborhood). If VALUES is not present, all elements of the structuring element 
+;		are 0, yielding the neighborhood maximum operator.
+; 	PRESERVE_TYPE (a boolean keyword)
+;		Set this keyword to return the same type as the input array. This keyword only 
+;		applies if the GRAY keyword is set.
+;	UINT (a boolean keyword)
+;		Set this keyword to return an unsigned integer array. This keyword only applies if 
+;		the GRAY keyword is set.
+; 	ULONG (a boolean keyword)
+;		Set this keyword to return an unsigned longword integer array. This keyword only 
+;		applies if the GRAY keyword is set.
+;	VALUES
+;		An array with the same dimensions as Structure providing the values of the 
+;		structuring element. The presence of this parameter implies grayscale dilation. 
+;		Each pixel of the result is the maximum of the sum of the corresponding elements 
+;		of VALUE and the Image pixel value. If the resulting sum is greater than 255, the 
+;		return value is 255.
+;  Return (from IDL): the dilation of image
+;  Syntax (from IDL): 
+;	Result = DILATE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /CONSTRAINED [, 
+;		 BACKGROUND=value]] [, /GRAY [, /PRESERVE_TYPE | , /UINT | , /ULONG]] [, 
+;		 VALUES=array] )
+;  Ref: http://www.harrisgeospatial.com/docs/DILATE.html
+;
+FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
+                 CONSTRAINED=CONSTRAINED, BACKGROUND=BACKGROUND, $ 
+                 GRAY=GRAY, PRESERVE_TYPE=PRESERVE_TYPE, $
+                 UINT=UINT, ULONG=ULONG, VALUES=VALUES
+; Return the caller of a procedure in the event of an error.
+  ON_ERROR, 2
+  
+; At least Image and Structure are needed.
+  IF (N_PARAMS() LE 1) THEN BEGIN
+     MESSAGE, 'Incorrect number of arguments.'
+  ENDIF
+  
+; Get the Structure size.
+  dimStt = SIZE(Structure)
+  
+; Get the image size.
+  dims = SIZE(Image)
+  
+; Make sure Structure has the same dimension as Image.
+  IF (dims[0] NE dimStt[0]) THEN BEGIN
+     CASE dimStt[0] OF
+        1: BEGIN
+           CASE dims[0] OF
+              2: Structure = [[Structure],[REPLICATE(0,dimStt[1],1)]]
+              3: Structure = [[[Structure],[REPLICATE(0,dimStt[1],1)]],[[REPLICATE(0,dimStt[1],2)]]]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        2: BEGIN
+           CASE dims[0] OF
+              1: Structure = Structure[*,0]
+              3: Structure = [[[Structure]],[[REPLICATE(0,dimStt[1],dimStt[2])]]]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        3: BEGIN
+           CASE dims[0] OF
+              1: Structure = Structure[*,0,0]
+              2: Structure = Structure[*,*,0]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+     ENDCASE
+     dimStt=SIZE(Structure)
+  ENDIF
+
+; Get the coordinate of the origin of Structure.
+  CASE dimStt[0] OF
+     1: IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+     2: BEGIN
+        IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+        IF (N_ELEMENTS(Y0) EQ 0) THEN Y0 = dimStt[2]/2
+     END
+     3: BEGIN
+        IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+        IF (N_ELEMENTS(Y0) EQ 0) THEN Y0 = dimStt[2]/2
+        IF (N_ELEMENTS(Z0) EQ 0) THEN Z0 = dimStt[3]/2
+     END
+     ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+  ENDCASE
+  
+; Set default value to BACKGROUND.
+  IF (KEYWORD_SET(BACKGROUND) EQ 0) THEN BACKGROUND = 0
+  
+; Gray: a boolean keyword.
+  IF (KEYWORD_SET(GRAY) OR KEYWORD_SET(VALUES)) THEN BEGIN
+; Gray image;
+;
+;	MESSAGE, 'A gray image is in processing.'
+;
+; Make sure VALUES has the same dimension as Image.
+     IF KEYWORD_SET(VALUES) THEN BEGIN
+        dimVal = SIZE(VALUES)
+        IF (dims[0] NE dimVal[0]) THEN BEGIN
+           CASE dimVal[0] OF
+              1: BEGIN
+                 CASE dims[0] OF
+                    2: VALUES = [[VALUES],[REPLICATE(0,dimVal[1],1)]]
+                    3: VALUES = [[[VALUES],[REPLICATE(0,dimVal[1],1)]],[[REPLICATE(0,dimVal[1],2)]]]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              2: BEGIN
+                 CASE dims[0] OF
+                    1: VALUES = VALUES[*,0]
+                    3: VALUES = [[[VALUES]],[[REPLICATE(0,dimVal[1],dimVal[2])]]]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              3: BEGIN
+                 CASE dims[0] OF
+                    1: VALUES = VALUES[*,0,0]
+                    2: VALUES = VALUES[*,*,0]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+           dimVal=SIZE(VALUES)
+        ENDIF
+        CASE dimVal[0] OF
+           1: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],1)]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+           END
+           2: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],dimVal[2])]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[2] LT dimStt[2] THEN VALUES = [[VALUES],[REPLICATE(0,dimVal[1],dimStt[2] - dimVal[2])]]
+              IF dimVal[2] GT dimStt[2] THEN VALUES = VALUES[*,0:dimStt[2]-1]
+           END
+           3: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],dimVal[2],dimVal[3])]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[2] LT dimStt[2] THEN VALUES = [[VALUES],[REPLICATE(0,dimVal[1],dimStt[2] - dimVal[2],dimVal[3])]]
+              IF dimVal[2] GT dimStt[2] THEN VALUES = VALUES[*,0:dimStt[2]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[3] LT dimStt[3] THEN VALUES = [[[VALUES]],[[REPLICATE(0,dimVal[1],dimVal[2],dimStt[3] - dimVal[3])]]]
+              IF dimVal[3] GT dimStt[3] THEN VALUES = VALUES[*,*,0:dimStt[3]-1]
+           END
+           ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+        ENDCASE
+     ENDIF
+;
+; In case VALUES are not given, as the image is Gray,
+; set VALUES to be of the same size as Structure
+; with all the elements to be 0.
+     IF (KEYWORD_SET(VALUES) EQ 0) THEN BEGIN
+        CASE dimStt[0] OF
+           1: VALUES = REPLICATE(0, dimStt[1])
+           2: VALUES = REPLICATE(0, dimStt[1], dimStt[2])
+           3: VALUES = REPLICATE(0, dimStt[1], dimStt[2], dimStt[3])
+           ELSE: BEGIN
+              MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           END
+        ENDCASE	
+     ENDIF
+;
+     dilateImg = TRANSPOSE(Image)
+;
+; Two situations: CONSTRAINED and UNCONSTRAINED
+     IF KEYWORD_SET(CONSTRAINED) THEN BEGIN
+; An auxiliary variable.
+        tmpImg = dilateImg
+; An auxiliary PARAMETER.
+        tmpMin = MIN(dilateImg)
+;  
+; CONSTRAINED situation.
+; 1D-3D.
+        CASE dimStt[0] OF
+           1: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 IF dilateImg[I] EQ BACKGROUND THEN BEGIN
+                    IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) THEN BEGIN
+                       tmpImg[I] = tmpMin
+                       FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                          IF (Structure[I - II + X0] EQ 1) THEN BEGIN
+                             IF (II LT 0) OR (II GT dims[1]-1) THEN BEGIN
+                                tmpII = tmpMin
+                             ENDIF ELSE BEGIN
+                                tmpII = dilateImg[II]
+                             ENDELSE
+                             tmpImg[I] = MIN([255,MAX([tmpImg[I], tmpII + VALUES[I - II + X0]])])
+                          ENDIF
+                       ENDFOR
+                    ENDIF ELSE BEGIN
+                       tmpImg[I] = tmpMin
+                    ENDELSE
+                 ENDIF
+              ENDFOR
+           END
+           2: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 FOR J = 0, dims[2]-1 DO BEGIN
+                    IF dilateImg[I,J] EQ BACKGROUND THEN BEGIN
+                       IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                          ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) THEN BEGIN
+                          tmpImg[I,J] = tmpMin
+                          FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                             FOR  JJ = (J - dimStt[2]+1 + Y0),(J + Y0) DO BEGIN
+                                IF (Structure[I - II + X0,J - JJ + Y0] EQ 1) THEN BEGIN
+                                   IF  (II LT 0) OR (II GT dims[1]-1) OR (JJ LT 0) OR (JJ GT dims[2]-1) THEN BEGIN
+                                      tmpIIJJ = tmpMin
+                                   ENDIF ELSE BEGIN
+                                      tmpIIJJ = dilateImg[II,JJ]
+                                   ENDELSE
+                                   tmpImg[I,J] =  MIN([255, MAX([tmpImg[I,J], tmpIIJJ + VALUES[I - II + X0,J - JJ + Y0]])])
+                                ENDIF
+                             ENDFOR
+                          ENDFOR
+                       ENDIF ELSE BEGIN
+                          tmpImg[I,J] = tmpMin
+                       ENDELSE
+                    ENDIF
+                 ENDFOR
+              ENDFOR
+           END
+           3: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 FOR J = 0, dims[2]-1 DO BEGIN
+                    FOR K = 0, dims[3]-1 DO BEGIN
+                       IF dilateImg[I,J,K] EQ BACKGROUND THEN BEGIN
+                          IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                             ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) AND $
+                             ((K - Z0) GE 0) AND ((K + dimStt[3]-1 - Z0) LE dims[3]-1) THEN BEGIN
+                             tmpImg[I,J,K] = tmpMin
+                             FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                                FOR JJ = (J - dimStt[2]+1 + Y0),(J + Y0) DO BEGIN
+                                   FOR KK = (K - dimStt[3]+1 + Z0),(K + Z0) DO BEGIN
+                                      IF (Structure[I - II + X0,J - JJ + Y0,K - KK + Z0] EQ 1) THEN BEGIN
+                                         IF  (II LT 0) OR (II GT dims[1]-1) OR (JJ LT 0) OR (JJ GT dims[2]-1) OR (KK LT 0) OR (KK GT dims[3]-1) THEN BEGIN
+                                            tmpIIJJKK = tmpMin
+                                         ENDIF ELSE BEGIN
+                                            tmpIIJJKK = dilateImg[II,JJ,KK]
+                                         ENDELSE
+                                         tmpImg[I,J,K] = $
+                                            MIN([255, MAX([tmpImg[I,J,K], tmpIIJJKK + $
+                                                           VALUES[I - II + X0,J - JJ + Y0,K - KK + Z0]])])
+                                      ENDIF
+                                   ENDFOR
+                                ENDFOR
+                             ENDFOR
+                          ENDIF ELSE BEGIN
+                             tmpImg[I,J,K] = tmpMin
+                          ENDELSE
+                       ENDIF
+                    ENDFOR
+                 ENDFOR
+              ENDFOR
+           END
+           ELSE: BEGIN
+              MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           END
+        ENDCASE	
+        dilateImg = TRANSPOSE(tmpImg)      
+;          
+     ENDIF ELSE BEGIN
+; An auxiliary variable.
+        tmpImg = dilateImg
+; An auxiliary PARAMETER.
+        tmpMin = MIN(dilateImg)
+;      
+; UNCONSTRAINED situation.
+; 1D-3D.
+        CASE dimStt[0] OF
+           1: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) THEN BEGIN
+                    tmpImg[I] = tmpMin
+                    FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                       IF (Structure[I - II + X0] EQ 1) THEN BEGIN
+                          IF (II LT 0) OR (II GT dims[1]-1) THEN BEGIN
+                             tmpII = tmpMin
+                          ENDIF ELSE BEGIN
+                             tmpII = dilateImg[II]
+                          ENDELSE
+                          tmpImg[I] = MIN([255,MAX([tmpImg[I], tmpII + VALUES[I - II + X0]])])
+                       ENDIF
+                    ENDFOR
+                 ENDIF ELSE BEGIN
+                    tmpImg[I] = tmpMin
+                 ENDELSE
+              ENDFOR
+           END
+           2: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 FOR J = 0, dims[2]-1 DO BEGIN
+                    IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                       ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) THEN BEGIN
+                       tmpImg[I,J] = tmpMin
+                       FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                          FOR  JJ = (J - dimStt[2]+1 + Y0),(J + Y0) DO BEGIN
+                             IF (Structure[I - II + X0,J - JJ + Y0] EQ 1) THEN BEGIN
+                                IF  (II LT 0) OR (II GT dims[1]-1) OR (JJ LT 0) OR (JJ GT dims[2]-1) THEN BEGIN
+                                   tmpIIJJ = tmpMin
+                                ENDIF ELSE BEGIN
+                                   tmpIIJJ = dilateImg[II,JJ]
+                                ENDELSE
+                                tmpImg[I,J] =  MIN([255, MAX([tmpImg[I,J], tmpIIJJ + VALUES[I - II + X0,J - JJ + Y0]])])
+                             ENDIF
+                          ENDFOR
+                       ENDFOR
+                    ENDIF ELSE BEGIN
+                       tmpImg[I,J] = tmpMin
+                    ENDELSE
+                 ENDFOR
+              ENDFOR
+           END
+           3: BEGIN
+              FOR I = 0, dims[1]-1 DO BEGIN
+                 FOR J = 0, dims[2]-1 DO BEGIN
+                    FOR K = 0, dims[3]-1 DO BEGIN
+                       IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                          ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) AND $
+                          ((K - Z0) GE 0) AND ((K + dimStt[3]-1 - Z0) LE dims[3]-1) THEN BEGIN
+                          tmpImg[I,J,K] = tmpMin
+                          FOR II = (I - dimStt[1]+1 + X0),(I + X0) DO BEGIN
+                             FOR JJ = (J - dimStt[2]+1 + Y0),(J + Y0) DO BEGIN
+                                FOR KK = (K - dimStt[3]+1 + Z0),(K + Z0) DO BEGIN
+                                   IF (Structure[I - II + X0,J - JJ + Y0,K - KK + Z0] EQ 1) THEN BEGIN
+                                      IF  (II LT 0) OR (II GT dims[1]-1) OR (JJ LT 0) OR (JJ GT dims[2]-1) OR (KK LT 0) OR (KK GT dims[3]-1) THEN BEGIN
+                                         tmpIIJJKK = tmpMin
+                                      ENDIF ELSE BEGIN
+                                         tmpIIJJKK = dilateImg[II,JJ,KK]
+                                      ENDELSE
+                                      tmpImg[I,J,K] = $
+                                         MIN([255, MAX([tmpImg[I,J,K], tmpIIJJKK + $
+                                                        VALUES[I - II + X0,J - JJ + Y0,K - KK + Z0]])])
+                                   ENDIF
+                                ENDFOR
+                             ENDFOR
+                          ENDFOR
+                       ENDIF ELSE BEGIN
+                          tmpImg[I,J,K] = tmpMin
+                       ENDELSE
+                    ENDFOR
+                 ENDFOR
+              ENDFOR
+           END
+           ELSE: BEGIN
+              MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           END
+        ENDCASE	
+        dilateImg = TRANSPOSE(tmpImg)
+     ENDELSE
+;
+  ENDIF ELSE BEGIN
+; Binary image otherwise.
+     dilateImg = Image GT 0
+;
+; An auxiliary variable.
+     tmpImg = dilateImg - dilateImg
+;
+; 1D-3D.
+     CASE dimStt[0] OF
+        1: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              IF (dilateImg[I] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) THEN BEGIN
+                 FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                    IF (Structure[II - I + X0] EQ 1) THEN tmpImg[II] = 1
+                 ENDFOR
+              ENDIF
+           ENDFOR
+           FOR I = 0, dims[1]-1 DO BEGIN
+              IF (dilateImg[I] EQ 1) AND (((I - X0) LT 0) OR ((I + dimStt[1]-1 - X0) GT dims[1]-1)) THEN dilateImg[I] = 0
+           ENDFOR
+        END
+        2: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 IF (dilateImg[I,J] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) $
+                    AND ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) THEN BEGIN
+                    FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                       FOR JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                          IF (Structure[II - I + X0,JJ - J + Y0] EQ 1) THEN tmpImg[II,JJ] = 1
+                       ENDFOR
+                    ENDFOR
+                 ENDIF
+              ENDFOR
+           ENDFOR
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 IF (dilateImg[I,J] EQ 1) AND (((I - X0) LT 0) OR ((I + dimStt[1]-1 - X0) GT dims[1]-1) $
+                                               OR ((J - Y0) LT 0) OR ((J + dimStt[2]-1 - Y0) GT dims[2]-1)) THEN dilateImg[I,J] = 0
+              ENDFOR
+           ENDFOR
+        END
+        3: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 FOR K = 0, dims[3]-1 DO BEGIN
+                    IF (dilateImg[I,J,K] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) $
+                       AND ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) $
+                       AND ((K - Z0) GE 0) AND ((K + dimStt[3]-1 - Z0) LE dims[3]-1) THEN BEGIN
+                       FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                          FOR JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                             FOR KK = (K - Z0),(K + dimStt[3]-1 - Z0) DO BEGIN
+                                IF (Structure[II - I + X0,JJ - J + Y0,KK - K + Z0] $
+                                    EQ 1) THEN tmpImg[II,JJ,KK] = 1
+                             ENDFOR
+                          ENDFOR
+                       ENDFOR
+                    ENDIF
+                 ENDFOR
+              ENDFOR
+           ENDFOR
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 FOR K = 0, dims[3]-1 DO BEGIN
+                    IF (dilateImg[I,J,K] EQ 1) AND (((I - X0) LT 0) OR ((I + dimStt[1]-1 - X0) GT dims[1]-1) $
+                                                    OR ((J - Y0) LT 0) OR ((J + dimStt[2]-1 - Y0) GT dims[2]-1) $
+                                                    OR ((K - Z0) LT 0) OR ((K + dimStt[3]-1 - Z0) GT dims[3]-1)) THEN dilateImg[II,JJ,KK] = 0
+                 ENDFOR
+              ENDFOR
+           ENDFOR
+        END
+        ELSE: BEGIN
+           MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+        END
+     ENDCASE	
+;
+     dilateImg = dilateImg OR tmpImg
+  ENDELSE
+  
+; Gray: a boolean keyword.
+  IF KEYWORD_SET(GRAY) THEN BEGIN
+; Gray image;
+;
+; Give the type of the returned array.
+     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN 
+        tp = TYPENAME(Image)
+        dilateImg = CALL_FUNCTION(tp,dilateImg)
+     ENDIF
+     IF KEYWORD_SET(UINT) THEN dilateImg = UINT(dilateImg)
+     IF KEYWORD_SET(ULONG) THEN dilateImg = ULONG(dilateImg)
+  ENDIF
+  
+  RETURN, dilateImg
+  
+END

--- a/src/pro/dilate.pro
+++ b/src/pro/dilate.pro
@@ -4,62 +4,62 @@
 ;  Aug. 2018
 ;
 ;  Arguments (from IDL): Image Structure X0 Y0 Z0
-;  Keywords (from IDL): 
-;  	BACKGROUND 
-;		Set this keyword to the pixel value that is to be considered the background when 
+;  Keywords (from IDL):
+;  	BACKGROUND
+;		Set this keyword to the pixel value that is to be considered the background when
 ;		dilation is being performed in constrained mode. The default value is 0.
 ; 	CONSTRAINED (a boolean keyword)
-;		If this keyword is set and grayscale dilation has been selected, the dilation 
-;		algorithm will operate in constrained mode. In this mode, a pixel is set to the 
-;		value determined by normal grayscale dilation rules in the output image only if 
-;		the current value destination pixel value matches the BACKGROUND pixel value. Once 
-;		a pixel in the output image has been set to a value other than the BACKGROUND 
+;		If this keyword is set and grayscale dilation has been selected, the dilation
+;		algorithm will operate in constrained mode. In this mode, a pixel is set to the
+;		value determined by normal grayscale dilation rules in the output image only if
+;		the current value destination pixel value matches the BACKGROUND pixel value. Once
+;		a pixel in the output image has been set to a value other than the BACKGROUND
 ;		value, it cannot change.
 ;	GRAY (a boolean keyword)
-;		Set this keyword to perform grayscale, rather than binary, dilation. The nonzero 
-;		elements of the Structure parameter determine the shape of the structuring element 
-;		(neighborhood). If VALUES is not present, all elements of the structuring element 
+;		Set this keyword to perform grayscale, rather than binary, dilation. The nonzero
+;		elements of the Structure parameter determine the shape of the structuring element
+;		(neighborhood). If VALUES is not present, all elements of the structuring element
 ;		are 0, yielding the neighborhood maximum operator.
 ; 	PRESERVE_TYPE (a boolean keyword)
-;		Set this keyword to return the same type as the input array. This keyword only 
+;		Set this keyword to return the same type as the input array. This keyword only
 ;		applies if the GRAY keyword is set.
 ;	UINT (a boolean keyword)
-;		Set this keyword to return an unsigned integer array. This keyword only applies if 
+;		Set this keyword to return an unsigned integer array. This keyword only applies if
 ;		the GRAY keyword is set.
 ; 	ULONG (a boolean keyword)
-;		Set this keyword to return an unsigned longword integer array. This keyword only 
+;		Set this keyword to return an unsigned longword integer array. This keyword only
 ;		applies if the GRAY keyword is set.
 ;	VALUES
-;		An array with the same dimensions as Structure providing the values of the 
-;		structuring element. The presence of this parameter implies grayscale dilation. 
-;		Each pixel of the result is the maximum of the sum of the corresponding elements 
-;		of VALUE and the Image pixel value. If the resulting sum is greater than 255, the 
+;		An array with the same dimensions as Structure providing the values of the
+;		structuring element. The presence of this parameter implies grayscale dilation.
+;		Each pixel of the result is the maximum of the sum of the corresponding elements
+;		of VALUE and the Image pixel value. If the resulting sum is greater than 255, the
 ;		return value is 255.
 ;  Return (from IDL): the dilation of image
-;  Syntax (from IDL): 
-;	Result = DILATE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /CONSTRAINED [, 
-;		 BACKGROUND=value]] [, /GRAY [, /PRESERVE_TYPE | , /UINT | , /ULONG]] [, 
+;  Syntax (from IDL):
+;	Result = DILATE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /CONSTRAINED [,
+;		 BACKGROUND=value]] [, /GRAY [, /PRESERVE_TYPE | , /UINT | , /ULONG]] [,
 ;		 VALUES=array] )
 ;  Ref: http://www.harrisgeospatial.com/docs/DILATE.html
 ;
 FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
-                 CONSTRAINED=CONSTRAINED, BACKGROUND=BACKGROUND, $ 
+                 CONSTRAINED=CONSTRAINED, BACKGROUND=BACKGROUND, $
                  GRAY=GRAY, PRESERVE_TYPE=PRESERVE_TYPE, $
                  UINT=UINT, ULONG=ULONG, VALUES=VALUES
 ; Return the caller of a procedure in the event of an error.
   ON_ERROR, 2
-  
+
 ; At least Image and Structure are needed.
   IF (N_PARAMS() LE 1) THEN BEGIN
      MESSAGE, 'Incorrect number of arguments.'
   ENDIF
-  
+
 ; Get the Structure size.
   dimStt = SIZE(Structure)
-  
+
 ; Get the image size.
   dims = SIZE(Image)
-  
+
 ; Make sure Structure has the same dimension as Image.
   IF (dims[0] NE dimStt[0]) THEN BEGIN
      CASE dimStt[0] OF
@@ -103,10 +103,10 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
      END
      ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
   ENDCASE
-  
+
 ; Set default value to BACKGROUND.
   IF (KEYWORD_SET(BACKGROUND) EQ 0) THEN BACKGROUND = 0
-  
+
 ; Gray: a boolean keyword.
   IF (KEYWORD_SET(GRAY) OR KEYWORD_SET(VALUES)) THEN BEGIN
 ; Gray image;
@@ -180,7 +180,7 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
            ELSE: BEGIN
               MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
            END
-        ENDCASE	
+        ENDCASE
      ENDIF
 ;
      dilateImg = TRANSPOSE(Image)
@@ -191,7 +191,7 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
         tmpImg = dilateImg
 ; An auxiliary PARAMETER.
         tmpMin = MIN(dilateImg)
-;  
+;
 ; CONSTRAINED situation.
 ; 1D-3D.
         CASE dimStt[0] OF
@@ -278,15 +278,15 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
            ELSE: BEGIN
               MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
            END
-        ENDCASE	
-        dilateImg = TRANSPOSE(tmpImg)      
-;          
+        ENDCASE
+        dilateImg = TRANSPOSE(tmpImg)
+;
      ENDIF ELSE BEGIN
 ; An auxiliary variable.
         tmpImg = dilateImg
 ; An auxiliary PARAMETER.
         tmpMin = MIN(dilateImg)
-;      
+;
 ; UNCONSTRAINED situation.
 ; 1D-3D.
         CASE dimStt[0] OF
@@ -367,7 +367,7 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
            ELSE: BEGIN
               MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
            END
-        ENDCASE	
+        ENDCASE
         dilateImg = TRANSPOSE(tmpImg)
      ENDELSE
 ;
@@ -444,24 +444,25 @@ FUNCTION DILATE, Image, Structure, X0, Y0, Z0, $
         ELSE: BEGIN
            MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
         END
-     ENDCASE	
+     ENDCASE
 ;
      dilateImg = dilateImg OR tmpImg
   ENDELSE
-  
+
 ; Gray: a boolean keyword.
   IF KEYWORD_SET(GRAY) THEN BEGIN
 ; Gray image;
 ;
 ; Give the type of the returned array.
-     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN 
+     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN
         tp = TYPENAME(Image)
         dilateImg = CALL_FUNCTION(tp,dilateImg)
      ENDIF
      IF KEYWORD_SET(UINT) THEN dilateImg = UINT(dilateImg)
      IF KEYWORD_SET(ULONG) THEN dilateImg = ULONG(dilateImg)
   ENDIF
-  
+
   RETURN, dilateImg
-  
+
 END
+

--- a/src/pro/erode.pro
+++ b/src/pro/erode.pro
@@ -1,0 +1,335 @@
+;
+;  GDL replacement to ERODE in IDL
+;  Bin Wu <bin.wu (at) edinsights.no>
+;  Aug. 2018
+;
+;  Arguments (from IDL): Image Structure X0 Y0 Z0
+;  Keywords (from IDL): 
+;	GRAY (a boolean keyword)
+;		Set this keyword to perform grayscale, rather than binary, erosion. Nonzero 
+;		elements of the Structure parameter determine the shape of the structuring element 
+;		(neighborhood). If VALUES is not present, all elements of the structuring element 
+;		are 0, yielding the neighborhood minimum operator.
+;	PRESERVE_TYPE (a boolean keyword)
+;		Set this keyword to return the same type as the input array. This keyword only 
+;		applies if the GRAY keyword is set. 
+;	UINT (a boolean keyword)
+;		Set this keyword to return an unsigned integer array. This keyword only applies if 
+;		the GRAY keyword is set.
+;	ULONG (a boolean keyword)
+;		Set this keyword to return an unsigned longword integer array. This keyword only 
+;		applies if the GRAY keyword is set.
+;	VALUES
+;		An array of the same dimensions as Structure providing the values of the 
+;		structuring element. The presence of this keyword implies grayscale erosion. Each 
+;		pixel of the result is the minimum of Image less the corresponding elements of 
+;		VALUE. If the resulting difference is less than zero, the return value will be 
+;		zero.
+;  Return (from IDL): the erosion of image
+;  Syntax (from IDL): 
+;	Result = ERODE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /GRAY [, /PRESERVE_TYPE | , /UINT 
+;		 | , /ULONG]] [, VALUES=array] )
+;  Ref: http://www.harrisgeospatial.com/docs/ERODE.html
+;
+FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
+                GRAY=GRAY, PRESERVE_TYPE=PRESERVE_TYPE, $
+                UINT=UINT, ULONG=ULONG, VALUES=VALUES
+; Return the caller of a procedure in the event of an error.
+  ON_ERROR, 2
+  
+; At least Image and Structure are needed.
+  IF (N_PARAMS() LE 1) THEN BEGIN
+     MESSAGE, 'Incorrect number of arguments.'
+  ENDIF
+  
+; Get the Structure size.
+  dimStt = SIZE(Structure)
+  
+; Get the image size.
+  dims = SIZE(Image)
+
+; Make sure Structure has the same dimension as Image.
+  IF (dims[0] NE dimStt[0]) THEN BEGIN
+     CASE dimStt[0] OF
+        1: BEGIN
+           CASE dims[0] OF
+              2: Structure = [[Structure],[REPLICATE(0,dimStt[1],1)]]
+              3: Structure = [[[Structure],[REPLICATE(0,dimStt[1],1)]],[[REPLICATE(0,dimStt[1],2)]]]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        2: BEGIN
+           CASE dims[0] OF
+              1: Structure = Structure[*,0]
+              3: Structure = [[[Structure]],[[REPLICATE(0,dimStt[1],dimStt[2])]]]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        3: BEGIN
+           CASE dims[0] OF
+              1: Structure = Structure[*,0,0]
+              2: Structure = Structure[*,*,0]
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+        END
+        ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+     ENDCASE
+     dimStt=SIZE(Structure)
+  ENDIF
+  
+; Get the coordinate of the origin of Structure.
+  CASE dimStt[0] OF
+     1: IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+     2: BEGIN
+        IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+        IF (N_ELEMENTS(Y0) EQ 0) THEN Y0 = dimStt[2]/2
+     END
+     3: BEGIN
+        IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
+        IF (N_ELEMENTS(Y0) EQ 0) THEN Y0 = dimStt[2]/2
+        IF (N_ELEMENTS(Z0) EQ 0) THEN Z0 = dimStt[3]/2
+     END
+     ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+  ENDCASE
+  
+; Gray: a boolean keyword.
+  IF (KEYWORD_SET(GRAY) OR KEYWORD_SET(VALUES)) THEN BEGIN
+; Gray image;
+;
+;	MESSAGE, 'A gray image is in processing.'
+;
+; Make sure VALUES has the same dimension as Image.
+     IF KEYWORD_SET(VALUES) THEN BEGIN
+        dimVal = SIZE(VALUES)
+        IF (dims[0] NE dimVal[0]) THEN BEGIN
+           CASE dimVal[0] OF
+              1: BEGIN
+                 CASE dims[0] OF
+                    2: VALUES = [[VALUES],[REPLICATE(0,dimVal[1],1)]]
+                    3: VALUES = [[[VALUES],[REPLICATE(0,dimVal[1],1)]],[[REPLICATE(0,dimVal[1],2)]]]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              2: BEGIN
+                 CASE dims[0] OF
+                    1: VALUES = VALUES[*,0]
+                    3: VALUES = [[[VALUES]],[[REPLICATE(0,dimVal[1],dimVal[2])]]]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              3: BEGIN
+                 CASE dims[0] OF
+                    1: VALUES = VALUES[*,0,0]
+                    2: VALUES = VALUES[*,*,0]
+                    ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+                 ENDCASE
+              END
+              ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           ENDCASE
+           dimVal=SIZE(VALUES)
+        ENDIF
+        CASE dimVal[0] OF
+           1: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],1)]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+           END
+           2: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],dimVal[2])]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[2] LT dimStt[2] THEN VALUES = [[VALUES],[REPLICATE(0,dimVal[1],dimStt[2] - dimVal[2])]]
+              IF dimVal[2] GT dimStt[2] THEN VALUES = VALUES[*,0:dimStt[2]-1]
+           END
+           3: BEGIN
+              IF dimVal[1] LT dimStt[1] THEN VALUES = [VALUES,REPLICATE(0,dimStt[1] - dimVal[1],dimVal[2],dimVal[3])]
+              IF dimVal[1] GT dimStt[1] THEN VALUES = VALUES[0:dimStt[1]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[2] LT dimStt[2] THEN VALUES = [[VALUES],[REPLICATE(0,dimVal[1],dimStt[2] - dimVal[2],dimVal[3])]]
+              IF dimVal[2] GT dimStt[2] THEN VALUES = VALUES[*,0:dimStt[2]-1,*]
+              dimVal = SIZE(VALUES)
+              IF dimVal[3] LT dimStt[3] THEN VALUES = [[[VALUES]],[[REPLICATE(0,dimVal[1],dimVal[2],dimStt[3] - dimVal[3])]]]
+              IF dimVal[3] GT dimStt[3] THEN VALUES = VALUES[*,*,0:dimStt[3]-1]
+           END
+           ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+        ENDCASE
+     ENDIF
+;
+; In case VALUES are not given, as the image is Gray,
+; set VALUES to be of the same size as Structure
+; with all the elements to be 0.
+     IF (KEYWORD_SET(VALUES) EQ 0) THEN BEGIN
+        CASE dimStt[0] OF
+           1: VALUES = REPLICATE(0, dimStt[1])
+           2: VALUES = REPLICATE(0, dimStt[1], dimStt[2])
+           3: VALUES = REPLICATE(0, dimStt[1], dimStt[2], dimStt[3])
+           ELSE: BEGIN
+              MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+           END
+        ENDCASE	
+     ENDIF
+;
+     erodeImg = Image
+;
+; An auxiliary variable.
+     tmpImg = erodeImg
+; An auxiliary PARAMETER.
+     tmpMin = 0
+; An auxiliary PARAMETER.
+     tmpMax = MAX(erodeImg)
+; 1D-3D.
+     CASE dimStt[0] OF
+        1: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) THEN BEGIN
+                 tmpImg[I] = tmpMax
+                 FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                    IF (Structure[II - I + X0] EQ 1) THEN $
+                       tmpImg[I] = MAX([0,MIN([tmpImg[I], erodeImg[II] - VALUES[II - I + X0]])])
+                 ENDFOR
+              ENDIF ELSE BEGIN
+                 tmpImg[I] = tmpMin
+              ENDELSE
+           ENDFOR
+        END
+        2: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                    ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) THEN BEGIN
+                    tmpImg[I,J] = tmpMax
+                    FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                       FOR  JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                          IF (Structure[II - I + X0,JJ - J + Y0] EQ 1) THEN $
+                             tmpImg[I,J] =  MAX([0, MIN([tmpImg[I,J], erodeImg[II,JJ] - VALUES[II - I + X0,JJ - J + Y0]])])
+                       ENDFOR
+                    ENDFOR
+                 ENDIF ELSE BEGIN
+                    tmpImg[I,J] = tmpMin
+                 ENDELSE
+              ENDFOR
+           ENDFOR
+        END
+        3: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 FOR K = 0, dims[3]-1 DO BEGIN
+                    IF ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) AND $
+                       ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) AND $
+                       ((K - Z0) GE 0) AND ((K + dimStt[3]-1 - Z0) LE dims[3]-1) THEN BEGIN
+                       tmpImg[I,J,K] = tmpMax
+                       FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                          FOR JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                             FOR KK = (K - Z0),(K + dimStt[3]-1 - Z0) DO BEGIN
+                                IF (Structure[II - I + X0,JJ - J + Y0,KK - K + Z0] EQ 1) THEN $
+                                   tmpImg[I,J,K] = $
+                                   MAX([0, MIN([tmpImg[I,J,K], erodeImg[II,JJ,KK] - $
+                                                VALUES[II - I + X0,JJ - J + Y0,KK - K + Z0]])])
+                             ENDFOR
+                          ENDFOR
+                       ENDFOR
+                    ENDIF ELSE BEGIN
+                       tmpImg[I,J,K] = tmpMin
+                    ENDELSE
+                 ENDFOR
+              ENDFOR
+           ENDFOR
+        END
+        ELSE: BEGIN
+           MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+        END
+     ENDCASE	
+     erodeImg = tmpImg
+  ENDIF ELSE BEGIN
+; Binary image otherwise.
+     erodeImg = Image GT 0
+;
+; An auxiliary variable.
+     tmpImg = erodeImg
+;
+; 1D-3D.
+     CASE dimStt[0] OF
+        1: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              IF (erodeImg[I] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) THEN BEGIN
+               idtStt = 1
+               FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                  IF (Structure[II - I + X0] EQ 1) THEN idtStt = idtStt AND erodeImg[II]
+               ENDFOR
+               IF idtStt NE 1 THEN BEGIN
+                  tmpImg[I] = 0
+               ENDIF
+            ENDIF ELSE BEGIN
+               tmpImg[I] = 0
+            ENDELSE
+         ENDFOR
+        END
+        2: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 IF (erodeImg[I,J] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) $
+                    AND ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) THEN BEGIN
+                    idtStt = 1
+                    FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                       FOR JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                          IF (Structure[II - I + X0,JJ - J + Y0] EQ 1) THEN idtStt = (idtStt AND erodeImg[II,JJ])
+                       ENDFOR
+                    ENDFOR
+                    IF idtStt NE 1 THEN BEGIN
+                       tmpImg[I,J] = 0
+                    ENDIF
+                 ENDIF ELSE BEGIN
+                    tmpImg[I,J] = 0
+                 ENDELSE
+              ENDFOR
+           ENDFOR
+        END
+        3: BEGIN
+           FOR I = 0, dims[1]-1 DO BEGIN
+              FOR J = 0, dims[2]-1 DO BEGIN
+                 FOR K = 0, dims[3]-1 DO BEGIN
+                    IF (erodeImg[I,J,K] EQ 1) AND ((I - X0) GE 0) AND ((I + dimStt[1]-1 - X0) LE dims[1]-1) $
+                       AND ((J - Y0) GE 0) AND ((J + dimStt[2]-1 - Y0) LE dims[2]-1) $
+                       AND ((K - Z0) GE 0) AND ((K + dimStt[3]-1 - Z0) LE dims[3]-1) THEN BEGIN
+                       idtStt = 1
+                       FOR II = (I - X0),(I + dimStt[1]-1 - X0) DO BEGIN
+                          FOR JJ = (J - Y0),(J + dimStt[2]-1 - Y0) DO BEGIN
+                             FOR KK = (K - Z0),(K + dimStt[3]-1 - Z0) DO BEGIN
+                                IF (Structure[II - I + X0,JJ - J + Y0,KK - K + Z0] $
+                                    EQ 1) THEN idtStt = idtStt AND erodeImg[II,JJ,KK]
+                             ENDFOR
+                          ENDFOR
+                       ENDFOR
+                       IF idtStt NE 1 THEN BEGIN
+                          tmpImg[I,J,K] = 0
+                       ENDIF
+                    ENDIF ELSE BEGIN
+                       tmpImg[I,J,Z] = 0
+                    ENDELSE
+                 ENDFOR
+              ENDFOR
+           ENDFOR
+        END
+        ELSE: BEGIN
+           MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
+        END
+     ENDCASE	
+;
+     erodeImg = erodeImg AND tmpImg
+  ENDELSE
+
+; Gray: a boolean keyword.
+  IF KEYWORD_SET(GRAY) THEN BEGIN
+; Gray image;
+;
+; Give the type of the returned array.
+     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN 
+        tp = TYPENAME(Image)
+        erodeImg = CALL_FUNCTION(tp,erodeImg)
+     ENDIF
+     IF KEYWORD_SET(UINT) THEN erodeImg = UINT(erodeImg)
+     IF KEYWORD_SET(ULONG) THEN erodeImg = ULONG(erodeImg)
+  ENDIF
+  
+  RETURN, erodeImg
+  
+END

--- a/src/pro/erode.pro
+++ b/src/pro/erode.pro
@@ -4,30 +4,30 @@
 ;  Aug. 2018
 ;
 ;  Arguments (from IDL): Image Structure X0 Y0 Z0
-;  Keywords (from IDL): 
+;  Keywords (from IDL):
 ;	GRAY (a boolean keyword)
-;		Set this keyword to perform grayscale, rather than binary, erosion. Nonzero 
-;		elements of the Structure parameter determine the shape of the structuring element 
-;		(neighborhood). If VALUES is not present, all elements of the structuring element 
+;		Set this keyword to perform grayscale, rather than binary, erosion. Nonzero
+;		elements of the Structure parameter determine the shape of the structuring element
+;		(neighborhood). If VALUES is not present, all elements of the structuring element
 ;		are 0, yielding the neighborhood minimum operator.
 ;	PRESERVE_TYPE (a boolean keyword)
-;		Set this keyword to return the same type as the input array. This keyword only 
-;		applies if the GRAY keyword is set. 
+;		Set this keyword to return the same type as the input array. This keyword only
+;		applies if the GRAY keyword is set.
 ;	UINT (a boolean keyword)
-;		Set this keyword to return an unsigned integer array. This keyword only applies if 
+;		Set this keyword to return an unsigned integer array. This keyword only applies if
 ;		the GRAY keyword is set.
 ;	ULONG (a boolean keyword)
-;		Set this keyword to return an unsigned longword integer array. This keyword only 
+;		Set this keyword to return an unsigned longword integer array. This keyword only
 ;		applies if the GRAY keyword is set.
 ;	VALUES
-;		An array of the same dimensions as Structure providing the values of the 
-;		structuring element. The presence of this keyword implies grayscale erosion. Each 
-;		pixel of the result is the minimum of Image less the corresponding elements of 
-;		VALUE. If the resulting difference is less than zero, the return value will be 
+;		An array of the same dimensions as Structure providing the values of the
+;		structuring element. The presence of this keyword implies grayscale erosion. Each
+;		pixel of the result is the minimum of Image less the corresponding elements of
+;		VALUE. If the resulting difference is less than zero, the return value will be
 ;		zero.
 ;  Return (from IDL): the erosion of image
-;  Syntax (from IDL): 
-;	Result = ERODE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /GRAY [, /PRESERVE_TYPE | , /UINT 
+;  Syntax (from IDL):
+;	Result = ERODE( Image, Structure [, X0 [, Y0 [, Z0]]] [, /GRAY [, /PRESERVE_TYPE | , /UINT
 ;		 | , /ULONG]] [, VALUES=array] )
 ;  Ref: http://www.harrisgeospatial.com/docs/ERODE.html
 ;
@@ -36,15 +36,15 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
                 UINT=UINT, ULONG=ULONG, VALUES=VALUES
 ; Return the caller of a procedure in the event of an error.
   ON_ERROR, 2
-  
+
 ; At least Image and Structure are needed.
   IF (N_PARAMS() LE 1) THEN BEGIN
      MESSAGE, 'Incorrect number of arguments.'
   ENDIF
-  
+
 ; Get the Structure size.
   dimStt = SIZE(Structure)
-  
+
 ; Get the image size.
   dims = SIZE(Image)
 
@@ -76,7 +76,7 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
      ENDCASE
      dimStt=SIZE(Structure)
   ENDIF
-  
+
 ; Get the coordinate of the origin of Structure.
   CASE dimStt[0] OF
      1: IF (N_ELEMENTS(X0) EQ 0) THEN X0 = dimStt[1]/2
@@ -91,7 +91,7 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
      END
      ELSE: PRINT, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
   ENDCASE
-  
+
 ; Gray: a boolean keyword.
   IF (KEYWORD_SET(GRAY) OR KEYWORD_SET(VALUES)) THEN BEGIN
 ; Gray image;
@@ -165,7 +165,7 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
            ELSE: BEGIN
               MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
            END
-        ENDCASE	
+        ENDCASE
      ENDIF
 ;
      erodeImg = Image
@@ -237,7 +237,7 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
         ELSE: BEGIN
            MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
         END
-     ENDCASE	
+     ENDCASE
      erodeImg = tmpImg
   ENDIF ELSE BEGIN
 ; Binary image otherwise.
@@ -312,7 +312,7 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
         ELSE: BEGIN
            MESSAGE, 'The input is an invalid image, considering only 1D, 2D, and 3D at the moment.'
         END
-     ENDCASE	
+     ENDCASE
 ;
      erodeImg = erodeImg AND tmpImg
   ENDELSE
@@ -322,14 +322,15 @@ FUNCTION ERODE, Image, Structure, X0, Y0, Z0, $
 ; Gray image;
 ;
 ; Give the type of the returned array.
-     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN 
+     IF KEYWORD_SET(PRESERVE_TYPE) THEN BEGIN
         tp = TYPENAME(Image)
         erodeImg = CALL_FUNCTION(tp,erodeImg)
      ENDIF
      IF KEYWORD_SET(UINT) THEN erodeImg = UINT(erodeImg)
      IF KEYWORD_SET(ULONG) THEN erodeImg = ULONG(erodeImg)
   ENDIF
-  
+
   RETURN, erodeImg
-  
+
 END
+

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -93,7 +93,9 @@ TESTS = \
   test_device.pro \
   test_diag_matrix.pro \
   test_dicom.pro \
+  test_dilate.pro \
   test_erfinv.pro \
+  test_erode.pro \
   test_execute.pro \
   test_extra_keywords.pro \
   test_fft.pro \

--- a/testsuite/test_dilate.pro
+++ b/testsuite/test_dilate.pro
@@ -6,7 +6,7 @@
 ;
 ; ---------------------
 ; Modification history:
-; 
+;
 ; 2018-08-30 : Bin Wu <bin.wu (at) edinsights (dot) no>
 ; - Initial version
 ; - Basic DILATE tests

--- a/testsuite/test_dilate.pro
+++ b/testsuite/test_dilate.pro
@@ -1,0 +1,53 @@
+;
+; Testing DILATE
+; Todo: DILATION of images
+;
+; Licensed under GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
+;
+; ---------------------
+; Modification history:
+; 
+; 2018-08-30 : Bin Wu <bin.wu (at) edinsights (dot) no>
+; - Initial version
+; - Basic DILATE tests
+; ---------------------
+;
+
+PRO TEST_DILATE, HELP = HELP, NERR_TOTAL, TEST = TEST, verbose = verbose
+
+  IF KEYWORD_SET(HELP) THEN BEGIN
+    PRINT, 'PRO TEST_DILATE, HELP=HELP, TEST=TEST, no_exit=no_exit, verbose=verbose'
+    RETURN
+  ENDIF
+  NERR = 0
+
+  ;; Test on 8-bit grayscale images. (There is no reference image can be used. Forget it.)
+  ;File = FILE_SEARCH_FOR_TESTSUIT('tiff/8bit_gray_geo.tif')
+  ;Image = READ_TIFF(File)
+  ;Image = DILATE(Image,REPLICATE(1,5,5),/GRAY)
+
+  ; Test on EXAMPLE 1 from http://www.harrisgeospatial.com/docs/DILATE.html
+  Image = BYTE([[0,1,0,0],[0,1,0,0],[0,1,1,0],[1,0,0,0],[0,0,0,0]])
+  S = [1,1]
+  Result = DILATE(Image,S,0,0)
+  Result_IDL = BYTE([[0,1,1,0],[0,1,1,0],[0,1,1,1],[1,1,0,0],[0,0,0,0]])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return value of DILATION on BINARY Image'
+
+  ; Test on EXAMPLE 2 from http://www.harrisgeospatial.com/docs/DILATE.html
+  Image = BYTE([2,1,3,3,3,3,1,2])
+  ; S = [1,1]
+  Result = DILATE(Image, S, /GRAY)
+  Result_IDL = BYTE([1,3,3,3,3,3,2,2])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return values of DILATION on GRAYscale Image: DILATION using no padding'
+  Result = DILATE([0, Image], S, /GRAY)
+  Result = Result[1:N_ELEMENTS(image)]
+  Result_IDL = BYTE([2,3,3,3,3,3,2,2])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return values of DILATION on GRAYscale Image: DILATION using padding'
+
+  BANNER_FOR_TESTSUITE, 'TEST_DILATE', NERR, /STATUS
+  ERRORS_CUMUL, NERR_TOTAL, NERR
+  IF KEYWORD_SET(TEST) THEN STOP
+END

--- a/testsuite/test_erode.pro
+++ b/testsuite/test_erode.pro
@@ -6,7 +6,7 @@
 ;
 ; ---------------------
 ; Modification history:
-; 
+;
 ; 2018-08-30 : Bin Wu <bin.wu (at) edinsights (dot) no>
 ; - Initial version
 ; - Basic ERODE tests

--- a/testsuite/test_erode.pro
+++ b/testsuite/test_erode.pro
@@ -1,0 +1,53 @@
+;
+; Testing ERODE
+; Todo: EROSION of images
+;
+; Licensed under GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
+;
+; ---------------------
+; Modification history:
+; 
+; 2018-08-30 : Bin Wu <bin.wu (at) edinsights (dot) no>
+; - Initial version
+; - Basic ERODE tests
+; ---------------------
+;
+
+PRO TEST_ERODE, HELP = HELP, NERR_TOTAL, TEST = TEST, verbose = verbose
+
+  IF KEYWORD_SET(HELP) THEN BEGIN
+    PRINT, 'PRO TEST_ERODE, HELP=HELP, TEST=TEST, no_exit=no_exit, verbose=verbose'
+    RETURN
+  ENDIF
+  NERR = 0
+
+  ;; Test on 8-bit grayscale images. (There is no reference image can be used. Forget it.)
+  ;File = FILE_SEARCH_FOR_TESTSUIT('tiff/8bit_gray_geo.tif')
+  ;Image = READ_TIFF(File)
+  ;Image = ERODE(Image,REPLICATE(1,5,5),/GRAY)
+
+  ; Test on EXAMPLE 1 from http://www.harrisgeospatial.com/docs/ERODE.html
+  Image = BYTE([[0,1,0,0],[0,1,0,0],[1,1,1,0],[1,0,0,0],[0,0,0,0]])
+  S = [1,1]
+  Result = ERODE(Image,S,0,0)
+  Result_IDL = BYTE([[0,0,0,0],[0,0,0,0],[0,1,1,0],[0,0,0,0],[0,0,0,0]])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return value of EROSION on BINARY Image'
+
+  ; Test on EXAMPLE 2 from http://www.harrisgeospatial.com/docs/ERODE.html
+  Image = BYTE([2,1,3,3,3,3,1,2])
+  ; S = [1,1]
+  Result = ERODE(Image, S, /GRAY)
+  Result_IDL = BYTE([0,1,1,3,3,3,1,1])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return values of EROSION on GRAYscale Image: EROSION using no padding'
+  Result = ERODE([MAX(Image), Image], S, /GRAY)
+  Result = Result[1:N_ELEMENTS(image)]
+  Result_IDL = BYTE([2,1,1,3,3,3,1,1])
+  IF ~ARRAY_EQUAL(Result, Result_IDL) THEN $
+    ERRORS_ADD, NERR, 'Unexpected return values of EROSION on GRAYscale Image: EROSION using padding'
+
+  BANNER_FOR_TESTSUITE, 'TEST_ERODE', NERR, /STATUS
+  ERRORS_CUMUL, NERR_TOTAL, NERR
+  IF KEYWORD_SET(TEST) THEN STOP
+END


### PR DESCRIPTION
The current C++ implementation of DILATE and ERODE only supports binary images, while we (the company I am working for) have written more feature complete versions in IDL supporting greyscale as well. Even though a potentially more performant C++ implementation is preferable, I still think supporting all features stated in the IDL documentation is more important.

A more performant C++ version can be enabled when completed. Unless someone else is working on this right now, we have talked about porting the code of this PR to C++ at a later point, but we are focusing on some other things right now.

We have also written some basic tests based on the IDL documentation for both [ERODE](https://www.harrisgeospatial.com/docs/ERODE.html) and [DILATE](https://www.harrisgeospatial.com/docs/DILATE.html).