### PR TITLE
adding ROUTINE_DIR(); finishing (?!) changes for GSHHG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,8 @@ set(PYTHON ON CACHE BOOL "GDL: Enable Python ?")
 set(PYTHONDIR "" CACHE PATH "GDL: Specifiy the use Python directory tree")
 set(PYTHONVERSION "" CACHE STRING "GDL: Specify the Python version to use")
 
-set(GSHHS ON CACHE BOOL "GDL: Enable GSHHS ?")
-set(GSHHSDIR "" CACHE PATH "GDL: Specifiy the GSHHS directory tree")
+set(GSHHG ON CACHE BOOL "GDL: Enable GSHHG ?")
+#set(GSHHGDIR "" CACHE PATH "GDL: Specifiy the GSHHG directory tree")
 
 if(NOT WIN32)
   set(NCURSESDIR "" CACHE PATH "GDL: Specify the ncurses (or curses) directory tree")
@@ -1023,25 +1023,14 @@ if(GLPK)
 endif(GLPK)
 #check_include_file(glpk.h HAVE_GLPK)
 
-# gshhs
+# gshhs/gshhg (renamed
 # -DGSHHS=ON|OFF
-if(GSHHS) 	
-    set(USE_GSHHS 1)
-endif(GSHHS)
-# -DGSHHSDIR=DIR
-#not needed anymore, gshhs include is in src/
-#	set(CMAKE_PREFIX_PATH ${GSHHSDIR} src/)
-#	find_path(GSHHS_INCLUDE_DIR gshhs.h)
-#	mark_as_advanced(GSHHS_INCLUDE_DIR)
-#	set(USE_GSHHS ${GSHHS_INCLUDE_DIR})
-#	if(USE_GSHHS)
-#		include_directories(${GSHHS_INCLUDE_DIR})
-#	else(USE_GSHHS)
-#		message(FATAL_ERROR "GSHHS is required but gshhs.h was not found.\n"
-#		"Use -DGSHHSDIR=DIR to specify the GSHHS directory tree.\n"
-#		"Use -DGSHHS=OFF to not use it.")
-#	endif(USE_GSHHS)
-#endif(GSHHS)
+if(GSHHG)
+  set(USE_GSHHG 1)
+endif(GSHHG)
+# -DGSHHSDIR=DIR 
+# AC 2019 not needed anymore, gshhs include is in src/
+# see in revision history if needed
 #
 # X11
 if(X11)
@@ -1178,8 +1167,8 @@ module(GRIB      "GRIB          ")
 # module(QHULL     "QHULL         ")
 set(GLPK_LIBRARIES ${GLPK_LIBRARIES})
 module(GLPK      "GLPK          ")
-set(GSHHS_LIBRARIES ${GSHHS_INCLUDE_DIR})
-module(GSHHS     "GSHHS         ")
+#set(GSHHS_LIBRARIES ${GSHHS_INCLUDE_DIR})
+module(GSHHG     "GSHHG         ")
 module(PSLIB	 "pslib         ")
 if(WIN32 AND NOT CYGWIN)
   module(XPORTMINGW	 "XPortMinGW (Win32 Xlib)       ")

--- a/MAP_INSTALL
+++ b/MAP_INSTALL
@@ -1,4 +1,5 @@
 Revised version by Gilles Duvert on July 2014
+Small revision by Alain on Jan. 2019 (mostly GSHHS --> GSHHG)
 
 To provide map projections support your first need to make sure the
 proj.4 library is installed. There are two libraries, the 'classic
@@ -51,35 +52,43 @@ that do not need the above procedures...
 
 ===========================================================================
 
-MAP_CONTINENTS is implemented in GDL using the GSHHSG (Global 
+MAP_CONTINENTS is implemented in GDL using the GSHHG (Global 
 Self-consistent, Hierarchical, High-resolution Geography Database) 
 available under the GNU GPL. To provide support for MAP_CONTINENTS the 
 database files and one header file (gshhs.h) need to be downloaded e.g. from:
 
-ftp://ftp.soest.hawaii.edu/pwessel/gshhsg
+http://www.soest.hawaii.edu/pwessel/gshhg/
 
-see file ftp://ftp.soest.hawaii.edu/pwessel/gshhg/README.TXT for
-complete description.
+Current version is : Version 2.3.7 Released June 15, 2017
 
 The header file for the 2.0 dataset is in the gshhs_1.12_src.zip file.
 The datafiles (*.b) are in the gshhs_2.0.tbz file.
 
-When compiling GDL, the "-DGSHHS=YES" option must be given (not
-enabled by default), optionally with an argument pointing to the GSHHS
-installation prefix: -DGSHHSDIR="DIR"
+When compiling GDL, GSHHG is enable by default (the optional with an
+argument pointing to the GSHHG installation prefix: -DGSHHGDIR="DIR"
+is currently disable (no need anymore)). Can be disable with :
+"-DGSHHG=no"
  
-Warning: At execution time, GDL will look for the GSHHS datafiles
-(gshhs_f.b, gshhs_l.b, etc...) in the $GSHHS_DATA_DIR. Before running
-GDL you can setup this variable (e.g. in bash : 
-export GSHHS_DATA_DIR=/my/path/to/gshhs/). 
-When GDL is compiled, if $GSHHS_DATA_DIR unknown, if $GDLDATADIR
-exists and if $GDLDATADIR/../gshhs/ exist too, this path is used as a
-defaut directory for gshhs data. So the files can/must be put there. 
+Warning: At execution time, GDL will look for the GSHHG datafiles
+(gshhs_XX.b, wdb_borders_XX.b, wdb_rivers_XX.b) (XX in : c, l, i, h, f, 
+see below) in the $GSHHG_DATA_DIR. Before running GDL you can setup
+this variable (e.g. in bash : export GSHHG_DATA_DIR=/my/path/to/gshhg/).
+When GDL is compiled, if $GSHHG_DATA_DIR unknown, if $GDLDATADIR
+exists and if $GDLDATADIR/../gshhg/ exist too, this path is used as a
+defaut directory for gshhg data. So the files can/must be put there.
 (we need a more flexible solution - FIXME!)
+
+Since Jan 2019 (0.9.9 git), is is possible to set !GSHHG_DATA_DIR directly
+!GSHHG_DATA_DIR=/a/path/to/GSHHG/gshhg_2.3.7/ (absolute or relative)
+or using MAP_GSHHG_PATH_SET procedure (in pro/gshhg_map/). The quality
+of the maps (_c : CRUDE, _l : LOW, _i : INTERMEDIATE, _h : HIGH, _f: FULL)
+is now stored in !GDL.map_quality and can be change with
+procedure MAP_GSHHG_QUALITY_SET
 
 Reference:
 Wessel, P. and Smith, W.H.F., 1996. A global, self-consistent, hierarchical, 
   high-resolution shoreline database. J. Geophys. Res., 101(B4): 8741--8743.
+http://www.soest.hawaii.edu/pwessel/gshhg/Wessel+Smith_1996_JGR.pdf
 
 ===========================================================================
 NOTE ON PROJECTION-RELATED PROCEDURES IN GDL (and IDL)

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -72,6 +72,8 @@ extern "C" char **environ;
 #include "typedefs.hpp"
 #include "base64.hpp"
 #include "objects.hpp"
+//#include "file.hpp"
+
 
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
@@ -126,8 +128,8 @@ static DStructGDL* GetObjStruct( BaseGDL* Objptr, EnvT* e)
 static bool trace_me(false);
 
 namespace lib {
-	bool trace_arg();
-	bool gdlarg_present(const char* s);
+  bool trace_arg();
+  bool gdlarg_present(const char* s);
   SizeT HASH_count( DStructGDL* oStructGDL);
   SizeT LIST_count( DStructGDL* oStructGDL);
   
@@ -7354,6 +7356,14 @@ BaseGDL* routine_filepath( EnvT* e)
 	}
 //    if(nParam == 0) return new DStringGDL(FullFileName);
     return res_guard.release();
+  }
+
+  //AC 2019 (see "routine_name.pro". Here another way to catch the name ...)
+  BaseGDL* routine_name_fun( EnvT* e)
+  {
+    EnvStackT& callStack = e->Interpreter()->CallStack();
+    string name=callStack.back()->GetProName();
+    return new DStringGDL(name);
   }
 
   BaseGDL* routine_info( EnvT* e)

--- a/src/basic_fun.hpp
+++ b/src/basic_fun.hpp
@@ -144,6 +144,8 @@ namespace lib {
   BaseGDL* bytscl( EnvT* e);
 
   BaseGDL* routine_info( EnvT* e);
+  //AC 2019
+  BaseGDL* routine_name_fun( EnvT* e);
 
   BaseGDL* temporary( EnvT* e);
 

--- a/src/exists_fun.cpp
+++ b/src/exists_fun.cpp
@@ -88,7 +88,7 @@ namespace lib {
 
   BaseGDL* gshhg_exists( EnvT* e )
   {
-#ifdef USE_GSHHS
+#ifdef USE_GSHHG
     //    e->Message( "GDL was compiled with support for GSHHG" );
     return new DIntGDL(1);
 #else

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -36,6 +36,9 @@
 #include "file.hpp"
 #include "objects.hpp"
 
+#include "dinterpreter.hpp"
+
+
 #include <zlib.h>
 
 #include <climits> // PATH_MAX
@@ -692,8 +695,7 @@ static void ExpandPathN( FileListT& result,
     DString cat = sArr[0];
     for( SizeT i=1; i<nArr; ++i)
       cat += pathsep + sArr[i];
-    return new DStringGDL( cat);
-  }
+    return new DStringGDL( cat);  }
 
 #ifdef _WIN32
 #define realpath(N,R) _fullpath((R),(N),_MAX_PATH) 
@@ -1169,6 +1171,7 @@ static void FileSearch( FileListT& fileList, const DString& pathSpec,
   }
 
 #endif
+
 
 static std::string Dirname(const string& tmp,
 	bool mark_dir = false)
@@ -3039,6 +3042,16 @@ void file_move( EnvT* e)
 			}
 		}
 		return;
+  }
+
+  BaseGDL* routine_dir_fun( EnvT* e)
+  {
+    EnvStackT& callStack = e->Interpreter()->CallStack();
+
+    string path=callStack.back()->GetFilename();
+    string toto=Dirname(path, true);
+
+    return new DStringGDL(toto);
   }
 
 } // namespace lib

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -24,6 +24,8 @@ namespace lib {
   BaseGDL* file_test( EnvT* e);
   BaseGDL* file_lines( EnvT* e);
 
+  BaseGDL* routine_dir_fun( EnvT* e);
+
   std::string PathSeparator();
   void cd_pro( EnvT* e);
 

--- a/src/gshhs.cpp
+++ b/src/gshhs.cpp
@@ -20,8 +20,8 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #else
-// default: assume we have GSHHS
-#define USE_GSHHS 1
+// default: assume we have GSHHG
+#define USE_GSHHG 1
 #endif
 
 #if defined(USE_LIBPROJ4)||defined(USE_LIBPROJ4_NEW)
@@ -33,7 +33,8 @@
 
 #include "initsysvar.hpp"
 
-#ifdef USE_GSHHS
+// AC 2019 we keep the old name for include, may be clarify
+#ifdef USE_GSHHG
 #include "gshhs.h"
 #endif
 
@@ -64,8 +65,8 @@ namespace lib {
   private:
 
     void old_body( EnvT* e, GDLGStream * actStream ) {
-#ifndef USE_GSHHS
-      e->Throw( "GDL was compiled without support for GSHHS" );
+#ifndef USE_GSHHG
+      e->Throw( "GDL was compiled without support for GSHHG" );
 #else
       static struct GSHHS_POINT p;
       bool externalMap;

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -128,6 +128,10 @@ void LibInit()
 				  "PARAMETERS","SOURCE", KLISTEND};
   new DLibFunRetNew(lib::routine_info,string("ROUTINE_INFO"),1,routine_infoKey);
 
+  new DLibFunRetNew(lib::routine_name_fun,string("ROUTINE_NAME_INTERNALGDL"),1);
+  new DLibFunRetNew(lib::routine_dir_fun,string("ROUTINE_DIR"),1);
+
+
 #ifdef _WIN32
 //Please note that NOWAIT and HIDE are WINDOWS-Reserved Keywords.
   const string spawnKey[] = { "COUNT", "EXIT_STATUS", "PID",

--- a/src/pro/gshhg_map/map_gshhg_path_set.pro
+++ b/src/pro/gshhg_map/map_gshhg_path_set.pro
@@ -10,7 +10,7 @@ pro MAP_GSHHG_PATH_SET, a_path, current=current, $
                         verbose=verbose, help=help, test=test
 ;
 if KEYWORD_SET(help) then begin
-   print, 'pro MAP_GSHHG_PATH_SET, a_path_to_gsshg_data, current=current, $ '
+   print, 'pro MAP_GSHHG_PATH_SET, a_path_to_gshhg_data, current=current, $ '
    print, '                        verbose=verbose, help=help, test=test'
    return
 endif

--- a/src/pro/gshhg_map/map_status.pro
+++ b/src/pro/gshhg_map/map_status.pro
@@ -76,7 +76,9 @@ if ~gshhg_dir_status then begin
    print, 'We cannnot check whether some map data are available'
    print, 'since the !GSHHG_DATA_DIR is not OK'
 endif else begin
-   MAP_GSHHG_DATA_CHECK, /verbose
+   ;;
+   print, 'TODO ! sorry, not ready now'
+;;   MAP_GSHHG_DATA_CHECK, /verbose
 endelse
 ;
 if KEYWORD_SET(test) then STOP

--- a/src/pro/utilities/routine_name.pro
+++ b/src/pro/utilities/routine_name.pro
@@ -5,6 +5,10 @@
 ; in which routine (pro or funct) we are ...
 ; It would be useful for various messages !
 ;
+; This code can be use in IDL and FL too
+;
+; In GDL, since Feb. 2019, we also have a ROUTINE_NAME_GDLINTERNAL()
+;
 function ROUTINE_NAME, lowercase=lowercase, test=test, verbose=verbose
 ;
 callStack = SCOPE_TRACEBACK()

--- a/testsuite/test_map.pro
+++ b/testsuite/test_map.pro
@@ -280,13 +280,13 @@ if (status_gshhg_data LT 0) then begin
    if (reponse EQ 'Y' or reponse EQ 'O') then begin
       GET_GSHHG_DATA
    endif else begin
-      MESSAGE, "GSHHS data are missing, you can set up !GSHHG_DATA_DIR if you have a local copy"
+      MESSAGE, "GSHHG data are missing, you can set up !GSHHG_DATA_DIR if you have a local copy"
    endelse
    ;;
    ;; now we can check again
    status_gshhg_data=CHECK_GSHHG_DATA()
    if (status_gshhg_data LT 0) then begin
-      MESSAGE, "GSHHS data still missing"
+      MESSAGE, "GSHHG data still missing"
    endif
 endif
 ;

--- a/testsuite/test_routine_dir.pro
+++ b/testsuite/test_routine_dir.pro
@@ -1,0 +1,108 @@
+;
+; Alain Coulais, 6 Feb. 2019. Under GNU GPL v2+
+;
+; preliminatry test suite for function ROUTINE_DIR
+; (introduced in IDL 8.7)
+;
+; ----------------------------------------------------
+; testing for a procedure
+pro AC_PRO_DIR_1234, cumul_errors, test=test, verbose=verbose
+;
+FORWARD_FUNCTION ROUTINE_DIR
+;
+name=ROUTINE_NAME()
+;
+nb_errors=0
+;
+;cd, cur=cur
+;cur=cur+PATH_SEP()
+
+cur=FILE_DIRNAME(ROUTINE_FILEPATH(name))+PATH_SEP()
+;
+dir=ROUTINE_DIR()
+;
+if KEYWORD_set(verbose) then begin
+   print, 'current : ', cur
+   print, 'dir     : ', dir
+endif
+;
+if (cur NE dir) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_DIR()'
+;
+; ----- final ----
+;
+BANNER_FOR_TESTSUITE, name, nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; ----------------------------------------------------
+; testing for a function
+function AC_FUNCT_DIR_1234, cumul_errors, test=test, verbose=verbose
+;
+FORWARD_FUNCTION ROUTINE_DIR
+;
+name=ROUTINE_NAME()
+;
+nb_errors=0
+;
+;cd, cur=cur
+;cur=cur+PATH_SEP()
+cur=FILE_DIRNAME(ROUTINE_FILEPATH(name,/is_function))+PATH_SEP()
+;
+dir=ROUTINE_DIR()
+;
+if KEYWORD_set(verbose) then begin
+   print, 'current : ', cur
+   print, 'dir     : ', dir
+endif
+;
+if (cur NE dir) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_DIR()'
+;
+; ----- final ----
+;
+BANNER_FOR_TESTSUITE, ROUTINE_NAME(), nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+return, 1
+;
+end
+;
+; ----------------------------------------------------
+;
+pro TEST_ROUTINE_DIR, help=help, verbose=verbose, short=short, $
+                      debug=debug, test=test, no_exit=no_exit
+;
+FORWARD_FUNCTION AC_PRO_DIR_1234, AC_FUNCT_DIR_1234
+;
+if KEYWORD_SET(help) then begin
+    print, 'pro TEST_ROUTINE_DIR, help=help, verbose=verbose, short=short, $'
+    print, '                      debug=debug, test=test, no_exit=no_exit'
+    return
+ endif
+;
+if ((GDL_IDL_FL() EQ 'IDL') and (GDL_VERSION() LT 80700)) then begin
+   txt='This ROUTINE_DIR() function appeared in IDL 8.7'
+   MESSAGE, /continue, 'IDL version too old. '+txt
+   EXIT, status=77
+endif
+;
+if (GDL_IDL_FL() EQ 'FL') then begin
+   txt='This ROUTINE_DIR() function don''t exist now in FL.'
+   MESSAGE, /continue, txt+' Please report when available.'
+   EXIT, status=77
+endif
+;
+cumul_errors=0
+;
+AC_PRO_DIR_1234, cumul_errors, test=test, verbose=verbose
+tmp=AC_FUNCT_DIR_1234(cumul_errors, test=test, verbose=verbose)
+;
+BANNER_FOR_TESTSUITE, 'TEST_ROUTINE_DIR', cumul_errors, short=short
+;
+if (cumul_errors NE 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
+end

--- a/testsuite/test_routine_name.pro
+++ b/testsuite/test_routine_name.pro
@@ -1,0 +1,82 @@
+;
+; Alain Coulais, 6 Feb. 2019. Under GNU GPL v2+
+;
+; preliminatry test suite for function ROUTINE_NAME
+;
+; ----------------------------------------------------
+; testing for a procedure
+pro AC_PRO1234, cumul_errors, test=test
+;
+FORWARD_FUNCTION ROUTINE_NAME_INTERNALGDL
+;
+nb_errors=0
+;
+ref='AC_PRO1234'
+n1=ROUTINE_NAME()
+;
+if (ref NE n1) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_NAME()'
+;
+if (GDL_IDL_FL() EQ 'GDL') then begin
+   n2=ROUTINE_NAME_INTERNALGDL()
+   if (ref NE n2) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_NAME_INTERNALGDL()'
+endif
+;
+; ----- final ----
+;
+BANNER_FOR_TESTSUITE, ref, nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; ----------------------------------------------------
+; testing for a function
+function AC_FUNCT1234, cumul_errors, test=test
+;
+FORWARD_FUNCTION ROUTINE_NAME_INTERNALGDL
+;
+nb_errors=0
+;
+ref='AC_FUNCT1234'
+n1=ROUTINE_NAME()
+;
+if (ref NE n1) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_NAME()'
+;
+if (GDL_IDL_FL() EQ 'GDL') then begin
+   n2=ROUTINE_NAME_INTERNALGDL()
+   if (ref NE n2) then ERRORS_ADD, nb_errors, 'pb with ROUTINE_NAME_INTERNALGDL()'
+endif
+;
+; ----- final ----
+;
+BANNER_FOR_TESTSUITE, ref, nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+return, 1
+;
+end
+;
+; ----------------------------------------------------
+;
+pro TEST_ROUTINE_NAME, help=help, verbose=verbose, short=short, $
+                       debug=debug, test=test, no_exit=no_exit
+;
+if KEYWORD_SET(help) then begin
+    print, 'pro TEST_ROUTINE_NAME, help=help, verbose=verbose, short=short, $'
+    print, '                       debug=debug, test=test, no_exit=no_exit'
+    return
+endif
+;
+cumul_errors=0
+;
+AC_PRO1234, cumul_errors, test=test
+tmp=AC_FUNCT1234(cumul_errors, test=test)
+;
+BANNER_FOR_TESTSUITE, 'TEST_ROUTINE_NAME', cumul_errors, short=short
+;
+if (cumul_errors NE 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
+end


### PR DESCRIPTION
1/ adding ROUTINE_DIR() introduced in IDL 8.7. tests added. Also add an internal 
ROUTINE_NAME_INTERNALGDL(). ROUTINE_NAME() don't exist in IDL but is very convenient !
the _routine_name.pro_ works in GDL, IDL and FL

2/ GDL_VERSION was change. Can now manage major.minor and major.minor.dev for GDL (!gdl.version), IDL (!version.release) and FL (!fl.release)

3/ continuing cleanup for GSHHG