### PR TITLE
trying to manage TERMINAL_SIZE(cols [,lines])

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -35,10 +35,8 @@
 
 #include "includefirst.hpp"
 
-// get_kbrd patch
-// http://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
 #ifndef _WIN32
-#include <termios.h> 
+//#include <termios.h> 
 #include <unistd.h> 
 #endif
 
@@ -68,7 +66,7 @@ extern "C" char **environ;
 #include "dpro.hpp"
 #include "dinterpreter.hpp"
 #include "basic_pro.hpp"
-#include "terminfo.hpp"
+//#include "terminfo.hpp"
 #include "typedefs.hpp"
 #include "base64.hpp"
 #include "objects.hpp"
@@ -7917,89 +7915,6 @@ BaseGDL* routine_filepath( EnvT* e)
     //      }
   }
 
-  BaseGDL* get_kbrd( EnvT* e)
-  {
-#if defined(HAVE_LIBREADLINE)
-#include <readline/readline.h>
-    rl_prep_terminal (0);
-#endif
-#if defined(HAVE_EDITLINE)
-#include <editline/readline.h>
-    rl_prep_terminal (0);
-#endif
-      
-      
-    SizeT nParam=e->NParam();
-
-    bool doWait = true;
-    if( nParam > 0)
-      {
-    doWait = false;
-    DLong waitArg = 0;
-    e->AssureLongScalarPar( 0, waitArg);
-    if( waitArg != 0)
-      {
-        doWait = true;
-      }
-      }
-
-    // https://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
-    // DONE: Implement proper SCALAR parameter handling (doWait variable)
-    // which is/was not blocking in the original program. 
-    // note: multi-byte input is not supported here.
-    
-    char c='\0'; //initialize is never a bad idea...
-
-    int fd=fileno(stdin);
-#ifndef _WIN32
-    struct termios orig, get; 
-#endif
-    // Get terminal setup to revert to it at end. 
-#ifndef _WIN32
-    (void)tcgetattr(fd, &orig); 
-    // New terminal setup, non-canonical.
-    get.c_lflag = ISIG; 
-#endif
-    if (doWait)
-      {
-    // will wait for a character
-#ifndef _WIN32
-    get.c_cc[VTIME]=0;
-    get.c_cc[VMIN]=1;
-    (void)tcsetattr(fd, TCSANOW, &get); 
-#endif
-    cin.get(c);
-      }
-    else 
-      {
-    // will not wait, but return EOF or next character in terminal buffer if present
-#ifndef _WIN32
-    get.c_cc[VTIME]=0;
-    get.c_cc[VMIN]=0;
-    (void)tcsetattr(fd, TCSANOW, &get); 
-#endif
-    //the trick is *not to use C++ functions here. cin.get would wait.*
-    c=std::fgetc(stdin);
-    //and to convert EOF to null (otherwise GDL may exit if not compiled with
-    //[lib][n]curses)
-    if(c==EOF) c='\0';
-      }
-    
-    // Restore original terminal settings. 
-#ifndef _WIN32
-    (void)tcsetattr(fd, TCSANOW, &orig); 
-#endif
-#if defined(HAVE_LIBREADLINE) || defined(HAVE_LIBEDITLINE)
-    rl_deprep_terminal ();
-#endif
-
-    DStringGDL* res = new DStringGDL( DString( i2s( c))); 
-
-    return res;
- 
-  }
-
-
   BaseGDL* temporary( EnvT* e)
   {
     SizeT nParam=e->NParam(1);
@@ -8011,17 +7926,6 @@ BaseGDL* routine_filepath( EnvT* e)
     *p0 = NULL; // make parameter undefined
     return ret;
   }
-  
-  
-    BaseGDL* terminal_size_fun( EnvT* e ) {
-        // TODO: Also allow setting width/height
-        SizeT nParam = e->NParam(0);
-        DLongGDL* ret = new DLongGDL( dimension(2) );
-        (*ret)[0] = TermWidth();
-        (*ret)[1] = TermHeight();
-        return ret;
-    }
-
   
   BaseGDL* memory( EnvT* e)
   {

--- a/src/basic_fun.hpp
+++ b/src/basic_fun.hpp
@@ -25,8 +25,6 @@ namespace lib {
   SizeT HASH_count( DStructGDL* oStructGDL);
   SizeT LIST_count( DStructGDL* oStructGDL);
 
-  BaseGDL* get_kbrd( EnvT* e);
-
   BaseGDL* bytarr( EnvT* e);
   BaseGDL* intarr( EnvT* e);
   BaseGDL* uintarr( EnvT* e);
@@ -146,8 +144,6 @@ namespace lib {
   BaseGDL* routine_name_fun( EnvT* e);
 
   BaseGDL* temporary( EnvT* e);
-
-  BaseGDL* terminal_size_fun( EnvT* e );
 
   BaseGDL* memory(EnvT* e);
 

--- a/src/gdlhelp.cpp
+++ b/src/gdlhelp.cpp
@@ -1147,17 +1147,16 @@ void help_help(EnvT* e)
 	  ctmp=my_get_kbrd(); 
 	  nb_lines=TermHeight();
 	  if ((tolower(ctmp) == 'h') || (ctmp == '?')) {
-	   *ostrp << "---------------------------------------------------    " << endl;
-	   *ostrp << "<space>		Display next page of text." << endl;
-	   *ostrp << "<return>	Display next line of text." << endl;
-	   *ostrp << "q or Q		Quit" << endl;
-	   *ostrp << "h, H, or ?	Display this message." << endl;
-	   *ostrp << "---------------------------------------------------" << endl;
+	    *ostrp << "---------------------------------------------------    " << endl;
+	    *ostrp << "<space>		Display next page of text." << endl;
+	    *ostrp << "<return>	Display next line of text. (TBD)" << endl;
+	    *ostrp << "q or Q		Quit" << endl;
+	    *ostrp << "h, H, or ?	Display this message." << endl;
+	    *ostrp << "---------------------------------------------------" << endl;
 	    ctmp=my_get_kbrd(); 
 	    nb_lines=TermHeight();
 	  }
-	  if (tolower(ctmp) == 'q') break;
-
+	  if (tolower(ctmp) == 'q') break;	  
 	}
       }
 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -49,6 +49,8 @@
 #include "linearprogramming.hpp"
 #include "saverestore.hpp"
 
+#include "terminfo.hpp"
+
 #ifdef USE_PYTHON
 #  include "gdlpython.hpp"
 #endif
@@ -129,7 +131,7 @@ void LibInit()
 
   new DLibFunRetNew(lib::temporary,string("TEMPORARY"),1);
   
-  new DLibFunRetNew(lib::terminal_size_fun,string("TERMINAL_SIZE"),0);
+  new DLibFunRetNew(lib::terminal_size_fun,string("TERMINAL_SIZE"),2);
 
   const string routine_infoKey[]={"FUNCTIONS","SYSTEM","DISABLED","ENABLED",
 				  "PARAMETERS","SOURCE", KLISTEND};

--- a/src/terminfo.cpp
+++ b/src/terminfo.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
- ***************************************************************************/
+***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -15,12 +15,23 @@
  *                                                                         *
  ***************************************************************************/
 /*
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
+  #ifdef HAVE_CONFIG_H
+  #include <config.h>
+  #endif
 */
 #include "includefirst.hpp"
 #include "stdio.h"
+#include <iostream>
+
+#ifndef _WIN32
+#include <termios.h> 
+#include <unistd.h> 
+#endif
+
+// used to defined GDL_TMPDIR: may have trouble on MSwin, help welcome
+#ifndef _WIN32
+#include <paths.h>
+#endif
 
 #include "terminfo.hpp"
 
@@ -49,6 +60,23 @@ int TermHeight()
 #include <readline/readline.h>
 #include <readline/history.h>
 
+
+// AC 2020-05-05 : <<found on the Internet>> Unclear for me :((
+
+void SetTermSize(int rows, int cols)
+{
+  //  std::cout << "hello" << std::endl;
+  rl_set_screen_size (rows, cols);
+#if defined(HAVE_READLINE) && defined(RL_ISSTATE) && defined(RL_INITIALIZED)
+  if (RL_ISSTATE(RL_INITIALIZED)) {
+    rl_resize_terminal();
+  }else {  std::cout << "Please report" << std::endl;
+  }
+#else
+std::cout << "Not ready for no Readline libs." << std::endl;
+#endif
+}
+
 int TermWidth()
 {
   int cols;
@@ -64,7 +92,7 @@ int TermHeight()
   //  std::cout << "hello" << std::endl;
   int cols;
   int rows;
-  rl_reset_screen_size ();
+  //  rl_reset_screen_size ();
   rl_get_screen_size(&rows, &cols);
   return rows;
 }
@@ -134,4 +162,134 @@ int TermHeight()
 }
 
 #endif
+
+
+namespace lib {
+  using namespace std;
+
+  // get_kbrd patch
+  // http://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
+
+  BaseGDL* get_kbrd( EnvT* e)
+  {
+#if defined(HAVE_LIBREADLINE)
+#include <readline/readline.h>
+    rl_prep_terminal (0);
+#endif
+#if defined(HAVE_EDITLINE)
+#include <editline/readline.h>
+    rl_prep_terminal (0);
+#endif
+  
+    SizeT nParam=e->NParam();
+  
+    bool doWait = true;
+    if( nParam > 0)
+      {
+	doWait = false;
+	DLong waitArg = 0;
+	e->AssureLongScalarPar( 0, waitArg);
+	if( waitArg != 0)
+	  {
+	    doWait = true;
+	  }
+      }
+
+    // https://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
+    // DONE: Implement proper SCALAR parameter handling (doWait variable)
+    // which is/was not blocking in the original program. 
+    // note: multi-byte input is not supported here.
+    
+    char c='\0'; //initialize is never a bad idea...
+
+    int fd=fileno(stdin);
+#ifndef _WIN32
+    struct termios orig, get; 
+#endif
+    // Get terminal setup to revert to it at end. 
+#ifndef _WIN32
+    (void)tcgetattr(fd, &orig); 
+    // New terminal setup, non-canonical.
+    get.c_lflag = ISIG; 
+#endif
+    if (doWait)
+      {
+	// will wait for a character
+#ifndef _WIN32
+	get.c_cc[VTIME]=0;
+	get.c_cc[VMIN]=1;
+	(void)tcsetattr(fd, TCSANOW, &get); 
+#endif
+	cin.get(c);
+      }
+    else 
+      {
+	// will not wait, but return EOF or next character in terminal buffer if present
+#ifndef _WIN32
+	get.c_cc[VTIME]=0;
+	get.c_cc[VMIN]=0;
+	(void)tcsetattr(fd, TCSANOW, &get); 
+#endif
+	//the trick is *not to use C++ functions here. cin.get would wait.*
+	c=std::fgetc(stdin);
+	//and to convert EOF to null (otherwise GDL may exit if not compiled with
+	//[lib][n]curses)
+	if(c==EOF) c='\0';
+      }
+    
+    // Restore original terminal settings. 
+#ifndef _WIN32
+    (void)tcsetattr(fd, TCSANOW, &orig); 
+#endif
+#if defined(HAVE_LIBREADLINE) || defined(HAVE_LIBEDITLINE)
+    rl_deprep_terminal ();
+#endif
+
+    DStringGDL* res = new DStringGDL( DString( i2s( c))); 
+
+    return res;
+ 
+  }
+
+
+  // get or change Terminal Size   
+  BaseGDL* terminal_size_fun( EnvT* e ) {
+
+    SizeT nParam = e->NParam();
+    cout << nParam << endl;
+
+    // Just returning the size of the Terminal
+    if (nParam == 0) {
+      DLongGDL* ret = new DLongGDL(dimension(2));
+      (*ret)[0] = TermWidth();
+      (*ret)[1] = TermHeight();
+      return ret;
+    }
+
+    DLong nb_lines = -1, nb_cols = -1;
+
+    if (nParam == 1) {
+      e->AssureLongScalarPar( 0, nb_cols);
+    }
+    if (nParam == 2) {
+      e->AssureLongScalarPar( 0, nb_cols);
+      e->AssureLongScalarPar( 1, nb_lines);
+    }
+    if (nb_lines <= 0) nb_lines = TermHeight();
+    if (nb_cols <= 0) nb_cols = TermWidth();
+
+    //    cout << nb_lines << " "<< nb_cols << endl;
+
+#if defined(HAVE_LIBREADLINE)
+    SetTermSize(nb_lines, nb_cols);
+#else 
+    Message("Setting Terminal Size not ready (OK only with Readline)");
+#endif
+    // reading again the new size 
+    DLongGDL* ret = new DLongGDL( dimension(2) );
+    (*ret)[0] = TermWidth();
+    (*ret)[1] = TermHeight();
+    return ret;
+  }
+} // namespace
 

--- a/src/terminfo.hpp
+++ b/src/terminfo.hpp
@@ -15,10 +15,25 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "includefirst.hpp"
+
 #ifndef TERMINFO_HPP_
 #define TERMINFO_HPP_
+
+#include "envt.hpp"
+
+#if defined(HAVE_LIBREADLINE)
+void SetTermSize(int rows, int cols);
+#endif
 
 int TermWidth();
 int TermHeight();
 
+namespace lib {
+  using namespace std;
+  
+  BaseGDL* terminal_size_fun( EnvT* e );
+  
+  BaseGDL* get_kbrd( EnvT* e);
+}
 #endif


### PR DESCRIPTION
* moving TERMINAL_SIZE() and GET_KBRD() from basic_fun.cpp in terminfo.cpp
* trying to add management of Lines and Columns in TERMINAL_SIZE(cols [,lines]). 
May not work outside Linux+Readline (TBC)

TBD: managing all the consequences of that in HELP procedure (I began for HELP, /recall)

I expect some side effects on OSX with EditLine & maybe on Window