### PR TITLE
Return a value in GDLEventHandlerPy

### DIFF
--- a/src/pythongdl.cpp
+++ b/src/pythongdl.cpp
@@ -271,7 +271,9 @@ int GDLEventHandlerPy()
 {
   GDLEventHandler();
   if( oldInputHook != NULL)
-    (*oldInputHook)();
+    return (*oldInputHook)();
+  else
+    return 0;
 }
   
 // Execute a GDL subroutine


### PR DESCRIPTION
The prototype of PyOS_InputHook requires to return a value (which is ignored, however):

    int (*PyOS_InputHook)(void);

Ignoring this and implementing a function without an explicit return seems to cause gcc-9 to weirdly optimize away the `if( oldInputHook != NULL)` condition, resulting in a segmentation fault in the next line (which then tries to call the `NULL` `oldInputHook()`. This happened recently on Debian unstable (after it was requilt with gcc 9).

This patch just makes sure that the function always returns something, which fixes this problem.