### PR TITLE
for bug #1030

### DIFF
--- a/src/prognode.hpp
+++ b/src/prognode.hpp
@@ -1108,6 +1108,8 @@ public:
     assert( down != NULL);
 	
     ProgNodeP statementList = this->GetStatementList();
+    if( statementList == NULL) return; // we say nothing at the compilation
+
     statementList->SetAllBreak( right);
 
     // down is expr


### PR DESCRIPTION
* the resulting behavior is not exactly the same than IDL when the content of the case is undefined, but when it is defined, it is the same behavior

* this bug was solve super quickly thank to the compilation option 
`cmake .. -DCMAKE_CXX_FLAGS="-fsanitize=null"`

* I have no idea how to add such a test case in the test suite :disappointed: 