### PR TITLE
PS outputs now have correct dimensions and position.

### DIFF
--- a/src/deviceps.hpp
+++ b/src/deviceps.hpp
@@ -60,7 +60,7 @@ class DevicePS: public GraphicsDevice
 
     if( nx <= 0) nx = 1;
     if( ny <= 0) ny = 1;
-    actStream = new GDLPSStream( nx, ny, (int)SysVar::GetPFont(), encapsulated, color, bitsPerPix);
+    actStream = new GDLPSStream( nx, ny, (int)SysVar::GetPFont(), encapsulated, color, bitsPerPix, orient_portrait);
 
     actStream->sfnam( fileName.c_str());
 
@@ -88,9 +88,8 @@ class DevicePS: public GraphicsDevice
      actStream->setopt( "portrait",NULL);
      actStream->sdidev( PL_NOTSET, PlplotInternalPageRatioXoverY, PL_NOTSET, PL_NOTSET ); //only OK if page ratio is 540x720 
      actStream->spage(DPI, DPI, XSIZE, YSIZE, YOFF, XOFF);
-
     } else {
-     actStream->spage(DPI, DPI, YSIZE, XSIZE, YOFF-YSIZE, XOFF); //invert axes, displace as does IDL..
+     actStream->spage(DPI, DPI, YSIZE, XSIZE, YOFF-XSIZE, XOFF); //invert axes, displace as does IDL..
      actStream->sdiori(2);
     }
 

--- a/src/deviceps.hpp
+++ b/src/deviceps.hpp
@@ -25,17 +25,13 @@
 
 #include "objects.hpp"
 
-#ifdef _MSC_VER
-#define CM2IN (.01 / GSL_CONST_MKSA_INCH) // This is not good, but works
-#define in2cm ( GSL_CONST_MKSA_INCH * 100)
-#define DPI 72.0 //in dpi;
-#define RESOL 1000.0
-#else
+
   static const float CM2IN = .01 / GSL_CONST_MKSA_INCH;
   static const float in2cm = GSL_CONST_MKSA_INCH*100;
   static const PLFLT DPI = 72.0 ; //in dpi;
+  static const PLFLT DPICM = 72.0/2.54 ; //dpi/cm;
   static const float RESOL = 1000.0;
-#endif
+  static const PLFLT PlplotInternalPageRatioXoverY=float(PIXELS_X)/float(PIXELS_Y); //1.3333333
 
 class DevicePS: public GraphicsDevice
 {
@@ -72,28 +68,32 @@ class DevicePS: public GraphicsDevice
     // AC 29-Avril-2013: the way I found to link GDLPSStream* and GDLStream*
     DLong lun=GetLUN();
     psUnit = &fileUnits[ lun-1];
-    psUnit->Open(fileName,fstream::out,false,false,false,
-		 defaultStreamWidth,false,false);
+    psUnit->Open(fileName,fstream::out,false,false,false,defaultStreamWidth,false,false);
     (*static_cast<DLongGDL*>( dStruct->GetTag(dStruct->Desc()->TagIndex("UNIT"))))[0]=lun;
 
     // zeroing offsets (xleng and yleng are the default ones but they need to be specified 
-    // for the offsets to be taken into account by spage(), works with plplot >= 5.9.9)    
-    actStream->spage(DPI, DPI, 540, 720, 0, 0); //plplot default: portrait!
+    // for the offsets to be taken into account by spage(), works with plplot >= 5.9.9)
+    PLINT XSIZE=ceil(XPageSize*DPICM);
+    PLINT YSIZE=ceil(YPageSize*DPICM);
+    PLINT XOFF=ceil(XOffset*DPICM);
+    PLINT YOFF=ceil(YOffset*DPICM);
 
     // as setting the offsets and sizes with plPlot is (extremely) tricky, and some of these setting
     // are hardcoded into plplot (like EPS header, and offsets in older versions of plplot)
     // here we play only with the aspect ratio 
-    
-    // patch 3611949 by Joanna, 29 Avril 2013
-    PLFLT pageRatio=XPageSize/YPageSize;
-    std::string as = i2s( pageRatio);
-    actStream->setopt( "a", as.c_str());
-    
+
     // plot orientation
     //std::cout  << "orientation : " << orient_portrait<< '\n';
-    
-    actStream->sdiori(orient_portrait ? 1 : 2);
-    
+    if (orient_portrait) { //X size will be OK, Y size must be scaled 
+     actStream->setopt( "portrait",NULL);
+     actStream->sdidev( PL_NOTSET, PlplotInternalPageRatioXoverY, PL_NOTSET, PL_NOTSET ); //only OK if page ratio is 540x720 
+     actStream->spage(DPI, DPI, XSIZE, YSIZE, YOFF, XOFF);
+
+    } else {
+     actStream->spage(DPI, DPI, YSIZE, XSIZE, YOFF-YSIZE, XOFF); //invert axes, displace as does IDL..
+     actStream->sdiori(2);
+    }
+
     // no pause on destruction
     actStream->spause( false);
 
@@ -105,8 +105,10 @@ class DevicePS: public GraphicsDevice
     actStream->SetColorMap0( r, g, b, ctSize);
     actStream->SetColorMap1( r, g, b, ctSize);
     // default: black+white (IDL behaviour)
+    //force TTF fonts as scaling of hershey fonts will not be good 
     short font=((int)SysVar::GetPFont()>-1)?1:0;
-    string what="text="+i2s(font)+",color="+i2s(color);
+//    string what="text="+i2s(font)+",color="+i2s(color);
+    string what="text=1,color="+i2s(color);
     actStream->setopt( "drvopt",what.c_str());
     actStream->scolbg(255,255,255); // start with a white background
 
@@ -120,22 +122,6 @@ class DevicePS: public GraphicsDevice
     actStream->vpor(0,1,0,1);
     actStream->wind(0,1,0,1);
     actStream->DefaultCharSize();
-   //in case these are not initalized, here is a good place to do it.
-//    if (actStream->updatePageInfo()==true)
-//    {
-//        actStream->GetPlplotDefaultCharSize(); //initializes everything in fact..
-//
-//    }
-//    PLFLT xp, yp;
-//    PLINT xleng, yleng, xoff, yoff;
-//    actStream->gpage(xp, yp, xleng, yleng, xoff, yoff);
-//    // to mimic IDL we must scale char so that the A4 charsize is constant whatever the size of the plot
-//    PLFLT size = (XPageSize>YPageSize)?XPageSize:YPageSize;
-//    PLFLT refsize= (xleng/xp>yleng/yp)?xleng/xp:yleng/yp;
-//    PLFLT charScale=(refsize*in2cm)/size;
-//    PLFLT defhmm, scalhmm;
-//    plgchr(&defhmm, &scalhmm); // height of a letter in millimetres
-//    actStream->RenewPlplotDefaultCharsize(defhmm * charScale);
   }
     
 private:
@@ -258,7 +244,7 @@ private:
 
 public:
   DevicePS(): GraphicsDevice(), fileName( "gdl.ps"), actStream( NULL),
-    XPageSize(17.78), YPageSize(12.7), XOffset(0.75),YOffset(5.0),
+    XPageSize(17.78), YPageSize(12.7), XOffset(1.905),YOffset(12.7),  //IDL default for offests: 54 pts /X and 360 pts/Y
     color(0), decomposed( 0), encapsulated(false), scale(1.), orient_portrait(true), bitsPerPix(8)
   {
     name = "PS";
@@ -324,7 +310,8 @@ public:
 
       delete actStream;
       actStream = NULL;
-      if (encapsulated) epsHacks(); // needs to be called after the plPlot-generated file is closed
+      //always : if (encapsulated) 
+       epsHacks(); // needs to be called after the plPlot-generated file is closed
     }
     return true;
   }

--- a/src/deviceps.hpp
+++ b/src/deviceps.hpp
@@ -31,7 +31,7 @@
   static const PLFLT DPI = 72.0 ; //in dpi;
   static const PLFLT DPICM = 72.0/2.54 ; //dpi/cm;
   static const float RESOL = 1000.0;
-  static const PLFLT PlplotInternalPageRatioXoverY=float(PIXELS_X)/float(PIXELS_Y); //1.3333333
+  static const PLFLT PlplotInternalPageRatioXoverY=4./3. ; //Some machines do not know PRIVATE values stored in plplotP.h 4/3=PlplotInternalPageRatioXoverY=float(PIXELS_X)/float(PIXELS_Y)
 
 class DevicePS: public GraphicsDevice
 {

--- a/src/deviceps.hpp
+++ b/src/deviceps.hpp
@@ -31,7 +31,7 @@
   static const PLFLT DPI = 72.0 ; //in dpi;
   static const PLFLT DPICM = 72.0/2.54 ; //dpi/cm;
   static const float RESOL = 1000.0;
-  static const PLFLT PlplotInternalPageRatioXoverY=4./3. ; //Some machines do not know PRIVATE values stored in plplotP.h 4/3=PlplotInternalPageRatioXoverY=float(PIXELS_X)/float(PIXELS_Y)
+  static const PLFLT PlplotInternalPageRatioXoverY=4./3.; //Some machines do not know PRIVATE values stored in plplotP.h 4/3=PlplotInternalPageRatioXoverY=float(PIXELS_X)/float(PIXELS_Y)
 
 class DevicePS: public GraphicsDevice
 {

--- a/src/gdlgstream.cpp
+++ b/src/gdlgstream.cpp
@@ -194,8 +194,8 @@ void GDLGStream::DefaultCharSize() {
   DLong chy = (*static_cast<DLongGDL*> (d->GetTag(Y_CH_SIZE, 0)))[0];
   DFloat xpxcm = (*static_cast<DFloatGDL*> (d->GetTag(X_PX_CM, 0)))[0];
   DFloat ypxcm = (*static_cast<DFloatGDL*> (d->GetTag(Y_PX_CM, 0)))[0];
-  DFloat xchsizemm = chx * CM_IN_MM / xpxcm;
-  DFloat linespacingmm = chy * CM_IN_MM / ypxcm;
+  DFloat xchsizemm = GetPlplotFudge() * chx * CM_IN_MM / xpxcm;
+  DFloat linespacingmm = GetPlplotFudge() * chy * CM_IN_MM / ypxcm;
   schr(xchsizemm, 1.0, linespacingmm);
 }
   void GDLGStream::RenewPlplotDefaultCharsize(PLFLT newMmSize)
@@ -332,8 +332,8 @@ void GDLGStream::GetGeometry( long& xSize, long& ySize)
     xSize = (*static_cast<DLongGDL*>(SysVar::D()->GetTag(SysVar::D()->Desc()->TagIndex("X_SIZE"), 0)))[0];
     ySize = (*static_cast<DLongGDL*>(SysVar::D()->GetTag(SysVar::D()->Desc()->TagIndex("Y_SIZE"), 0)))[0];
   } else {
-    xSize = xleng;
-    ySize = yleng;
+  xSize = xleng;
+  ySize = yleng;
   }
   if (xSize<1.0||ySize<1) //plplot gives back crazy values! z-buffer for example!
   {

--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -684,7 +684,7 @@ public:
   void SetColorMap1Table(PLINT tableSize, BaseGDL *passed_colors, DLong decomposed=0);
   //if create a colormap1 with a black to white ramp.
   void SetColorMap1Ramp(DLong decomposed=0, PLFLT minlight=0.0);
-  void DefaultCharSize();
+  virtual void DefaultCharSize();
   void NextPlot( bool erase=true); // handles multi plots
 
   void NoSub(); // no subwindows (/NORM, /DEVICE)

--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -685,6 +685,7 @@ public:
   //if create a colormap1 with a black to white ramp.
   void SetColorMap1Ramp(DLong decomposed=0, PLFLT minlight=0.0);
   virtual void DefaultCharSize();
+  virtual float GetPlplotFudge(){return 1;}; //correction factor 
   void NextPlot( bool erase=true); // handles multi plots
 
   void NoSub(); // no subwindows (/NORM, /DEVICE)
@@ -735,7 +736,6 @@ public:
   void RenewPlplotDefaultCharsize(PLFLT newMmSize);
   
   void GetPlplotDefaultCharSize();
-  virtual float GetPlplotFudge(){return 1.0;};
 
   // SA: overloading plplot methods in order to handle IDL-plplot extended
   // text formating syntax conversion

--- a/src/gdlpsstream.cpp
+++ b/src/gdlpsstream.cpp
@@ -169,3 +169,19 @@ bool GDLPSStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *po
 #undef LINEWIDTH
 }
 
+//special DefaultCharZise() to compensate a (plplot?) problem in reporting size of TT fonts: rescale by ~1.8 seems OK.
+void GDLPSStream::DefaultCharSize() {
+      DStructGDL* d = SysVar::D();
+  DStructDesc* s = d->Desc();
+  int X_CH_SIZE = s->TagIndex("X_CH_SIZE");
+  int Y_CH_SIZE = s->TagIndex("Y_CH_SIZE");
+  int X_PX_CM = s->TagIndex("X_PX_CM");
+  int Y_PX_CM = s->TagIndex("Y_PX_CM");
+  DLong chx = (*static_cast<DLongGDL*> (d->GetTag(X_CH_SIZE, 0)))[0];
+  DLong chy = (*static_cast<DLongGDL*> (d->GetTag(Y_CH_SIZE, 0)))[0];
+  DFloat xpxcm = (*static_cast<DFloatGDL*> (d->GetTag(X_PX_CM, 0)))[0];
+  DFloat ypxcm = (*static_cast<DFloatGDL*> (d->GetTag(Y_PX_CM, 0)))[0];
+  DFloat xchsizemm = GetPlplotFudge() * chx * CM_IN_MM / xpxcm;
+  DFloat linespacingmm = GetPlplotFudge() * chy * CM_IN_MM / ypxcm;
+  schr(xchsizemm, 1.0, linespacingmm);
+}

--- a/src/gdlpsstream.cpp
+++ b/src/gdlpsstream.cpp
@@ -62,43 +62,22 @@ void image_compress(unsigned char *idata, PLINT size, long bpp)
 }
 bool GDLPSStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *pos,
         DLong trueColorOrder, DLong channel) {
-  if (firstTime){
-    firstTime=false;
-    this->OnePageSaveLayout();
-    this->vpor(0, 1, 0, 1); //ALL PAGE
-    this->wind(0, 1, 0, 1); //ALL PAGE
-    PLFLT x=0;
-    PLFLT y=0;
-    this->poin(1,&x,&y,-1); //put a point at 0,0 wherever it is on the plot
-    this->Flush();
-    pls->bytecnt += fprintf(pls->OutFile, "\ncurrentpoint /YMIN exch def /XMIN exch def\n");
-    x=1;
-    y=1;
-    this->poin(1,&x,&y,-1); //put a point at 0,0 wherever it is on the plot
-    this->Flush();
-    this->RestoreLayout();
-//autotest whether PS was rotated + define good sizes.
-    pls->bytecnt += fprintf(pls->OutFile, "\ncurrentpoint /YMAX exch def /XMAX exch def\n");
-    pls->bytecnt += fprintf(pls->OutFile, "YMAX YMIN lt /LAND exch def \n");
-    pls->bytecnt += fprintf(pls->OutFile, "LAND { YMAX /YMAX YMIN def /YMIN exch def /ROT 270 def} {/ROT 0 def} ifelse\n");
-    pls->bytecnt += fprintf(pls->OutFile, "XMAX XMIN sub /XRANGE exch def YMAX YMIN sub /YRANGE exch def\n");
-    pls->bytecnt += fprintf(pls->OutFile, "LAND {/X0 XMIN def /Y0 YMAX def /RX YRANGE def /RY XRANGE def}"
-    "{/X0 XMIN def /Y0 YMIN def /RX XRANGE def /RY YRANGE def} ifelse\n");
-  }
-  //need to : check position in file Ok; update bounding box values.
-  //test black and white:
   bool bw = (((*static_cast<DLongGDL*> (SysVar::D()->GetTag(SysVar::D()->Desc()->TagIndex("FLAGS"), 0)))[0] & 16) == 0); 
-  long xs, ys;
-  GDLPSStream::GetGeometry(xs, ys);
   SizeT nelem;
   if (channel > 0) {
     cerr << "TV: Value of CHANNEL (use TRUE instead) is out of allowed range." << endl;
     return false;
   } 
- 
-  pls->bytecnt += fprintf(pls->OutFile, "%%BeginObject: Image\n S gsave\nX0 Y0 translate ROT rotate RX RY scale\n");
-  pls->bytecnt += fprintf(pls->OutFile, "%d %ld div %d %ld div translate\n", pos[0], xs, pos[2], ys);
-  pls->bytecnt += fprintf(pls->OutFile, "%d %ld div %d %ld div scale\n", pos[1], xs, pos[3], ys);
+  pls->bytecnt += fprintf(pls->OutFile, "\n%%BeginObject: Image\n");
+  
+  // note PLPLOT_PS_MAGIC_FACTOR = 1000 (dpi) /72 * 2.54 = 0.028346458 
+
+  if (portrait) {
+  pls->bytecnt += fprintf(pls->OutFile, "%d 0.028346458 mul XScale div %d 0.028346458 mul YScale div translate\n", pos[0], pos[2]);
+  } else {
+  pls->bytecnt += fprintf(pls->OutFile, "%d 0.028346458 mul YScale div hs 0.028346458 div %d sub 0.028346458 mul XScale div translate 270 rotate\n", pos[2], pos[0]);
+  }
+  pls->bytecnt += fprintf(pls->OutFile, "%d 0.028346458 mul XScale div %d 0.028346458 mul YScale div scale\n", pos[1], pos[3]);
 #define LINEWIDTH 80
 
   if (trueColorOrder == 0) { 
@@ -167,21 +146,4 @@ bool GDLPSStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *po
   pls->bytecnt += fprintf(pls->OutFile, "\ngrestore\n%%EndObject: Image\n       ");
   return true;
 #undef LINEWIDTH
-}
-
-//special DefaultCharZise() to compensate a (plplot?) problem in reporting size of TT fonts: rescale by ~1.8 seems OK.
-void GDLPSStream::DefaultCharSize() {
-      DStructGDL* d = SysVar::D();
-  DStructDesc* s = d->Desc();
-  int X_CH_SIZE = s->TagIndex("X_CH_SIZE");
-  int Y_CH_SIZE = s->TagIndex("Y_CH_SIZE");
-  int X_PX_CM = s->TagIndex("X_PX_CM");
-  int Y_PX_CM = s->TagIndex("Y_PX_CM");
-  DLong chx = (*static_cast<DLongGDL*> (d->GetTag(X_CH_SIZE, 0)))[0];
-  DLong chy = (*static_cast<DLongGDL*> (d->GetTag(Y_CH_SIZE, 0)))[0];
-  DFloat xpxcm = (*static_cast<DFloatGDL*> (d->GetTag(X_PX_CM, 0)))[0];
-  DFloat ypxcm = (*static_cast<DFloatGDL*> (d->GetTag(Y_PX_CM, 0)))[0];
-  DFloat xchsizemm = GetPlplotFudge() * chx * CM_IN_MM / xpxcm;
-  DFloat linespacingmm = GetPlplotFudge() * chy * CM_IN_MM / ypxcm;
-  schr(xchsizemm, 1.0, linespacingmm);
 }

--- a/src/gdlpsstream.hpp
+++ b/src/gdlpsstream.hpp
@@ -51,6 +51,8 @@ public:
   bool PaintImage(unsigned char *idata, PLINT nx, PLINT ny,  DLong *pos, DLong tru, DLong chan);
   //logically close the svg each time an update is made, then rollback to the last graphic section for further graphics.
   void Update(){plstream::cmd(PLESC_EXPOSE, NULL);fprintf(pls->OutFile," S\neop\n");fseek(pls->OutFile,-7, SEEK_END);} 
+  float GetPlplotFudge(){return 1;}; //correction factor 
+  void DefaultCharSize();
 };
 
 #endif

--- a/src/gdlpsstream.hpp
+++ b/src/gdlpsstream.hpp
@@ -26,10 +26,10 @@ class GDLPSStream: public GDLGStream
 private:
   int page;
   bool encapsulated;
+  bool portrait;
   long bitsPerPix;
-  bool firstTime; //to enable a PS hack on correspondence postscript pixels - plplot position. 
 public:
-  GDLPSStream( int nx, int ny, int pfont, bool encaps, int color, int bpp):
+  GDLPSStream( int nx, int ny, int pfont, bool encaps, int color, int bpp, bool orient_portrait):
 #ifdef _MSC_VER
     GDLGStream( nx, ny, /*pfont == 1 ? "psttf" :*/ (color==0)?"ps":"psc")
 #else
@@ -38,7 +38,7 @@ public:
   {
     encapsulated = encaps;
     page = 0;
-    firstTime=true;
+    portrait = orient_portrait;
     bitsPerPix=bpp;
   }
 
@@ -52,7 +52,6 @@ public:
   //logically close the svg each time an update is made, then rollback to the last graphic section for further graphics.
   void Update(){plstream::cmd(PLESC_EXPOSE, NULL);fprintf(pls->OutFile," S\neop\n");fseek(pls->OutFile,-7, SEEK_END);} 
   float GetPlplotFudge(){return 1;}; //correction factor 
-  void DefaultCharSize();
 };
 
 #endif

--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -96,22 +96,7 @@ void GDLWXStream::EventHandler() {
   // plplot event handler
   plstream::cmd(PLESC_EH, NULL);
 }
-//special DefaultCharZise() to compensate a (plplot?) problem in reporting size of TT fonts: rescale by ~1.8 seems OK.
-void GDLWXStream::DefaultCharSize() {
-      DStructGDL* d = SysVar::D();
-  DStructDesc* s = d->Desc();
-  int X_CH_SIZE = s->TagIndex("X_CH_SIZE");
-  int Y_CH_SIZE = s->TagIndex("Y_CH_SIZE");
-  int X_PX_CM = s->TagIndex("X_PX_CM");
-  int Y_PX_CM = s->TagIndex("Y_PX_CM");
-  DLong chx = (*static_cast<DLongGDL*> (d->GetTag(X_CH_SIZE, 0)))[0];
-  DLong chy = (*static_cast<DLongGDL*> (d->GetTag(Y_CH_SIZE, 0)))[0];
-  DFloat xpxcm = (*static_cast<DFloatGDL*> (d->GetTag(X_PX_CM, 0)))[0];
-  DFloat ypxcm = (*static_cast<DFloatGDL*> (d->GetTag(Y_PX_CM, 0)))[0];
-  DFloat xchsizemm = GetPlplotFudge() * chx * CM_IN_MM / xpxcm;
-  DFloat linespacingmm = GetPlplotFudge() * chy * CM_IN_MM / ypxcm;
-  schr(xchsizemm, 1.0, linespacingmm);
-}
+
 void GDLWXStream::SetGdlxwGraphicsPanel(gdlwxGraphicsPanel* w, bool isPlot)
 {
   container = w;

--- a/src/gdlwxstream.hpp
+++ b/src/gdlwxstream.hpp
@@ -53,7 +53,6 @@ public:
     void SetSize( const wxSize s );   //!< Set new size of plot area.
     void RenewPlot();   //!< Redo plot.
     void Update();
-    void DefaultCharSize();
     void SetGdlxwGraphicsPanel(gdlwxGraphicsPanel* w, bool isPlot=true);
     gdlwxGraphicsPanel* GetMyContainer(){return container;}
     void DestroyContainer(){delete container; container=NULL;}
@@ -99,7 +98,7 @@ public:
     DString GetVisualName();
     bool GetScreenResolution(double& resx, double& resy);
     DByteGDL* GetBitmapData();
-    float GetPlplotFudge(){return 1.8;}; //correction factor see gdlwxStream.cpp
+    float GetPlplotFudge(){return 1.8;}; //correction factor
     static void DefineSomeWxCursors(); //global initialisation of 77 X11-like cursors.
 };
 

--- a/src/plotting_image.cpp
+++ b/src/plotting_image.cpp
@@ -184,7 +184,6 @@ namespace lib {
 
       DLong xPageSize = actStream->xPageSize();
       DLong yPageSize = actStream->yPageSize();
-
       DLong positionOnPage = 0;
       botLeftPixelX = 0;
       botLeftPixelY = 0;
@@ -198,7 +197,7 @@ namespace lib {
       devy = 0;
       bool xSizeGiven, ySizeGiven;
       double aspect=static_cast<double>(imageWidth)/static_cast<double>(imageHeight);
-
+        
         xSizeGiven=e->KeywordPresent(XSIZE);
         if (xSizeGiven) e->AssureDoubleScalarKWIfPresent(XSIZE, devx);
         ySizeGiven=e->KeywordPresent(YSIZE);
@@ -207,25 +206,37 @@ namespace lib {
         //interpret size:
         if (xSizeGiven || ySizeGiven) {
           PLFLT x1,y1, x2 ,y2;
-          if (coordinateSystem == DATA) {
+          if (coordinateSystem == DATA) { //devx and devy interpreted as floats
             actStream->world2device(0, 0, x1,y1);
             actStream->world2device(devx, devy, x2,y2);
             devx=x2-x1; 
             devy=y2-y1;
-          } else if (coordinateSystem == NORMAL) {
+          } else if (coordinateSystem == NORMAL) { //devx and devy interpreted as floats
             actStream->NormedDeviceToDevice(0, 0, x1,y1);
             actStream->NormedDeviceToDevice(devx, devy, x2,y2);
             devx=(x2-x1); 
             devy=(y2-y1);
-          } else if (coordinateSystem == DEVICE) {
+          } else if (coordinateSystem == DEVICE) { //devx and devy must be interpreted as ints to mimic IDL . test all cases with xsize=0.5 to check. 
+            //devx and devy must be interpreted as ints to mimic IDL in the DEVICE mode. 
+            // if this mode is set, then devx < 1 (resp devy) will be as if the xsize (resp. ysize) option was a /NORM value.
+            if (xSizeGiven && devx < 1) {
+              actStream->NormedDeviceToDevice(0, 0, x1,y1);
+              actStream->NormedDeviceToDevice(1, 0, x2,y2);
+              devx=(x2-x1); 
+            } 
+            if (ySizeGiven && devy < 1) {
+              actStream->NormedDeviceToDevice(0, 0, x1,y1);
+              actStream->NormedDeviceToDevice(0, 1, x2,y2);
+              devy=(y2-y1); 
+            }             
           } else {
-            if (e->KeywordSet(INCHES)) {
+            if (e->KeywordSet(INCHES)) { //devx and devy interpreted as floats
               devx *= (10 * 2.54);
               devy *= (10 * 2.54);
               actStream->mm2device(devx, devy, x,y);
               devx=x;
               devy=y;
-            } else if (e->KeywordSet(CENTIMETERS)) {
+            } else if (e->KeywordSet(CENTIMETERS)) { //devx and devy interpreted as floats
               devx *= (10.);
               devy *= (10.);
               actStream->mm2device(devx, devy, x,y);
@@ -238,10 +249,10 @@ namespace lib {
         } else {
           double pageaspect=xPageSize/yPageSize;
           if (aspect>pageaspect){
-            devx=xPageSize*0.9; //10% margin 
+            devx=xPageSize;
             devy=devx/aspect;
           } else {
-            devy=yPageSize*0.9; //10% margin
+            devy=yPageSize;
             devx=devy*aspect;
           }
         }


### PR DESCRIPTION
However we do not success in preserving the aspect ratio of Hershey fonts and PSYMs as the plplot ps driver rotates, stretches and scale a fixed-aspect internal 'surface'.
The aspect is thus only preserved for sizes that scale in proportion 4/3.
To avoid unpleasant surprises, the font is always the PostScript font, not the Hershey one as the PS fonts are not stretched by the plplot driver.
It would be marginally possible to get nice plots by customizing the postScript header afterwards, you are welcome.