### PR TITLE
Added support for object-references in TAG_NAMES.

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -6962,29 +6962,42 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
   BaseGDL* tag_names_fun( EnvT* e)
   {
     SizeT nParam=e->NParam();
-    DStructGDL* struc= e->GetParAs<DStructGDL>(0);
+
+    DObjGDL* obj = e->GetParAs<DObjGDL>(0);
+    DObj objRef;
+    DStructGDL* struc = nullptr;
+    if( obj && obj->Scalar( objRef ) ) {
+      try {
+        struc = e->GetObjHeap( objRef );
+      } catch ( GDLInterpreter::HeapException& ) { }
+    }
+    
+    if( !struc ) {
+      struc = e->GetParAs<DStructGDL>(0);
+    }
 
     static int structureNameIx = e->KeywordIx( "STRUCTURE_NAME" );
     bool structureName = e->KeywordSet( structureNameIx );
-    
+
     DStringGDL* tagNames;
 
     if(structureName){
         
-      if ((*struc).Desc()->Name() != "$truct")
-    tagNames =  new DStringGDL((*struc).Desc()->Name());
-      else
-    tagNames =  new DStringGDL("");
-
+      if ((*struc).Desc()->Name() != "$truct") {
+        tagNames =  new DStringGDL((*struc).Desc()->Name());
+      } else {
+        tagNames =  new DStringGDL("");
+      }
     } else {
       SizeT nTags = (*struc).Desc()->NTags();
-    
       tagNames = new DStringGDL(dimension(nTags));
-      for(int i=0; i < nTags; ++i)
+      for(int i=0; i < nTags; ++i) {
         (*tagNames)[i] = (*struc).Desc()->TagName(i);
+      }
     }
 
     return tagNames;
+      
   }
 
   // AC 12-Oc-2011: better version for: len=len, /Extract and /Sub

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -6962,18 +6962,22 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
   BaseGDL* tag_names_fun( EnvT* e)
   {
     SizeT nParam=e->NParam();
-
-    DObjGDL* obj = e->GetParAs<DObjGDL>(0);
-    DObj objRef;
+    BaseGDL* p = e->GetParDefined(0);
     DStructGDL* struc = nullptr;
-    if( obj && obj->Scalar( objRef ) ) {
-      try {
-        struc = e->GetObjHeap( objRef );
-      } catch ( GDLInterpreter::HeapException& ) { }
+    if( p->Type() == DObjGDL::t ) {
+        DObjGDL* obj = static_cast<DObjGDL*>( p);
+        DObj objRef;
+        if( obj && obj->Scalar( objRef ) ) {
+        try {
+            struc = e->GetObjHeap( objRef );
+        } catch ( GDLInterpreter::HeapException& ) { }
+        }
+    } else if( p->Type() == DStructGDL::t ) {
+       struc = static_cast<DStructGDL*>( p);
     }
-    
+
     if( !struc ) {
-      struc = e->GetParAs<DStructGDL>(0);
+        e->Throw( "Error: Failed to obtain structure. Input type: " + p->TypeStr() );
     }
 
     static int structureNameIx = e->KeywordIx( "STRUCTURE_NAME" );

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -212,6 +212,7 @@ TESTS = \
   test_structures.pro \
   test_suite.pro \
   test_systime.pro \
+  test_tag_names.pro \
   test_tic_toc.pro \
   test_tiff.pro \
   test_total.pro \

--- a/testsuite/test_tag_names.pro
+++ b/testsuite/test_tag_names.pro
@@ -1,0 +1,75 @@
+;
+; Tomas Hillberg, 8 Sep. 2019. Under GNU GPL v2+
+;
+; Preliminatry test suite for function TAG_NAMES
+;
+
+
+
+; testing internal call within a procedure
+pro TH_STRUCT::PROC1, expected, cumul_errors, test=test
+
+    nb_errors = 0
+
+    if( min(TAG_NAMES(self) eq expected ) ne 1 ) then ERRORS_ADD, nb_errors, 'TH_STRUCT::PROC1 : TAG_NAMES(self)'
+
+    BANNER_FOR_TESTSUITE, 'TH_STRUCT::PROC1', nb_errors, /short
+    ERRORS_CUMUL, cumul_errors, nb_errors
+    
+    if KEYWORD_set(test) then STOP
+
+end
+
+; testing internal call within a function
+function TH_STRUCT::FUNC1, expected, cumul_errors, test=test
+    
+    nb_errors=0
+
+    if( min(TAG_NAMES(self) eq expected ) ne 1 ) then ERRORS_ADD, nb_errors, 'TH_STRUCT::FUNC1 : TAG_NAMES(self)'
+
+    BANNER_FOR_TESTSUITE, 'TH_STRUCT::FUNC1', nb_errors, /short
+    ERRORS_CUMUL, cumul_errors, nb_errors
+    
+    if KEYWORD_set(test) then STOP
+    
+    return, 1
+
+end
+
+
+pro TEST_TAG_NAMES, help=help, verbose=verbose, short=short, $
+                       debug=debug, test=test, no_exit=no_exit
+
+    if KEYWORD_SET(help) then begin
+        print, 'pro TEST_TAG_NAMES, help=help, verbose=verbose, short=short, $'
+        print, '                       debug=debug, test=test, no_exit=no_exit'
+        return
+    endif
+
+    cumul_errors = 0
+
+    expected = ['FIRST','SECOND','THIRD']
+    anon_struct = { first:1L,second:'a_string',third:1.234 }
+    named_struct = { TH_STRUCT, first:1L,second:'a_string',third:1.234 }
+    if( min(TAG_NAMES(anon_struct) eq expected ) ne 1 ) then ERRORS_ADD, cumul_errors, 'TAG_NAMES(anon_struct)'
+    if( min(TAG_NAMES(anon_struct) eq expected ) ne 1 ) then ERRORS_ADD, cumul_errors, 'TAG_NAMES(named_struct)'
+
+    my_obj = OBJ_NEW('TH_STRUCT')
+    
+    ; Note: the line below will fail on IDL since thy don't support tag-lookup from outside an object, for GDL it is valid though.
+    ;if( min(TAG_NAMES(my_obj) eq expected ) ne 1 ) then ERRORS_ADD, cumul_errors, 'TAG_NAMES(obj_instance)'
+    
+    ; The below two lines are valid in IDL
+    my_obj->PROC1, expected, cumul_errors, test=test
+    dummy = my_obj->FUNC1( expected, cumul_errors, test=test )
+    
+    OBJ_DESTROY, my_obj
+
+
+    BANNER_FOR_TESTSUITE, 'TEST_TAG_NAMES', cumul_errors, short=short
+
+    if (cumul_errors NE 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+
+    if KEYWORD_SET(test) then STOP
+
+end


### PR DESCRIPTION
IDL does not generally support this. However,the special case of calling TAG_NAMES from within a method, with 'self' as argument, *is* supported.