### PR TITLE
Repair file.cpp for gcc 9/win32; gdlpython compile error.

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -38,7 +38,7 @@
 // get_kbrd patch
 // http://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
 #ifndef _WIN32
-#include <termios.h> 
+//#include <termios.h> 
 #include <unistd.h> 
 #endif
 
@@ -68,7 +68,7 @@ extern "C" char **environ;
 #include "dpro.hpp"
 #include "dinterpreter.hpp"
 #include "basic_pro.hpp"
-#include "terminfo.hpp"
+//#include "terminfo.hpp"
 #include "typedefs.hpp"
 #include "base64.hpp"
 #include "objects.hpp"
@@ -7917,88 +7917,6 @@ BaseGDL* routine_filepath( EnvT* e)
     //      }
   }
 
-  BaseGDL* get_kbrd( EnvT* e)
-  {
-#if defined(HAVE_LIBREADLINE)
-#include <readline/readline.h>
-    rl_prep_terminal (0);
-#endif
-#if defined(HAVE_EDITLINE)
-#include <editline/readline.h>
-    rl_prep_terminal (0);
-#endif
-      
-      
-    SizeT nParam=e->NParam();
-
-    bool doWait = true;
-    if( nParam > 0)
-      {
-    doWait = false;
-    DLong waitArg = 0;
-    e->AssureLongScalarPar( 0, waitArg);
-    if( waitArg != 0)
-      {
-        doWait = true;
-      }
-      }
-
-    // https://sourceforge.net/forum/forum.php?thread_id=3292183&forum_id=338691
-    // DONE: Implement proper SCALAR parameter handling (doWait variable)
-    // which is/was not blocking in the original program. 
-    // note: multi-byte input is not supported here.
-    
-    char c='\0'; //initialize is never a bad idea...
-
-    int fd=fileno(stdin);
-#ifndef _WIN32
-    struct termios orig, get; 
-#endif
-    // Get terminal setup to revert to it at end. 
-#ifndef _WIN32
-    (void)tcgetattr(fd, &orig); 
-    // New terminal setup, non-canonical.
-    get.c_lflag = ISIG; 
-#endif
-    if (doWait)
-      {
-    // will wait for a character
-#ifndef _WIN32
-    get.c_cc[VTIME]=0;
-    get.c_cc[VMIN]=1;
-    (void)tcsetattr(fd, TCSANOW, &get); 
-#endif
-    cin.get(c);
-      }
-    else 
-      {
-    // will not wait, but return EOF or next character in terminal buffer if present
-#ifndef _WIN32
-    get.c_cc[VTIME]=0;
-    get.c_cc[VMIN]=0;
-    (void)tcsetattr(fd, TCSANOW, &get); 
-#endif
-    //the trick is *not to use C++ functions here. cin.get would wait.*
-    c=std::fgetc(stdin);
-    //and to convert EOF to null (otherwise GDL may exit if not compiled with
-    //[lib][n]curses)
-    if(c==EOF) c='\0';
-      }
-    
-    // Restore original terminal settings. 
-#ifndef _WIN32
-    (void)tcsetattr(fd, TCSANOW, &orig); 
-#endif
-#if defined(HAVE_LIBREADLINE) || defined(HAVE_LIBEDITLINE)
-    rl_deprep_terminal ();
-#endif
-
-    DStringGDL* res = new DStringGDL( DString( i2s( c))); 
-
-    return res;
- 
-  }
-
 
   BaseGDL* temporary( EnvT* e)
   {
@@ -8011,16 +7929,6 @@ BaseGDL* routine_filepath( EnvT* e)
     *p0 = NULL; // make parameter undefined
     return ret;
   }
-  
-  
-    BaseGDL* terminal_size_fun( EnvT* e ) {
-        // TODO: Also allow setting width/height
-        SizeT nParam = e->NParam(0);
-        DLongGDL* ret = new DLongGDL( dimension(2) );
-        (*ret)[0] = TermWidth();
-        (*ret)[1] = TermHeight();
-        return ret;
-    }
 
   
   BaseGDL* memory( EnvT* e)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -57,6 +57,9 @@
 #   define S_IFLNK 0xA000
 #   define S_ISLNK(mode) (((mode) & S_IFLNK) == S_IFLNK)
 #    endif
+#   if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFLNK) == S_IFLNK)
+#   endif
 #endif
 
 #ifndef _MSC_VER

--- a/src/gdlpython.cpp
+++ b/src/gdlpython.cpp
@@ -37,7 +37,7 @@ using namespace std;
 #if PY_MAJOR_VERSION >= 3
 int PythonInit()
 {
-  if( Py_IsInitialized()) return NULL;
+  if( Py_IsInitialized()) return 0;
 #else
 void PythonInit()
 {
@@ -58,7 +58,7 @@ void PythonInit()
   // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#miscellaneous
   import_array();
 #if PY_MAJOR_VERSION >= 3
-  return NULL;
+  return 0;
 #endif
 }
 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -141,11 +141,11 @@ void LibInit()
 
   const string spawnKey[]={ "COUNT","EXIT_STATUS","NOSHELL","NULL_STDIN","PID","STDERR","UNIT", //All platforms
 #ifdef _WIN32
-	  "HIDE", "LOG_OUTPUT", "NOWAIT",};
+	  "HIDE", "LOG_OUTPUT", "NOWAIT",  KLISTEND};
+
 #else
-  "NOTTYRESET","SH",
+  "NOTTYRESET","SH",  KLISTEND};
 #endif
-  KLISTEND};
  
   new DLibPro(lib::spawn_pro,string("SPAWN"),3,spawnKey);
 

--- a/src/terminfo.cpp
+++ b/src/terminfo.cpp
@@ -135,3 +135,105 @@ int TermHeight()
 
 #endif
 
+ // AC 2020-05-05 : <<found on the Internet>> Unclear for me :((
+#if defined(HAVE_LIBREADLINE) && defined(RL_GET_SCREEN_SIZE)
+
+#include <readline/readline.h>
+#include <readline/history.h>
+
+void SetTermSize(int rows, int cols)
+{
+  //  std::cout << "hello" << std::endl;
+  rl_set_screen_size (rows, cols);
+#if defined(HAVE_READLINE) && defined(RL_ISSTATE) && defined(RL_INITIALIZED)
+  if (RL_ISSTATE(RL_INITIALIZED)) {
+    rl_resize_terminal();
+  }else {  std::cout << "Please report" << std::endl;
+  }
+#else
+std::cout << "Not ready for no Readline libs." << std::endl;
+#endif
+}
+#endif
+namespace lib {
+    using namespace std;
+	
+  BaseGDL* get_kbrd( EnvT* e)
+  {
+      
+    SizeT nParam=e->NParam();
+
+    bool doWait = true;
+    if( nParam > 0)      {
+		doWait = false;
+		DLong waitArg = 0;
+		e->AssureLongScalarPar( 0, waitArg);
+		if( waitArg != 0)
+			doWait = true;
+      }
+    
+    char c='\0'; 
+
+    if (doWait)
+      {    cin.get(c);      }
+    else 
+      {    c=std::fgetc(stdin);
+		      if(c==EOF) c='\0';
+      }
+
+    DStringGDL* res = new DStringGDL( DString( i2s( c))); 
+
+    return res;
+ 
+  }
+
+  
+ /*   BaseGDL* terminal_size_fun( EnvT* e ) {
+        // TODO: Also allow setting width/height
+        SizeT nParam = e->NParam(0);
+        DLongGDL* ret = new DLongGDL( dimension(2) );
+        (*ret)[0] = TermWidth();
+        (*ret)[1] = TermHeight();
+        return ret;
+    }*/
+ 
+   // get or change Terminal Size   
+  BaseGDL* terminal_size_fun( EnvT* e ) {
+
+    SizeT nParam = e->NParam();
+    cout << nParam << endl;
+
+    // Just returning the size of the Terminal
+    if (nParam == 0) {
+      DLongGDL* ret = new DLongGDL(dimension(2));
+      (*ret)[0] = TermWidth();
+      (*ret)[1] = TermHeight();
+      return ret;
+    }
+
+    DLong nb_lines = -1, nb_cols = -1;
+
+    if (nParam == 1) {
+      e->AssureLongScalarPar( 0, nb_cols);
+    }
+    if (nParam == 2) {
+      e->AssureLongScalarPar( 0, nb_cols);
+      e->AssureLongScalarPar( 1, nb_lines);
+    }
+    if (nb_lines <= 0) nb_lines = TermHeight();
+    if (nb_cols <= 0) nb_cols = TermWidth();
+
+    //    cout << nb_lines << " "<< nb_cols << endl;
+
+#if defined(HAVE_LIBREADLINE)
+    SetTermSize(nb_lines, nb_cols);
+#else 
+    Message("Setting Terminal Size not ready (OK only with Readline)");
+#endif
+    // reading again the new size 
+    DLongGDL* ret = new DLongGDL( dimension(2) );
+    (*ret)[0] = TermWidth();
+    (*ret)[1] = TermHeight();
+    return ret;
+  }
+} // namespace

--- a/src/terminfo.hpp
+++ b/src/terminfo.hpp
@@ -15,10 +15,24 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "includefirst.hpp"
+
 #ifndef TERMINFO_HPP_
 #define TERMINFO_HPP_
+#include "envt.hpp"
+
+#if defined(HAVE_LIBREADLINE)
+void SetTermSize(int rows, int cols);
+#endif
 
 int TermWidth();
 int TermHeight();
+namespace lib {
+  using namespace std;
+
+  BaseGDL* terminal_size_fun( EnvT* e );
+
+  BaseGDL* get_kbrd( EnvT* e);
+}
 
 #endif


### PR DESCRIPTION
gdlpython changes addresses issue #742 but there remains a warning for the call to import_array()
file.cpp change assures that an S_ISLNK is defined if it hasn't been already, as is case for GCC 9