### PR TITLE
found the culprit for significant speed regression

### DIFF
--- a/src/gdlarray.hpp
+++ b/src/gdlarray.hpp
@@ -206,14 +206,11 @@ public:
 
   T& operator[]( SizeT ix) throw()
   {
-      if( ix >= sz) std::cout << "GDLArray line 210 ix=" << ix
-				<<", sz = " << sz << " indexing overflow" << std::endl;
-    assert( ix < sz);  // see note in basic_fun.cpp at obj_valid()
+    assert( ix < sz);
     return buf[ ix];
   }
   const T& operator[]( SizeT ix) const throw()
   {
-//     if( ix >= sz) // debug 
       assert( ix < sz);
     return buf[ ix];
   }


### PR DESCRIPTION
Such basic "inside" operators should be treated with extreme precaution, as conditional clauses are bound to slow the code. Asserts are valid as they are not used in optimized code, but debug lines should always rendered inactive by defining debug=0 at star and then making debug code conditional as in
`if (debug) do_something;`
