### PR TITLE
apparent string length were not OK when a string was filled externall…

### DIFF
--- a/src/default_io.cpp
+++ b/src/default_io.cpp
@@ -1834,7 +1834,9 @@ bool compress, XDR *xdrs ) {
         } else {
           os.read( &vbuf[0], nChar );
         }
-        (*this)[i].assign( &vbuf[0], nChar );
+        //we have read nChar but this (a std::string) may be filled with ASCII NULL chars. These MUST be removed if we want the rest of GDL behave correctly on string manipulations (strlen, where etc...)
+        while (vbuf[nChar-1]==0 && nChar>1) {nChar--;}
+	(*this)[i].assign( &vbuf[0], nChar );
       }
     }
   }


### PR DESCRIPTION
…y (such as READU)

.. Since the space may be filled by ASCII NULLs, we need to remove all terminating (?) NULLS if we want STRLEN and other utilities behave correctly (correctly=as IDL does).