### PR TITLE
add some more features to build_gdl.sh

### DIFF
--- a/.ci/build_gdl.sh
+++ b/.ci/build_gdl.sh
@@ -18,6 +18,7 @@ real_path() {
 }
 GDL_DIR=$(real_path "$(dirname $0)/..")
 ROOT_DIR=${ROOT_DIR:-"${GDL_DIR}"}
+INSTALL_PREFIX=${INSTALL_PREFIX:-"${ROOT_DIR}/install"}
 PYTHONVERSION=${PYTHONVERSION:-"3"}
 GDLDE_VERSION=${GDLDE_VERSION:-"v1.0.0"}  #needed by 'pack' (at the moment Windows only)
 BUILD_OS=$(uname)
@@ -381,7 +382,7 @@ function configure_gdl {
         cmake ${GDL_DIR} -G"${GENERATOR}" \
           -DCMAKE_BUILD_TYPE=${Configuration} \
           -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
-          -DCMAKE_INSTALL_PREFIX="${ROOT_DIR}/install" \
+          -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DWXWIDGETS=ON -DGRAPHICSMAGICK=ON \
           -DNETCDF=ON -DHDF=${WITH_HDF4} -DHDF5=ON \
           -DMPI=${WITH_MPI} -DTIFF=ON -DGEOTIFF=ON \
@@ -392,7 +393,7 @@ function configure_gdl {
         cmake ${GDL_DIR} -G"${GENERATOR}" \
           -DCMAKE_BUILD_TYPE=${Configuration} \
           -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
-          -DCMAKE_INSTALL_PREFIX="${ROOT_DIR}/install" \
+          -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
           -DREADLINE=OFF -DPNGLIB=OFF -DOPENMP=OFF \
           -DGRAPHICSMAGICK=OFF -DWXWIDGETS=OFF \
           -DINTERACTIVE_GRAPHICS=OFF -DMAGICK=OFF \

--- a/.ci/build_gdl.sh
+++ b/.ci/build_gdl.sh
@@ -488,12 +488,12 @@ function pack_gdl {
 
 function prep_deploy {
     if [ ${BUILD_OS} == "Windows" ]; then
-        cd ${ROOT_DIR}/gdl
-        mv ../package/gdlsetup.exe gdlsetup-${BUILD_OS}-${arch}-${DEPS}.exe
+        cd ${GDL_DIR}
+        mv ${ROOT_DIR}/package/gdlsetup.exe gdlsetup-${BUILD_OS}-${arch}-${DEPS}.exe
     fi
     cd ${ROOT_DIR}/install
-    zip -qr ../gdl/gdl-${BUILD_OS}-${arch}-${DEPS}.zip *
-    cd ${ROOT_DIR}/gdl
+    zip -qr ${GDL_DIR}/gdl-${BUILD_OS}-${arch}-${DEPS}.zip *
+    cd ${GDL_DIR}
 }
 
 AVAILABLE_OPTIONS="prep prep_dryrun configure build install check pack prep_deploy"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     env:
-      DEPS: full
+      DEPS: debug
       Configuration: Debug
       ROOT_DIR: ${{ github.workspace }}/..
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,18 +24,18 @@ jobs:
       id: set-matrix-windows
       run: |
         if [[ '${{ github.event_name }}' == "schedule" ]]; then 
-            matrix="{deps: ['full-msmpi', 'full', 'mini'], arch: ['x86_64', 'i686'], configuration: ['Release']}"
+            matrix="{deps: ['standard', 'headless'], arch: ['x86_64'], configuration: ['Release']}"
         else
-            matrix="{deps: ['full-msmpi'], arch: ['x86_64'], configuration: ['Debug']}"
+            matrix="{deps: ['debug'], arch: ['x86_64'], configuration: ['Debug']}"
         fi
         echo "::set-output name=matrix-windows::$matrix"
     - name: Create Build Matrix (Linux/macOS)
       id: set-matrix-others
       run: |
         if [[ '${{ github.event_name }}' == "schedule" ]]; then 
-            matrix="{os: ['ubuntu-latest', 'macos-latest'], deps: ['full', 'mini'], configuration: ['Release']}"
+            matrix="{os: ['ubuntu-latest', 'macos-latest'], deps: ['standard', 'headless'], configuration: ['Release']}"
         else
-            matrix="{os: ['ubuntu-latest', 'macos-latest'], deps: ['full'], configuration: ['Debug']}"
+            matrix="{os: ['ubuntu-latest', 'macos-latest'], deps: ['debug'], configuration: ['Debug']}"
         fi
         echo "::set-output name=matrix-others::$matrix"
     - name: Remove Release (scheduled build only)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,9 @@ jobs:
           done
       - name: Build GDL
         run: |
+          .ci/build_gdl.sh configure
           .ci/build_gdl.sh build
+          .ci/build_gdl.sh install
       - name: Package GDL
         run: |
           .ci/build_gdl.sh prep_deploy
@@ -220,7 +222,9 @@ jobs:
           else
             export PYTHONVERSION="${{ steps.setup-python-64.outputs.python-version }}"
           fi
+          .ci/build_gdl.sh configure
           .ci/build_gdl.sh build
+          .ci/build_gdl.sh install
       - name: Package GDL
         shell: msys2 {0}  
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
         with:
           repository: gnudatalanguage/gdlde
       - name: Install MSMPI
-        if: matrix.deps == 'full-msmpi'
+        if: matrix.deps == 'debug' || matrix.deps == 'headless'
         run: |
           Invoke-WebRequest -Uri https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisetup.exe -OutFile MSMpiSetup.exe
           .\MSMpiSetup.exe -unattend
@@ -198,19 +198,18 @@ jobs:
       - name: Setup Python (64 bit)
         id: setup-python-64
         uses: actions/setup-python@v2
-        if: matrix.arch == 'x86_64' && (matrix.deps == 'full-msmpi' || matrix.deps == 'full')
+        if: matrix.arch == 'x86_64'
         with:
           python-version: '3.x'
           architecture: x64
       - name: Setup Python (32 bit)
         id: setup-python-32
         uses: actions/setup-python@v2
-        if: matrix.arch == 'i686' && (matrix.deps == 'full-msmpi' || matrix.deps == 'full')
+        if: matrix.arch == 'i686'
         with:
           python-version: '3.x'
           architecture: x86
       - name: Install Numpy
-        if: matrix.deps == 'full-msmpi' || matrix.deps == 'full'
         run: pip install numpy
       - name: Build GDL
         shell: msys2 {0}


### PR DESCRIPTION
- Changed `ROOT_DIR` to the source directory, not the dir one level above.
- Add dry run mode for 'prep': `build_gdl.sh prep_packages_dryrun`
- Separated configure, build, and install: `build_gdl.sh configure`, `build_gdl.sh build`, `build_gdl.sh install`
- Added `INSTALL_PREFIX` environment variable, which can be used to specify install location
- Removed `mini` build type, introduced three new build types: `standard`, `headless`, and `debug`.
  - `standard`: everything without MPI
  - `headless`: everything without wxWidgets
  - `debug`: includes both MPI and wxWidgets, for debugging purposes
- Removed Windows i686 builds.