### PR TITLE
Adding builtin function for SCOPE_VARNAME, and a test-script for it.

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -8540,7 +8540,111 @@ BaseGDL* parse_url( EnvT* env)
     e->Throw("LVariable not found: " + varName);
     return NULL; // compiler shut-up
   }
-  
+
+    BaseGDL* scope_varname_fun( EnvT* e ) {
+
+        SizeT nParam = e->NParam();
+
+        EnvStackT& callStack = e->Interpreter()->CallStack();
+        
+        DLong currentLvl = callStack.size();
+        DLong level = currentLvl;               // default to current level
+
+        DStringGDL* retVal = nullptr;
+        SizeT count(0);
+        
+        static int commonIx = e->KeywordIx("COMMON");
+        static int countIx = e->KeywordIx("COUNT");
+        static int levelIx = e->KeywordIx("LEVEL");
+        
+        if( e->KeywordSet(commonIx) ) {
+            
+            if( e->KeywordSet(levelIx) ) e->Throw("Conflicting keywords.");
+                
+            DString commonName = "";
+            e->AssureStringScalarKW( commonIx, commonName );
+            DSubUD* pro = static_cast<DSubUD*>( e->Caller()->GetPro() );
+            SizeT nComm = pro->CommonsSize();
+            DCommon* common = pro->Common( StrUpCase(commonName) );
+            count = nParam;
+            retVal = new DStringGDL( dimension( nParam ), BaseGDL::NOZERO );
+            for( SizeT i(0); i<nParam; ++i ) {
+                DLong par;
+                e->AssureLongScalarPar( i, par );
+                if( (par >= 0) && (par < nComm) ) {
+                    (*retVal)[i] = common->VarName( par );
+                } else (*retVal)[i] = "";
+            }
+        } else {
+            
+            DLongGDL* kwLvl = e->IfDefGetKWAs<DLongGDL>(levelIx);
+            if( kwLvl ) {
+                DLong tmp = (*kwLvl)[0];
+                if( tmp > 0 ) level = tmp;
+                else level += tmp;
+                level = std::max( std::min(level, currentLvl), 1 );
+            }
+            
+            EnvT* requestedScope = (EnvT*)callStack[level-1];
+            DSubUD* scope_pro = static_cast<DSubUD*>( requestedScope->GetPro() );
+            SizeT scope_nVar = scope_pro->Size();
+            SizeT scope_nComm = scope_pro->CommonsSize();
+
+            if( nParam == 0 ) {         // Just list and return all defined parameters at the requested level.
+                count = scope_nVar+scope_nComm;
+                if( !count ) {
+                    retVal = new DStringGDL("");
+                } else {                // N.B. Order doesn't matter since the result is lexically sorted.
+                    vector<string> names(count);
+                    for( SizeT i(0); i<scope_nVar; ++i ) {
+                        names[ i ] = scope_pro->GetVarName( i );
+                        if( names[ i ].empty() ) names[ i ] = "*";
+                    }
+                    if( scope_nComm ) {
+                        DStringGDL* list = static_cast<DStringGDL*>(scope_pro->GetCommonVarNameList());
+                        for( SizeT i(0); i < list->N_Elements(); ++i ) {
+                            names[ scope_nVar+i ] = (*list)[i];
+                        }
+                    }
+                    std::sort( names.begin(), names.end() );
+                    retVal = new DStringGDL( dimension( count ), BaseGDL::NOZERO );
+                    for( SizeT i(0); i<count; ++i) {
+                        (*retVal)[i] = names[i];
+                    }
+                }
+            } else {
+                count = nParam;
+                retVal = new DStringGDL( dimension( nParam ), BaseGDL::NOZERO );
+                for( SizeT i(0); i<nParam; ++i ) {
+                    (*retVal)[i] = "";      // not found
+                    BaseGDL*& par = e->GetPar( i );
+                    std::string tmp_name;
+                    if( scope_pro->GetCommonVarName( par, tmp_name ) ) { // Variable found in common-block, so use that name first.
+                        (*retVal)[i] = tmp_name;
+                        continue;
+                    }
+                    if( level == currentLvl ) {                         // For current level we need to resolve using e
+                        (*retVal)[i] = e->GetParString( i );
+                    } else if( par ) {
+                        DString parString = requestedScope->GetString( par );
+                        (*retVal)[i] = parString;
+                        continue;
+                    }
+                    
+                }
+            }
+            
+        }
+        
+        // set the COUNT keyword
+        if( e->KeywordPresent(countIx) ) {
+            e->AssureGlobalKW(countIx);
+            e->SetKW( countIx, new DLongGDL(count) );
+        }
+
+        return retVal;
+        
+    }
 
 } // namespace
 

--- a/src/basic_fun.hpp
+++ b/src/basic_fun.hpp
@@ -178,6 +178,7 @@ namespace lib {
   BaseGDL* scope_traceback( EnvT* e);
   BaseGDL* scope_varfetch_value( EnvT* e); // regular library function
   BaseGDL** scope_varfetch_reference( EnvT* e); // special version for LEval()
+  BaseGDL* scope_varname_fun( EnvT* e);
   BaseGDL* mean_fun(EnvT* e); 
   BaseGDL* moment_fun(EnvT* e); 
 } // namespace

--- a/src/dcommon.cpp
+++ b/src/dcommon.cpp
@@ -47,7 +47,8 @@ void DCommon::DeleteData()
 
 void DCommon::AddVar(const string& v)
 {
-  var.push_back(new DVar(v));
+  DByteGDL* dummy=new DByteGDL(0);      // TODO: This dummy should be replaced by a proper "undefined" type/placeholder when such exists.
+  var.push_back(new DVar(v,dummy));
 }
 
 const string& DCommon::Name() const

--- a/src/dcommon.cpp
+++ b/src/dcommon.cpp
@@ -20,6 +20,7 @@
 #include "gdlexception.hpp"
 #include "dcommon.hpp"
 #include "str.hpp"
+#include "nullgdl.hpp"
 #include "objects.hpp"
 
 // common block ********************************************

--- a/src/dcommon.cpp
+++ b/src/dcommon.cpp
@@ -47,8 +47,7 @@ void DCommon::DeleteData()
 
 void DCommon::AddVar(const string& v)
 {
-  DByteGDL* dummy=new DByteGDL(0);      // TODO: This dummy should be replaced by a proper "undefined" type/placeholder when such exists.
-  var.push_back(new DVar(v,dummy));
+  var.push_back( new DVar(v, NullGDL::GetSingleInstance() ) );
 }
 
 const string& DCommon::Name() const

--- a/src/dcommon.hpp
+++ b/src/dcommon.hpp
@@ -21,6 +21,8 @@
 #include "gdlexception.hpp"
 #include "dvar.hpp"
 
+class DCommon;
+
 class DCommonBase 
 {
 public:
@@ -32,6 +34,8 @@ public:
   virtual int Find(const BaseGDL*)=0;
   virtual const std::string& VarName(const unsigned i)=0;
   virtual DVar* Var(unsigned ix)=0;
+  virtual DCommon* getCommon(void)=0;
+  virtual bool isRef(void) const { return false; };
 };
 
 // common block *******************************************************
@@ -58,6 +62,7 @@ public:
   DVar* Find(const std::string&);
   int Find(const BaseGDL*);
   DVar* Var(unsigned ix) { return var[ix];}
+  DCommon* getCommon(void) { return this; };
 };
 
 class DCommon_eq: public std::unary_function<DCommon,bool>
@@ -90,6 +95,8 @@ public:
   DVar* Find(const std::string&);
   int Find(const BaseGDL*);
   DVar* Var(unsigned ix);
+  DCommon* getCommon(void) { return cRef; };
+  bool isRef(void) const { return true; };
 };
 
 typedef std::vector<DCommonBase*> CommonBaseListT;

--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -387,9 +387,11 @@ public:
   DCommon* Common(const std::string& n)
   {
     CommonBaseListT::iterator c = common.begin();
-    for(; c != common.end(); ++c)
-      if( dynamic_cast< DCommon*>( *c) != NULL && (*c)->Name() == n)
-	return static_cast< DCommon*>( *c);
+    for(; c != common.end(); ++c) {
+      if( (*c)->Name() == n) {
+        return (*c)->getCommon();
+      }
+    }
     return NULL;
   }
 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -109,6 +109,8 @@ void LibInit()
   new DLibFun(lib::scope_varfetch_value,string("SCOPE_VARFETCH"),-1,scope_varfetchKey,scope_varfetchWarnKey);
   const string scope_tracebackKey[]={"STRUCTURE","SYSTEM", KLISTEND};
   new DLibFunRetNew(lib::scope_traceback,string("SCOPE_TRACEBACK"),0,scope_tracebackKey);
+  const string scope_varnameKey[]={ "COMMON", "COUNT", "LEVEL", KLISTEND };
+  new DLibFun( lib::scope_varname_fun, string("SCOPE_VARNAME"), -1, scope_varnameKey );
 
   const string cpuKey[]={ "RESET","RESTORE","TPOOL_MAX_ELTS", "TPOOL_MIN_ELTS",
 					"TPOOL_NTHREADS","VECTOR_ENABLE",KLISTEND};

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -196,6 +196,7 @@ TESTS = \
   test_same_name.pro \
   test_save_restore.pro \
   test_scope_varfetch.pro \
+  test_scope_varname.pro \
   test_sem.pro \
   test_simplex.pro \
   test_size.pro \

--- a/testsuite/test_scope_varname.pro
+++ b/testsuite/test_scope_varname.pro
@@ -1,0 +1,200 @@
+;
+; Tomas Hillberg, 01 Sep. 2019. Under GNU GPL v2+
+;
+; Preliminatry test suite for function SCOPE_VARNAME
+;
+; TODO: There seem to be some discrepancies when routines are compiled, so that
+; the order of the COMMON blocks might be different. For that reason, using
+; SCOPE_VARNAME with the /COMMON keyword might output different results when
+; compared to IDL. 
+;
+
+COMMON TH_COM1, gvar1, gvar2, gvar3
+
+
+; testing internal calls within a procedure
+pro TH_PROC1, proc1_arg, proc1_ce, test=test, key1=proc1_key, key2=proc1_unusedkey
+
+    COMMON TH_COM1, p1gvar1, p1gvar2, p1gvar3
+    p1gvar2=1
+    
+    expected = [ $
+        'EXPECTED P1GVAR1 P1GVAR2 P1GVAR3 PROC1_ARG PROC1_CE PROC1_ERRORS PROC1_KEY PROC1_UNDEFINED PROC1_UNUSEDKEY TEST', $
+        'CUMUL_ERRORS GVAR1 GVAR2 GVAR3 HELP NO_EXIT SHORT TEST TH_OBJ', $
+        'PROC1_CE P1GVAR2 PROC1_UNUSEDKEY P1GVAR3 P1GVAR1 PROC1_UNDEFINED', $
+        'CUMUL_ERRORS GVAR2  GVAR3 GVAR1 ', $
+        '' $
+    ]
+    proc1_errors = 0
+    
+    ; List all variables in current scope
+    if ( strjoin(SCOPE_VARNAME(count=p1gvar2),' ') ne expected[0] ) then begin
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME()'
+        print, 'PROC with SCOPE_VARNAME()   result: "' + strjoin(SCOPE_VARNAME(),' ') + '"'
+        print, 'PROC with SCOPE_VARNAME() expected: "' + expected[0] + '"'
+    endif
+    if ( p1gvar2 ne 11 ) then begin
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME() : '+string(p1gvar2)+' ne 11'
+    endif
+    
+    ; List all variables in parent scope
+    if ( strjoin(SCOPE_VARNAME(count=p1gvar2,level=-1),' ') ne expected[1] ) then begin $
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME(level=-1)'
+        print, 'PROC with SCOPE_VARNAME(level=-1)   result: "' + strjoin(SCOPE_VARNAME(level=-1),' ') + '"'
+        print, 'PROC with SCOPE_VARNAME(level=-1) expected: "' + expected[1] + '"'
+    endif
+    if ( p1gvar2 ne 9 ) then begin
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME(level=-1) : '+string(p1gvar2)+' ne 9'
+    endif
+    
+    ; List some variables in current scope
+    if ( strjoin(SCOPE_VARNAME( proc1_ce, proc1_arg, proc1_unusedkey, proc1_key, p1gvar1, proc1_undefined, count=p1gvar2 ),' ') ne $
+            expected[2] ) then begin $
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME({local_vars})'
+        print, 'PROC with SCOPE_VARNAME( {local_vars} )   result: "'+strjoin(SCOPE_VARNAME(proc1_ce, proc1_arg, proc1_unusedkey, proc1_key, p1gvar1, proc1_undefined),' ')+'"'
+        print, 'PROC with SCOPE_VARNAME( {local_vars} ) expected: "' + expected[2] + '"'
+    endif
+    if ( p1gvar2 ne 6 ) then begin
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME({local_vars}) : '+string(p1gvar2)+' ne 6'
+    endif
+    
+    ; List the corresponding name in the parent scope for a few variables in current scope
+    if ( strjoin(SCOPE_VARNAME( proc1_ce, proc1_arg, proc1_unusedkey, proc1_key, p1gvar1, proc1_undefined, count=p1gvar2, level=-1 ),' ') ne $
+            expected[3] ) then begin $
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME({local_vars}, level=-1)'
+        print, 'PROC with SCOPE_VARNAME( {local_vars}, level=-1 )   result: "'+strjoin(SCOPE_VARNAME(proc1_ce, proc1_arg, proc1_unusedkey, proc1_key, p1gvar1, proc1_undefined, level=-1),' ')+'"'
+        print, 'PROC with SCOPE_VARNAME( {local_vars}, level=-1 ) expected: "' + expected[3] + '"'
+    endif
+    if ( p1gvar2 ne 6 ) then begin ; N.B. the empty strings returned are counted too
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME({local_vars}, level=-1) : '+string(p1gvar2)+' ne 6'
+    endif
+
+    ; List unexisting name in the parent scope for a few variables (should return '')
+    if ( strjoin(SCOPE_VARNAME( proc1_undefined, count=p1gvar2, level=-1 ),' ') ne  expected[4] ) then begin $
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME(undefined, level=-1)'
+        print, 'PROC with SCOPE_VARNAME( undefined, level=-1 )   result: "'+strjoin(SCOPE_VARNAME(proc1_undefined, count=p1gvar2, level=-1),' ')+'"'
+        print, 'PROC with SCOPE_VARNAME( undefined, level=-1 ) expected: "' + expected[4] + '"'
+    endif
+    if ( p1gvar2 ne 1 ) then begin
+        ERRORS_ADD, proc1_errors, 'PROC with SCOPE_VARNAME(undefined, level=-1) : '+string(p1gvar2)+' ne 1'
+    endif
+
+    BANNER_FOR_TESTSUITE, 'TH_PROC1', proc1_errors, /short
+    ERRORS_CUMUL, proc1_ce, proc1_errors
+    
+    if KEYWORD_set(test) then STOP
+
+end
+
+; testing internal calls within a function
+function TH_FUNC1, func1_arg, func1_ce, test=test, key1=func1_key, key2=func1_unusedkey
+
+    COMMON TH_COM1, f1gvar1, f1gvar2, f1gvar3
+    f1gvar2=2
+    
+    expected = [ $
+        'EXPECTED F1GVAR1 F1GVAR2 F1GVAR3 FUNC1_ARG FUNC1_CE FUNC1_ERRORS FUNC1_KEY FUNC1_UNDEFINED FUNC1_UNUSEDKEY TEST', $
+        'CUMUL_ERRORS GVAR1 GVAR2 GVAR3 HELP NO_EXIT SHORT TEST TH_OBJ', $
+        'FUNC1_CE F1GVAR2 FUNC1_UNUSEDKEY F1GVAR3 F1GVAR1 FUNC1_UNDEFINED', $
+        'CUMUL_ERRORS GVAR2  GVAR3 GVAR1 ', $
+        '' $
+    ]
+    func1_errors = 0
+    
+    ; List all variables in current scope
+    if ( strjoin(SCOPE_VARNAME(count=f1gvar2),' ') ne expected[0] ) then begin
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME()'
+        print, 'FUNC with SCOPE_VARNAME()   result: "' + strjoin(SCOPE_VARNAME(),' ') + '"'
+        print, 'FUNC with SCOPE_VARNAME() expected: "' + expected[0] + '"'
+    endif
+    if ( f1gvar2 ne 11 ) then begin
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME() : '+string(f1gvar2)+' ne 11'
+    endif
+    
+    ; List all variables in parent scope
+    if ( strjoin(SCOPE_VARNAME(count=f1gvar2, level=-1),' ') ne expected[1] ) then begin $
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME(level=-1)'
+        print, 'FUNC with SCOPE_VARNAME(level=-1)   result: "' + strjoin(SCOPE_VARNAME(level=-1),' ') + '"'
+        print, 'FUNC with SCOPE_VARNAME(level=-1) expected: "' + expected[1] + '"'
+    endif
+    if ( f1gvar2 ne 9 ) then begin
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME(level=-1) : '+string(f1gvar2)+' ne 9'
+    endif
+    
+    ; List some variables in current scope
+    if ( strjoin(SCOPE_VARNAME( func1_ce, func1_arg, func1_unusedkey, func1_key, f1gvar1, func1_undefined, count=f1gvar2 ),' ') ne $
+            expected[2] ) then begin $
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME({local_vars})'
+        print, 'FUNC with SCOPE_VARNAME( {local_vars} )   result: "'+strjoin(SCOPE_VARNAME(func1_ce, func1_arg, func1_unusedkey, func1_key, f1gvar1, func1_undefined),' ')+'"'
+        print, 'FUNC with SCOPE_VARNAME( {local_vars} ) expected: "' + expected[2] + '"'
+    endif
+    if ( f1gvar2 ne 6 ) then begin
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME({local_vars}) : '+string(f1gvar2)+' ne 6'
+    endif
+    
+    ; List the corresponding name in the parent scope for a few variables in current scope
+    if ( strjoin(SCOPE_VARNAME( func1_ce, func1_arg, func1_unusedkey, func1_key, f1gvar1, func1_undefined, count=f1gvar2, level=-1 ),' ') ne $
+            expected[3] ) then begin $
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME({local_vars}, level=-1)'
+        print, 'FUNC with SCOPE_VARNAME( {local_vars}, level=-1 )   result: "'+strjoin(SCOPE_VARNAME(func1_ce, func1_arg, func1_unusedkey, func1_key, f1gvar1, func1_undefined, level=-1),' ')+'"'
+        print, 'FUNC with SCOPE_VARNAME( {local_vars}, level=-1 ) expected: "' + expected[3] + '"'
+    endif
+    if ( f1gvar2 ne 6 ) then begin ; N.B. the empty strings returned are counted too
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME({local_vars}, level=-1) : '+string(f1gvar2)+' ne 6'
+    endif
+
+    ; List unexisting name in the parent scope for a few variables (should return '')
+    if ( strjoin(SCOPE_VARNAME( func1_undefined, count=f1gvar2, level=-1 ),' ') ne  expected[4] ) then begin $
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME(undefined, level=-1)'
+        print, 'FUNC with SCOPE_VARNAME( undefined, level=-1 )   result: "'+strjoin(SCOPE_VARNAME(func1_undefined, level=-1),' ')+'"'
+        print, 'FUNC with SCOPE_VARNAME( undefined, level=-1 ) expected: "' + expected[4] + '"'
+    endif
+    if ( f1gvar2 ne 1 ) then begin
+        ERRORS_ADD, func1_errors, 'FUNC with SCOPE_VARNAME(undefined, level=-1) : '+string(f1gvar2)+' ne 1'
+    endif
+
+    BANNER_FOR_TESTSUITE, 'TH_FUNC1', func1_errors, /short
+    ERRORS_CUMUL, func1_ce, func1_errors
+    
+    if KEYWORD_set(test) then STOP
+    
+    return, 1
+
+end
+
+
+pro TEST_SCOPE_VARNAME, help=help, short=short, test=test, no_exit=no_exit
+
+    if KEYWORD_SET(help) then begin
+        print, 'pro TEST_SCOPE_VARNAME, help=help, short=short, test=test, no_exit=no_exit'
+        return
+    endif
+
+    COMMON TH_COM1, gvar1, gvar2, gvar3
+    cumul_errors = 0
+    
+    ; create an object/struct just to verify that the name-resolution in SCOPE_VARNAME is OK.
+    gvar1 = CREATE_STRUCT( NAME='TH_STRUCT', ['an_int'], 1 )
+    th_obj = OBJ_NEW('TH_STRUCT')
+    
+    TH_PROC1, gvar2, cumul_errors, test=test, key1=gvar3
+    gvar1 = TH_FUNC1( gvar2, cumul_errors, test=test, key1=gvar3 )
+
+    OBJ_DESTROY, th_obj
+
+    if ( strjoin(SCOPE_VARNAME( common='th_com1', count=gvar1, 0, 1, 2 ), ' ') ne 'GVAR1 GVAR2 GVAR3' ) then begin
+        ERRORS_ADD, cumul_errors, 'SCOPE_VARNAME( common="th_com1", 0, 1, 2)'
+        print, 'SCOPE_VARNAME( common="th_com1", 0, 1, 2)   result: "' + strjoin(SCOPE_VARNAME(common='th_com1', 0, 1, 2),' ') + '"'
+        print, 'SCOPE_VARNAME( common="th_com1", 0, 1, 2) expected: "GVAR1 GVAR2 GVAR3"'
+    endif
+    if ( gvar1 ne 3 ) then begin
+        ERRORS_ADD, cumul_errors, 'SCOPE_VARNAME( common="th_com1", 0, 1, 2) : '+string(gvar1)+' ne 3'
+    endif
+
+    BANNER_FOR_TESTSUITE, 'TEST_SCOPE_VARNAME', cumul_errors, short=short
+
+    if (cumul_errors NE 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+
+    if KEYWORD_SET(test) then STOP
+
+end


### PR DESCRIPTION
N.B. There seem to be some discrepancies when routines are compiled, so that
the order of the COMMON blocks might be different when compared to IDL.
For that reason, using SCOPE_VARNAME with the /COMMON keyword might not have predictable outcome until the order of the COMMON-blocks have been sorted out.