### PR TITLE
Rename to x:  Changed behaviour, see #990 

### DIFF
--- a/src/devicewx.hpp
+++ b/src/devicewx.hpp
@@ -38,8 +38,8 @@
 class DeviceWX : public GraphicsMultiDevice {
   
 public:
-
-    DeviceWX(std::string name_="MAC") : GraphicsMultiDevice( 1, 3, 3, 0) { //force decomposed=true until we find a better way (::wxDispayDepth() crashes)
+//is called "WIN" as there is no other choice on WINDOWS, and "WIN" is still ok on linux and macOSX
+    DeviceWX(std::string name_="WIN") : GraphicsMultiDevice( 1, 3, 3, 0) { //force decomposed=true until we find a better way (::wxDispayDepth() crashes)
         name = name_; 
         DLongGDL origin(dimension(2));
         DLongGDL zoom(dimension(2));

--- a/src/devicewx.hpp
+++ b/src/devicewx.hpp
@@ -39,7 +39,7 @@ class DeviceWX : public GraphicsMultiDevice {
   
 public:
 //is called "WIN" as there is no other choice on WINDOWS, and "WIN" is still ok on linux and macOSX
-    DeviceWX(std::string name_="WIN") : GraphicsMultiDevice( 1, 3, 3, 0) { //force decomposed=true until we find a better way (::wxDispayDepth() crashes)
+    DeviceWX(std::string name_="WX") : GraphicsMultiDevice( 1, 3, 3, 0) { //force decomposed=true until we find a better way (::wxDispayDepth() crashes)
         name = name_; 
         DLongGDL origin(dimension(2));
         DLongGDL zoom(dimension(2));

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -227,6 +227,7 @@ int main(int argc, char *argv[])
   bool syntaxOptionSet=false;
 
   bool force_no_wxgraphics = false;
+  usePlatformDeviceNames=false;
   forceWxWidgetsUglyFonts = false;
   useDSFMTAcceleration = true;
   iAmANotebook=false; //option --notebook
@@ -254,7 +255,7 @@ int main(int argc, char *argv[])
       cerr << "                     Use enviromnment variable \"GDL_IS_FUSSY\" to set up permanently this feature." << endl;
       cerr << "  --sloppy           Sets the traditional (default) compiling option where \"()\"  can be used both with functions and arrays." << endl;
       cerr << "                     Needed to counteract temporarily the effect of the enviromnment variable \"GDL_IS_FUSSY\"." << endl;
-      cerr << "  --use-wx (default if GDL is linked with wxWidgets): Tells GDL to use WxWidgets graphics instead of X11 or Windows. (nicer plots)." << endl;
+      cerr << "  --true-device-names        Device will be 'X' on unix, 'WIN' on Windows and 'MAC' on macs." << endl;
       cerr << "  --no-use-wx        Tells GDL not to use WxWidgets graphics." << endl;
       cerr << "                     Also enabled by setting the environment variable GDL_DISABLE_WX_PLOTS to a non-null value." << endl;
       cerr << "  --notebook         Force SVG-only device, used only when GDL is a Python Notebook Kernel." << endl;
@@ -263,6 +264,9 @@ int main(int argc, char *argv[])
       cerr << "                     Using this option may render some historical widgets unworkable (as they are based on fixed sizes)." << endl;
       cerr << "  --no-dSFMT         Tells GDL not to use double precision SIMD oriented Fast Mersenne Twister(dSFMT) for random doubles." << endl;
       cerr << "                     Also disable by setting the environment variable GDL_NO_DSFMT to a non-null value." << endl;
+#ifdef _WIN32
+      cerr << "  --posix (Windows only): paths will be posix paths (experimental)." << endl;
+#endif
       cerr << endl;
       cerr << "IDL-compatible options:" << endl;
       cerr << "  -arg value tells COMMAND_LINE_ARGS() to report" << endl;
@@ -356,9 +360,6 @@ int main(int argc, char *argv[])
       {
            useDSFMTAcceleration = false;
       }
-      else if (string(argv[a]) == "--use-wx") //obsoleted
-      {
-      }
       else if (string(argv[a]) == "--widget-compat")
       {
           forceWxWidgetsUglyFonts = true;
@@ -366,6 +367,10 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
       else if (string(argv[a]) == "--posix") lib::posixpaths=true;
 #endif
+      else if (string(argv[a]) == "--true-device-names")
+      {
+         usePlatformDeviceNames = true;
+      }
       else if (string(argv[a]) == "--no-use-wx")
       {
          force_no_wxgraphics = true;

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
   bool syntaxOptionSet=false;
 
   bool force_no_wxgraphics = false;
-  usePlatformDeviceNames=false;
+  usePlatformDeviceName=false;
   forceWxWidgetsUglyFonts = false;
   useDSFMTAcceleration = true;
   iAmANotebook=false; //option --notebook
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
       cerr << "                     Use enviromnment variable \"GDL_IS_FUSSY\" to set up permanently this feature." << endl;
       cerr << "  --sloppy           Sets the traditional (default) compiling option where \"()\"  can be used both with functions and arrays." << endl;
       cerr << "                     Needed to counteract temporarily the effect of the enviromnment variable \"GDL_IS_FUSSY\"." << endl;
-      cerr << "  --true-device-names        Device will be 'X' on unix, 'WIN' on Windows and 'MAC' on macs." << endl;
+      cerr << "  --MAC              Graphic device will be called 'MAC' on MacOSX. (default: 'X')" << endl;
       cerr << "  --no-use-wx        Tells GDL not to use WxWidgets graphics." << endl;
       cerr << "                     Also enabled by setting the environment variable GDL_DISABLE_WX_PLOTS to a non-null value." << endl;
       cerr << "  --notebook         Force SVG-only device, used only when GDL is a Python Notebook Kernel." << endl;
@@ -367,9 +367,9 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
       else if (string(argv[a]) == "--posix") lib::posixpaths=true;
 #endif
-      else if (string(argv[a]) == "--true-device-names")
+      else if (string(argv[a]) == "--MAC")
       {
-         usePlatformDeviceNames = true;
+         usePlatformDeviceName = true;
       }
       else if (string(argv[a]) == "--no-use-wx")
       {

--- a/src/graphicsdevice.cpp
+++ b/src/graphicsdevice.cpp
@@ -202,9 +202,9 @@ void GraphicsDevice::Init()
   
   std::string defaultDeviceName=std::string("X"); //what we expect the plot device to be
 #ifdef _WIN32
-  if (usePlatformDeviceNames) defaultDeviceName=std::string("WIN");
+  defaultDeviceName=std::string("WIN"); //ALWAYS WIN on WINDOWS!
 #elif __APPLE__
-  if (usePlatformDeviceNames) defaultDeviceName=std::string("MAC");
+  if (usePlatformDeviceName) defaultDeviceName=std::string("MAC");
 #endif
   
   // if GDL_DISABLE_WX_PLOTS (or switch --no-use-wx ) IS NOT PRESENT , and has wxWidgets, the wxWidgets device becomes 'X' or 'WIN' depending on machine,
@@ -217,30 +217,30 @@ void GraphicsDevice::Init()
 #ifdef HAVE_X
     current_device=new DeviceX(defaultDeviceName); //X on unix, MAC on mac... is it necessary ?
 #elif _WIN32
-    current_device=new DeviceWIN(defaultDeviceName);
+    current_device=NULL; 
 #endif
-    actGUIDevice = NULL; //no wxWidgets at all!
+    actGUIDevice = NULL; //no wxWidgets at all, because on Windows without wX, or everywhere else without wX and X11.
 #endif
   } else {  //wxWidgets will *NOT*be used for plot windows, unless there is nothing else left.
 #ifdef HAVE_LIBWXWIDGETS
-    if (useWxWidgets) {
-    actGUIDevice = new DeviceWX();  //even if wx is not used for plots, it will be used for widget_draw. But set_plot,"MAC" will exist.
+    if (useWxWidgets) { //wxWidgets is present but not as default plot system.
+    actGUIDevice = new DeviceWX();  //even if wx is not used for plots, it will be used for widget_draw. The corresponding name will be (unsupported) "WX".
     deviceList.push_back(actGUIDevice); // do not forget to add it to list!
     }
 #endif   
 #ifdef HAVE_X
-    current_device= new DeviceX(defaultDeviceName);
-#elif _WIN32
-    current_device= new DeviceWIN(defaultDeviceName);
-#else //may be wxWidgets is here?
+    current_device= new DeviceX(defaultDeviceName); //X on unix & Mac , MAC on mac if --MAC switch asked for.
+#else 
+    current_device=NULL; //prepare to the worst..
+    //but, hey, may be wxWidgets is here?
 #ifdef HAVE_LIBWXWIDGETS
-    if (useWxWidgets) current_device= new DeviceWX(defaultDeviceName);    //define wxWidgets 'plot' as either X..
+    if (useWxWidgets) current_device= new DeviceWX(defaultDeviceName);    //define wxWidgets 'plot' as either X or WIN and use it despite the orders.
 #endif
 #endif
   }
 //nothing should prevent gdl to be used without 'direct' graphics ?
   if (current_device == NULL) {
-    defaultDeviceName.assign("NULL");
+    defaultDeviceName.assign("NULL"); //the NULL device. handy.
   } else deviceList.push_back(current_device); //push the 'PLOT' device.
   if (iAmANotebook) defaultDeviceName.assign("SVG"); 
   if( !SetDevice(defaultDeviceName) ){

--- a/src/graphicsdevice.cpp
+++ b/src/graphicsdevice.cpp
@@ -200,12 +200,11 @@ void GraphicsDevice::Init()
   deviceList.push_back( new DeviceSVG());
   deviceList.push_back( new DeviceZ());
   
-#ifdef _WIN32
-  std::string defaultDeviceName=std::string("WIN");
-#elif __APPLE__
-  std::string defaultDeviceName=std::string("MAC");
-#else
   std::string defaultDeviceName=std::string("X"); //what we expect the plot device to be
+#ifdef _WIN32
+  if (usePlatformDeviceNames) defaultDeviceName=std::string("WIN");
+#elif __APPLE__
+  if (usePlatformDeviceNames) defaultDeviceName=std::string("MAC");
 #endif
   
   // if GDL_DISABLE_WX_PLOTS (or switch --no-use-wx ) IS NOT PRESENT , and has wxWidgets, the wxWidgets device becomes 'X' or 'WIN' depending on machine,

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -104,7 +104,7 @@ volatile bool useWxWidgetsForGraphics;
 //do we use SVG for graphics in python notebook use?
 volatile bool iAmANotebook;
 //do we use name Devices differently among platforms?
-volatile bool usePlatformDeviceNames;
+volatile bool usePlatformDeviceName;
 // do we force fonts to be the ugly IDL fonts?
 volatile bool forceWxWidgetsUglyFonts;
 

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -103,7 +103,8 @@ volatile bool useWxWidgets;
 volatile bool useWxWidgetsForGraphics;
 //do we use SVG for graphics in python notebook use?
 volatile bool iAmANotebook;
-
+//do we use name Devices differently among platforms?
+volatile bool usePlatformDeviceNames;
 // do we force fonts to be the ugly IDL fonts?
 volatile bool forceWxWidgetsUglyFonts;
 

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -76,7 +76,7 @@ extern volatile bool useWxWidgetsForGraphics;
 extern volatile bool forceWxWidgetsUglyFonts;
 //do we favor SIMD-accelerated random number generation?
 extern volatile bool useDSFMTAcceleration;
-extern volatile bool usePlatformDeviceNames;
+extern volatile bool usePlatformDeviceName;
 extern          int  debugMode;
 
 enum DebugCode {

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -76,7 +76,7 @@ extern volatile bool useWxWidgetsForGraphics;
 extern volatile bool forceWxWidgetsUglyFonts;
 //do we favor SIMD-accelerated random number generation?
 extern volatile bool useDSFMTAcceleration;
-
+extern volatile bool usePlatformDeviceNames;
 extern          int  debugMode;
 
 enum DebugCode {

--- a/src/otherdevices/devicex.hpp
+++ b/src/otherdevices/devicex.hpp
@@ -40,7 +40,7 @@ class DeviceX : public GraphicsMultiDevice {
     
 public:
     
-    DeviceX(std::string name_="MAC") : GraphicsMultiDevice( -1, XC_crosshair, 3, 0) {
+    DeviceX(std::string name_="X") : GraphicsMultiDevice( -1, XC_crosshair, 3, 0) {
         name = name_;
         DLongGDL origin(dimension(2));
         DLongGDL zoom(dimension(2));


### PR DESCRIPTION
'X' is the default name of graphic device on linux and MacOSX and 'WIN' on windows. the --MAC switch will enable the name "MAC" on Mac machines in the hope it can be useful for running some procedures.