### PR TITLE
Add sincos fallback for OS X 10.8 and earlier

### DIFF
--- a/src/ssrfpack.c
+++ b/src/ssrfpack.c
@@ -3,8 +3,12 @@
  * are not required to compile and link the sph supplement.
  */
 #ifdef __APPLE__
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
 #define sincos(x, s, c) __sincos(x, s, c)
 #define sincosf(x, s, c) __sincosf(x, s, c)
+#else
+#define sincos(x,s,c) (*s = sin(x), *c = cos(x))
+#endif
 #endif
 
 #ifdef __FreeBSD__


### PR DESCRIPTION
This PR allows gnudatalanguage to build on OS X 10.8 and earlier. (`__sincos` was first available in OS X 10.9.)

It might be even better to add detection of `__sincos` to the configure script, rather than hardcoding information about different operating systems in this file.