### PR TITLE
two details : keeping compilable on old U14.04, gdl_status cleaning

### DIFF
--- a/src/math_fun_ac.cpp
+++ b/src/math_fun_ac.cpp
@@ -583,7 +583,7 @@ namespace lib {
     bool Yderiv0ok=false;
     if (Yderiv0 != NULL ) {
       YP0 = e->GetKWAs<DDoubleGDL>(firstderiv);
-      Yderiv0ok=(fabs((*YP0)[0])<SPL_INIT_BIG || isnan((*YP0)[0])); //apparently IDL stops considering second derivative if > SPL_INIT_BIG, but lets NaN pass.
+      Yderiv0ok=(fabs((*YP0)[0])<SPL_INIT_BIG || std::isnan((*YP0)[0])); //apparently IDL stops considering second derivative if > SPL_INIT_BIG, but lets NaN pass.
     }
 
 // follow same template even if there is only 1 KW?    
@@ -598,7 +598,7 @@ namespace lib {
     bool YderivNok=false;
     if (YderivN != NULL) {
       YPN = e->GetKWAs<DDoubleGDL>(secondderiv);
-      YderivNok=(fabs((*YPN)[0])<SPL_INIT_BIG || isnan((*YPN)[0]) ); //apparently IDL stops considering second derivative if > SPL_INIT_BIG, but lets NaN pass.
+      YderivNok=(fabs((*YPN)[0])<SPL_INIT_BIG || std::isnan((*YPN)[0]) ); //apparently IDL stops considering second derivative if > SPL_INIT_BIG, but lets NaN pass.
     }
     
     // we only issue a message

--- a/src/pro/utilities/gdl_status.pro
+++ b/src/pro/utilities/gdl_status.pro
@@ -19,6 +19,9 @@
 ; 2020-Mar-30 : AC. 
 ; -- I clearly prefer keyword /missing ! (more nmemonic)
 ;
+; 2021-Aug-03 : AC.
+; -- it was not a good idea to use GDL_IDL_FL() here, removing it.
+;
 ; ---------------------------------------------------
 ;
 pro IPRINT, ii, txt, status, skip
@@ -38,10 +41,12 @@ end
 pro GDL_STATUS, missing=missing, only_off=only_off, $
                 test=test, verbose=verbose, help=help
 ;
-FORWARD_FUNCTION DSFMT_EXISTS, EIGEN_EXISTS, FFTW_EXISTS, GEOTIFF_EXISTS, $
+FORWARD_FUNCTION DSFMT_EXISTS, EIGEN_EXISTS, EXPAT_EXISTS, $
+   FFTW_EXISTS, GEOTIFF_EXISTS, $
    GLPK_EXISTS, GRIB_EXISTS, GSHHG_EXISTS, HDF5_EXISTS, HDF_EXISTS, $
-   MAGICK_EXISTS, NCDF4_EXISTS, NCDF_EXISTS, OPENMP_EXISTS, PNGLIB_EXISTS, $
-   PROJ_EXISTS, PYTHON_EXISTS, $
+   MAGICK_EXISTS, MPI_EXISTS, NCDF4_EXISTS, NCDF_EXISTS, $
+   OPENMP_EXISTS, PNGLIB_EXISTS, $
+   PROJ_EXISTS, PYTHON_EXISTS, SHAPELIB_EXISTS, $
    TIFF_EXISTS, UDUNITS_EXISTS, WXWIDGETS_EXISTS, X11_EXISTS
 ;
 ON_ERROR, 2
@@ -52,8 +57,8 @@ if KEYWORD_SET(help) then begin
    return
 endif
 ;
-if GDL_IDL_FL(/uppercase) NE 'GDL' then $
-   MESSAGE, 'This code can be run only under GDL !'
+DEFSYSV, '!gdl', exist=exist
+if ~exist then MESSAGE, 'This code can be run only under GDL !'
 ;
 ; counting ...
 i=1


### PR DESCRIPTION
* concerning `math_fun_ac.cpp` this simple change allows me to continue to compile GDL on my old laptop running U14.04 just with : 
```cmake .. -DPLPLOTDIR=~/GDL/Save/plplot-5.12.0/Compilation -DX11=on -DINTERACTIVE_GRAPHICS=OFF -DEIGEN3=OFF -DGRIB=OFF```

* this utility `gdl_status.pro` is convenient but was containing a function provided in testsuite/ which is not ship usually. Cleaning.