### PR TITLE
 create IS_BIGENDIAN macro at cmake stage for usage in sorting.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include(CheckCSourceRuns)
 include(CheckCXXSourceCompiles)
 include(FindPkgConfig)
 include(FindPackageHandleStandardArgs)
+include(TestBigEndian)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/CMakeModules)
 
@@ -149,6 +150,9 @@ set(GDL_DATA_DIR "/share/gnudatalanguage" CACHE PATH "GDL: data directory relati
 if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
     set(HAVE_64BIT_OS 1)
 endif(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+# check for endianness, and set macro in case it is big.
+TEST_BIG_ENDIAN(IS_BIGENDIAN)
 
 #### check headers and libraries
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -57,6 +57,7 @@
 #ifndef HAVE_EXT_STDIO_FILEBUF_H
 #cmakedefine HAVE_EXT_STDIO_FILEBUF_H 1
 #endif
+#cmakedefine IS_BIGENDIAN
 #cmakedefine OLD_DARWIN
 #cmakedefine PYTHON_MODULE 1
 #cmakedefine RL_GET_SCREEN_SIZE 1

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -55,8 +55,7 @@ namespace lib {
 //3. This notice may not be removed or altered from any source distribution.
 //------------------Radix Sorting Codes ------------------------------------------------------------------------------
 //    
-#if defined(__APPLE__) || defined(_XBOX) //IEEE little_endian in fact --> should use a better ifdef.
-	#define H1_OFFSET2	0
+#if defined(IS_BIGENDIAN)
 	#define H0_OFFSET2	256
 	#define BYTES_INC2	(1-j)
     #define H0_OFFSET4	768

--- a/testsuite/test_sort.pro
+++ b/testsuite/test_sort.pro
@@ -21,7 +21,7 @@ nb_errors=0
 array=RANDOMU(seed, nbps)
 sort_array=array[SORT(array)]
 ;
-nb_errors=TOTAL(sort_array[1:*] LE sort_array[0])
+nb_errors=TOTAL(sort_array[1:*] LT sort_array)
 ;
 ; ----- final ----
 ;


### PR DESCRIPTION
(presuming it will work) cmake's TEST_BIG_ENDIAN macro is included and a test is made.
In case it is big (motorola 68000 series, VAX, XBOX) then radix sort should work out.