### PR TITLE
Initialize GraphicsMagick on library load

### DIFF
--- a/src/magick_cl.cpp
+++ b/src/magick_cl.cpp
@@ -66,6 +66,10 @@ namespace lib {
   unsigned int gCount = 0;
   static bool notInitialized = true;
 
+  __attribute__((constructor)) static void init(void) {
+    START_MAGICK;
+  }
+
   void magick_setup() {
     int i;
     for (i = 0; i < 40; ++i) gValid[i] = 0;


### PR DESCRIPTION
Forwarding a bugfix that I received from @gcsideal for the Debian package. The problem is that with the latest ImageMagick version (from their repository), gdl does not start anymore but dies with

```
gdl: magick/semaphore.c:606: LockSemaphoreInfo:
 Assertion `semaphore_info != (SemaphoreInfo *) NULL' failed.
Aborted
```

The GNU Data Language library uses GraphicsMagick via static variables as well.
These get initialized and used on its library load and initialization. For this reason GM library needs to be initialized on GDL library load.

Relevant bug: [Debian#927307](https://bugs.debian.org/927307)