### PR TITLE
update of "minima_script.sh" & online_help.pro

### DIFF
--- a/scripts/minimum_script4gdl.sh
+++ b/scripts/minimum_script4gdl.sh
@@ -19,6 +19,7 @@
 #              flag for OpenMP (OSX)
 # 2018-08-07 : force cmake 3+, force plplot 5.12 or 5.13
 # 2018-12-19 : move to 0.9.9
+# 2020-06-17 : move to 1.0.0rc2
 #
 # The purpose of this shell script is to automaticaly compile a minimum GDL
 # as a basic user even if mandatory packages are not available
@@ -41,8 +42,8 @@
 # step 2 : GSL
 # step 3 : CMake
 # step 4 : Plplot
-# step 5 : GDL 0.9.9 vanilla
-# step 6 : GDL 0.9.9 Git
+# step 5 : GDL 1.0.0rc2 vanilla
+# step 6 : GDL on Git master (the version on today !)
 #
 # $1 == $use_curl, $2 = $URL, $3 = $filename
 run_wget_or_curl(){
@@ -89,7 +90,7 @@ GSL_URL="ftp://ftp.gnu.org/gnu/gsl/gsl-1.16.tar.gz"
 PLPLOT_URL512="https://sourceforge.net/projects/plplot/files/plplot/5.12.0%20Source/plplot-5.12.0.tar.gz/download?use_mirror=autoselect"
 PLPLOT_URL513="https://sourceforge.net/projects/plplot/files/plplot/5.13.0%20Source/plplot-5.13.0.tar.gz/download?use_mirror=autoselect"
 #
-GDL_VANILLA_URL="https://github.com/gnudatalanguage/gdl/archive/v0.9.9.tar.gz"
+GDL_VANILLA_URL="https://github.com/gnudatalanguage/gdl/archive/v1.0.0-rc.2.tar.gz"
 GDL_GIT_URL="https://codeload.github.com/gnudatalanguage/gdl/zip/master"
 #
 step=$1
@@ -225,7 +226,7 @@ echo "** preparing CMAKE"
 cd $RACINE
 #
 do_cmake_compil=1
-CmakeEXE=`which -a cmake`
+CmakeEXE=`which cmake`
 #echo "CMake exe : " $CmakeEXE
 if [ -x $CmakeEXE ] ; then 
     cmake_version=`cmake --version | head -1 | awk -F " " '{print $3}'`
@@ -318,8 +319,8 @@ echo "** preparing GDL"
 cd $RACINE
 #
 if [ "$gdl_git" -eq 1 ] ; then
-    echo "preparing to compiled GDL 0.9.9 Git version"
-    gdl_path='gdl-0.9.9git'`date +%y%m%d`
+    echo "preparing to compiled GDL 1.0.0rc2 Git version"
+    gdl_path='gdl-1.0.0rc2_git'`date +%y%m%d`
     gdl_name=${gdl_path}'.tgz'
     if [ ! -e $gdl_name ] ; then
 	run_wget_or_curl_v2 $use_curl $GDL_GIT_URL $gdl_name
@@ -327,8 +328,8 @@ if [ "$gdl_git" -eq 1 ] ; then
     unzip $gdl_name
     mv gdl-master $gdl_path
 else 
-    echo "preparing to compiled GDL 0.9.9 VANILLA version"
-    gdl_path='gdl-0.9.9'
+    echo "preparing to compiled GDL 1.0.0rc2 VANILLA version"
+    gdl_path='gdl-1.0.0-rc.2'
     gdl_name=${gdl_path}'.tgz'
     if [ ! -e $gdl_name ] ; then
 	run_wget_or_curl_v2 $use_curl $GDL_VANILLA_URL $gdl_name
@@ -344,9 +345,9 @@ else
 fi
 #
 # 2018-12-19 the code in Vanilla don't compile if Eigen3 off AND openmp on
-if [ "$gdl_git" -eq 0 ] ; then
-    flag_openmp=OFF
-fi
+#if [ "$gdl_git" -eq 0 ] ; then
+#    flag_openmp=OFF
+#fi
 #
 cd $gdl_path
 if [ -d "build" ]; then
@@ -360,7 +361,8 @@ $CmakeEXE .. \
    -DGSLDIR=$GSL_PATH -DOPENMP=$flag_openmp \
    -DPLPLOTDIR=$RACINE/$PLPLOT_DIR/Compilation/ \
    -DWXWIDGETS=off -DMAGICK=OFF -DNETCDF=OFF -DHDF=OFF \
-   -DHDF5=off -DFFTW=OFF -DEIGEN3=OFF -DPYTHON=OFF
+   -DHDF5=off -DFFTW=OFF -DEIGEN3=OFF -DPSLIB=OFF -DPYTHON=OFF \
+   -DSHAPELIB=OFF -DUDUNITS2=OFF -DGRIB=off -DGLPK=off
 make -s -j $cpus
 #
 if [ "$gdl_check" -eq 1 ] ; then


### PR DESCRIPTION
* this update of "minima_script.sh" was tested (in mode 5 and 6) on Debian 9 & 10, Ubuntu, Fedora, and OSX 10.14. I do not remember why I used a "which -a cmake" in the past ... for sure with a good reason :(
In mode 5, the default, it download [GDL v1.0.0-rc.2.tar.gz](https://github.com/gnudatalanguage/gdl/archive/v1.0.0-rc.2.tar.gz) as linked in the button of [rc2 release notes](https://github.com/gnudatalanguage/gdl/releases/tag/v1.0.0-rc.2)
In mode 6, as usual, it does download a copy (as a TGZ) of the current GDL Git master branch, and compile it
One time again, since this script does switch off a lot of options, it does not reflect the whole GDL capabilities. But may help you to make some tests.

* this update of _online\_help.pro_ should solve two main issues & a link #760
 ** It should work with xdg-open
 ** thanks to unset MOZ_NO_REMOTE it should work even if Firefox (the default) is already running.

Please remember than, depending the *context* the result will be different ! If using xdg-open, the way to open the PDF may differ, and some PDF viewers cannot go directly to the keywords inside the PDF. If the func/pro is not an intrinsic one, it will open an extra window, to display the code.
 