### PR TITLE
List and hash compatiblity fix

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -878,7 +878,7 @@ static BaseGDL* structP_tohash( EnvT* e,BaseGDL* par, bool foldcasekw, bool extr
   }
 
   
-// checks wether referenced values are equal (recursively) 
+// checks wether referenced values are equal (recursively). This is IDL behaviour.
 bool PtrDerefEqual( DPtrGDL* l, DPtrGDL* r)
 {
   SizeT nEl = l->N_Elements();
@@ -2836,14 +2836,14 @@ BaseGDL* hash_duplicate(DStructGDL* self) {
 // We've gotten past any list, hash,or struct/
         DType theType = theref->Type();
             if(trace_me) std::cout << " theType="<<theType;
-// de-reference any pointers we find. (// This is probably not IDL behavior.)
+// DO NOT EVER de-reference any pointers we find. This is *not* IDL behavior.
 // in order to turn this off, a ptr scalar must go in as a ptrarr[1];
 //
-        if( theType == GDL_PTR && theref->Rank() == 0) {
-            DPtr p=(*static_cast<DPtrGDL*>( theref))[0];
-              if( p != 0) theref = BaseGDL::interpreter->GetHeap( p);
-              theType = theref->Type();
-          }
+//        if( theType == GDL_PTR && theref->Rank() == 0) {
+//            DPtr p=(*static_cast<DPtrGDL*>( theref))[0];
+//              if( p != 0) theref = BaseGDL::interpreter->GetHeap( p);
+//              theType = theref->Type();
+//          }
 // right bracket, we are done if only 3 parameters left (?).
         if(finalprm) {
             if(trace_me) help_item(std::cout, theref, " ->Dup():",false);

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -1141,14 +1141,7 @@ BaseGDL* LIST___OverloadBracketsRightSide( EnvUDT* e)
 			break;}
 		DType theType = theref->Type();
 			if(trace_me) std::cout << " theType="<<theType;
-// Enhance (?) it by allowing pointers to lists to represent lists.
-// in order to turn this off, a ptr scalar must go in as a ptrarr[1];
-// This is probably not IDL behavior.
-		if( theType == GDL_PTR && theref->Rank() == 0) {
-			DPtr p=(*static_cast<DPtrGDL*>( theref))[0];
-			  if( p != 0) theref = BaseGDL::interpreter->GetHeap( p);
-			  theType = theref->Type();
-		  }
+
 		if(trace_me) help_item(std::cout, theref, trcn+"theref ",false);
 		islist = false;
 		ishash = false;
@@ -1698,16 +1691,7 @@ void LIST___OverloadBracketsLeftSide( EnvUDT* e)
 			ThrowFromInternalUDSub( e, " struct tags inaccessible");
 		} else {break;}
 		DType theType = theref->Type();
-// Enhance (?) it by allowing pointers to lists to represent lists.
-// in order to turn this off, a ptr scalar must go in as a ptrarr[1];
-// This is probably not IDL behavior.
-		if( theType == GDL_PTR && theref->Rank() == 0) {
-			  theref = BaseGDL::interpreter->GetHeap(
-				(*static_cast<DPtrGDL*>( theref))[0] );
-			  theType = theref->Type();
-			  // this is probably so odd itshould be advertised when it happens:
-			  std::cout<<" **p= "<<std::endl;
-		  }
+
 //		if(iprm+isRangeIx+1 == nParam) return theref->Dup(); 
 		if( iprm + prmbeg  == nParam) break;//( no prms left)
 		if(trace_me) help_item(std::cout, theref, trcn+"theref ",false);

--- a/testsuite/test_hash.pro
+++ b/testsuite/test_hash.pro
@@ -5,6 +5,36 @@ MESSAGE, /continue, message
 end
 ;
 pro test_HASH,debug=debug, verbose=verbose
+nb_errors = 0
+
+; below a few simple tests on HASH before the more internal tests provided originally
+;
+; define two hashtables, with pointers and check Where()
+a=33L
+p=ptr_new(a)
+hsh = HASH('key1', 1.414, 'key2', 3.14, 'key3', ptr_new(a)) ;
+hshp = HASH('key1', 1.414, 'key2', 3.14, 'key3', p) ;
+
+c=hsh.where(ptr_new(a)) ; c must be a 0 element list  IS NOT AT THE MOMENT. Issued 
+; SUPRESSED UNTIL issue  #578 has been closed.
+;if ~c.IsEmpty() then ERRORS_ADD, nb_errors,' error where() on different pointers to same value '
+
+c=hsh.where(1.414) ; c must be a LIST of 1 element and c[0]='key1'
+if c ne 'key1' then ERRORS_ADD, nb_errors,' error where() on key=Float '
+
+c=hshp.where(p) ; 
+if c ne 'key3' then ERRORS_ADD, nb_errors,' error where() on key=ptr '
+
+; now check EQ (I suppose NEQ will work)
+
+result = hsh EQ 1.414
+if result.count() ne 1 and result[0] ne 'key1' then ERRORS_ADD, nb_errors,' error EQ Float for HASH ' 
+
+result = hshp EQ p
+if result.count() ne 1 and result[0] ne 'key3' then ERRORS_ADD, nb_errors,' error EQ pointer for HASH ' 
+
+; "more internal" tests - to de bedited and made more undertsandable to maintainers.
+;
 isgit = 0
 defsysv,"!GDL",exists=isgdl
 if isgdl then $
@@ -34,7 +64,6 @@ if keyword_set(verbose) then begin
     help,/st,struchash
     endif
 ; 
-nb_errors = 0
     ; make a comparison hash from the structure.
         hcomp = hash(struchash,/lower,/fold)
     nstash = n_tags(struchash)


### PR DESCRIPTION
Patched LIST and HASH that were incorrectly replacing pointers to what was pointed by the pointer, rendering the whole thing incompatible with IDL.