### PR TITLE
fix regression that caused a bug with 'H5T_STRING' type data introduced in PR #987.

### DIFF
--- a/src/hdf5_fun.cpp
+++ b/src/hdf5_fun.cpp
@@ -589,6 +589,10 @@ hid_t
        if (elem_dtype < 0) { string msg; e->Throw(hdf5_error_message(msg)); }
        hdf5_type_guard elem_dtype_guard = hdf5_type_guard(elem_dtype);
 
+    } else if (H5Tget_class(datatype)==H5T_STRING ) {
+
+       elem_dtype = datatype;
+
     } else {
 
        elem_dtype = H5Tcopy(datatype);
@@ -767,6 +771,10 @@ hid_t
        elem_dtype = H5Tget_super(datatype);
        if (elem_dtype < 0) { string msg; e->Throw(hdf5_error_message(msg)); }
        hdf5_type_guard elem_dtype_guard = hdf5_type_guard(elem_dtype);
+
+    } else if (H5Tget_class(datatype)==H5T_STRING ) {
+
+       elem_dtype = datatype;
 
     } else {
 

--- a/src/hdf5_fun.cpp
+++ b/src/hdf5_fun.cpp
@@ -721,7 +721,7 @@ hid_t
   BaseGDL* h5d_read_fun(EnvT* e) {
 
     /* Jul 2021, Oliver Gressel <ogressel@gmail.com>
-       - add support for attributes of type 'H5T_ARRAY'
+       - add support for datasets of type 'H5T_ARRAY'
     */
 
     bool debug = false;


### PR DESCRIPTION
HDF5 `hid_t` are just handles, so assigning the value to a new variable shouldn't mess with any destructors on the original handle. So, in principle, the type guard on `elem_dtype` should not be required unless `H5Tcopy()` is used.