### PR TITLE
improvment of IdlNetUrl, separation of Tiff & GeoTiff tests

### DIFF
--- a/src/pro/utilities/idlneturl__define.pro
+++ b/src/pro/utilities/idlneturl__define.pro
@@ -16,9 +16,22 @@
 ; Usually, Curl is available by default on OSX, 
 ; but not on most GNU/Linux ... we will try to use Wget too ...
 ;
+; ----------------------------------------------------
+; Modifications history :
+;
+; 2018-Sep-10 : AC.
+; -- add self.URL_QUERY
+; -- add "-L" for Curl
+; -- better management of keyword filename= & string_array=
+; -- tested with current (in 2018) QuerySimbad,'GAL045.45+00.06' in astrolib
+;
+; ----------------------------------------------------
+;
+;
 pro idlneturl::CloseConnections
 end
-function idlneturl::Get, filename=filename
+function idlneturl::Get, filename=filename, string_array=string_array, $
+                         test=test, verbose=verbose
 ;
 tmpIDLDir = GETENV('IDL_TMPDIR')
 if STRLEN(tmpIDLDir) EQ 0 then tmpIDLDir='/tmp/'
@@ -27,15 +40,39 @@ id_cmd=''
 ;
 if STRLEN(self.URL_USERNAME) GT 0 then id_cmd=' -u '+self.URL_USERNAME
 if STRLEN(self.URL_PASSWORD) GT 0 then id_cmd=id_cmd+':'+self.URL_PASSWORD+' '
+id_cmd=id_cmd+self.URL_SCHEME+'://'+self.URL_HOSTNAME
+if STRLEN(self.URL_PORT) GT 0 then id_cmd=id_cmd+':'+self.URL_PORT
+id_cmd=id_cmd+self.URL_PATH
+if STRLEN(self.URL_QUERY) GT 0 then id_cmd=id_cmd+'?'+self.URL_QUERY
 ;
-cmd='curl -O '+id_cmd+self.URL_SCHEME+'://'+self.URL_HOSTNAME
-cmd=cmd+self.URL_PATH
+; AC, 2018-sep-20 : option -L in curl
+; in vizier, the /viz-bin was moved into a /cgi-bin ...
 ;
-print, cmd
+curl_cmd='curl -L '
+if KEYWORD_SET(filename) then begin
+   curl_cmd=curl_cmd+'-o '+filename+' '
+endif else begin
+   ;; when Query, not going through a file ...
+   if STRLEN(self.URL_QUERY) EQ 0 then curl_cmd=curl_cmd+'-O '
+endelse
 ;
-spawn, cmd
+cmd=curl_cmd+id_cmd
+if KEYWORD_SET(verbose) then print, cmd
 ;
-return, 'toto'
+SPAWN, cmd, result, blahblah
+;
+if KEYWORD_SET(test) then STOP
+;
+; order of Keywords is : STRING, BUFFER, FILENAME
+if KEYWORD_SET(string_array) then return, result
+if KEYWORD_SET(buffer) then print, 'what is a BUFFER ?!'
+if KEYWORD_SET(filename) then return, FILE_SEARCH(filename, /full)
+;
+; AC 2018-sep-20 : somethings not clear here because I succeed
+; to got "idl.dat" !
+;
+; return an empty string if none of the previous 3 keywords !
+return, ''
 ;
 end
 ;
@@ -45,6 +82,7 @@ pro idlneturl::SetProperty, URL_SCHEME = URL_SCHEME, $
                             URL_HOSTNAME = URL_HOSTNAME, $
                             URL_PATH = URL_PATH, $
                             URL_PORT = URL_PORT, $
+                            URL_QUERY= URL_QUERY, $
                             URL_USERNAME =  URL_USERNAME, $
                             URL_PASSWORD =  URL_PASSWORD
 ;
@@ -52,6 +90,7 @@ IF KEYWORD_SET(URL_SCHEME) then self.URL_SCHEME=URL_SCHEME
 IF KEYWORD_SET(URL_HOSTNAME) then self.URL_HOSTNAME=URL_HOSTNAME
 IF KEYWORD_SET(URL_PATH) then self.URL_PATH=URL_PATH
 IF KEYWORD_SET(URL_PORT) then self.URL_PORT=URL_PORT
+IF KEYWORD_SET(URL_QUERY) then self.URL_QUERY=URL_QUERY
 IF KEYWORD_SET(URL_USERNAME) then self.URL_USERNAME=URL_USERNAME
 IF KEYWORD_SET(URL_PASSWORD) then self.URL_PASSWORD=URL_PASSWORD
 ;

--- a/testsuite/test_idlneturl.pro
+++ b/testsuite/test_idlneturl.pro
@@ -7,7 +7,7 @@
 ; and try to connect to a remote server with logs.
 ;
 ; Very very limited but working version :
-;  improvments needed (no outputs ...)
+; improvments needed (no outputs ...)
 ;
 pro TEST_IDLNETURL, help=help, test=test, no_exit=no_exit
 ;
@@ -16,33 +16,75 @@ if KEYWORD_SET(help) then begin
    return
 endif
 ;
+error=0
+;
 url='aramis.obspm.fr/~coulais/'
-localFullPath='idlneturl4gdl.txt'
-remoteFileName='GDL/Extra/'+localFullPath
+FileName='idlneturl4gdl.txt'
+remoteFileName='GDL/Extra/'+FileName
 ;
-; cleaning local file
-FILE_DELETE, localFullPath
+localPaths=['','','SubDirNetUrl/','../testsuite/SubDirNetUrl/']
 ;
-oUrl = OBJ_NEW('IDLnetUrl')
-oUrl->SetProperty, URL_SCHEME = 'http'
-oUrl->SetProperty, URL_HOSTNAME = url
-oUrl->SetProperty, URL_PATH = remoteFileName
-oUrl->SetProperty, URL_USERNAME = ''
-oUrl->SetProperty, URL_PASSWORD = ''
-retrievedFilePath = oUrl->Get(FILENAME=localFullPath)
-oUrl->CloseConnections
-OBJ_DESTROY, oUrl
+for ii=0, N_ELEMENTS(localPaths)-1 do begin
+   localFullPath=localPaths[ii]+FileName
+   ;;
+   if ii GT 0 then localFullPath=localFullPath+'_'+GDL_IDL_FL()+'_'+STRCOMPRESS(STRING(ii),/remove)
+   ;; cleaning local file
+   if FILE_TEST(localFullPath) then begin
+      print, 'Removing pre-existing file : '+localFullPath
+      FILE_DELETE, localFullPath
+   endif
+   if STRLEN(localPaths[ii]) GT 0 then begin
+      if ~FILE_TEST(localPaths[ii],/dir) then begin
+         print, 'Path not found : ', localPaths[ii]
+         FILE_MKDIR, localPaths[ii]
+         print, 'Path created : ', localPaths[ii]        
+      endif
+   endif
+   ;;
+   oUrl = OBJ_NEW('IDLnetUrl')
+   oUrl->SetProperty, URL_SCHEME = 'http'
+   oUrl->SetProperty, URL_HOSTNAME = url
+   oUrl->SetProperty, URL_PATH = remoteFileName
+   oUrl->SetProperty, URL_USERNAME = ''
+   oUrl->SetProperty, URL_PASSWORD = ''
+   if (ii GT 0) then begin
+      retrievedFilePath = oUrl->Get(FILENAME=localFullPath)
+   endif else begin
+      retrievedFilePath = oUrl->Get() ;; only the basic one
+      ;;
+      ;; AC 2018-sep-20 : somthing is not clear here :((
+      retrievedFilePath2 = oUrl->Get(string_array=content)
+   endelse
+   oUrl->CloseConnections
+   OBJ_DESTROY, oUrl
+   ;;
+   ;; is the file really arrived ?!
+   ;;
+   if KEYWORD_SET(verbose) then begin
+      print, "step      : ", ii
+      print, "Input file name     :", localFullPath
+      print, "Full retrieved file :", retrievedFilePath
+   endif
+   ;;
+   if FILE_TEST(localFullPath) then begin
+      ;;
+      ;; reading back the file
+      ;;
+      tmp=''
+      OPENR, lun, localFullPath, /get_lun
+      READF, lun, tmp
+      CLOSE, lun
+      FREE_lun, lun
+      ;;
+      ;; is the content as expected ?
+      expected_content='AC 22 Feb 2017'
+      if (expected_content NE tmp) then ERRORS_ADD, error, 'Bad content in file'
+   endif else begin
+      ERRORS_ADD, error, 'Missing file : '+localFullPath
+   endelse
+endfor
 ;
-; reading back the file
-;
-tmp=''
-OPENR, lun, localFullPath, /get_lun
-READF, lun, tmp
-CLOSE, lun
-FREE_lun, lun
-;
-expected_content='AC 22 Feb 2017'
-if (expected_content EQ tmp) then error=0 else error=1
+; ----------------- final message ----------
 ;
 BANNER_FOR_TESTSUITE, 'TEST_IDLNETURL', error
 ;

--- a/testsuite/test_tiff.pro
+++ b/testsuite/test_tiff.pro
@@ -4,7 +4,7 @@
 ;
 ; Licensed under GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
 ;
-; ---------------------
+; ------------------------------------------
 ; Modification history:
 ; 
 ; 2018-06-20 : Remi A. Solås <remi.solaas (at) edinsights (dot) no>
@@ -15,120 +15,187 @@
 ; - Initial version
 ; - Basic QUERY_TIFF tests for both tiff and geotiff
 ;
-; ---------------------
+; 2018-09-19 : AC :
+; - Allowing running it on IDL ...
+; - Maj for most Pro/Funct
+; - This code is not working with FL Fawlty Language 0.79.43.1
 ;
-
-pro test_query_tiff, ntoterr, test=test, verbose=verbose
-  nerr=0
-
-  ; Regular TIFF, tiled
-  file=file_search_for_testsuite('tiff/8bit_gray_tiled.tif')
-  if query_tiff(file, info) eq 1 then begin
-    if info.channels ne 1 then $
-      errors_add, nerr, 'Unexpected number of CHANNELS in ' + file
-
-    if ~array_equal(info.dimensions, [1024, 1024]) then $
-      errors_add, nerr, 'Unexpected value of DIMENSIONS in ' + file
-
-    if info.has_palette ne 0 then $
-      errors_add, nerr, 'Unexpected value of HAS_PALETTE in ' + file
-
-    if info.num_images ne 1 then $
-      errors_add, nerr, 'Unexpected value of NUM_IMAGES in ' + file
-
-    if info.image_index ne 0 then $
-      errors_add, nerr, 'Unexpected value of IMAGE_INDEX in ' + file
-
-    if info.pixel_type ne 1 then $
-      errors_add, nerr, 'Unexpected value of PIXEL_TYPE in ' + file
-
-    if info.type ne 'TIFF' then $
-      errors_add, nerr, 'Unexpected value of TYPE in ' + file
-
-    if info.bits_per_sample ne 8 then $
-      errors_add, nerr, 'Unexpected value of BITS_PER_SAMPLE in ' + file
-
-    if info.orientation ne 1 then $
-      errors_add, nerr, 'Unexpected value of ORIENTATION in ' + file
-
-    if info.planar_config ne 1 then $
-      errors_add, nerr, 'Unexpected value of PLANAR_CONFIG in ' + file
-
-    if ~array_equal(info.resolution, [1, 1]) then $
-      errors_add, nerr, 'Unexpected value of RESOLUTION in ' + file
-
-    if info.units ne 2 then $
-      errors_add, nerr, 'Unexpected value of UNITS in ' + file
-
-    if ~array_equal(info.tile_size, [256, 112]) then $
-      errors_add, nerr, 'Unexpected value of TILE_SIZE in ' + file
-
-  endif else errors_add, nerr, 'QUERY_TIFF failed to query ' + file
-
-  if geotiff_exists() then begin
-    ; GeoTIFF, untiled
-    file=file_search_for_testsuite('tiff/8bit_gray_geo.tif')
-    if query_tiff(file, info, geotiff=geo) eq 1 then begin
-      if ~array_equal(info.tile_size, [info.dimensions[0], 1]) then $
-        errors_add, nerr, 'Unexpected value of TILE_SIZE in ' + file
-
-      if ~array_equal(geo.modelPixelScaleTag, [60, 60, 0]) then $
-        errors_add, nerr, 'Unexpected value of MODELPIXELSCALETAG in ' + file
-
-      if ~array_equal(geo.modelTiePointTag, [0, 0, 0, 440720, 100000, 0]) then $
-        errors_add, nerr, 'Unexpected value of MODELTIEPOINTTAG in ' + file
-
-      if geo.gtModelTypeGeoKey ne 1 then $
-        errors_add, nerr, 'Unexpected value of GTMODELTYPEGEOKEY in ' + file
-
-      if geo.gtRasterTypeGeoKey ne 1 then $
-        errors_add, nerr, 'Unexpected value of GTRASTERTYPEGEOKEY in ' + file
-
-      if geo.projectedCsTypeGeoKey ne 21892 then $
-        errors_add, nerr, 'Unexpected value of PROJECTEDCRTYPEGEOKEY in ' + file
-
-    endif else errors_add, nerr, 'QUERY_TIFF failed to query ' + file
-  endif
-
-  banner_for_testsuite, 'test_query_tiff', nerr, /status
-  errors_cumul, ntoterr, nerr
-  if keyword_set(test) then STOP
+; ------------------------------------------
+;
+function INTERNAL_GDL_TIFF
+FORWARD_FUNCTION TIFF_EXISTS
+return, TIFF_EXISTS()
 end
-
-pro test_read_tiff, ntoterr, test=test, verbose=verbose
-  nerr=0
-
-  ; 8-bit grayscale with SUB_RECT
-  file=file_search_for_testsuite('tiff/8bit_gray_geo.tif')
-  image=tiff_read(file, sub_rect=[5, 15, 30, 90])
-
-  if ~array_equal(size(image, /dimensions), [30, 90]) then $
-    errors_add, nerr, 'Unexpected return value of SUB_RECT of ' + file
-
-  if ~array_equal(image[0:5], [107, 107, 115, 140, 99, 115]) then $
-    errors_add, nerr, 'Unexpected pixel values in tested range of ' + file
-
-  if ((image[0, 0] ne 107) || (image[0, 89] ne 0) || (image[29, 0] ne 107) || (image[29, 89] ne 41)) then $
-    errors_add, nerr, 'Unexpected pixel values in corners of ' + file
-
-  banner_for_testsuite, 'test_read_tiff', nerr, /status
-  errors_cumul, ntoterr, nerr
-  if keyword_set(test) then STOP
+;
+function INTERNAL_GDL_GEOTIFF
+FORWARD_FUNCTION GEOTIFF_EXISTS
+return, GEOTIFF_EXISTS()
 end
+;
+; ------------------------------------------
+;
+pro TEST_QUERY_TIFF, ntoterr, test=test, verbose=verbose
+;
+nerr=0
 
-pro test_tiff, help=help, test=test, no_exit=no_exit, verbose=verbose
-  if keyword_set(help) then begin
-    print, 'pro test_tiff, help=help, test=test, no_exit=no_exit, verbose=verbose'
-    return
-  endif
+;; Regular TIFF, tiled
+file=FILE_SEARCH_for_testsuite('tiff/8bit_gray_tiled.tif')
+;
+if QUERY_TIFF(file, info) eq 1 then begin
+   if info.channels ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected number of CHANNELS in ' + file
 
-  if tiff_exists() then begin
-    test_query_tiff, ntoterr, test=test, verbose=verbose
-    test_read_tiff, ntoterr, test=test, verbose=verbose
-  endif
+   if ~ARRAY_EQUAL(info.dimensions, [1024, 1024]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of DIMENSIONS in ' + file
 
-  banner_for_testsuite, 'test_tiff', ntoterr
-  if ntoterr gt 0 && ~keyword_set(no_exit) then exit, status=1
-  if keyword_set(test) then stop
+   if info.has_palette ne 0 then $
+      ERRORS_ADD, nerr, 'Unexpected value of HAS_PALETTE in ' + file
+
+   if info.num_images ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of NUM_IMAGES in ' + file
+
+   if info.image_index ne 0 then $
+      ERRORS_ADD, nerr, 'Unexpected value of IMAGE_INDEX in ' + file
+
+   if info.pixel_type ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of PIXEL_TYPE in ' + file
+
+   if info.type ne 'TIFF' then $
+      ERRORS_ADD, nerr, 'Unexpected value of TYPE in ' + file
+
+   if info.bits_per_sample ne 8 then $
+      ERRORS_ADD, nerr, 'Unexpected value of BITS_PER_SAMPLE in ' + file
+
+   if info.orientation ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of ORIENTATION in ' + file
+
+   if info.planar_config ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of PLANAR_CONFIG in ' + file
+
+   if ~ARRAY_EQUAL(info.resolution, [1, 1]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of RESOLUTION in ' + file
+
+   if info.units ne 2 then $
+      ERRORS_ADD, nerr, 'Unexpected value of UNITS in ' + file
+
+   if ~ARRAY_EQUAL(info.tile_SIZE, [256, 112]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of TILE_SIZE in ' + file
+
+endif else ERRORS_ADD, nerr, 'QUERY_TIFF failed to query ' + file
+;
+; ------
+;
+BANNER_FOR_TESTSUITE, 'TEST_QUERY_GEOTIFF', nerr, /status
+ERRORS_CUMUL, ntoterr, nerr
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; ------------------------------------------
+;
+pro TEST_QUERY_GEOTIFF, ntoterr, test=test, verbose=verbose
+;
+nerr=0
+;; GeoTIFF, untiled
+file=FILE_SEARCH_for_testsuite('tiff/8bit_gray_geo.tif')
+if QUERY_TIFF(file, info, geotiff=geo) eq 1 then begin
+   if ~ARRAY_EQUAL(info.tile_SIZE, [info.dimensions[0], 1]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of TILE_SIZE in ' + file
+
+   if ~ARRAY_EQUAL(geo.modelPixelScaleTag, [60, 60, 0]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of MODELPIXELSCALETAG in ' + file
+
+   if ~ARRAY_EQUAL(geo.modelTiePointTag, [0, 0, 0, 440720, 100000, 0]) then $
+      ERRORS_ADD, nerr, 'Unexpected value of MODELTIEPOINTTAG in ' + file
+
+   if geo.gtModelTypeGeoKey ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of GTMODELTYPEGEOKEY in ' + file
+
+   if geo.gtRasterTypeGeoKey ne 1 then $
+      ERRORS_ADD, nerr, 'Unexpected value of GTRASTERTYPEGEOKEY in ' + file
+
+   if geo.projectedCsTypeGeoKey ne 21892 then $
+      ERRORS_ADD, nerr, 'Unexpected value of PROJECTEDCRTYPEGEOKEY in ' + file
+
+endif else ERRORS_ADD, nerr, 'QUERY_TIFF failed to query ' + file
+;
+; ------
+;
+BANNER_FOR_TESTSUITE, 'TEST_QUERY_GEOTIFF', nerr, /status
+ERRORS_CUMUL, ntoterr, nerr
+if KEYWORD_SET(test) then STOP
+;
+end
+; ------------------------------------------
+
+pro TEST_READ_TIFF, ntoterr, test=test, verbose=verbose
+;
+nerr=0
+;
+;; 8-bit grayscale with SUB_RECT
+file=FILE_SEARCH_FOR_TESTSUITE('tiff/8bit_gray_geo.tif')
+
+; AC 2018-sep-19 : not very happy ! 
+;
+;image=TIFF_READ(file, sub_rect=[5, 15, 30, 90])
+image=READ_TIFF(file, sub_rect=[5, 15, 30, 90])
+
+if ~ARRAY_EQUAL(SIZE(image, /dimensions), [30, 90]) then $
+   ERRORS_ADD, nerr, 'Unexpected return value of SUB_RECT of ' + file
+
+if ~ARRAY_EQUAL(image[0:5], [107, 107, 115, 140, 99, 115]) then $
+   ERRORS_ADD, nerr, 'Unexpected pixel values in tested range of ' + file
+
+if ((image[0, 0] ne 107) || (image[0, 89] ne 0) || $
+    (image[29, 0] ne 107) || (image[29, 89] ne 41)) then $
+       ERRORS_ADD, nerr, 'Unexpected pixel values in corners of ' + file
+;
+; ------
+;
+BANNER_FOR_TESTSUITE, 'TEST_READ_TIFF', nerr, /status
+ERRORS_CUMUL, ntoterr, nerr
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; ------------------------------------------
+;
+pro TEST_TIFF, help=help, test=test, no_exit=no_exit, verbose=verbose
+
+if KEYWORD_SET(help) then begin
+   print, 'pro TEST_TIFF, help=help, test=test, no_exit=no_exit, verbose=verbose'
+   return
+endif
+;
+if (GDL_IDL_FL() EQ 'FL') then MESSAGE, /continue, 'This code don''t work on FL now'
+;
+DEFSYSV, '!gdl', exists=is_it_gdl
+;
+if (is_it_gdl) then begin 
+   status_tiff=INTERNAL_GDL_TIFF()
+   if ~status_tiff then begin
+      MESSAGE, /continue, 'GDL was compiled without TIFF support'
+      EXIT, status=77
+   endif
+   status_geotiff=INTERNAL_GDL_GEOTIFF()
+   if ~status_geotiff then MESSAGE, /continue, 'GDL was compiled without GEO TIFF support'
+endif else begin
+   status_tiff=1
+   status_geotiff=1
+endelse
+;
+if status_tiff then begin
+   TEST_QUERY_TIFF, ntoterr, test=test, verbose=verbose
+   TEST_READ_TIFF, ntoterr, test=test, verbose=verbose   
+endif
+if status_geotiff then TEST_QUERY_GEOTIFF, ntoterr, test=test, verbose=verbose
+;
+; ----------------- final MESSAGE ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_TIFF', ntoterr
+;
+if ntoterr gt 0 && ~KEYWORD_SET(no_exit) then EXIT, status=1
+if KEYWORD_SET(test) then stop
+;
 end
 


### PR DESCRIPTION
in "test_tiff.pro", I decided to split the Tiff & GeoTiff parts ...

adding Query in IdlNetUrl. extension of the related test "test_idlneturl.pro"

The example in the current version of query_simbad.pro in idl_astro is OK, but previous version not.
No time to check whether it is OK in Debian Git of this lib. :( 

