### PR TITLE
WIP - appveyor experiments (travis builds reduced)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,31 +5,31 @@ matrix:
   include:
 #    - os: linux
 #      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
-    - os: linux
-      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+#    - os: linux
+#      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=MINI
+#    - os: osx
+#      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=MINI
 
-    - os: linux
-      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
-    - os: linux
-      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
+#    - os: linux
+#      env: COMPILER=icc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL
+#    - os: linux
+#      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Debug    DEPS=FULL  CODECOV=yes
+#    - os: osx
+#      env: COMPILER=clang CMAKE_BUILD_TYPE=Debug    DEPS=FULL
 
 #    - os: linux
 #      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
     - os: linux
       env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=MINI
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
+#    - os: osx
+#      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=MINI
 
-    - os: linux
-      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
+#    - os: linux
+#      env: COMPILER=gcc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
 #    - os: linux
 #      env: COMPILER=icc   CMAKE_BUILD_TYPE=Release  DEPS=FULL
-    - os: osx
-      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=FULL
+#    - os: osx
+#      env: COMPILER=clang CMAKE_BUILD_TYPE=Release  DEPS=FULL
 
 before_install:
     # TEMPORARILY disabling tests that did not work at "day zero" (i.e. SF -> github migration)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,13 @@ branches:
 clone_folder: c:\projects\gdl
 configuration:
   - Release
-  - Debug
+  #- Debug
 environment:
   matrix:
   # #- platform: mingw64720x8664
-  - platform: mingw64630x8664
+  #- platform: mingw64630x8664 64-bit off
+  # try gcc version 7.3 then back to 6.3 (32-bit)
+  - platform: mingw64730x8664
   - platform: mingw64630i686
   # #- platform: mingw64730x8664
    

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,7 @@ configuration:
 environment:
   matrix:
   # #- platform: mingw64720x8664
-  #- platform: mingw64630x8664 64-bit off
-  # try gcc version 7.3 then back to 6.3 (32-bit)
-  - platform: mingw64730x8664
+  - platform: mingw64630x8664
   - platform: mingw64630i686
   # #- platform: mingw64730x8664
    

--- a/src/dstructdesc.cpp
+++ b/src/dstructdesc.cpp
@@ -77,12 +77,13 @@ DStructDesc* FindInStructList(StructListT v, const string& s)
 
 void DUStructDesc::AddTag( const string& tagName, const BaseGDL* data)
 {
+  string TN = StrUpCase( tagName);  // prevent non-capitalized chars.
   for( SizeT i=0; i < tNames.size(); i++)
-    if( tNames[i] == tagName)
-      throw GDLException(tagName+" is already defined "
+    if( tNames[i] == TN)
+      throw GDLException(TN+" is already defined "
 			 "with a conflicting definition");
   
-  tNames.push_back(tagName);
+  tNames.push_back(  TN);
   Add( data->GetTag());
 }
 

--- a/src/dstructdesc.hpp
+++ b/src/dstructdesc.hpp
@@ -45,16 +45,38 @@ protected:
   // and DStringGDL (considers actual string sizes)
   SizeT nBytes = tags.back()->NBytes();
 
-  // alignment 
+//  2-May-2019 GVJ
+//  Align data in structures according to data lengthin accord with IDL).
+/********************
 #ifdef USE_EIGEN
+ (This forced all data to be aligned on 16-bytes.  There was no perceptible perfomance gain,
+ nor was any penalty found for simply using 2-byte alignment.
+
+  const int alignmentInBytes = 2; // there was no performance difference.
+
   assert( sizeof( char*) <= 16); 
   const int alignmentInBytes = 16; // set to multiple of 16 >= sizeof( char*)
 #else
   const int alignmentInBytes = sizeof( char*);
 #endif
+******************/
+
+  const int alignmentInBytes = sizeof( char*);
+
+// The old way:
+/******
   SizeT exceed = nBytes % alignmentInBytes;
   if( exceed > 0)
 	nBytes += alignmentInBytes - exceed;
+*****/
+// replacement:
+  SizeT Align = (nBytes < alignmentInBytes)? nBytes: alignmentInBytes;
+  SizeT initOffset = tagOffset.back();
+  SizeT Oddbytes = initOffset % Align;
+  if(Oddbytes > 0) { 
+	  tagOffset.pop_back();
+	  tagOffset.push_back( initOffset + (Align-Oddbytes));
+  }
 
   // valid tagOffset (used by NBytes())
   tagOffset.push_back( tagOffset.back() + nBytes);


### PR DESCRIPTION
  Appveyor builds at 32 bits (i686) fail more often than 64-bits, often with a segfault.
IDL test errors usually pass Appveyor because the "make" command is embedded in a posix script.
 This first experiment is to see if a change of GCC version improves behavior.