### PR TITLE
Drop unneeded using namespace std that conflicts with ALTIVEC vector

### DIFF
--- a/src/randomgenerators.cpp
+++ b/src/randomgenerators.cpp
@@ -35,7 +35,6 @@
 
 namespace lib {
 
-  using namespace std;
 #ifdef USE_EIGEN
   /* following are some modified codes taken from the GNU Scientific Library.
    * 


### PR DESCRIPTION
On ppc64le I get:
```
In file included from /builddir/build/BUILD/gdl-0.9.9/src/randomgenerators.cpp:62:
/builddir/build/BUILD/gdl-0.9.9/src/dSFMT/dSFMT.h: At global scope:
/builddir/build/BUILD/gdl-0.9.9/src/dSFMT/dSFMT.h:146:3: error: invalid use of template-name 'std::vector' without an argument list
   vector unsigned int s;
   ^~~~~~
```
This is because of the "using namespace std" above the include.