### PR TITLE
Congrid has no missing

### DIFF
--- a/src/gsl_fun.cpp
+++ b/src/gsl_fun.cpp
@@ -2023,9 +2023,9 @@ namespace lib {
     // bool dbl = e->KeywordSet(dblIx);
 
     static int missingIx = e->KeywordIx("MISSING");
-    bool use_missing = e->KeywordSet(missingIx);
-    DDouble missing;
-    e->AssureDoubleScalarKWIfPresent(missingIx, missing);
+    bool use_missing = e->KeywordPresent(missingIx);
+    DDouble missing=0;
+    if (use_missing) e->AssureDoubleScalarKWIfPresent(missingIx, missing);
 
     DDoubleGDL* p0D[2];
     DDoubleGDL* p1D;

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -225,7 +225,7 @@ namespace lib
   // plots are not exactly what IDL does in the same conditions. The reasons for the choices should be
   // clearly described in the code, to be checked by others.
   
-  PLFLT gdlAdjustAxisRange(EnvT* e, string axis, DDouble &start, DDouble &end, bool log /* = false */, int code /* = 0 */) {
+  PLFLT gdlAdjustAxisRange(EnvT* e, int axisId, DDouble &start, DDouble &end, bool log /* = false */, int code /* = 0 */) {
     gdlHandleUnwantedAxisValue(start, end, log);
 
     DDouble min, max;
@@ -379,7 +379,7 @@ namespace lib
 
     //check if tickinterval would make more than 59 ticks (IDL apparent limit). In which case, IDL plots only the first 59 intervals:
     DDouble TickInterval;
-    gdlGetDesiredAxisTickInterval(e, axis, TickInterval);
+    gdlGetDesiredAxisTickInterval(e, axisId, TickInterval);
     if ( TickInterval > 0.0 ) if ((max-min)/TickInterval > 59) max=min+59.0*TickInterval;
 
     if (invert) {
@@ -1037,12 +1037,12 @@ namespace lib
   
   //crange to struct
 
-  void gdlStoreAxisCRANGE(string axis, DDouble Start, DDouble End, bool log)
+  void gdlStoreAxisCRANGE(int axisId, DDouble Start, DDouble End, bool log)
   {
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) Struct=SysVar::X();
-    if ( axis=="Y" ) Struct=SysVar::Y();
-    if ( axis=="Z" ) Struct=SysVar::Z();
+    if ( axisId==XAXIS ) Struct=SysVar::X();
+    if ( axisId==YAXIS ) Struct=SysVar::Y();
+    if ( axisId==ZAXIS ) Struct=SysVar::Z();
     if ( Struct!=NULL )
     {
       int debug=0;
@@ -1065,12 +1065,12 @@ namespace lib
 
   //CRANGE from struct
 
-  void gdlGetCurrentAxisRange(string axis, DDouble &Start, DDouble &End, bool checkMapset)
+  void gdlGetCurrentAxisRange(int axisId, DDouble &Start, DDouble &End, bool checkMapset)
   {
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) Struct=SysVar::X();
-    if ( axis=="Y" ) Struct=SysVar::Y();
-    if ( axis=="Z" ) Struct=SysVar::Z();
+    if ( axisId==XAXIS ) Struct=SysVar::X();
+    if ( axisId==YAXIS ) Struct=SysVar::Y();
+    if ( axisId==ZAXIS ) Struct=SysVar::Z();
     Start=0;
     End=0;
     if ( Struct!=NULL )
@@ -1079,12 +1079,12 @@ namespace lib
       if ( debug ) cout<<"Get     :"<<Start<<" "<<End<<endl;
       bool isProj;
       get_mapset(isProj);
-      if (checkMapset && isProj && axis!="Z") {
+      if (checkMapset && isProj && axisId!=ZAXIS) {
         DStructGDL* mapStruct=SysVar::Map();   //MUST NOT BE STATIC, due to .reset 
         static unsigned uvboxTag=mapStruct->Desc()->TagIndex("UV_BOX");
         static DDoubleGDL *uvbox;
         uvbox=static_cast<DDoubleGDL*>(mapStruct->GetTag(uvboxTag, 0));
-        if (axis=="X") {
+        if (axisId==XAXIS) {
           Start=(*uvbox)[0];
           End=(*uvbox)[2];
         } else {
@@ -1107,12 +1107,12 @@ namespace lib
     }
   }
 
-  void gdlGetCurrentAxisWindow(string axis, DDouble &wStart, DDouble &wEnd)
+  void gdlGetCurrentAxisWindow(int axisId, DDouble &wStart, DDouble &wEnd)
   {
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) Struct=SysVar::X();
-    if ( axis=="Y" ) Struct=SysVar::Y();
-    if ( axis=="Z" ) Struct=SysVar::Z();
+    if ( axisId==XAXIS ) Struct=SysVar::X();
+    if ( axisId==YAXIS ) Struct=SysVar::Y();
+    if ( axisId==ZAXIS ) Struct=SysVar::Z();
     wStart=0;
     wEnd=0;
     if ( Struct!=NULL )
@@ -1124,14 +1124,14 @@ namespace lib
   }
 
   //Stores [XYZ].WINDOW, .REGION and .S
-  void gdlStoreAxisSandWINDOW(GDLGStream* actStream, string axis, DDouble Start, DDouble End, bool log)
+  void gdlStoreAxisSandWINDOW(GDLGStream* actStream, int axisId, DDouble Start, DDouble End, bool log)
   {
     PLFLT p_xmin, p_xmax, p_ymin, p_ymax, norm_min, norm_max, charDim;
     actStream->gvpd(p_xmin, p_xmax, p_ymin, p_ymax); //viewport normalized coords
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) {Struct=SysVar::X(); norm_min=p_xmin; norm_max=p_xmax; charDim=actStream->nCharLength();}
-    if ( axis=="Y" ) {Struct=SysVar::Y(); norm_min=p_ymin; norm_max=p_ymax; charDim=actStream->nCharHeight();}
-    if ( axis=="Z" ) {Struct=SysVar::Z(); norm_min=0; norm_max=1; charDim=actStream->nCharLength();}
+    if ( axisId==XAXIS ) {Struct=SysVar::X(); norm_min=p_xmin; norm_max=p_xmax; charDim=actStream->nCharLength();}
+    if ( axisId==YAXIS ) {Struct=SysVar::Y(); norm_min=p_ymin; norm_max=p_ymax; charDim=actStream->nCharHeight();}
+    if ( axisId==ZAXIS ) {Struct=SysVar::Z(); norm_min=0; norm_max=1; charDim=actStream->nCharLength();}
     if ( Struct!=NULL )
     {
       unsigned marginTag=Struct->Desc()->TagIndex("MARGIN");
@@ -1162,12 +1162,12 @@ namespace lib
     for ( i=0; i<clipBox->N_Elements(); ++i ) (*static_cast<DLongGDL*>(pStruct->GetTag(clipTag, 0)))[i]=(*clipBox)[i];
   }
 
-  void gdlGetAxisType(string axis, bool &log)
+  void gdlGetAxisType(int axisId, bool &log)
   {
     DStructGDL* Struct;
-    if ( axis=="X" ) Struct=SysVar::X();
-    if ( axis=="Y" ) Struct=SysVar::Y();
-    if ( axis=="Z" ) Struct=SysVar::Z();
+    if ( axisId==XAXIS ) Struct=SysVar::X();
+    if ( axisId==YAXIS ) Struct=SysVar::Y();
+    if ( axisId==ZAXIS ) Struct=SysVar::Z();
     if ( Struct!=NULL )
     {
       static unsigned typeTag=Struct->Desc()->TagIndex("TYPE");
@@ -1205,12 +1205,12 @@ namespace lib
 
   //axis type (log..)
 
-  void gdlStoreAxisType(string axis, bool Type)
+  void gdlStoreAxisType(int axisId, bool Type)
   {
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) Struct=SysVar::X();
-    if ( axis=="Y" ) Struct=SysVar::Y();
-    if ( axis=="Z" ) Struct=SysVar::Z();
+    if ( axisId==XAXIS ) Struct=SysVar::X();
+    if ( axisId==YAXIS ) Struct=SysVar::Y();
+    if ( axisId==ZAXIS ) Struct=SysVar::Z();
     if ( Struct!=NULL )
     {
       static unsigned typeTag=Struct->Desc()->TagIndex("TYPE");

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -99,6 +99,19 @@ enum ORIENTATION3D
     XZYZ,
     XZXY
   };
+  
+enum PLOT_AXES_IDENTIFIERS
+{
+ XAXIS=0,
+ YAXIS,
+ ZAXIS,
+ XAXIS2, //special identifiere for gdlAxis
+ YAXIS2,
+ ZAXIS2
+};
+
+static const std::string axisName[6]={"X","Y","Z","X","Y","Z"}; 
+  
 #define GDL_NONE -1
 #define GDL_TICKFORMAT 0
 #define GDL_TICKUNITS 1
@@ -288,12 +301,12 @@ namespace lib {
   void gdlHandleUnwantedAxisValue(DDouble &min, DDouble &max, bool log);
   void gdlSetGraphicsPenColorToBackground(GDLGStream *a);
   void gdlLineStyle(GDLGStream *a, DLong style);
-  void gdlStoreAxisCRANGE(string axis, DDouble Start, DDouble End, bool log);
-  void gdlStoreAxisSandWINDOW(GDLGStream* actStream, string axis, DDouble Start, DDouble End, bool log=false);
-  void gdlGetAxisType(string axis, bool &log);
-  void gdlGetCurrentAxisRange(string axis, DDouble &Start, DDouble &End, bool checkMapset=FALSE);
-  void gdlGetCurrentAxisWindow(string axis, DDouble &wStart, DDouble &wEnd);
-  void gdlStoreAxisType(string axis, bool type);
+  void gdlStoreAxisCRANGE(int axisId, DDouble Start, DDouble End, bool log);
+  void gdlStoreAxisSandWINDOW(GDLGStream* actStream, int axisId, DDouble Start, DDouble End, bool log=false);
+  void gdlGetAxisType(int axisId, bool &log);
+  void gdlGetCurrentAxisRange(int axisId, DDouble &Start, DDouble &End, bool checkMapset=FALSE);
+  void gdlGetCurrentAxisWindow(int axisId, DDouble &wStart, DDouble &wEnd);
+  void gdlStoreAxisType(int axisId, bool type);
   void gdlGetCharSizes(GDLGStream *a, PLFLT &nsx, PLFLT &nsy, DDouble &wsx, DDouble &wsy, 
 		       DDouble &dsx, DDouble &dsy, DDouble &lsx, DDouble &lsy); 
   void GetSFromPlotStructs(DDouble **sx, DDouble **sy, DDouble **sz=NULL);
@@ -305,7 +318,7 @@ namespace lib {
   void gdlStoreCLIP(DLongGDL* clipBox);
   void GetCurrentUserLimits(GDLGStream *a, 
 			    DDouble &xStart, DDouble &xEnd, DDouble &yStart, DDouble &yEnd);
-  PLFLT gdlAdjustAxisRange(EnvT* e, string axis, DDouble &val_min, DDouble &val_max, bool log = false, int calendarcode = 0);
+  PLFLT gdlAdjustAxisRange(EnvT* e, int axisId, DDouble &val_min, DDouble &val_max, bool log = false, int calendarcode = 0);
   PLFLT AutoTick(DDouble x);
   void setIsoPort(GDLGStream* actStream,PLFLT x1,PLFLT x2,PLFLT y1,PLFLT y2,PLFLT aspect);
   void GetMinMaxVal( DDoubleGDL* val, double* minVal, double* maxVal);
@@ -452,7 +465,7 @@ namespace lib {
     a->Thick(charthick);
   }
    
-  static PLFLT gdlComputeTickInterval(EnvT *e, string axis, DDouble &min, DDouble &max, bool log)
+  static PLFLT gdlComputeTickInterval(EnvT *e, int axisId, DDouble &min, DDouble &max, bool log)
   {
     DLong nticks=0;
 
@@ -461,9 +474,9 @@ namespace lib {
     static int ZTICKSIx = e->KeywordIx("ZTICKS");
     int choosenIx=XTICKSIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKSIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKSIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKSIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKSIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKSIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKSIx; }
 
     if ( Struct!=NULL )
     {
@@ -482,7 +495,7 @@ namespace lib {
     return intv;
   }
   
-  static void gdlGetDesiredAxisCharsize(EnvT* e, string axis, DFloat &charsize)
+  static void gdlGetDesiredAxisCharsize(EnvT* e, int axisId, DFloat &charsize)
   {
     //default:
     charsize=1.0;
@@ -501,9 +514,9 @@ namespace lib {
     static int ZCharsizeIx = e->KeywordIx("ZCHARSIZE");
     int choosenIx=XCharsizeIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XCharsizeIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YCharsizeIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZCharsizeIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XCharsizeIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YCharsizeIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZCharsizeIx; }
 
     if ( Struct!=NULL )
     {
@@ -513,12 +526,12 @@ namespace lib {
       if (axisCharsizeMultiplier>0.0) charsize*=axisCharsizeMultiplier; //IDL Behaviour...
     }
   }
-  static  void gdlSetAxisCharsize(EnvT *e, GDLGStream *a, string axis)
+  static  void gdlSetAxisCharsize(EnvT *e, GDLGStream *a, int axisId)
   {
 
     DFloat charsize=0.0;
     DDouble pmultiscale=1.0;
-    gdlGetDesiredAxisCharsize(e, axis, charsize);
+    gdlGetDesiredAxisCharsize(e, axisId, charsize);
     // adjust if MULTI:
     DLongGDL* pMulti=SysVar::GetPMulti();
     if ( (*pMulti)[1]>2||(*pMulti)[2]>2 ) pmultiscale=0.5; //IDL behaviour
@@ -527,7 +540,7 @@ namespace lib {
     a->sizeChar(charsize*pmultiscale);
   }
 
-  static void gdlGetDesiredAxisGridStyle(EnvT* e, string axis, DLong &axisGridstyle)
+  static void gdlGetDesiredAxisGridStyle(EnvT* e, int axisId, DLong &axisGridstyle)
   {
     axisGridstyle=0;
     DStructGDL* Struct=NULL;
@@ -535,9 +548,9 @@ namespace lib {
     static int YGRIDSTYLEIx = e->KeywordIx("YGRIDSTYLE");
     static int ZGRIDSTYLEIx = e->KeywordIx("ZGRIDSTYLE");
     int choosenIx=XGRIDSTYLEIx;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XGRIDSTYLEIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YGRIDSTYLEIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZGRIDSTYLEIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XGRIDSTYLEIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YGRIDSTYLEIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZGRIDSTYLEIx; }
 
     if ( Struct!=NULL )
     {
@@ -546,16 +559,16 @@ namespace lib {
       e->AssureLongScalarKWIfPresent(choosenIx, axisGridstyle);
     }
   }
-  static void gdlGetDesiredAxisMargin(EnvT *e, string axis, DFloat &start, DFloat &end)
+  static void gdlGetDesiredAxisMargin(EnvT *e, int axisId, DFloat &start, DFloat &end)
   {
     static int XMARGINIx = e->KeywordIx("XMARGIN");
     static int YMARGINIx = e->KeywordIx("YMARGIN");
     static int ZMARGINIx = e->KeywordIx("ZMARGIN");
     int choosenIx=XMARGINIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XMARGINIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YMARGINIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZMARGINIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XMARGINIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YMARGINIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZMARGINIx; }
 
     if ( Struct!=NULL )
     {
@@ -568,7 +581,7 @@ namespace lib {
     if ( Margin!=NULL )
     {
       if ( Margin->N_Elements()>2 )
-        e->Throw("Keyword array parameter "+axis+"MARGIN must have from 1 to 2 elements.");
+        e->Throw("Keyword array parameter "+axisName[axisId]+"MARGIN must have from 1 to 2 elements.");
       Guard<DFloatGDL> guard;
       DFloatGDL* MarginF=static_cast<DFloatGDL*>
       (Margin->Convert2(GDL_FLOAT, BaseGDL::COPY));
@@ -578,7 +591,7 @@ namespace lib {
         end=(*MarginF)[1];
     }
   }
-  static void gdlGetDesiredAxisMinor(EnvT* e, string axis, DLong &axisMinor)
+  static void gdlGetDesiredAxisMinor(EnvT* e, int axisId, DLong &axisMinor)
   {
     axisMinor=0;
     static int XMINORIx = e->KeywordIx("XMINOR");
@@ -586,9 +599,9 @@ namespace lib {
     static int ZMINORIx = e->KeywordIx("ZMINOR");
     int choosenIx=XMINORIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XMINORIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YMINORIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZMINORIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XMINORIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YMINORIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZMINORIx; }
    if ( Struct!=NULL )
     {
       unsigned AxisMinorTag=Struct->Desc()->TagIndex("MINOR");
@@ -596,7 +609,7 @@ namespace lib {
     }
     e->AssureLongScalarKWIfPresent(choosenIx, axisMinor);
   }
-  static bool gdlGetDesiredAxisRange(EnvT *e, string axis, DDouble &start, DDouble &end)
+  static bool gdlGetDesiredAxisRange(EnvT *e, int axisId, DDouble &start, DDouble &end)
   {
     bool set=FALSE;
     static int XRANGEIx = e->KeywordIx("XRANGE");
@@ -604,9 +617,9 @@ namespace lib {
     static int ZRANGEIx = e->KeywordIx("ZRANGE");
     int choosenIx=XRANGEIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XRANGEIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YRANGEIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZRANGEIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XRANGEIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YRANGEIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZRANGEIx; }
     if ( Struct!=NULL )
     {
       DDouble test1, test2;
@@ -624,7 +637,7 @@ namespace lib {
     if ( Range!=NULL )
     {
       if ( Range->N_Elements()!=2 )
-        e->Throw("Keyword array parameter "+axis+"RANGE must have 2 elements.");
+        e->Throw("Keyword array parameter "+axisName[axisId]+"RANGE must have 2 elements.");
       Guard<DDoubleGDL> guard;
       DDoubleGDL* RangeF=static_cast<DDoubleGDL*>(Range->Convert2(GDL_DOUBLE, BaseGDL::COPY));
       guard.Reset(RangeF);
@@ -637,16 +650,16 @@ namespace lib {
     }
     return set;
   }
-  static  void gdlGetDesiredAxisStyle(EnvT *e, string axis, DLong &style)
+  static  void gdlGetDesiredAxisStyle(EnvT *e, int axisId, DLong &style)
   {
     static int XSTYLEIx = e->KeywordIx("XSTYLE");
     static int YSTYLEIx = e->KeywordIx("YSTYLE");
     static int ZSTYLEIx = e->KeywordIx("ZSTYLE");
     int choosenIx=XSTYLEIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XSTYLEIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YSTYLEIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZSTYLEIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XSTYLEIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YSTYLEIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZSTYLEIx; }
 
     if ( Struct!=NULL )
     {
@@ -656,7 +669,7 @@ namespace lib {
 
     e->AssureLongScalarKWIfPresent( choosenIx, style);
   }
-    static void gdlGetDesiredAxisThick(EnvT *e,  string axis, DFloat &thick)
+    static void gdlGetDesiredAxisThick(EnvT *e,  int axisId, DFloat &thick)
   {
     thick=1.0;
     static int XTHICKIx = e->KeywordIx("XTHICK");
@@ -664,9 +677,9 @@ namespace lib {
     static int ZTHICKIx = e->KeywordIx("ZTHICK");
     int choosenIx=XTHICKIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTHICKIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTHICKIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTHICKIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTHICKIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTHICKIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTHICKIx; }
 
     if ( Struct!=NULL )
     {
@@ -677,21 +690,21 @@ namespace lib {
     e->AssureFloatScalarKWIfPresent(choosenIx, thick);
     if ( thick <= 0.0 ) thick=1.0;
   }
-   static void gdlGetDesiredAxisTickget(EnvT *e,  string axis, DDoubleGDL *Axistickget)
+   static void gdlGetDesiredAxisTickget(EnvT *e,  int axisId, DDoubleGDL *Axistickget)
   {
     //TODO!
   }
 
-  static void gdlGetDesiredAxisTickFormat(EnvT* e, string axis, DStringGDL* &axisTickformatVect)
+  static void gdlGetDesiredAxisTickFormat(EnvT* e, int axisId, DStringGDL* &axisTickformatVect)
   {
     static int XTICKFORMATIx = e->KeywordIx("XTICKFORMAT");
     static int YTICKFORMATIx = e->KeywordIx("YTICKFORMAT");
     static int ZTICKFORMATIx = e->KeywordIx("ZTICKFORMAT");
     int choosenIx=XTICKFORMATIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKFORMATIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKFORMATIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKFORMATIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKFORMATIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKFORMATIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKFORMATIx; }
 
    if ( Struct!=NULL )
     {
@@ -704,7 +717,7 @@ namespace lib {
     }
   }
 
-  static void gdlGetDesiredAxisTickInterval(EnvT* e, string axis, DDouble &axisTickinterval)
+  static void gdlGetDesiredAxisTickInterval(EnvT* e, int axisId, DDouble &axisTickinterval)
   {
     axisTickinterval=0;
     static int XTICKINTERVALIx = e->KeywordIx("XTICKINTERVAL");
@@ -712,9 +725,9 @@ namespace lib {
     static int ZTICKINTERVALIx = e->KeywordIx("ZTICKINTERVAL");
     int choosenIx=XTICKINTERVALIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKINTERVALIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKINTERVALIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKINTERVALIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKINTERVALIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKINTERVALIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKINTERVALIx; }
 
     if ( Struct!=NULL )
     {
@@ -725,7 +738,7 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent(choosenIx, axisTickinterval);
   }
 
-  static void gdlGetDesiredAxisTickLayout(EnvT* e, string axis, DLong &axisTicklayout)
+  static void gdlGetDesiredAxisTickLayout(EnvT* e, int axisId, DLong &axisTicklayout)
   {
     axisTicklayout=0;
     static int XTICKLAYOUTIx = e->KeywordIx("XTICKLAYOUT");
@@ -733,9 +746,9 @@ namespace lib {
     static int ZTICKLAYOUTIx = e->KeywordIx("ZTICKLAYOUT");
     int choosenIx=XTICKLAYOUTIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKLAYOUTIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKLAYOUTIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKLAYOUTIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKLAYOUTIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKLAYOUTIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKLAYOUTIx; }
     if ( Struct!=NULL )
     {
       axisTicklayout=(*static_cast<DLongGDL*>
@@ -745,7 +758,7 @@ namespace lib {
     e->AssureLongScalarKWIfPresent(choosenIx, axisTicklayout);
   }
 
-  static void gdlGetDesiredAxisTickLen(EnvT* e, string axis, DFloat &ticklen)
+  static void gdlGetDesiredAxisTickLen(EnvT* e, int axisId, DFloat &ticklen)
   {
     // order: !P.TICKLEN, TICKLEN, !X.TICKLEN, /XTICKLEN
     // get !P preference
@@ -761,9 +774,9 @@ namespace lib {
     static int ZTICKLENIx = e->KeywordIx("ZTICKLEN");
     int choosenIx=XTICKLENIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKLENIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKLENIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKLENIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKLENIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKLENIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKLENIx; }
     if ( Struct!=NULL )
     {
       unsigned ticklenTag=Struct->Desc()->TagIndex("TICKLEN");
@@ -773,7 +786,7 @@ namespace lib {
     }
   }
 
- static void gdlGetDesiredAxisTickName(EnvT* e, GDLGStream* a, string axis, DStringGDL* &axisTicknameVect)
+ static void gdlGetDesiredAxisTickName(EnvT* e, GDLGStream* a, int axisId, DStringGDL* &axisTicknameVect)
   {
 
     static int XTICKNAMEIx = e->KeywordIx("XTICKNAME");
@@ -781,9 +794,9 @@ namespace lib {
     static int ZTICKNAMEIx = e->KeywordIx("ZTICKNAME");
     int choosenIx=XTICKNAMEIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKNAMEIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKNAMEIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKNAMEIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKNAMEIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKNAMEIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKNAMEIx; }
     if ( Struct!=NULL )
     {
       unsigned AxisTicknameTag=Struct->Desc()->TagIndex("TICKNAME");
@@ -803,7 +816,7 @@ namespace lib {
 
   }
 
-  static void gdlGetDesiredAxisTicks(EnvT* e, string axis, DLong &axisTicks)
+  static void gdlGetDesiredAxisTicks(EnvT* e, int axisId, DLong &axisTicks)
   {
     axisTicks=0;
 
@@ -812,9 +825,9 @@ namespace lib {
     static int ZTICKSIx = e->KeywordIx("ZTICKS");
     int choosenIx=XTICKSIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKSIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKSIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKSIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKSIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKSIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKSIx; }
 
     if ( Struct!=NULL )
     {
@@ -830,16 +843,16 @@ namespace lib {
   //if axis tick units is specified, first tickunit determines how the automatic limits are computed.
   // for example, if tickunits=['year','day'] the limits will be on a round nuber of years.
   // This is conveyed by the code
-  static int gdlGetCalendarCode(EnvT* e, string axis)
+  static int gdlGetCalendarCode(EnvT* e, int axisId)
   {
     static int XTICKUNITSIx = e->KeywordIx("XTICKUNITS");
     static int YTICKUNITSIx = e->KeywordIx("YTICKUNITS");
     static int ZTICKUNITSIx = e->KeywordIx("ZTICKUNITS");
     int choosenIx=XTICKUNITSIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKUNITSIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKUNITSIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKUNITSIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKUNITSIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKUNITSIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKUNITSIx; }
     DStringGDL* axisTickunitsVect=NULL;
     if ( Struct!=NULL )
     {
@@ -863,16 +876,16 @@ namespace lib {
     return code;
   }
  
- static void gdlGetDesiredAxisTickUnits(EnvT* e, string axis, DStringGDL* &axisTickunitsVect)
+ static void gdlGetDesiredAxisTickUnits(EnvT* e, int axisId, DStringGDL* &axisTickunitsVect)
   {
     static int XTICKUNITSIx = e->KeywordIx("XTICKUNITS");
     static int YTICKUNITSIx = e->KeywordIx("YTICKUNITS");
     static int ZTICKUNITSIx = e->KeywordIx("ZTICKUNITS");
     int choosenIx=XTICKUNITSIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKUNITSIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKUNITSIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKUNITSIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKUNITSIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKUNITSIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKUNITSIx; }
    if ( Struct!=NULL )
     {
       unsigned AxisTickunitsTag=Struct->Desc()->TagIndex("TICKUNITS");
@@ -884,16 +897,16 @@ namespace lib {
     }
       }
 
-  static void gdlGetDesiredAxisTickv(EnvT* e, string axis, DDoubleGDL* axisTickvVect)
+  static void gdlGetDesiredAxisTickv(EnvT* e, int axisId, DDoubleGDL* axisTickvVect)
   {
     static int XTICKVIx = e->KeywordIx("XTICKV");
     static int YTICKVIx = e->KeywordIx("YTICKV");
     static int ZTICKVIx = e->KeywordIx("ZTICKV");
     int choosenIx=XTICKVIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTICKVIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTICKVIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTICKVIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTICKVIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTICKVIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTICKVIx; }
     if ( Struct!=NULL )
     {
       unsigned AxisTickvTag=Struct->Desc()->TagIndex("TICKV");
@@ -906,16 +919,16 @@ namespace lib {
     }
   }
 
-  static void gdlGetDesiredAxisTitle(EnvT *e, string axis, DString &title)
+  static void gdlGetDesiredAxisTitle(EnvT *e, int axisId, DString &title)
   {
     static int XTITLEIx = e->KeywordIx("XTITLE");
     static int YTITLEIx = e->KeywordIx("YTITLE");
     static int ZTITLEIx = e->KeywordIx("ZTITLE");
     int choosenIx=XTITLEIx;
     DStructGDL* Struct=NULL;
-    if ( axis=="X" ) { Struct=SysVar::X(); choosenIx=XTITLEIx; }
-    if ( axis=="Y" ) { Struct=SysVar::Y(); choosenIx=YTITLEIx; }
-    if ( axis=="Z" ) { Struct=SysVar::Z(); choosenIx=ZTITLEIx; }
+    if ( axisId==XAXIS ) { Struct=SysVar::X(); choosenIx=XTITLEIx; }
+    if ( axisId==YAXIS ) { Struct=SysVar::Y(); choosenIx=YTITLEIx; }
+    if ( axisId==ZAXIS ) { Struct=SysVar::Z(); choosenIx=ZTITLEIx; }
 
     if ( Struct!=NULL )
     {
@@ -1024,7 +1037,7 @@ namespace lib {
     if ( e->KeywordSet( YRANGEIx)) return TRUE;
     //Style contains 1?
     DLong ystyle;
-    gdlGetDesiredAxisStyle(e, "Y", ystyle);
+    gdlGetDesiredAxisStyle(e, YAXIS, ystyle);
     if (ystyle&1) return TRUE;
 
     DLong nozero=0;
@@ -1092,17 +1105,17 @@ namespace lib {
   {
 
    // set ![XY].CRANGE Before doing anything relative to 3D.
-    gdlStoreAxisCRANGE("X", xStart, xEnd, xLog);
-    gdlStoreAxisCRANGE("Y", yStart, yEnd, yLog);
-    gdlStoreAxisCRANGE("Z", zStart, zEnd, zLog);
+    gdlStoreAxisCRANGE(XAXIS, xStart, xEnd, xLog);
+    gdlStoreAxisCRANGE(YAXIS, yStart, yEnd, yLog);
+    gdlStoreAxisCRANGE(ZAXIS, zStart, zEnd, zLog);
     //set ![XY].type
-    gdlStoreAxisType("X",xLog);
-    gdlStoreAxisType("Y",yLog);
-    gdlStoreAxisType("Z",zLog);
+    gdlStoreAxisType(XAXIS,xLog);
+    gdlStoreAxisType(YAXIS,yLog);
+    gdlStoreAxisType(ZAXIS,zLog);
     //set ![XY].WINDOW and ![XY].S
-    gdlStoreAxisSandWINDOW(actStream, "X", xStart, xEnd, xLog);
-    gdlStoreAxisSandWINDOW(actStream, "Y", yStart, yEnd, yLog);
-    gdlStoreAxisSandWINDOW(actStream, "Z", zStart, zEnd, zLog);
+    gdlStoreAxisSandWINDOW(actStream, XAXIS, xStart, xEnd, xLog);
+    gdlStoreAxisSandWINDOW(actStream, YAXIS, yStart, yEnd, yLog);
+    gdlStoreAxisSandWINDOW(actStream, ZAXIS, zStart, zEnd, zLog);
 
     //3D work
     enum{ DATA=0,
@@ -1134,8 +1147,8 @@ namespace lib {
 
     PLFLT xMR, xML, yMB, yMT;
     DFloat xMarginL, xMarginR, yMarginB, yMarginT;
-    gdlGetDesiredAxisMargin(e, "X", xMarginL, xMarginR);
-    gdlGetDesiredAxisMargin(e, "Y", yMarginB, yMarginT);
+    gdlGetDesiredAxisMargin(e, XAXIS, xMarginL, xMarginR);
+    gdlGetDesiredAxisMargin(e, YAXIS, yMarginB, yMarginT);
     PLFLT scl=actStream->nCharLength(); //current char width
     xML=xMarginL*scl; //margin as percentage of subpage
     xMR=xMarginR*scl;
@@ -1508,16 +1521,16 @@ namespace lib {
     //        cout << "yStart " << yStart << "  yEnd "<<yEnd<<endl;
     
     // set ![XYZ].CRANGE (Z is not defined but must be [0,1])
-    gdlStoreAxisCRANGE("X", xStart, xEnd, FALSE); //already in log here if relevant!
-    gdlStoreAxisCRANGE("Y", yStart, yEnd, FALSE);
+    gdlStoreAxisCRANGE(XAXIS, xStart, xEnd, FALSE); //already in log here if relevant!
+    gdlStoreAxisCRANGE(YAXIS, yStart, yEnd, FALSE);
 
     //set ![XY].type
-    gdlStoreAxisType("X",xLog); 
-    gdlStoreAxisType("Y",yLog);
+    gdlStoreAxisType(XAXIS,xLog); 
+    gdlStoreAxisType(YAXIS,yLog);
 
     //set ![XY].WINDOW and ![XY].S
-    gdlStoreAxisSandWINDOW(actStream, "X", xStart, xEnd, FALSE);//already in log here if relevant!
-    gdlStoreAxisSandWINDOW(actStream, "Y", yStart, yEnd, FALSE);
+    gdlStoreAxisSandWINDOW(actStream, XAXIS, xStart, xEnd, FALSE);//already in log here if relevant!
+    gdlStoreAxisSandWINDOW(actStream, YAXIS, yStart, yEnd, FALSE);
     //set P.CLIP (done by PLOT, CONTOUR, SHADE_SURF, and SURFACE)
     Guard<BaseGDL> clipbox_guard;
     DLongGDL* clipBox= new DLongGDL(4, BaseGDL::ZERO); clipbox_guard.Reset(clipBox);
@@ -1652,7 +1665,7 @@ namespace lib {
 //    a->box( "bc", 0, 0, "bc", 0.0, 0);
     return TRUE;
   }
-    static bool gdlAxis(EnvT *e, GDLGStream *a, string axis, DDouble Start, DDouble End, bool Log,
+    static bool gdlAxis(EnvT *e, GDLGStream *a, int axisId, DDouble Start, DDouble End, bool Log,
     DLong modifierCode=0, DDouble NormedLength=0)
   {
     static GDL_TICKNAMEDATA data;
@@ -1677,38 +1690,38 @@ namespace lib {
 
     //special values
     PLFLT OtherAxisSizeInMm;
-    if (axis=="X") OtherAxisSizeInMm=a->mmyPageSize()*(a->boxnYSize());
-    if (axis=="Y") OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize());
+    if (axisId==XAXIS) OtherAxisSizeInMm=a->mmyPageSize()*(a->boxnYSize());
+    if (axisId==YAXIS) OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize());
     //special for AXIS who change the requested box size!
-    if (axis=="axisX") {axis="X"; OtherAxisSizeInMm=a->mmyPageSize()*(NormedLength);}
-    if (axis=="axisY") {axis="Y"; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);}
+    if (axisId==XAXIS2) {axisId=XAXIS; OtherAxisSizeInMm=a->mmyPageSize()*(NormedLength);}
+    if (axisId==YAXIS2) {axisId=YAXIS; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);}
     
     DLong GridStyle;
-    gdlGetDesiredAxisGridStyle(e, axis, GridStyle);
+    gdlGetDesiredAxisGridStyle(e, axisId, GridStyle);
     DLong Minor;
-    gdlGetDesiredAxisMinor(e, axis, Minor);
+    gdlGetDesiredAxisMinor(e, axisId, Minor);
     DLong Style;
-    gdlGetDesiredAxisStyle(e, axis, Style);
+    gdlGetDesiredAxisStyle(e, axisId, Style);
     DFloat Thick;
-    gdlGetDesiredAxisThick(e, axis, Thick);
+    gdlGetDesiredAxisThick(e, axisId, Thick);
     DStringGDL* TickFormat;
-    gdlGetDesiredAxisTickFormat(e, axis, TickFormat);
+    gdlGetDesiredAxisTickFormat(e, axisId, TickFormat);
     DDouble TickInterval;
-    gdlGetDesiredAxisTickInterval(e, axis, TickInterval);
+    gdlGetDesiredAxisTickInterval(e, axisId, TickInterval);
     DLong TickLayout;
-    gdlGetDesiredAxisTickLayout(e, axis, TickLayout);
+    gdlGetDesiredAxisTickLayout(e, axisId, TickLayout);
     DFloat TickLen;
-    gdlGetDesiredAxisTickLen(e, axis, TickLen);
+    gdlGetDesiredAxisTickLen(e, axisId, TickLen);
     DStringGDL* TickName;
-    gdlGetDesiredAxisTickName(e, a, axis, TickName);
+    gdlGetDesiredAxisTickName(e, a, axisId, TickName);
     DLong Ticks;
-    gdlGetDesiredAxisTicks(e, axis, Ticks);
+    gdlGetDesiredAxisTicks(e, axisId, Ticks);
     DStringGDL* TickUnits;
-    gdlGetDesiredAxisTickUnits(e, axis, TickUnits);
+    gdlGetDesiredAxisTickUnits(e, axisId, TickUnits);
 //    DDoubleGDL *Tickv;
-//    gdlGetDesiredAxisTickv(e, axis, Tickv);
+//    gdlGetDesiredAxisTickv(e, axisId, Tickv);
     DString Title;
-    gdlGetDesiredAxisTitle(e, axis, Title);
+    gdlGetDesiredAxisTitle(e, axisId, Title);
     
     bool hasTickUnitDefined = (TickUnits->NBytes()>0);
     int tickUnitArraySize=(hasTickUnitDefined)?TickUnits->N_Elements():0;
@@ -1717,15 +1730,15 @@ namespace lib {
     DFloat ticklen_in_mm= TickLen;
     if (TickLen<0) ticklen_in_mm*=-1;
     //ticklen in a percentage of box x or y size, to be expressed in mm 
-    if (axis=="X") ticklen_in_mm=a->mmyPageSize()*(a->boxnYSize())*ticklen_in_mm;
-    if (axis=="Y") ticklen_in_mm=a->mmxPageSize()*(a->boxnXSize())*ticklen_in_mm;
-    DFloat ticklen_as_norm=(axis=="X")?a->mm2ndy(ticklen_in_mm):a->mm2ndx(ticklen_in_mm); //in normed coord
+    if (axisId==XAXIS) ticklen_in_mm=a->mmyPageSize()*(a->boxnYSize())*ticklen_in_mm;
+    if (axisId==YAXIS) ticklen_in_mm=a->mmxPageSize()*(a->boxnXSize())*ticklen_in_mm;
+    DFloat ticklen_as_norm=(axisId==XAXIS)?a->mm2ndy(ticklen_in_mm):a->mm2ndx(ticklen_in_mm); //in normed coord
     //eventually, each succesive X or Y axis is separated from previous by interligne + ticklen in adequate units. 
     DFloat interligne_as_char;
     DFloat interligne_as_norm;
-    DFloat typical_char_size_mm= (axis=="X")?a->mmCharHeight():a->mmCharLength();
-    interligne_as_char=(axis=="X")?a->mmLineSpacing()/typical_char_size_mm:a->mmCharLength()/typical_char_size_mm; //in normed coord
-    interligne_as_norm=(axis=="X")?a->nLineSpacing():a->nCharLength(); //in normed coord
+    DFloat typical_char_size_mm= (axisId==XAXIS)?a->mmCharHeight():a->mmCharLength();
+    interligne_as_char=(axisId==XAXIS)?a->mmLineSpacing()/typical_char_size_mm:a->mmCharLength()/typical_char_size_mm; //in normed coord
+    interligne_as_norm=(axisId==XAXIS)?a->nLineSpacing():a->nCharLength(); //in normed coord
     DFloat displacement_of_new_axis_as_norm=2*interligne_as_norm+ticklen_as_norm;
     DFloat current_displacement=0;
     DFloat title_position=0;
@@ -1736,14 +1749,14 @@ namespace lib {
       string otherOpt;
       if (TickInterval==0)
       {
-        if (Ticks<=0) TickInterval=gdlComputeTickInterval(e, axis, Start, End, Log);
+        if (Ticks<=0) TickInterval=gdlComputeTickInterval(e, axisId, Start, End, Log);
         else if (Ticks>1) TickInterval=(End-Start)/Ticks;
         else TickInterval=(End-Start);
       } else { //check that tickinterval does not make more than 59 ticks:
        if (abs((End-Start)/TickInterval) > 59) TickInterval=(End-Start)/59;
       }
       //first write labels only:
-      gdlSetAxisCharsize(e, a, axis);
+      gdlSetAxisCharsize(e, a, axisId);
       gdlSetPlotCharthick(e, a);
 
       //axis, 1st time: labels
@@ -1762,10 +1775,10 @@ namespace lib {
         a->slabelfunc( gdlSingleAxisTickNamedFunc, &data );
         Opt+="o";
         if (modifierCode==2) Opt+="m"; else Opt+="n";
-        if (axis=="X") a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
-        else if (axis=="Y") a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
+        if (axisId==XAXIS) a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
+        else if (axisId==YAXIS) a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
         nchars=data.nchars;
-        if (axis=="Y") title_position=nchars+2.5; else title_position=3.5;
+        if (axisId==YAXIS) title_position=nchars+2.5; else title_position=3.5;
         a->slabelfunc( NULL, NULL );
       }
       //care Tickunits size is 10 if not defined because it is the size of !X.TICKUNITS.
@@ -1792,7 +1805,7 @@ namespace lib {
         {
           muaxdata.nchars=0; //set nchars to 0, at the end nchars will be the maximum size.
           if (i>0) Opt=otherOpt+"b"; //supplementary axes are to be wwritten with ticks, no smallticks;
-          if (axis=="X") 
+          if (axisId==XAXIS) 
           {
             a->vpor(un,deux,trois-current_displacement,quatre);
             a->wind(xun,xdeux,xtrois,xquatre);
@@ -1800,7 +1813,7 @@ namespace lib {
             title_position=current_displacement/a->nCharHeight()+3.5;
             current_displacement+=displacement_of_new_axis_as_norm; //and the spacing plus the ticklengths
           }
-          else if (axis=="Y") 
+          else if (axisId==YAXIS) 
           {
             a->vpor(un-current_displacement,deux,trois,quatre);
             a->wind(xun,xdeux,xtrois,xquatre);
@@ -1826,10 +1839,10 @@ namespace lib {
         a->slabelfunc( gdlMultiAxisTickFunc, &muaxdata );
         Opt+="o";
         if (modifierCode==2) Opt+="m"; else Opt+="n";
-        if (axis=="X") a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
-        else if (axis=="Y") a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
+        if (axisId==XAXIS) a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
+        else if (axisId==YAXIS) a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
         nchars=muaxdata.nchars;
-        if (axis=="Y") title_position=nchars+2; else title_position=3.5;
+        if (axisId==YAXIS) title_position=nchars+2; else title_position=3.5;
         a->slabelfunc( NULL, NULL );
       }
       else
@@ -1838,22 +1851,22 @@ namespace lib {
         a->slabelfunc( gdlSimpleAxisTickFunc, &tdata );
         Opt+="o";
         if (modifierCode==2) Opt+="m"; else Opt+="n";
-        if (axis=="X") a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
-        else if (axis=="Y") a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
+        if (axisId==XAXIS) a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
+        else if (axisId==YAXIS) a->box("", 0.0 ,0.0, Opt.c_str(), TickInterval, Minor);
         nchars=tdata.nchars;
-        if (axis=="Y") title_position=nchars+2; else title_position=3.5;
+        if (axisId==YAXIS) title_position=nchars+2; else title_position=3.5;
         a->slabelfunc( NULL, NULL );
       }
 
       if (modifierCode==0 ||modifierCode==1)
       {
-        if (axis=="X") a->mtex("b",title_position, 0.5, 0.5, Title.c_str());
-        else if (axis=="Y") a->mtex("l",title_position,0.5,0.5,Title.c_str());
+        if (axisId==XAXIS) a->mtex("b",title_position, 0.5, 0.5, Title.c_str());
+        else if (axisId==YAXIS) a->mtex("l",title_position,0.5,0.5,Title.c_str());
       }
       else if (modifierCode==2)
       {
-        if (axis=="X") a->mtex("t", title_position, 0.5, 0.5, Title.c_str());
-        else if (axis=="Y") a->mtex("r",title_position,0.5,0.5,Title.c_str());
+        if (axisId==XAXIS) a->mtex("t", title_position, 0.5, 0.5, Title.c_str());
+        else if (axisId==YAXIS) a->mtex("r",title_position,0.5,0.5,Title.c_str());
       }      
       
       if (TickLayout==0)
@@ -1880,8 +1893,8 @@ namespace lib {
         //gridstyle applies here:
         gdlLineStyle(a,GridStyle);
         if ( Log ) Opt+="l";
-        if (axis=="X") a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
-        else if (axis=="Y") a->box("", 0.0, 0, Opt.c_str(), TickInterval, Minor);
+        if (axisId==XAXIS) a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0);
+        else if (axisId==YAXIS) a->box("", 0.0, 0, Opt.c_str(), TickInterval, Minor);
         //reset gridstyle
         gdlLineStyle(a,0);
         // pass over with outer box, with thick. No style applied, only ticks
@@ -1897,8 +1910,8 @@ namespace lib {
           case 0:
             if ( (Style&8)==8 ) Opt+="b"; else Opt+="bc";
         }
-        if (axis=="X") a->box(Opt.c_str(), 0.0, 0, "", 0.0, 0);
-        else if (axis=="Y") a->box("", 0.0, 0 , Opt.c_str(), 0.0, 0);
+        if (axisId==XAXIS) a->box(Opt.c_str(), 0.0, 0, "", 0.0, 0);
+        else if (axisId==YAXIS) a->box("", 0.0, 0 , Opt.c_str(), 0.0, 0);
       }
       //reset charsize & thick
       a->Thick(1.0);
@@ -1911,12 +1924,12 @@ namespace lib {
   static bool gdlBox(EnvT *e, GDLGStream *a, DDouble xStart, DDouble xEnd, DDouble yStart, DDouble yEnd, bool xLog, bool yLog)
   {
     gdlWriteTitleAndSubtitle(e, a);
-    gdlAxis(e, a, "X", xStart, xEnd, xLog);
-    gdlAxis(e, a, "Y", yStart, yEnd, yLog);
+    gdlAxis(e, a, XAXIS, xStart, xEnd, xLog);
+    gdlAxis(e, a, YAXIS, yStart, yEnd, yLog);
     // title and sub title
     return true;
   }
-  static bool gdlAxis3(EnvT *e, GDLGStream *a, string axis, DDouble Start, DDouble End, bool Log, DLong zAxisCode=0, DDouble NormedLength=0)
+  static bool gdlAxis3(EnvT *e, GDLGStream *a, int axisId, DDouble Start, DDouble End, bool Log, DLong zAxisCode=0, DDouble NormedLength=0)
   {
     string addCode="b"; //for X and Y, and some Z
     if(zAxisCode==1 || zAxisCode==4) addCode="cm";
@@ -1945,44 +1958,44 @@ namespace lib {
     
     //special values
     PLFLT OtherAxisSizeInMm;
-    if (axis=="X") OtherAxisSizeInMm=a->mmyPageSize()*(a->boxnYSize());
-    if (axis=="Y") OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize());
-    if (axis=="Z") OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize()); //not always correct
+    if (axisId==XAXIS) OtherAxisSizeInMm=a->mmyPageSize()*(a->boxnYSize());
+    if (axisId==YAXIS) OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize());
+    if (axisId==ZAXIS) OtherAxisSizeInMm=a->mmxPageSize()*(a->boxnXSize()); //not always correct
     //special for AXIS who change the requested box size!
-    if (axis=="axisX") {axis="X"; OtherAxisSizeInMm=a->mmyPageSize()*(NormedLength);}
-    if (axis=="axisY") {axis="Y"; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);}
-    if (axis=="axisZ") {axis="Y"; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);} //not always correct
+    if (axisId==XAXIS2) {axisId=XAXIS; OtherAxisSizeInMm=a->mmyPageSize()*(NormedLength);}
+    if (axisId==YAXIS2) {axisId=YAXIS; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);}
+    if (axisId==ZAXIS2) {axisId=ZAXIS; OtherAxisSizeInMm=a->mmxPageSize()*(NormedLength);} //not always correct
     
 //    DFloat Charsize;//done in gdlSetAxisCharsize() below
-//    gdlGetDesiredAxisCharsize(e, axis, Charsize);
+//    gdlGetDesiredAxisCharsize(e, axisId, Charsize);
     DLong GridStyle;
-    gdlGetDesiredAxisGridStyle(e, axis, GridStyle);
+    gdlGetDesiredAxisGridStyle(e, axisId, GridStyle);
 //    DFloat MarginL, MarginR; //unused yet (fixme)
-//    gdlGetDesiredAxisMargin(e, axis, MarginL, MarginR);
+//    gdlGetDesiredAxisMargin(e, axisId, MarginL, MarginR);
     DLong Minor;
-    gdlGetDesiredAxisMinor(e, axis, Minor);
+    gdlGetDesiredAxisMinor(e, axisId, Minor);
     DLong Style;
-    gdlGetDesiredAxisStyle(e, axis, Style);
+    gdlGetDesiredAxisStyle(e, axisId, Style);
     DFloat Thick;
-    gdlGetDesiredAxisThick(e, axis, Thick);
+    gdlGetDesiredAxisThick(e, axisId, Thick);
     DStringGDL* TickFormat;
-    gdlGetDesiredAxisTickFormat(e, axis, TickFormat);
+    gdlGetDesiredAxisTickFormat(e, axisId, TickFormat);
     DDouble TickInterval;
-    gdlGetDesiredAxisTickInterval(e, axis, TickInterval);
+    gdlGetDesiredAxisTickInterval(e, axisId, TickInterval);
     DLong TickLayout;
-    gdlGetDesiredAxisTickLayout(e, axis, TickLayout);
+    gdlGetDesiredAxisTickLayout(e, axisId, TickLayout);
     DFloat TickLen;
-    gdlGetDesiredAxisTickLen(e, axis, TickLen);
+    gdlGetDesiredAxisTickLen(e, axisId, TickLen);
     DStringGDL* TickName;
-    gdlGetDesiredAxisTickName(e, a, axis, TickName);
+    gdlGetDesiredAxisTickName(e, a, axisId, TickName);
     DLong Ticks;
-    gdlGetDesiredAxisTicks(e, axis, Ticks);
+    gdlGetDesiredAxisTicks(e, axisId, Ticks);
     DStringGDL* TickUnits;
-    gdlGetDesiredAxisTickUnits(e, axis, TickUnits);
+    gdlGetDesiredAxisTickUnits(e, axisId, TickUnits);
 //    DDoubleGDL* Tickv;
-//    gdlGetDesiredAxisTickv(e, axis, Tickv);
+//    gdlGetDesiredAxisTickv(e, axisId, Tickv);
     DString Title;
-    gdlGetDesiredAxisTitle(e, axis, Title);
+    gdlGetDesiredAxisTitle(e, axisId, Title);
 
     bool hasTickUnitDefined = (TickUnits->NBytes()>0);
     int tickUnitArraySize=(hasTickUnitDefined)?TickUnits->N_Elements():0;
@@ -1990,18 +2003,18 @@ namespace lib {
     DFloat ticklen_in_mm= TickLen;
     if (TickLen<0) ticklen_in_mm*=-1;
     //ticklen in a percentage of box x or y size, to be expressed in mm 
-    if (axis=="X") ticklen_in_mm=a->mmyPageSize()*(a->boxnYSize())*ticklen_in_mm;
-    if (axis=="Y") ticklen_in_mm=a->mmyPageSize()*(a->boxnXSize())*ticklen_in_mm;
-    //eventually, each succesive X or Y axis is separated from previous by interligne + ticklen in adequate units. 
+    if (axisId==XAXIS) ticklen_in_mm=a->mmyPageSize()*(a->boxnYSize())*ticklen_in_mm;
+    if (axisId==YAXIS) ticklen_in_mm=a->mmyPageSize()*(a->boxnXSize())*ticklen_in_mm;
+    //eventually, each succesive X or Y axisId is separated from previous by interligne + ticklen in adequate units. 
     DFloat interligne;
-    if (axis=="X") interligne=a->mmLineSpacing()/a->mmCharHeight(); //in units of character size      
-    if (axis=="Y") interligne=a->mmLineSpacing()/a->mmCharLength(); //in units of character size 
+    if (axisId==XAXIS) interligne=a->mmLineSpacing()/a->mmCharHeight(); //in units of character size      
+    if (axisId==YAXIS) interligne=a->mmLineSpacing()/a->mmCharLength(); //in units of character size 
 
     if ( (Style&4)!=4 ) //if we write the axis...
     {
       if (TickInterval==0)
       {
-        if (Ticks<=0) TickInterval=gdlComputeTickInterval(e, axis, Start, End, Log);
+        if (Ticks<=0) TickInterval=gdlComputeTickInterval(e, axisId, Start, End, Log);
         else if (Ticks>1) TickInterval=(End-Start)/Ticks;
         else TickInterval=(End-Start);
       }
@@ -2012,14 +2025,14 @@ namespace lib {
       }
       string Opt;
       //first write labels only:
-      gdlSetAxisCharsize(e, a, axis);
+      gdlSetAxisCharsize(e, a, axisId);
       gdlSetPlotCharthick(e, a);
       // axis legend if box style, else do not draw. Take care writing BELOW/ABOVE all axis if tickunits present:actStream->wCharHeight()
       DDouble displacement=(tickUnitArraySize>1)?2.5*tickUnitArraySize:0;
 
       //no option to care of placement of Z axis???
-      if (axis=="X") a->mtex3("xp",3.5+displacement, 0.5, 0.5, Title.c_str());
-      else if (axis=="Y") a->mtex3("yp",5.0+displacement,0.5,0.5,Title.c_str());
+      if (axisId==XAXIS) a->mtex3("xp",3.5+displacement, 0.5, 0.5, Title.c_str());
+      else if (axisId==YAXIS) a->mtex3("yp",5.0+displacement,0.5,0.5,Title.c_str());
       else if (doZ) a->mtex3("zp",5.0+displacement,0.5,0.5,Title.c_str());
       
       //axis, 1st time: labels
@@ -2032,9 +2045,9 @@ namespace lib {
         data.nTickName=TickName->N_Elements();
         a->slabelfunc( gdlSingleAxisTickNamedFunc, &data );
         Opt+="o";
-        if      (axis=="X") a->box3(Opt.c_str(), "" , TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
-        else if (axis=="Y") a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
-        else if (doZ) if (axis=="Z") a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
+        if      (axisId==XAXIS) a->box3(Opt.c_str(), "" , TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
+        else if (axisId==YAXIS) a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
+        else if (doZ) if (axisId==ZAXIS) a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
         a->slabelfunc( NULL, NULL );
       }
       //care Tickunits size is 10 if not defined because it is the size of !X.TICKUNITS.
@@ -2058,9 +2071,9 @@ namespace lib {
 //          PLFLT un,deux,trois,quatre,xun,xdeux,xtrois,xquatre;
 //          a->plstream::gvpd(un,deux,trois,quatre);
 //          a->plstream::gvpw(xun,xdeux,xtrois,xquatre);
-            if      (axis=="X") a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
-            else if (axis=="Y") a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
-            else if (doZ) if (axis=="Z") a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
+            if      (axisId==XAXIS) a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
+            else if (axisId==YAXIS) a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
+            else if (doZ) if (axisId==ZAXIS) a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
 //          a->plstream::vpor(un,deux,trois,quatre);
 //          a->plstream::wind(xun,xdeux,xtrois,xquatre);
             muaxdata.counter++;
@@ -2075,9 +2088,9 @@ namespace lib {
         muaxdata.nTickFormat=1;
         a->slabelfunc( gdlMultiAxisTickFunc, &muaxdata );
         Opt+="o";
-        if      (axis=="X") a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
-        else if (axis=="Y") a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
-        else if (doZ) if (axis=="Z") a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
+        if      (axisId==XAXIS) a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
+        else if (axisId==YAXIS) a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
+        else if (doZ) if (axisId==ZAXIS) a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
         
         a->slabelfunc( NULL, NULL );
       }
@@ -2085,9 +2098,9 @@ namespace lib {
       {
         a->slabelfunc( gdlSimpleAxisTickFunc, &tdata );
         Opt+="o";
-        if      (axis=="X") a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
-        else if (axis=="Y") a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
-        else if (doZ) if (axis=="Z") a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
+        if      (axisId==XAXIS) a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
+        else if (axisId==YAXIS) a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
+        else if (doZ) if (axisId==ZAXIS) a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
         a->slabelfunc( NULL, NULL );
       }
 
@@ -2105,17 +2118,17 @@ namespace lib {
         //gridstyle applies here:
         gdlLineStyle(a,GridStyle);
         if ( Log ) Opt+="l";
-        if      (axis=="X") a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
-        else if (axis=="Y") a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
-        else if (doZ) if (axis=="Z") a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
+        if      (axisId==XAXIS) a->box3(Opt.c_str(), "", TickInterval, Minor, "", "", 0.0, 0, "", "", 0.0, 0);
+        else if (axisId==YAXIS) a->box3("", "", 0.0 ,0.0, Opt.c_str(),"", TickInterval, Minor, "", "", 0.0, 0);
+        else if (doZ) if (axisId==ZAXIS) a->box3("", "", 0.0, 0, "", "", 0.0, 0, Opt.c_str(), "", TickInterval, Minor);
         //reset ticks to default plplot value...
         //reset gridstyle
         gdlLineStyle(a,0);
         // pass over with outer box, with thick. No style applied, only ticks
         Opt="b";
-        if      (axis=="X") a->box3(Opt.c_str(), "", TickInterval, Minor, "","",0,0,"","",0,0);
-        else if (axis=="Y") a->box3("","",0,0, Opt.c_str(), "", TickInterval, Minor, "","",0,0);
-        else if (doZ) if (axis=="Z") a->box3("","",0,0,"","",0,0, Opt.c_str(), "", TickInterval, Minor);
+        if      (axisId==XAXIS) a->box3(Opt.c_str(), "", TickInterval, Minor, "","",0,0,"","",0,0);
+        else if (axisId==YAXIS) a->box3("","",0,0, Opt.c_str(), "", TickInterval, Minor, "","",0,0);
+        else if (doZ) if (axisId==ZAXIS) a->box3("","",0,0,"","",0,0, Opt.c_str(), "", TickInterval, Minor);
       }
       //reset charsize & thick
       a->Thick(1.0);
@@ -2130,9 +2143,9 @@ namespace lib {
     DLong zAxisCode=0;
     static int ZAXISIx=e->KeywordIx("ZAXIS");
     if (doSpecialZAxisPlacement) e->AssureLongScalarKWIfPresent(ZAXISIx, zAxisCode);
-    gdlAxis3(e, a, "X", xStart, xEnd, xLog, 0);
-    gdlAxis3(e, a, "Y", yStart, yEnd, yLog, 0);
-    gdlAxis3(e, a, "Z", zStart, zEnd, zLog, zAxisCode);
+    gdlAxis3(e, a, XAXIS, xStart, xEnd, xLog, 0);
+    gdlAxis3(e, a, YAXIS, yStart, yEnd, yLog, 0);
+    gdlAxis3(e, a, ZAXIS, zStart, zEnd, zLog, zAxisCode);
     // title and sub title
     gdlWriteTitleAndSubtitle(e, a);
     return true;

--- a/src/plotting_axis.cpp
+++ b/src/plotting_axis.cpp
@@ -71,16 +71,16 @@ namespace lib {
     }
     
     // MARGIN
-    gdlGetDesiredAxisMargin(e, "X",xMarginL, xMarginR);
-    gdlGetDesiredAxisMargin(e, "Y",yMarginB, yMarginT);
+    gdlGetDesiredAxisMargin(e, XAXIS,xMarginL, xMarginR);
+    gdlGetDesiredAxisMargin(e, YAXIS,yMarginB, yMarginT);
 
     // will handle axis logness..
     bool xLog, yLog, zLog;
     // is current box log or not?
     bool xAxisWasLog, yAxisWasLog, zAxisWasLog;
-    gdlGetAxisType("X", xAxisWasLog);
-    gdlGetAxisType("Y", yAxisWasLog);
-    gdlGetAxisType("Z", zAxisWasLog);
+    gdlGetAxisType(XAXIS, xAxisWasLog);
+    gdlGetAxisType(YAXIS, yAxisWasLog);
+    gdlGetAxisType(ZAXIS, zAxisWasLog);
     xLog=xAxisWasLog;
     yLog=yAxisWasLog; //by default logness is similar until another option is set
     zLog=zAxisWasLog;
@@ -102,8 +102,8 @@ namespace lib {
 
     // get viewport coordinates in normalised units
     PLFLT ovpXL, ovpXR, ovpYB, ovpYT;
-    gdlGetCurrentAxisWindow("X", ovpXL, ovpXR);
-    gdlGetCurrentAxisWindow("Y", ovpYB, ovpYT);
+    gdlGetCurrentAxisWindow(XAXIS, ovpXL, ovpXR);
+    gdlGetCurrentAxisWindow(YAXIS, ovpYB, ovpYT);
     //undefined or null previous viewport, seems IDL returns without complain:
     if ((ovpXL==ovpXR) || (ovpYB==ovpYT)) return;
 
@@ -113,8 +113,8 @@ namespace lib {
     DDouble oyStart, oyEnd;
 
     // get ![XY].CRANGE
-    gdlGetCurrentAxisRange("X", oxStart, oxEnd, FALSE); //ignore projection limits, convert to linear values if necessary.
-    gdlGetCurrentAxisRange("Y", oyStart, oyEnd, FALSE);
+    gdlGetCurrentAxisRange(XAXIS, oxStart, oxEnd, FALSE); //ignore projection limits, convert to linear values if necessary.
+    gdlGetCurrentAxisRange(YAXIS, oyStart, oyEnd, FALSE);
 
     if ((oyStart == oyEnd) || (oxStart == oxEnd))
     {
@@ -162,8 +162,8 @@ namespace lib {
 
     //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly
     DDouble xAxisStart, xAxisEnd, yAxisStart, yAxisEnd;
-    bool setx=gdlGetDesiredAxisRange(e, "X", xAxisStart, xAxisEnd);
-    bool sety=gdlGetDesiredAxisRange(e, "Y", yAxisStart, yAxisEnd);
+    bool setx=gdlGetDesiredAxisRange(e, XAXIS, xAxisStart, xAxisEnd);
+    bool sety=gdlGetDesiredAxisRange(e, YAXIS, yAxisStart, yAxisEnd);
     if (sety)
     {
       yStart=yAxisStart;
@@ -182,15 +182,15 @@ namespace lib {
 
     // [XY]STYLE
     DLong xStyle=0, yStyle=0;
-    gdlGetDesiredAxisStyle(e, "X", xStyle);
-    gdlGetDesiredAxisStyle(e, "Y", yStyle);
+    gdlGetDesiredAxisStyle(e, XAXIS, xStyle);
+    gdlGetDesiredAxisStyle(e, YAXIS, yStyle);
 
      //xStyle and yStyle apply on range values
     if ((xStyle & 1) != 1) {
-      PLFLT intv = gdlAdjustAxisRange(e, "X", xStart, xEnd, xLog);
+      PLFLT intv = gdlAdjustAxisRange(e, XAXIS, xStart, xEnd, xLog);
     }
     if ((yStyle & 1) != 1) {
-      PLFLT intv = gdlAdjustAxisRange(e, "Y", yStart, yEnd, yLog);
+      PLFLT intv = gdlAdjustAxisRange(e, YAXIS, yStart, yEnd, yLog);
     }
     
     DDouble yVal, xVal;
@@ -290,26 +290,26 @@ namespace lib {
     actStream->wind(xStart, xEnd, yStart, yEnd);
 
     if ( xAxis )
-    { //special name "axisX" needed because we artificially changed size of box
-      gdlAxis(e, actStream, "axisX", xStart, xEnd, xLog, standardNumPos?1:2, ovpSizeY);
+    { //special ID "XAXIS2" needed because we artificially changed size of box
+      gdlAxis(e, actStream, XAXIS2, xStart, xEnd, xLog, standardNumPos?1:2, ovpSizeY);
 
       if ( e->KeywordSet(SAVEIx) )
       {
-        gdlStoreAxisCRANGE("X", xStart, xEnd, xLog);
-        gdlStoreAxisType("X", xLog);
-        gdlStoreAxisSandWINDOW(actStream, "X", xStart, xEnd, xLog);
+        gdlStoreAxisCRANGE(XAXIS, xStart, xEnd, xLog);
+        gdlStoreAxisType(XAXIS, xLog);
+        gdlStoreAxisSandWINDOW(actStream,XAXIS, xStart, xEnd, xLog);
       }
     }
 
     if ( yAxis )
-    {//special name "axisY" needed because we artificially changed size of box
-      gdlAxis(e, actStream, "axisY", yStart, yEnd, yLog, standardNumPos?1:2, ovpSizeX);
+    {//special id "YAXIS2" needed because we artificially changed size of box
+      gdlAxis(e, actStream, YAXIS2, yStart, yEnd, yLog, standardNumPos?1:2, ovpSizeX);
 
       if ( e->KeywordSet(SAVEIx) )
       {
-        gdlStoreAxisCRANGE("Y", yStart, yEnd, yLog);
-        gdlStoreAxisType("Y", yLog);
-        gdlStoreAxisSandWINDOW(actStream, "Y", yStart, yEnd, yLog);
+        gdlStoreAxisCRANGE(YAXIS, yStart, yEnd, yLog);
+        gdlStoreAxisType(YAXIS, yLog);
+        gdlStoreAxisSandWINDOW(actStream,YAXIS, yStart, yEnd, yLog);
       }
     }
     // reset the viewport and world coordinates to the original values

--- a/src/plotting_contour.cpp
+++ b/src/plotting_contour.cpp
@@ -197,8 +197,8 @@ namespace lib
       GetMinMaxVal ( yVal, &yStart, &yEnd );
       //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly
       DDouble xAxisStart, xAxisEnd, yAxisStart, yAxisEnd;
-      bool setx=gdlGetDesiredAxisRange(e, "X", xAxisStart, xAxisEnd);
-      bool sety=gdlGetDesiredAxisRange(e, "Y", yAxisStart, yAxisEnd);
+      bool setx=gdlGetDesiredAxisRange(e, XAXIS, xAxisStart, xAxisEnd);
+      bool sety=gdlGetDesiredAxisRange(e, YAXIS, yAxisStart, yAxisEnd);
       if (setx) {
         xStart = xAxisStart;
         xEnd = xAxisEnd;
@@ -213,7 +213,7 @@ namespace lib
       GetMinMaxVal ( zVal, &datamin, &datamax );
       zStart=datamin;
       zEnd=datamax;
-      setZrange = gdlGetDesiredAxisRange(e, "Z", zStart, zEnd);
+      setZrange = gdlGetDesiredAxisRange(e, ZAXIS, zStart, zEnd);
 
       return false;
     }
@@ -270,15 +270,15 @@ namespace lib
 
       // [XY]STYLE
       DLong xStyle=0, yStyle=0, zStyle=0; ;
-      gdlGetDesiredAxisStyle(e, "X", xStyle);
-      gdlGetDesiredAxisStyle(e, "Y", yStyle);
-      gdlGetDesiredAxisStyle(e, "Z", zStyle);
+      gdlGetDesiredAxisStyle(e, XAXIS, xStyle);
+      gdlGetDesiredAxisStyle(e, YAXIS, yStyle);
+      gdlGetDesiredAxisStyle(e, ZAXIS, zStyle);
 
       // MARGIN
       DFloat xMarginL, xMarginR, yMarginB, yMarginT, zMarginF, zMarginB;
-      gdlGetDesiredAxisMargin(e, "X", xMarginL, xMarginR);
-      gdlGetDesiredAxisMargin(e, "Y", yMarginB, yMarginT);
-      gdlGetDesiredAxisMargin(e, "Z", zMarginF, zMarginB);
+      gdlGetDesiredAxisMargin(e, XAXIS, xMarginL, xMarginR);
+      gdlGetDesiredAxisMargin(e, YAXIS, yMarginB, yMarginT);
+      gdlGetDesiredAxisMargin(e, ZAXIS, zMarginF, zMarginB);
 
       // handle Log options passing via Keywords
       // note: undocumented keywords [xyz]type still exist and
@@ -309,12 +309,12 @@ namespace lib
 
       if ( ( xStyle&1 )!=1 )
 	{
-	  PLFLT intv=gdlAdjustAxisRange (e, "X", xStart, xEnd, xLog );
+	  PLFLT intv=gdlAdjustAxisRange (e, XAXIS, xStart, xEnd, xLog );
 	}
 
       if ( ( yStyle&1 )!=1 )
 	{
-	  PLFLT intv=gdlAdjustAxisRange (e, "Y", yStart, yEnd, yLog );
+	  PLFLT intv=gdlAdjustAxisRange (e, YAXIS, yStart, yEnd, yLog );
 	}
 
       static int MIN_VALUE=e->KeywordIx("MIN_VALUE");
@@ -329,7 +329,7 @@ namespace lib
       // then only apply expansion  of axes:
       if ( ( zStyle&1 )!=1 )
 	{
-	  PLFLT intv=gdlAdjustAxisRange (e, "Z", zStart, zEnd, zLog );
+	  PLFLT intv=gdlAdjustAxisRange (e, ZAXIS, zStart, zEnd, zLog );
 	}
 
       //OVERPLOT: get stored range values instead to use them!
@@ -356,9 +356,9 @@ namespace lib
       if (overplot) //retrieve information in case they are not in the command line ans apply
                     // some computation (alas)!
 	{
-	  gdlGetAxisType("X", xLog);
-	  gdlGetAxisType("Y", yLog);
-	  gdlGetAxisType("Z", zLog);
+	  gdlGetAxisType(XAXIS, xLog);
+	  gdlGetAxisType(YAXIS, yLog);
+	  gdlGetAxisType(ZAXIS, zLog);
 	  GetCurrentUserLimits(actStream, xStart, xEnd, yStart, yEnd);
       
 	  if (!doT3d) {
@@ -376,7 +376,7 @@ namespace lib
 
 	    actStream->vpor( wx[0], wx[1], wy[0], wy[1] );
 	    actStream->wind( pxStart, pxEnd, pyStart, pyEnd );
-	  } else gdlGetCurrentAxisRange("Z", zStart, zEnd); //we should memorize the number of levels!
+	  } else gdlGetCurrentAxisRange(ZAXIS, zStart, zEnd); //we should memorize the number of levels!
 
 	}
 
@@ -920,8 +920,8 @@ namespace lib
 ////      finished? Store Zrange and Loginess unless we are overplot:
 //      if ( make2dBox || make3dBox )
 //	{
-	  gdlStoreAxisCRANGE("Z", zStart, zEnd, zLog);
-	  gdlStoreAxisType("Z",zLog);
+	  gdlStoreAxisCRANGE(ZAXIS, zStart, zEnd, zLog);
+	  gdlStoreAxisType(ZAXIS,zLog);
 //	}
 
       if (doT3d) {
@@ -947,8 +947,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale*(1.0 - zValue),
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "X", xStart, xEnd, xLog);
-	  gdlAxis3(e, actStream, "Y", yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, XAXIS, xStart, xEnd, xLog);
+	  gdlAxis3(e, actStream, YAXIS, yStart, yEnd, yLog);
 	  break;
 	case XY: // X->Y Y->X plane XY
 	  t3yStart=(xLog)?log10(xStart):xStart,
@@ -960,8 +960,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale*(1.0 - zValue),
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "Y", xStart, xEnd, xLog);
-	  gdlAxis3(e, actStream, "X", yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, XAXIS, yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, YAXIS, xStart, xEnd, xLog);
 	  break;
 	case XZ: // Y->Y X->Z plane YZ
 	  t3zStart=(xLog)?log10(xStart):xStart,
@@ -973,8 +973,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale,
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "Z", xStart, xEnd, xLog, 0);
-	  gdlAxis3(e, actStream, "Y", yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, ZAXIS, xStart, xEnd, xLog, 0);
+	  gdlAxis3(e, actStream, YAXIS, yStart, yEnd, yLog);
 	  break;
 	case YZ: // X->X Y->Z plane XZ
 	  t3xStart=(xLog)?log10(xStart):xStart,
@@ -986,8 +986,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale,
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "X", xStart, xEnd, xLog);
-	  gdlAxis3(e, actStream, "Z", yStart, yEnd, yLog,1);
+	  gdlAxis3(e, actStream, XAXIS, xStart, xEnd, xLog);
+	  gdlAxis3(e, actStream, ZAXIS, yStart, yEnd, yLog,1);
 	  break;
 	case XZXY: //X->Y Y->Z plane YZ
 	  t3yStart=(xLog)?log10(xStart):xStart,
@@ -999,8 +999,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale,
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "Y", xStart, xEnd, xLog);
-	  gdlAxis3(e, actStream, "Z", yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, YAXIS, xStart, xEnd, xLog);
+	  gdlAxis3(e, actStream, ZAXIS, yStart, yEnd, yLog);
 	  break;
 	case XZYZ: //X->Z Y->X plane XZ
 	  t3zStart=(xLog)?log10(xStart):xStart,
@@ -1012,8 +1012,8 @@ namespace lib
 	  actStream->w3d(scale, scale, scale,
 			 t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
 			 alt, az);
-	  gdlAxis3(e, actStream, "Z", xStart, xEnd, xLog,1);
-	  gdlAxis3(e, actStream, "X", yStart, yEnd, yLog);
+	  gdlAxis3(e, actStream, ZAXIS, xStart, xEnd, xLog,1);
+	  gdlAxis3(e, actStream, XAXIS, yStart, yEnd, yLog);
 	  break;
         }
         // title and sub title

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -88,9 +88,9 @@ namespace lib {
     GetSFromPlotStructs(&sx, &sy, &sz);
     
     bool xLog, yLog, zLog;
-    gdlGetAxisType("X", xLog);
-    gdlGetAxisType("Y", yLog);
-    gdlGetAxisType("Z", zLog);
+    gdlGetAxisType(XAXIS, xLog);
+    gdlGetAxisType(YAXIS, yLog);
+    gdlGetAxisType(ZAXIS, zLog);
         
     int xSize, ySize;
     //give default values

--- a/src/plotting_cursor.cpp
+++ b/src/plotting_cursor.cpp
@@ -103,8 +103,8 @@ void tvcrs( EnvT* e)
 #endif
     }
      bool xLog, yLog;
-     gdlGetAxisType("X", xLog);
-     gdlGetAxisType("Y", yLog);
+     gdlGetAxisType(XAXIS, xLog);
+     gdlGetAxisType(YAXIS, yLog);
      if(xLog) tempx=pow(10,tempx);
      if(yLog) tempy=pow(10,tempy);
     actStream->WorldToDevice(tempx,tempy,ix,iy);
@@ -245,8 +245,8 @@ void cursor(EnvT* e){
       }
 #endif
       bool xLog, yLog;
-      gdlGetAxisType("X", xLog);
-      gdlGetAxisType("Y", yLog);
+      gdlGetAxisType(XAXIS, xLog);
+      gdlGetAxisType(YAXIS, yLog);
       if(xLog) tempx=pow(10,tempx);
       if(yLog) tempy=pow(10,tempy);
       x = new DDoubleGDL(tempx);

--- a/src/plotting_oplot.cpp
+++ b/src/plotting_oplot.cpp
@@ -164,8 +164,8 @@ private:
 
     bool xLog;
     bool yLog;
-    gdlGetAxisType("X", xLog);
-    gdlGetAxisType("Y", yLog);
+    gdlGetAxisType(XAXIS, xLog);
+    gdlGetAxisType(YAXIS, yLog);
 
    GetCurrentUserLimits(actStream, xStart, xEnd, yStart, yEnd);
 

--- a/src/plotting_plot.cpp
+++ b/src/plotting_plot.cpp
@@ -197,8 +197,8 @@ private:
     static int xTickunitsIx = e->KeywordIx( "XTICKUNITS" );
     static int yTickunitsIx = e->KeywordIx( "YTICKUNITS" );
 
-    calendar_codex = gdlGetCalendarCode(e,"X");
-    calendar_codey = gdlGetCalendarCode(e,"Y");
+    calendar_codex = gdlGetCalendarCode(e,XAXIS);
+    calendar_codey = gdlGetCalendarCode(e,YAXIS);
     if ( e->KeywordSet( xTickunitsIx ) && xLog) {
       Message( "PLOT: LOG setting ignored for Date/Time TICKUNITS." );
       xLog = FALSE;
@@ -267,8 +267,8 @@ private:
     if (yEnd <= yStart) yEnd=yStart+1;
     //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly
     DDouble xAxisStart, xAxisEnd, yAxisStart, yAxisEnd;
-    bool setx=gdlGetDesiredAxisRange(e, "X", xAxisStart, xAxisEnd);
-    bool sety=gdlGetDesiredAxisRange(e, "Y", yAxisStart, yAxisEnd);
+    bool setx=gdlGetDesiredAxisRange(e, XAXIS, xAxisStart, xAxisEnd);
+    bool sety=gdlGetDesiredAxisRange(e, YAXIS, yAxisStart, yAxisEnd);
     if(setx && sety)
     {
       xStart=xAxisStart;
@@ -312,21 +312,21 @@ private:
 
     // [XY]STYLE
     DLong xStyle=0, yStyle=0;
-    gdlGetDesiredAxisStyle(e, "X", xStyle);
-    gdlGetDesiredAxisStyle(e, "Y", yStyle);
+    gdlGetDesiredAxisStyle(e, XAXIS, xStyle);
+    gdlGetDesiredAxisStyle(e, YAXIS, yStyle);
 
      //xStyle and yStyle apply on range values
     if ((xStyle & 1) != 1) {
-      PLFLT intv = gdlAdjustAxisRange(e, "X", xStart, xEnd, xLog, calendar_codex);
+      PLFLT intv = gdlAdjustAxisRange(e, XAXIS, xStart, xEnd, xLog, calendar_codex);
     }
     if ((yStyle & 1) != 1) {
-      PLFLT intv = gdlAdjustAxisRange(e, "Y", yStart, yEnd, yLog, calendar_codey);
+      PLFLT intv = gdlAdjustAxisRange(e, YAXIS, yStart, yEnd, yLog, calendar_codey);
     }
 
     // MARGIN
     DFloat xMarginL, xMarginR, yMarginB, yMarginT;
-    gdlGetDesiredAxisMargin(e, "X", xMarginL, xMarginR);
-    gdlGetDesiredAxisMargin(e, "Y", yMarginB, yMarginT);
+    gdlGetDesiredAxisMargin(e, XAXIS, xMarginL, xMarginR);
+    gdlGetDesiredAxisMargin(e, YAXIS, yMarginB, yMarginT);
 
     // viewport and world coordinates
     // set the PLOT charsize before setting viewport (margin depend on charsize)
@@ -366,8 +366,8 @@ private:
           actStream->w3d(scale, scale, scale*(1.0 - zValue),
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "X", xStart, xEnd, xLog);
-          gdlAxis3(e, actStream, "Y", yStart, yEnd, yLog);
+          gdlAxis3(e, actStream, XAXIS, xStart, xEnd, xLog);
+          gdlAxis3(e, actStream, YAXIS, yStart, yEnd, yLog);
           break;
         case XY: // X->Y Y->X plane XY
           t3yStart=(xLog)?log10(xStart):xStart,
@@ -379,8 +379,8 @@ private:
           actStream->w3d(scale, scale, scale*(1.0 - zValue),
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "Y", xStart, xEnd, xLog);
-          gdlAxis3(e, actStream, "X", yStart, yEnd, yLog);
+          gdlAxis3(e, actStream, YAXIS, xStart, xEnd, xLog);
+          gdlAxis3(e, actStream, XAXIS, yStart, yEnd, yLog);
           break;
         case XZ: // Y->Y X->Z plane YZ
           t3zStart=(xLog)?log10(xStart):xStart,
@@ -392,8 +392,8 @@ private:
           actStream->w3d(scale, scale, scale,
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "Z", xStart, xEnd, xLog,0);
-          gdlAxis3(e, actStream, "Y", yStart, yEnd, yLog);
+          gdlAxis3(e, actStream, ZAXIS, xStart, xEnd, xLog,0);
+          gdlAxis3(e, actStream, YAXIS, yStart, yEnd, yLog);
           break;
         case YZ: // X->X Y->Z plane XZ
           t3xStart=(xLog)?log10(xStart):xStart,
@@ -405,8 +405,8 @@ private:
           actStream->w3d(scale, scale, scale,
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "X", xStart, xEnd, xLog);
-          gdlAxis3(e, actStream, "Z", yStart, yEnd, yLog,1);
+          gdlAxis3(e, actStream, XAXIS, xStart, xEnd, xLog);
+          gdlAxis3(e, actStream, ZAXIS, yStart, yEnd, yLog,1);
           break;
         case XZXY: //X->Y Y->Z plane YZ
           t3yStart=(xLog)?log10(xStart):xStart,
@@ -418,8 +418,8 @@ private:
           actStream->w3d(scale, scale, scale,
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "Y", xStart, xEnd, xLog);
-          gdlAxis3(e, actStream, "Z", yStart, yEnd, yLog);
+          gdlAxis3(e, actStream, YAXIS, xStart, xEnd, xLog);
+          gdlAxis3(e, actStream, ZAXIS, yStart, yEnd, yLog);
           break;
         case XZYZ: //X->Z Y->X plane XZ
           t3zStart=(xLog)?log10(xStart):xStart,
@@ -431,8 +431,8 @@ private:
           actStream->w3d(scale, scale, scale,
           t3xStart,t3xEnd,t3yStart,t3yEnd,t3zStart,t3zEnd,
           alt, az);
-          gdlAxis3(e, actStream, "Z", xStart, xEnd, xLog,1);
-          gdlAxis3(e, actStream, "X", yStart, yEnd, yLog);
+          gdlAxis3(e, actStream, ZAXIS, xStart, xEnd, xLog,1);
+          gdlAxis3(e, actStream, XAXIS, yStart, yEnd, yLog);
           break;
       }
       //finish box: since there is no option in plplot for upper box 3d axes, do it ourselve:

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -215,14 +215,14 @@ namespace lib
       if (coordinateSystem == DEVICE) doT3d =false;
       
       // get_axis_type
-      gdlGetAxisType("X", xLog);
-      gdlGetAxisType("Y", yLog);
-      gdlGetAxisType("Z", zLog);
+      gdlGetAxisType(XAXIS, xLog);
+      gdlGetAxisType(YAXIS, yLog);
+      gdlGetAxisType(ZAXIS, zLog);
       
       //get DATA limits (not necessary CRANGE, see AXIS / SAVE behaviour!)
       GetCurrentUserLimits(actStream, xStart, xEnd, yStart, yEnd);
       // get !Z.CRANGE
-      gdlGetCurrentAxisRange("Z", zStart, zEnd);
+      gdlGetCurrentAxisRange(ZAXIS, zStart, zEnd);
 
       if (zStart != 0.0 && zStart == zEnd)
       {

--- a/src/plotting_polyfill.cpp
+++ b/src/plotting_polyfill.cpp
@@ -183,14 +183,14 @@ namespace lib
       if (coordinateSystem == DEVICE) doT3d =false;
       
       // get_axis_type
-      gdlGetAxisType("X", xLog);
-      gdlGetAxisType("Y", yLog);
-      gdlGetAxisType("Z", zLog);
+      gdlGetAxisType(XAXIS, xLog);
+      gdlGetAxisType(YAXIS, yLog);
+      gdlGetAxisType(ZAXIS, zLog);
 
       //get DATA limits (not necessary CRANGE, see AXIS / SAVE behaviour!)
       GetCurrentUserLimits(actStream, xStart, xEnd, yStart, yEnd);
       // get !Z.CRANGE
-      gdlGetCurrentAxisRange("Z", zStart, zEnd);
+      gdlGetCurrentAxisRange(ZAXIS, zStart, zEnd);
 
       if (zStart != 0.0 && zStart == zEnd)
       {

--- a/src/plotting_shade_surf.cpp
+++ b/src/plotting_shade_surf.cpp
@@ -159,8 +159,8 @@ namespace lib
       GetMinMaxVal ( yVal, &yStart, &yEnd );
       //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly
       DDouble xAxisStart, xAxisEnd, yAxisStart, yAxisEnd;
-      bool setx=gdlGetDesiredAxisRange(e, "X", xAxisStart, xAxisEnd);
-      bool sety=gdlGetDesiredAxisRange(e, "Y", yAxisStart, yAxisEnd);
+      bool setx=gdlGetDesiredAxisRange(e, XAXIS, xAxisStart, xAxisEnd);
+      bool sety=gdlGetDesiredAxisRange(e, YAXIS, yAxisStart, yAxisEnd);
       if (setx) {
         xStart=xAxisStart;
         xEnd=xAxisEnd;
@@ -175,7 +175,7 @@ namespace lib
       GetMinMaxVal ( zVal, &datamin, &datamax );
       zStart=datamin;
       zEnd=datamax;
-      setZrange = gdlGetDesiredAxisRange(e, "Z", zStart, zEnd);
+      setZrange = gdlGetDesiredAxisRange(e, ZAXIS, zStart, zEnd);
 
       //SHADES: Doing the job will be for nothing since plplot does not give the functionality.
       static int shadesIx=e->KeywordIx ( "SHADES" ); doShade=false;
@@ -213,9 +213,9 @@ namespace lib
 
       // [XYZ]STYLE
       DLong xStyle=0, yStyle=0, zStyle=0; ;
-      gdlGetDesiredAxisStyle(e, "X", xStyle);
-      gdlGetDesiredAxisStyle(e, "Y", yStyle);
-      gdlGetDesiredAxisStyle(e, "Z", zStyle);
+      gdlGetDesiredAxisStyle(e, XAXIS, xStyle);
+      gdlGetDesiredAxisStyle(e, YAXIS, yStyle);
+      gdlGetDesiredAxisStyle(e, ZAXIS, zStyle);
 
       //check here since after AutoIntvAC values will be good but arrays passed
       //to plplot will be bad...
@@ -234,12 +234,12 @@ namespace lib
 
       if ( ( xStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange (e, "X", xStart, xEnd, xLog );
+        PLFLT intv=gdlAdjustAxisRange (e, XAXIS, xStart, xEnd, xLog );
       }
 
       if ( ( yStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange (e, "Y", yStart, yEnd, yLog );
+        PLFLT intv=gdlAdjustAxisRange (e, YAXIS, yStart, yEnd, yLog );
       }
 
       static int MIN_VALUEIx = e->KeywordIx( "MIN_VALUE");
@@ -260,7 +260,7 @@ namespace lib
       // then only apply expansion  of axes:
       if ( ( zStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange ( e, "Z", zStart, zEnd, zLog );
+        PLFLT intv=gdlAdjustAxisRange ( e, ZAXIS, zStart, zEnd, zLog );
       }
 
       // background BEFORE next plot since it is the only place plplot may redraw the background...

--- a/src/plotting_surface.cpp
+++ b/src/plotting_surface.cpp
@@ -158,8 +158,8 @@ namespace lib
       GetMinMaxVal ( yVal, &yStart, &yEnd );
       //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly
       DDouble xAxisStart, xAxisEnd, yAxisStart, yAxisEnd;
-      bool setx=gdlGetDesiredAxisRange(e, "X", xAxisStart, xAxisEnd);
-      bool sety=gdlGetDesiredAxisRange(e, "Y", yAxisStart, yAxisEnd);
+      bool setx=gdlGetDesiredAxisRange(e, XAXIS, xAxisStart, xAxisEnd);
+      bool sety=gdlGetDesiredAxisRange(e, YAXIS, yAxisStart, yAxisEnd);
       if (setx) {
         xStart=xAxisStart;
         xEnd=xAxisEnd;
@@ -175,7 +175,7 @@ namespace lib
       GetMinMaxVal ( zVal, &datamin, &datamax );
       zStart=datamin;
       zEnd=datamax;
-      setZrange = gdlGetDesiredAxisRange(e, "Z", zStart, zEnd);
+      setZrange = gdlGetDesiredAxisRange(e, ZAXIS, zStart, zEnd);
 
         return false;
     } 
@@ -205,9 +205,9 @@ namespace lib
 
       // [XYZ]STYLE
       DLong xStyle=0, yStyle=0, zStyle=0; ;
-      gdlGetDesiredAxisStyle(e, "X", xStyle);
-      gdlGetDesiredAxisStyle(e, "Y", yStyle);
-      gdlGetDesiredAxisStyle(e, "Z", zStyle);
+      gdlGetDesiredAxisStyle(e, XAXIS, xStyle);
+      gdlGetDesiredAxisStyle(e, YAXIS, yStyle);
+      gdlGetDesiredAxisStyle(e, ZAXIS, zStyle);
 
       //check here since after AutoIntvAC values will be good but arrays passed
       //to plplot will be bad...
@@ -226,12 +226,12 @@ namespace lib
 
       if ( ( xStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange (e,"X",  xStart, xEnd, xLog );
+        PLFLT intv=gdlAdjustAxisRange (e,XAXIS,  xStart, xEnd, xLog );
       }
 
       if ( ( yStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange (e, "Y", yStart, yEnd, yLog );
+        PLFLT intv=gdlAdjustAxisRange (e, YAXIS, yStart, yEnd, yLog );
       }
 
       static int MIN_VALUEIx = e->KeywordIx( "MIN_VALUE");
@@ -252,7 +252,7 @@ namespace lib
       // then only apply expansion  of axes:
       if ( ( zStyle&1 )!=1 )
       {
-        PLFLT intv=gdlAdjustAxisRange (e, "Z", zStart, zEnd, zLog );
+        PLFLT intv=gdlAdjustAxisRange (e, ZAXIS, zStart, zEnd, zLog );
       }
 
       // background BEFORE next plot since it is the only place plplot may redraw the background...

--- a/src/plotting_xyouts.cpp
+++ b/src/plotting_xyouts.cpp
@@ -183,14 +183,14 @@ namespace lib
       if (coordinateSystem == DEVICE) doT3d =false;
       
       // get_axis_type
-      gdlGetAxisType("X", xLog);
-      gdlGetAxisType("Y", yLog);
-      gdlGetAxisType("Z", zLog);
+      gdlGetAxisType(XAXIS, xLog);
+      gdlGetAxisType(YAXIS, yLog);
+      gdlGetAxisType(ZAXIS, zLog);
 
       //get DATA limits (not necessary CRANGE, see AXIS / SAVE behaviour!)
       GetCurrentUserLimits(actStream, xStart, xEnd, yStart, yEnd);
       // get !Z.CRANGE
-      gdlGetCurrentAxisRange("Z", zStart, zEnd);
+      gdlGetCurrentAxisRange(ZAXIS, zStart, zEnd);
 
       if (zStart != 0.0 && zStart == zEnd)
       {

--- a/src/pro/congrid.pro
+++ b/src/pro/congrid.pro
@@ -22,7 +22,6 @@
 ;       /CENTER means assume pixels centered.  This means
 ;         the pixel at (0,[0,[0]]) is clipped to 1/4 size.
 ;         Default is that pixel start (not center) is at index.'
-;       MISSING=missing gives a value for undefined pixels.
 ;       /MINUS_ONE: option will be ignored. MISSING can be used instead.
 ;       /HELP gives this help.'
 ;
@@ -48,7 +47,6 @@ function CONGRID, t, mx, my, mz, $
                   INTERP=interp, $
                   CUBIC = cubic, $
                   MINUS_ONE=minus_one, $
-                  MISSING=missing, $
                   HELP=help, test=test
 
 npar=N_PARAMS()
@@ -67,7 +65,6 @@ if (npar lt 2) or (npar gt 4) or KEYWORD_SET(help) then begin
     print,'   the pixel at (0,[0,[0]]) is clipped to 1/4 size.'
     print,'   Default is that pixel start (not center) is at index.'
     print,'   CUBIC=cubic: use a cubic interpolation.'
-    print,'   MISSING=missing gives a value for undefined pixels.'
     print,'   /MINUS_ONE: option will be ignored. MISSING can be used instead.'
     print, '  /HELP gives this help.'
     print,' NOTE: CONGRID performs a resampling. Does not conserve Fluxes.'
@@ -118,17 +115,17 @@ IF (nopt lt ndim) THEN BEGIN
     p=SHIFT(INDGEN(ndim),-nopt)
     temp=TRANSPOSE(t,p)
     CASE nopt OF
-        3: temp2 = INTERPOLATE(temp,x,y,z,/grid,cubic=cubic,missing=missing)
-        2: temp2 = INTERPOLATE(temp,x,y,/grid,nearest_neighbour=nnbor,cubic=cubic,missing=missing)
-        1: temp2 = INTERPOLATE(temp,x,/grid,nearest_neighbour=nnbor,cubic=cubic,missing=missing)
+        3: temp2 = INTERPOLATE(temp,x,y,z,/grid,cubic=cubic)
+        2: temp2 = INTERPOLATE(temp,x,y,/grid,nearest_neighbour=nnbor,cubic=cubic)
+        1: temp2 = INTERPOLATE(temp,x,/grid,nearest_neighbour=nnbor,cubic=cubic)
     ENDCASE
     p=SHIFT(INDGEN(ndim),nopt)
     t2=TRANSPOSE(temp2,p)
 ENDIF ELSE BEGIN
     CASE nopt OF
-        3: t2 = INTERPOLATE(t,x,y,z,/grid,cubic=cubic,missing=missing)
-        2: t2 = INTERPOLATE(t,x,y,/grid,nearest_neighbour=nnbor,cubic=cubic,missing=missing)
-        1: t2 = INTERPOLATE(t,x,/grid,nearest_neighbour=nnbor,cubic=cubic,missing=missing)
+        3: t2 = INTERPOLATE(t,x,y,z,/grid,cubic=cubic)
+        2: t2 = INTERPOLATE(t,x,y,/grid,nearest_neighbour=nnbor,cubic=cubic)
+        1: t2 = INTERPOLATE(t,x,/grid,nearest_neighbour=nnbor,cubic=cubic)
     ENDCASE
 ENDELSE
 ;

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -1030,7 +1030,7 @@ PROJDATA protect_proj_fwd(PROJDATA idata, PROJTYPE proj)
     return p;
   }
 
-  void rotate3d(Point3d &p1, const Point3d a, DDouble theta)
+  void rotate3d(Point3d &p1, const Point3d &a, DDouble theta)
   {
     DDouble st,ct;
     gdl_sincos(theta,&st,&ct);


### PR DESCRIPTION
 interpolate in gsl_fun did not correctly handle the "MISSING" keyword, as one could not say 'missing=0'. This is solved here.
Unfortunately our version of CONGRID (pro/congrid.pro) had a MISSING keyword which should not exist and was causing internally a call to interpolate with an unwanted missing value, thus #609 was failing.

Note this PR contains also the commits of #620 ...