### PR TITLE
Add mallinfo2 and prefer over mallinfo in case it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ endif(HAVE_DL)
 check_function_exists(malloc_zone_statistics HAVE_MALLOC_ZONE_STATISTICS)
 check_function_exists(sbrk HAVE_SBRK)
 check_function_exists(mallinfo HAVE_MALLINFO)
+check_function_exists(mallinfo2 HAVE_MALLINFO2)
 
 # mallocs
 check_include_file(malloc.h HAVE_MALLOC_H)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -22,6 +22,7 @@
 #cmakedefine HAVE_LOCALE_H 1
 #cmakedefine HAVE_SBRK 1
 #cmakedefine HAVE_MALLINFO 1
+#cmakedefine HAVE_MALLINFO2 1
 #cmakedefine HAVE_MALLOC_H 1
 #cmakedefine HAVE_MALLOC_MALLOC_H 1
 #cmakedefine HAVE_MALLOC_ZONE_STATISTICS 1

--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -770,7 +770,7 @@ SizeT MemStats::NumFree = 0;
 SizeT MemStats::HighWater = 0;
 SizeT MemStats::Current = 0;
 
-#if !defined(HAVE_MALLINFO) 
+#if (!defined(HAVE_MALLINFO) && !defined(HAVE_MALLINFO2))
 #  if (!defined(HAVE_MALLOC_ZONE_STATISTICS) || !defined(HAVE_MALLOC_MALLOC_H))
 #    if defined(HAVE_SBRK)
 char* MemStats::StartOfMemory = reinterpret_cast<char*>(::sbrk(0));
@@ -785,7 +785,12 @@ char* MemStats::StartOfMemory = reinterpret_cast<char*>(::sbrk(0));
     // - the LLVM project (lib/System/Unix/Process.inc) see http://llvm.org/
     // - the Squid cache project (src/tools.cc) see http://squid-cache.org/
     // TODO (TOCHECK): Squid considers also gnumalloc.h - ?
-#if defined(HAVE_MALLINFO)
+#if defined(HAVE_MALLINFO2)
+    // Docs see below, newer versions of glibc deprecated mallinfo()
+    static struct mallinfo2 mi;
+    mi = mallinfo2();
+    Current = mi.arena+mi.hblkhd;
+#elif defined(HAVE_MALLINFO)
     // Linux case for example
     static struct mallinfo mi;
     mi = mallinfo();

--- a/src/basegdl.hpp
+++ b/src/basegdl.hpp
@@ -37,7 +37,7 @@
 #ifdef HAVE_MALLOC_MALLOC_H
 #  include <malloc/malloc.h>
 #endif
-#if !defined(HAVE_MALLINFO) 
+#if (!defined(HAVE_MALLINFO) && !defined(HAVE_MALLINFO2))
 #  if (!defined(HAVE_MALLOC_ZONE_STATISTICS) || !defined(HAVE_MALLOC_MALLOC_H))
 #    if defined(HAVE_SBRK)
 #      include <unistd.h>
@@ -310,7 +310,7 @@ private:
   // SizeT has architecture-dependant size (32/64 bit)
   static SizeT NumAlloc, NumFree, HighWater, Current;
 
-#if !defined(HAVE_MALLINFO) 
+#if (!defined(HAVE_MALLINFO) && !defined(HAVE_MALLINFO2))
 #  if (!defined(HAVE_MALLOC_ZONE_STATISTICS) || !defined(HAVE_MALLOC_MALLOC_H))
 #    if defined(HAVE_SBRK)
   static char* StartOfMemory;


### PR DESCRIPTION
Newer versions of glibc deprecated mallinfo() in favour of mallinfo2(). This patch introduces a check for mallinfo2 and prefers that over mallinfo, if available. This removes deprecation warnings when building gdl.