### PR TITLE
Null handling in keywords, Widget  KILL_NOTIFY ok, better tracebacks.

### DIFF
--- a/src/GDLInterpreter.cpp
+++ b/src/GDLInterpreter.cpp
@@ -562,7 +562,7 @@ GDLInterpreter::GDLInterpreter()
 		//                     if( e.getLine() == 0 && _retTree != NULL)
 		//                         e.SetLine( _retTree->getLine());
 		if( e.getLine() == 0 && last != NULL)
-		e.SetLine( last->getLine());
+		e.SetLine( last->getLine()); //probably false -- see ReportError, was obliged to replace e.getLine() by callStack.back()->GetLineNumber()
 		
 		if( interruptEnable)
 		ReportError(e, "Error occurred at:");

--- a/src/GDLInterpreter.hpp
+++ b/src/GDLInterpreter.hpp
@@ -765,7 +765,7 @@ std::cout << add << " + <ObjHeapVar" << id << ">" << std::endl;
         std::string file=callStack.back()->GetFilename();
         if( file != "")
         {
-            SizeT line = e.getLine();
+            SizeT line = callStack.back()->GetLineNumber(); //e.getLine();
             if( line != 0)
             {       
                 std::cerr << std::right << std::setw(6) << line;

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -2333,11 +2333,6 @@ namespace lib {
   BaseGDL* strlowcase( BaseGDL* p0, bool isReference)//( EnvT* e)
   {
     assert( p0 != NULL);
-    assert( p0->N_Elements() > 0);
-
-    //     e->NParam( 1);//, "STRLOWCASE");
-
-    //     DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
     DStringGDL* p0S;
     DStringGDL* res;
     //  Guard<DStringGDL> guard;
@@ -2391,11 +2386,6 @@ namespace lib {
   BaseGDL* strupcase( BaseGDL* p0, bool isReference)//( EnvT* e)
   {
     assert( p0 != NULL);
-    assert( p0->N_Elements() > 0);
-
-    //     e->NParam( 1);//, "STRLOWCASE");
-
-    //     DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
     DStringGDL* p0S;
     DStringGDL* res;
     //  Guard<DStringGDL> guard;
@@ -2449,10 +2439,6 @@ namespace lib {
   BaseGDL* strlen( BaseGDL* p0, bool isReference)//( EnvT* e)
   {
     assert( p0 != NULL);
-    assert( p0->N_Elements() > 0);
-
-    //     e->NParam( 1);//, "STRLEN");
-
     DStringGDL* p0S;
     Guard<DStringGDL> guard;
     

--- a/src/devicewx.hpp
+++ b/src/devicewx.hpp
@@ -183,12 +183,13 @@ public:
     plotFrame->ShowWithoutActivating();
     plotFrame->Raise();
   }
-  //really show by letting the loop do its magic.
-#ifdef __WXMAC__
-  wxTheApp->Yield();
-#else
-  wxGetApp().MainLoop(); //central loop for wxEvents!
-#endif
+  plotFrame->UpdateWindowUI();
+//  //really show by letting the loop do its magic.
+//#ifdef __WXMAC__
+//  wxTheApp->Yield();
+//#else
+//  wxGetApp().MainLoop(); //central loop for wxEvents!
+//#endif
   return true;
  }
 

--- a/src/envt.hpp
+++ b/src/envt.hpp
@@ -282,6 +282,7 @@ public:
 
   // returns environment data, by value (but that by C++ reference)
   BaseGDL*& GetKW(SizeT ix) { return env[ix];}
+  BaseGDL* GetDefinedKW(SizeT ix);
 
   // used by HELP, SetNextPar(...)
   SizeT EnvSize() const { return env.size();}

--- a/src/gdlc.i.g
+++ b/src/gdlc.i.g
@@ -818,7 +818,7 @@ std::cout << add << " + <ObjHeapVar" << id << ">" << std::endl;
         std::string file=callStack.back()->GetFilename();
         if( file != "")
         {
-            SizeT line = e.getLine();
+            SizeT line = callStack.back()->GetLineNumber(); //e.getLine();
             if( line != 0)
             {       
                 std::cerr << std::right << std::setw(6) << line;
@@ -1377,7 +1377,7 @@ statement returns[ RetCode retCode]
 //                     if( e.getLine() == 0 && _retTree != NULL)
 //                         e.SetLine( _retTree->getLine());
                     if( e.getLine() == 0 && last != NULL)
-                        e.SetLine( last->getLine());
+                        e.SetLine( last->getLine()); //probably false -- see ReportError, was obliged to replace e.getLine() by callStack.back()->GetLineNumber()
 
                     if( interruptEnable)
                         ReportError(e, "Error occurred at:");

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1590,20 +1590,27 @@ GDLWidgetContainer::GDLWidgetContainer( WidgetIDT parentID, EnvT* e, ULong event
 
   // delete all children (in reverse order ?)
   while (!children.empty()) {
-    GDLWidget* child=GetWidget(children.back()); children.pop_back();
+    GDLWidget* child = GetWidget(children.back());
+    children.pop_back();
 
      if (child) {
+      WidgetIDT childID = child->GetWidgetID();
 #ifdef GDL_DEBUG_WIDGETS
-      std::cout << "~GDLWidgetContainer, deleting child ID #" << child->GetWidgetID() << " of container  #" << widgetID << std::endl;
+      std::cout << "~GDLWidgetContainer, deleting child ID #" << childID << " of container  #" << widgetID << std::endl;
 #endif
+      // call KILL_NOTIFY procedures
+      child->OnKill();
+      // widget may have been killed by above OnKill:
+      child = GDLWidget::GetWidget(childID);
+      if (child != NULL) {
       //special case for WIDGET_DRAW: delete from 'wdelete' command-like:
       if (child->IsDraw()) {
         gdlwxGraphicsPanel* draw=static_cast<gdlwxGraphicsPanel*>(child->GetWxWidget());
         draw->DeleteUsingWindowNumber(); //just emit quivalent to "wdelete,winNum".
       } else delete child;
      }
+    }
   }
-    
   if (theWxContainer) static_cast<wxWindow*>(theWxContainer)->Destroy(); //which is the panel.
 }
 

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1452,9 +1452,6 @@ GDLWidget::~GDLWidget()
   this->SetUnValid();
   if (m_windowTimer) {if (m_windowTimer->IsRunning()) m_windowTimer->Stop();}
 
-  // call KILL_NOTIFY procedures
-  this->OnKill();
-
   // kill followers (here?)
   // delete all followers (in reverse order ?)
   while (!followers.empty()) {

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -561,12 +561,13 @@ void GDLWidget::UpdateGui()
     actID = widget->parentID;
   }
   this->GetMyTopLevelFrame()->Fit();
+  this->GetMyTopLevelFrame()->Update();
   END_CHANGESIZE_NOEVENT
-#ifdef __WXMAC__
-  wxTheApp->Yield();
-#else
-  wxGetApp().MainLoop(); //central loop for wxEvents!
-#endif
+//#ifdef __WXMAC__
+//  wxTheApp->Yield();
+//#else
+//  wxGetApp().MainLoop(); //central loop for wxEvents!
+//#endif
 }
 
 //Alternate version if there were sizing problems with the one above.
@@ -6055,6 +6056,7 @@ void gdlwxGraphicsPanel::RepaintGraphics(bool doClear) {
 //  dc.SetDeviceClippingRegion(GetUpdateRegion());
   if (doClear) dc.Clear();
   dc.Blit(0, 0, drawSize.x, drawSize.y, wx_dc, 0, 0);
+  this->Update();
 }
 
 ////Stem for generalization of Drag'n'Drop, a WIDGET_DRAW can receive drop events from something else than a tree widget...

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -1326,8 +1326,9 @@ void gdlwxFrame::OnUnhandledCloseFrame( wxCloseEvent & event)
 
   // call KILL_NOTIFY procedures
   widget->OnKill();
-    //destroy TLB widget
-   delete gdlOwner;
+  //widget may have been killed after this OnKill:
+  widget = GDLWidget::GetWidget(event.GetId());
+  if (widget != NULL)   delete widget; //gdlOwner; //destroy TLB widget
 }
 
 void gdlwxPlotFrame::OnUnhandledClosePlotFrame(wxCloseEvent & event) {

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -1323,6 +1323,9 @@ void gdlwxFrame::OnUnhandledCloseFrame( wxCloseEvent & event)
   GDLWidget* widget = GDLWidget::GetWidget( event.GetId());
   if( widget == NULL) {event.Skip(); return;} 
   if (!gdlOwner) {event.Skip(); return;}
+
+  // call KILL_NOTIFY procedures
+  widget->OnKill();
     //destroy TLB widget
    delete gdlOwner;
 }

--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -108,11 +108,11 @@ void GDLWXStream::Update()
   if( this->valid && container != NULL) {
     container->RepaintGraphics();
     //will be updated by eventloop.
-#ifdef __WXMAC__
-  wxTheApp->Yield();
-#else
-  wxGetApp().MainLoop(); //central loop for wxEvents!
-#endif
+//#ifdef __WXMAC__
+//  wxTheApp->Yield();
+//#else
+//  wxGetApp().MainLoop(); //central loop for wxEvents!
+//#endif
   }
 }
 

--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -140,6 +140,7 @@ void GDLWXStream::SetSize( wxSize s )
   this->cmd(PLESC_RESIZE, (void*)&s );
   m_width = s.x;
   m_height = s.y;
+  Update();
 }
 
 void GDLWXStream::WarpPointer(DLong x, DLong y) {
@@ -320,7 +321,7 @@ bool GDLWXStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *po
   image.Destroy();
   temp_dc.SelectObject( wxNullBitmap);
   *streamBitmap = streamDC->GetAsBitmap();
-//  Update();
+  Update();  //very much necessary for wxWidgets!
   return true;
 }
 

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -1087,8 +1087,6 @@ namespace lib {
   //   BaseGDL* alog10_fun( EnvT* e)
   BaseGDL* alog10_fun( BaseGDL* p0, bool isReference)
   {
-    assert( p0 != NULL);
-    assert( p0->N_Elements() > 0);
     if( !isReference) //e->StealLocalPar( 0))
       {
 	return p0->Log10This();

--- a/src/nullgdl.cpp
+++ b/src/nullgdl.cpp
@@ -26,6 +26,16 @@ using namespace std;
 char NullGDL::buf[sizeof(NullGDL)];
 
 NullGDL* NullGDL::instance = NULL;
+// as GetParString of EnvT but directly from BaseGDL if possible:
+// get the name of 'i'th parameter
+
+const std::string NullGDL::GetParString() {
+  EnvUDT* caller = interpreter->CallStackBack();
+  int i = caller->findvar(this);
+  DString parString = "Unkown.";
+  if (i > 0) parString = caller->GetParString(i);
+  return parString;
+}
 
 NullGDL::~NullGDL()
 {
@@ -182,7 +192,7 @@ BaseGDL* NullGDL::Convert2( DType destTy, Convert2Mode mode)
 {
   if( destTy == GDL_STRING)
     return new DStringGDL( "!NULL");
-  throw GDLException("Variable is undefined: !NULL");  
+  throw GDLException("Variable is undefined: "+GetParString());  
 }
 
 BaseGDL* NullGDL::GetTag() const 
@@ -231,7 +241,7 @@ bool NullGDL::True()
 bool NullGDL::NullGDL::True()
 #endif
 {
-  throw GDLException("Operation not defined for !NULL 3.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 3.");
 }
 
 #ifdef _MSC_VER
@@ -240,35 +250,35 @@ bool NullGDL::False()
 bool NullGDL::NullGDL::False()
 #endif
 {
-  throw GDLException("Operation not defined for !NULL 4.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4.");
 }
 
 bool NullGDL::LogTrue()
 {
-  throw GDLException("Operation not defined for !NULL 4a.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4a.");
 }
 
 bool NullGDL::LogTrue( SizeT ix)
 {
-  throw GDLException("Operation not defined for !NULL 4b.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4b.");
 }
 void NullGDL::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret)
 {
-  throw GDLException("Operation not defined for !NULL 4b.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4b.");
 }
 void NullGDL::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret)
 {
-  throw GDLException("Operation not defined for !NULL 4b.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4b.");
 }
 
 BaseGDL* NullGDL::LogNeg()
 {
-  throw GDLException("Operation not defined for !NULL 4c.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 4c.");
 }
 
 int NullGDL::Sgn() // -1,0,1
 {
-  throw GDLException("Operation not defined for !NULL 5.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 5.");
 }
 
 bool NullGDL::Equal( BaseGDL*) const
@@ -283,40 +293,40 @@ bool NullGDL::EqualNoDelete( const BaseGDL*) const
 
 bool NullGDL::ArrayEqual( BaseGDL*)
 {
-  throw GDLException("Operation not defined for !NULL 6b.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 6b.");
 }
 
 // for statement compliance (int types , float types scalar only)
 bool NullGDL::ForCheck( BaseGDL**, BaseGDL**)
 {
-  throw GDLException("Operation not defined for !NULL 7.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 7.");
   return false;
 }
 
 bool NullGDL::ForCondUp( BaseGDL*)
 {
-  throw GDLException("Operation not defined for !NULL 8.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 8.");
 }
 
 bool NullGDL::ForAddCondUp( BaseGDL* loopInfo)
 // bool NullGDL::ForAddCondUp( ForLoopInfoT& loopInfo)
 {
-  throw GDLException("Operation not defined for !NULL 8a.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 8a.");
 }
 
 bool NullGDL::ForCondDown( BaseGDL*)
 {
-  throw GDLException("Operation not defined for !NULL 9.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 9.");
 }
 
 // bool NullGDL::ForCondUpDown( BaseGDL*)
 // {
-//   throw GDLException("Operation not defined for !NULL 9a.");
+//   throw GDLException("Operation not defined for "+GetParString()+" - !NULL 9a.");
 // }
 
 void NullGDL::ForAdd( BaseGDL* add)
 {
-  throw GDLException("Operation not defined for !NULL 10.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 10.");
 }
 
 BaseGDL* NullGDL::CatArray( ExprListT& exprList,
@@ -334,37 +344,37 @@ BaseGDL* NullGDL::Index( ArrayIndexListT* ixList)
 // used in r_expr
 BaseGDL* NullGDL::UMinus()              
 {
-  throw GDLException("Operation not defined for !NULL 11.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 11.");
 }
 
 BaseGDL* NullGDL::NotOp()               
 {
-  throw GDLException("Operation not defined for !NULL 12.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 12.");
 }
 
 BaseGDL* NullGDL::AndOp( BaseGDL* r)    
 {
-  throw GDLException("Operation not defined for !NULL 13.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 13.");
 }
 
 BaseGDL* NullGDL::AndOpInv( BaseGDL* r) 
 {
-  throw GDLException("Operation not defined for !NULL 14.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 14.");
 }
 
 BaseGDL* NullGDL::OrOp( BaseGDL* r)    
 {
-  throw GDLException("Operation not defined for !NULL 13.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 13.");
 }
 
 BaseGDL* NullGDL::OrOpInv( BaseGDL* r) 
 {
-  throw GDLException("Operation not defined for !NULL 14.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 14.");
 }
 
 BaseGDL* NullGDL::XorOp( BaseGDL* r)    
 {
-  throw GDLException("Operation not defined for !NULL 13.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 13.");
 }
 
 BaseGDL* NullGDL::XorOpS( BaseGDL* r)    
@@ -449,71 +459,71 @@ BaseGDL* NullGDL::GtOp( BaseGDL* r)
 
 BaseGDL* NullGDL::Add( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 15.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 15.");
 }
 BaseGDL* NullGDL::AddInv( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 15.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 15.");
 }
 
 BaseGDL* NullGDL::Sub( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::SubInv( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::LtMark( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 18.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 18.");
 }
 
 BaseGDL* NullGDL::GtMark( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 19.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 19.");
 }
 
 BaseGDL* NullGDL::Mult( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 19a.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 19a.");
 }
 
 BaseGDL* NullGDL::Div( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::DivInv( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::Mod( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::ModInv( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::Pow( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::PowInv( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 BaseGDL* NullGDL::PowInt( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 170.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 170.");
 }
 
 BaseGDL* NullGDL::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
 {
-  throw GDLException("Operation not defined for !NULL 18.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 18.");
 }
 
 void NullGDL::AssignAt( BaseGDL* srcIn,	ArrayIndexListT* ixList, SizeT offset)
@@ -606,132 +616,132 @@ PyObject* NullGDL::ToPython()
 
 BaseGDL* NullGDL::AndOpS( BaseGDL* r)    
 {
-  throw GDLException("Operation not defined for !NULL 13.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 13.");
 }
 
 BaseGDL* NullGDL::AndOpInvS( BaseGDL* r) 
 {
-  throw GDLException("Operation not defined for !NULL 14.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 14.");
 }
 
 BaseGDL* NullGDL::OrOpS( BaseGDL* r)    
 {
-  throw GDLException("Operation not defined for !NULL 13.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 13.");
 }
 
 BaseGDL* NullGDL::OrOpInvS( BaseGDL* r) 
 {
-  throw GDLException("Operation not defined for !NULL 14.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 14.");
 }
 
 BaseGDL* NullGDL::AddS( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 15.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 15.");
 }
 BaseGDL* NullGDL::AddInvS( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 15.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 15.");
 }
 
 BaseGDL* NullGDL::SubS( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::SubInvS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::LtMarkS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 18.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 18.");
 }
 
 BaseGDL* NullGDL::GtMarkS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 19.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 19.");
 }
 
 BaseGDL* NullGDL::MultS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 19a.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 19a.");
 }
 
 BaseGDL* NullGDL::DivS( BaseGDL* r)
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::DivInvS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::ModS( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::ModInvS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::PowS( BaseGDL* r)      
 {
-  throw GDLException("Operation not defined for !NULL 16.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 16.");
 }
 BaseGDL* NullGDL::PowInvS( BaseGDL* r)   
 {
-  throw GDLException("Operation not defined for !NULL 17.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 17.");
 }
 
 BaseGDL* NullGDL::NewIx( SizeT ix)
 {
-  throw GDLException("Operation not defined for !NULL 20.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 20.");
 }
 BaseGDL* NullGDL::NewIx( BaseGDL* ix, bool strict)
 {
-  throw GDLException("Operation not defined for !NULL 21.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 21.");
 }
 BaseGDL* NullGDL::NewIx( AllIxBaseT* ix, const dimension* dIn)
 {
-  throw GDLException("Operation not defined for !NULL 22.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 22.");
 }
 BaseGDL* NullGDL::NewIxFrom( SizeT s)
 {
-  throw GDLException("Operation not defined for !NULL 23.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 23.");
 }
 BaseGDL* NullGDL::NewIxFrom( SizeT s, SizeT e)
 {
-  throw GDLException("Operation not defined for !NULL 24.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 24.");
 }
 BaseGDL* NullGDL::NewIxFromStride( SizeT s, SizeT stride)
 {
-  throw GDLException("Operation not defined for !NULL 25.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 25.");
 }
 BaseGDL* NullGDL::NewIxFromStride( SizeT s, SizeT e, SizeT stride)
 {
-  throw GDLException("Operation not defined for !NULL 26.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 26.");
 }
 BaseGDL* NullGDL::Log()              
 { 
-  throw GDLException("Operation not defined for !NULL 27a.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 27a.");
 }
 BaseGDL* NullGDL::LogThis()              
 { 
-  throw GDLException("Operation not defined for !NULL 27b.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 27b.");
 }
 BaseGDL* NullGDL::Log10()              
 { 
-  throw GDLException("Operation not defined for !NULL 27c.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 27c.");
 }
 BaseGDL* NullGDL::Log10This()              
 { 
-  throw GDLException("Operation not defined for !NULL 27d.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 27d.");
 }
 
 void NullGDL::AssignAtIx( RangeT ix, BaseGDL* srcIn)
 { 
-  throw GDLException("Operation not defined for !NULL 28.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 28.");
 }
 
 RangeT NullGDL::LoopIndex() const
@@ -745,60 +755,60 @@ DDouble NullGDL::HashValue() const
 
 BaseGDL* NullGDL::Rotate( DLong dir)
 { 
-  throw GDLException("Operation not defined for !NULL 30.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 30.");
 }
 
 void NullGDL::Reverse( DLong dim)
 { 
-  throw GDLException("Operation not defined for !NULL 31.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 31.");
 }
 
 BaseGDL* NullGDL::DupReverse( DLong dim)
 { 
-  throw GDLException("Operation not defined for !NULL 32.");
+  throw GDLException("Operation not defined for "+GetParString()+" - !NULL 32.");
 }
 
-  BaseGDL* NullGDL::AndOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 40.");}
-  BaseGDL* NullGDL::AndOpInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 41.");}
-  BaseGDL* NullGDL::OrOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 42.");}
-  BaseGDL* NullGDL::OrOpInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 43.");}
-  BaseGDL* NullGDL::XorOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 44.");}
-//   BaseGDL* NullGDL::EqOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 45.");}
-//   BaseGDL* NullGDL::NeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 46.");}
-//   BaseGDL* NullGDL::LeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 47.");}
-//   BaseGDL* NullGDL::GeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 48.");}
-//   BaseGDL* NullGDL::LtOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 49.");}
-//   BaseGDL* NullGDL::GtOpNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 50.");}
-  BaseGDL* NullGDL::AddNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 51.");}       // implemented
-  BaseGDL* NullGDL::AddInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 52.");}       // implemented
-  BaseGDL* NullGDL::SubNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 53.");}
-  BaseGDL* NullGDL::SubInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 54.");}
-  BaseGDL* NullGDL::LtMarkNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 55.");}
-  BaseGDL* NullGDL::GtMarkNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 56.");}
-  BaseGDL* NullGDL::MultNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 57.");}    // implemented
-  BaseGDL* NullGDL::DivNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 58.");}
-  BaseGDL* NullGDL::DivInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 59.");}
-  BaseGDL* NullGDL::ModNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 60.");}
-  BaseGDL* NullGDL::ModInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 61.");}
-  BaseGDL* NullGDL::PowNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 62.");}
-  BaseGDL* NullGDL::PowInvNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 63.");}
-  BaseGDL* NullGDL::PowIntNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 64.");}    // implemented
+  BaseGDL* NullGDL::AndOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 40.");}
+  BaseGDL* NullGDL::AndOpInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 41.");}
+  BaseGDL* NullGDL::OrOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 42.");}
+  BaseGDL* NullGDL::OrOpInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 43.");}
+  BaseGDL* NullGDL::XorOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 44.");}
+//   BaseGDL* NullGDL::EqOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 45.");}
+//   BaseGDL* NullGDL::NeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 46.");}
+//   BaseGDL* NullGDL::LeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 47.");}
+//   BaseGDL* NullGDL::GeOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 48.");}
+//   BaseGDL* NullGDL::LtOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 49.");}
+//   BaseGDL* NullGDL::GtOpNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 50.");}
+  BaseGDL* NullGDL::AddNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 51.");}       // implemented
+  BaseGDL* NullGDL::AddInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 52.");}       // implemented
+  BaseGDL* NullGDL::SubNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 53.");}
+  BaseGDL* NullGDL::SubInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 54.");}
+  BaseGDL* NullGDL::LtMarkNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 55.");}
+  BaseGDL* NullGDL::GtMarkNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 56.");}
+  BaseGDL* NullGDL::MultNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 57.");}    // implemented
+  BaseGDL* NullGDL::DivNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 58.");}
+  BaseGDL* NullGDL::DivInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 59.");}
+  BaseGDL* NullGDL::ModNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 60.");}
+  BaseGDL* NullGDL::ModInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 61.");}
+  BaseGDL* NullGDL::PowNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 62.");}
+  BaseGDL* NullGDL::PowInvNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 63.");}
+  BaseGDL* NullGDL::PowIntNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 64.");}    // implemented
 
-  BaseGDL* NullGDL::AndOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 65.");}
-  BaseGDL* NullGDL::AndOpInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 66.");}
-  BaseGDL* NullGDL::OrOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 67.");}
-  BaseGDL* NullGDL::OrOpInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 68.");}
-  BaseGDL* NullGDL::XorOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 69.");}
-  BaseGDL* NullGDL::AddSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 70.");}          // implemented
-  BaseGDL* NullGDL::AddInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 71.");}     // implemented
-  BaseGDL* NullGDL::SubSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 73.");}
-  BaseGDL* NullGDL::SubInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 74.");}
-  BaseGDL* NullGDL::LtMarkSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 75.");}
-  BaseGDL* NullGDL::GtMarkSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 76.");}
-  BaseGDL* NullGDL::MultSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 77.");}       // implemented
-  BaseGDL* NullGDL::DivSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 78.");}
-  BaseGDL* NullGDL::DivInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 79.");}
-  BaseGDL* NullGDL::ModSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 80.");}
-  BaseGDL* NullGDL::ModInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 81.");}
-  BaseGDL* NullGDL::PowSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 82.");}
-  BaseGDL* NullGDL::PowInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for !NULL 83.");}
+  BaseGDL* NullGDL::AndOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 65.");}
+  BaseGDL* NullGDL::AndOpInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 66.");}
+  BaseGDL* NullGDL::OrOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 67.");}
+  BaseGDL* NullGDL::OrOpInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 68.");}
+  BaseGDL* NullGDL::XorOpSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 69.");}
+  BaseGDL* NullGDL::AddSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 70.");}          // implemented
+  BaseGDL* NullGDL::AddInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 71.");}     // implemented
+  BaseGDL* NullGDL::SubSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 73.");}
+  BaseGDL* NullGDL::SubInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 74.");}
+  BaseGDL* NullGDL::LtMarkSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 75.");}
+  BaseGDL* NullGDL::GtMarkSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 76.");}
+  BaseGDL* NullGDL::MultSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 77.");}       // implemented
+  BaseGDL* NullGDL::DivSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 78.");}
+  BaseGDL* NullGDL::DivInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 79.");}
+  BaseGDL* NullGDL::ModSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 80.");}
+  BaseGDL* NullGDL::ModInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 81.");}
+  BaseGDL* NullGDL::PowSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 82.");}
+  BaseGDL* NullGDL::PowInvSNew( BaseGDL* r) { throw GDLException("Operation not defined for "+GetParString()+" - !NULL 83.");}

--- a/src/nullgdl.hpp
+++ b/src/nullgdl.hpp
@@ -30,7 +30,11 @@ class NullGDL: public BaseGDL
     NullGDL(): BaseGDL() {} 
 
     ~NullGDL(); // virtual due to base class -> can be called nevertheless (but this would be an error here)
-
+  
+    // as GetParString of EnvT but directly from BaseGDL if possible:
+    // get the name of 'i'th parameter
+    const std::string GetParString();
+  
   public:
 
     void* operator new( size_t bytes, char* cP)

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -366,7 +366,7 @@ namespace lib {
     int realcolorIx=colorIx;
     //eventually do not get color from standard "COLOR" keyword but from another...
     if (OtherColorKw != "") realcolorIx=e->KeywordIx (OtherColorKw);
-    if ( e->GetKW ( realcolorIx )!=NULL )
+    if ( e->GetDefinedKW ( realcolorIx )!=NULL )
     {
       colorVect=e->GetKWAs<DLongGDL>( realcolorIx ); //color can be vectorial, but...
       color=(*colorVect)[0]; //this function only sets color to 1st arg in list!
@@ -445,7 +445,7 @@ namespace lib {
       charsize=fcharsize;
     }
     static int charsizeIx=e->KeywordIx ( "CHARSIZE" );
-    if ( e->GetKW ( charsizeIx )!=NULL )
+    if ( e->GetDefinedKW ( charsizeIx )!=NULL )
     {
       DFloatGDL* charsizeVect=e->GetKWAs<DFloatGDL>( charsizeIx );
       charsize=(*charsizeVect)[0];
@@ -465,7 +465,7 @@ namespace lib {
               (pStruct->GetTag
                (pStruct->Desc()->TagIndex("CHARTHICK"), 0)))[0];
     static int charthickIx=e->KeywordIx ( "CHARTHICK" ); //Charthick values may be vector in GDL, not in IDL!
-    if ( e->GetKW ( charthickIx )!=NULL )
+    if ( e->GetDefinedKW ( charthickIx )!=NULL )
     {
       DFloatGDL* charthickVect=e->GetKWAs<DFloatGDL>( charthickIx );
       charthick=(*charthickVect)[0];
@@ -642,7 +642,7 @@ namespace lib {
         set=true;
       }
     }
-    BaseGDL* Range=e->GetKW(choosenIx);
+    BaseGDL* Range=e->GetDefinedKW(choosenIx);
     if ( Range!=NULL )
     {
       if ( Range->N_Elements()!=2 )
@@ -720,7 +720,7 @@ namespace lib {
       unsigned AxisTickformatTag=Struct->Desc()->TagIndex("TICKFORMAT");
       axisTickformatVect = static_cast<DStringGDL*>(Struct->GetTag(AxisTickformatTag,0));
     }
-    if ( e->GetKW ( choosenIx )!=NULL )
+    if ( e->GetDefinedKW ( choosenIx )!=NULL )
     {
       axisTickformatVect=e->GetKWAs<DStringGDL>( choosenIx );
     }
@@ -811,7 +811,7 @@ namespace lib {
       unsigned AxisTicknameTag=Struct->Desc()->TagIndex("TICKNAME");
       axisTicknameVect=static_cast<DStringGDL*>(Struct->GetTag(AxisTicknameTag,0));
     }
-    if ( e->GetKW ( choosenIx )!=NULL )
+    if ( e->GetDefinedKW ( choosenIx )!=NULL )
     {
       axisTicknameVect=e->GetKWAs<DStringGDL>( choosenIx );
       //translate format codes here:
@@ -868,7 +868,7 @@ namespace lib {
       unsigned AxisTickunitsTag=Struct->Desc()->TagIndex("TICKUNITS");
       axisTickunitsVect=static_cast<DStringGDL*>(Struct->GetTag(AxisTickunitsTag,0));
     }
-    if ( e->GetKW ( choosenIx )!=NULL )
+    if ( e->GetDefinedKW ( choosenIx )!=NULL )
     {
       axisTickunitsVect=e->GetKWAs<DStringGDL>( choosenIx );
     }
@@ -900,7 +900,7 @@ namespace lib {
       unsigned AxisTickunitsTag=Struct->Desc()->TagIndex("TICKUNITS");
       axisTickunitsVect=static_cast<DStringGDL*>(Struct->GetTag(AxisTickunitsTag,0));
     }
-    if ( e->GetKW ( choosenIx )!=NULL )
+    if ( e->GetDefinedKW ( choosenIx )!=NULL )
     {
       axisTickunitsVect=e->GetKWAs<DStringGDL>( choosenIx );
     }
@@ -922,7 +922,7 @@ namespace lib {
       axisTickvVect=static_cast<DDoubleGDL*>(Struct->GetTag(AxisTickvTag,0));
 
     }
-    if ( e->GetKW ( choosenIx )!=NULL )
+    if ( e->GetDefinedKW ( choosenIx )!=NULL )
     {
       axisTickvVect=e->GetKWAs<DDoubleGDL>( choosenIx );
     }
@@ -1096,7 +1096,7 @@ namespace lib {
     if ( pos==NULL )
     {
       static int positionIx=e->KeywordIx("POSITION");
-      if ( e->GetKW ( positionIx )!=NULL )
+      if ( e->GetDefinedKW ( positionIx )!=NULL )
       {
        pos=e->GetKWAs<DFloatGDL>(positionIx);
       }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3468,7 +3468,7 @@ void widget_control( EnvT* e ) {
       WidgetIDT id;
       gdlwxFrame* local_topFrame;
       bool reconnect = widget->DisableSizeEvents(local_topFrame, id);
-      if (id = widgetID) reconnect = false; //no need reconnec a destroyed widget...
+      if (id == widgetID) reconnect = false; //no need reconnec a destroyed widget...
       // call KILL_NOTIFY procedures
       widget->OnKill();
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3459,21 +3459,32 @@ void widget_control( EnvT* e ) {
   if ( xmanActCom ) {
     //       cout << "Set xmanager active command: " << widgetID << endl;
     widget->SetXmanagerActiveCommand( );
-  }
+    }
 
-  if ( destroy ) {
-    WidgetIDT id;
-    gdlwxFrame* local_topFrame;
-    bool reconnect = widget->DisableSizeEvents(local_topFrame, id);
-    if (widget->IsDraw()) {
-      GDLWidgetDraw* d=static_cast<GDLWidgetDraw*>(widget);
-      gdlwxGraphicsPanel* draw=static_cast<gdlwxGraphicsPanel*>(d->GetWxWidget());
-      draw->DeleteUsingWindowNumber(); //just emit quivalent to "wdelete,winNum".
-    } else 
-      delete widget;
-    if (reconnect) GDLWidget::EnableSizeEvents(local_topFrame,id);
-    return;
-  }
+  // This is the sole programmatic entry where a widget can be destroyed, apart 2 other special cases:
+  // - the destruction of a toplevel widget using a (trapped, managed) click on the close window.
+  // - the destruction of a widget induced by its parent destruction or a group leader.
+    if (destroy) { 
+      WidgetIDT id;
+      gdlwxFrame* local_topFrame;
+      bool reconnect = widget->DisableSizeEvents(local_topFrame, id);
+      if (id = widgetID) reconnect = false; //no need reconnec a destroyed widget...
+      // call KILL_NOTIFY procedures
+      widget->OnKill();
+
+      // widget may have been killed by above OnKill:
+      widget = GDLWidget::GetWidget(widgetID);
+      if (widget != NULL) {
+        if (widget->IsDraw()) {
+          GDLWidgetDraw* d = static_cast<GDLWidgetDraw*> (widget);
+          gdlwxGraphicsPanel* draw = static_cast<gdlwxGraphicsPanel*> (d->GetWxWidget());
+          draw->DeleteUsingWindowNumber(); //just emit quivalent to "wdelete,winNum".
+        } else delete widget;
+
+        if (reconnect) GDLWidget::EnableSizeEvents(local_topFrame, id);
+      }
+      return;
+    }
 
   if ( sensitiveControl) {
     if (e->KeywordSet(sensitiveControlIx)) widget->SetSensitive( true );

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -125,18 +125,19 @@ toto=["A","list","created","with","WIDGET_LIST","YSIZE=3"]
 print,toto[event.index] 
 end
 pro handle_Event,ev
-common mycount,count
-help,ev,/str
-if tag_names(ev, /structure_name) eq 'WIDGET_KILL_REQUEST' then begin
-   acceptance=dialog_message(dialog_parent=ev.id,"I Do want to close the window", /CANCEL, /DEFAULT_NO,/QUESTION) ; +strtrim(ev.id,2))
-   if acceptance eq "Yes" then begin
-      widget_control,ev.id,tlb_kill_request_events=0 ; remove blocking kill
-      widget_control,ev.id,/destroy
-   endif
-   
-endif
-
-widget_control,ev.id,get_uvalue=uv 
+  common mycount,count
+  help,ev,/str
+  if tag_names(ev, /structure_name) eq 'WIDGET_KILL_REQUEST' then begin
+     acceptance=dialog_message(dialog_parent=ev.id,"I Do want to close the window", /CANCEL, /DEFAULT_NO,/QUESTION) ; +strtrim(ev.id,2))
+     if acceptance eq "Yes" then begin
+        widget_control,ev.id,tlb_kill_request_events=0 ; remove blocking kill
+        widget_control,ev.id,/destroy
+        return
+     endif
+     
+  endif
+  
+  widget_control,ev.id,get_uvalue=uv 
   widget_control,ev.top,get_uvalue=topuv
   if n_elements(uv) gt 0 then begin
      if (strlen(tag_names(ev,/structure_name)) le 1) then begin


### PR DESCRIPTION
Using the cgzplot procedure issue as a start, unfold a serie of problems due to GDL not ignoring !NULL values when passed in Keywords (as it should). ---> Solved.
Next, as the internal KILL_NOTIFY handling in cgzplot caused a crash on a double delete, found the good way to handle this event.
Further, found places where a call to wxWidgets's Update() function was missing, giving seemingly unresponsive draw widgets. (This because we do not -- and cannot --- use wxWidget's eventloop in a 'normal' way)