### PR TITLE
Switch to un-deprecated Numpy API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 install/
 gdlde/
 gdlde*.zip
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@
 
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
+# Set some policies to fix warnings in newer versions of cmake
+cmake_policy(SET CMP0075 NEW)
+cmake_policy(SET CMP0077 NEW)
+
 project(GDL)
 set(CMAKE_CXX_STANDARD 11)
 

--- a/src/gdlpython.cpp
+++ b/src/gdlpython.cpp
@@ -127,27 +127,27 @@ BaseGDL* FromPython( PyObject* pyObj)
   if( array == NULL)
     throw GDLException( "Error getting python array.") ;
   
-  int nDim = array->nd;
+  int nDim = PyArray_NDIM(array);
   SizeT dimArr[ MAXRANK];
   if( nDim > MAXRANK)
     {
     Warning( "Python array has more than "+MAXRANK_STR+
 	     " dimensions. Extending last one."); 
-    SizeT lastDim = array->dimensions[ MAXRANK-1];
-    for( SizeT i=MAXRANK; i<nDim; ++i) lastDim *= array->dimensions[ i];
+    SizeT lastDim = PyArray_DIM(array, MAXRANK-1);
+    for( SizeT i=MAXRANK; i<nDim; ++i) lastDim *= PyArray_DIM(array, i);
     for( SizeT i=0; i<MAXRANK-1; ++i)
-      dimArr[ i] = array->dimensions[ i];
+      dimArr[ i] = PyArray_DIM(array, i);
     dimArr[ MAXRANK-1] = lastDim;
     nDim = MAXRANK;
     }
   else
     {
       for( SizeT i=0; i<nDim; ++i)
-	dimArr[ i] = array->dimensions[ i];
+	dimArr[ i] = PyArray_DIM(array, i);
     }
   dimension dim( dimArr, nDim);
 
-  switch( array->descr->type_num) 
+  switch( PyArray_DTYPE(array)->type_num)
     {
     case NPY_UINT8:   //GDL_BYTE
       return NewFromPyArrayObject< DByteGDL>( dim, array);

--- a/src/topython.cpp
+++ b/src/topython.cpp
@@ -19,6 +19,7 @@
 #ifdef INCLUDE_TOPYTHON_CPP
 
 #if defined(USE_PYTHON) || defined(PYTHON_MODULE)
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #endif
 
@@ -68,12 +69,12 @@ PyObject* Data_<Sp>::ToPython()
   //  (PyArray_SimpleNewFromData( n_dim, dimArr, item_type, DataAddr()));
 
   PyObject* ret = PyArray_SimpleNew(n_dim, dimArr, item_type);
-  if (!PyArray_CHKFLAGS(ret, NPY_C_CONTIGUOUS))
+  if (!PyArray_CHKFLAGS((PyArrayObject*)ret, NPY_ARRAY_C_CONTIGUOUS))
   {
     // TODO: free the memory:  PyArray_Free(PyObject* op, void* ptr) ?
     throw GDLException("Failed to convert array to python.");
   }
-  memcpy(PyArray_DATA(ret), DataAddr(), this->NBytes());
+  memcpy(PyArray_DATA((PyArrayObject*)ret), DataAddr(), this->NBytes());
   return ret;
 }
 


### PR DESCRIPTION
This patch fixes the numpy depracated api warung when compiling gdl. It also fixes two deprecation warning on newer cmake versions by expicitly enabling the behaviour that is default on cmake 3.10 and cmake 3.12, respectively.

Tests for gdl still work; however I'm not too sure on how to run the python test not having installed the freshly built GDL module beforehand.