### PR TITLE
Fix #1101

### DIFF
--- a/src/magick_cl.hpp
+++ b/src/magick_cl.hpp
@@ -31,9 +31,8 @@ namespace lib {
   string GDLutos(unsigned int i);
   void magick_setup(void);
   unsigned int magick_id(void);
-  Image& magick_image(EnvT * e,unsigned int mid);
-  unsigned int magick_image(EnvT* e,Image &imImage);
-  void magick_replace(EnvT* e, unsigned int mid, Image &imImage);
+  Image* magick_image(EnvT *e, unsigned int mid);
+  unsigned int magick_image(EnvT *e, Image *imImage);
   //interface
   BaseGDL* magick_open(EnvT *e);
   BaseGDL* magick_create(EnvT *e);


### PR DESCRIPTION
As reported in #1101, GraphicsMagick crashes with any related functions. Also related to #1060, #1063.

The recent commits changed the way how images are stored in GDL, now as pointers to avoid they are initialized before `InitializeMagick` is called. The problem is that the images are created within each relevant `lib` function, then automatically destructed when the function exits.

I changed all Images to be pointers and dynamically initialized all images so that they are not destructed until the program exits.

To prevent creating more issues related to Magick, it would be great if more testing can be done before this PR is merged.