### PR TITLE
various optimizations, huge changes, WIP

### DIFF
--- a/README.THREADPOOL
+++ b/README.THREADPOOL
@@ -39,9 +39,9 @@ Geeks corner:
 - some code like where() or interpolate() etc are not with this simple scheme as the section put in parallel is often very long. Usually, for any problem
   size, the speed is on par or better than IDL. Test reports welcome.
 
-- It is up to the user on mumti-core machines to adapt the values of !CPU (using the 'CPU' command) to get the most of the machine. Remember, one
-  can change the !CPU values at each line of code.
-
+- It is up to the user on multi-core machines to adapt the values of !CPU (using the 'CPU' command) to get the most of the machine. Remember, one
+  can change the !CPU values at each line of code, and ThreadPool friendly commands can even be called with one of the 3 keywords, TPOOL_NOTHREAD,
+  TPOOL_MAX_ELTS and TPOOL_MIN_ELTS
 - TRACE_OMP_CALLS (in src/typedefs.hpp) may be used to trace the calls to OpenMP sections.
 
  

--- a/README.THREADPOOL
+++ b/README.THREADPOOL
@@ -33,11 +33,12 @@ WHERE, REPLICATE_INPLACE, BYTEORDER , LOGICAL_OR , LOGICAL_AND , LOGICAL_TRUE
 
 Geeks corner:
 - setting the OpenMP machinery is time-consuming, and was working in defavour of GDL for small numbers. The solution (probably perfectible) has been
- to duplicate the code everywhere necessary in a 'if (!parallelize) { ... code ...} else { ... same code, with OMP #pragmas ... }' , with 'parallelize'
- given by the TPOOL rules. Apparently this solves most of the reported GDL sluggishness.
+ to duplicate the code everywhere necessary in a 'if (GDL_NTHREADS=parallelize( nEl)==1) { ... code ...} else { ... same code, with OMP #pragmas ... }' ,
+ where the global GDL_NTHREADS is returned by the function parallelize( nElements), the only one to decide, based on nElements and current setup of !CPU
+ how many (GDL_NTHREADS) threads must be used (if any). Apparently this solves most of the reported GDL sluggishness.
 
-- some code like where() or interpolate() etc are not with this simple scheme as the section put in parallel is often very long. Usually, for any problem
-  size, the speed is on par or better than IDL. Test reports welcome.
+- some code like where() or interpolate() etc are not exactly aligned  this simple scheme as the section put in parallel is often very long.
+  Usually, for any problem size, the speed is on par or better than IDL. Test reports welcome.
 
 - It is up to the user on multi-core machines to adapt the values of !CPU (using the 'CPU' command) to get the most of the machine. Remember, one
   can change the !CPU values at each line of code, and ThreadPool friendly commands can even be called with one of the 3 keywords, TPOOL_NOTHREAD,

--- a/README.THREADPOOL
+++ b/README.THREADPOOL
@@ -1,0 +1,47 @@
+GDL uses, if enabled, the OpenMP mechanism for parallelization of expensive computations.
+With a small number of exceptions, the routines using OpenMP are the same as for IDL (list below)
+The threaded version of the function or procedure is triggered by the size (N_ELEMENTS()) of the variable(s) involved, and the values of the members of the !CPU structure
+!CPU.TPOOOL_NTHREADS fixes the number of threads to use, (defaults to the number of threads of the machine or, if defined, the value of the env.var. OMP_NUM_THREADS)
+!CPU.TPOOOL_MIN_ELTS is the minimum number of elements that will trigger parallell processing. Default is 100000.
+!CPU.TPOOOL_MAX_ELTS limits the parallel processing to arrays of size inferior to this value. Defaults to 0, which means: no maximum value.
+
+At the moment, operations on objects and pointers are not using OpenMP. Please open an issue (with simple working example) if this seems necessary.
+
+The list of 'thread pool' operations, functions, routines, etc that use it is:
+
+Operators + , - , * , / , # , ##  ( unless Eigen:: is used, in which case we use Eigen::)
+Operators ++ , -- , ^ , < , > , AND , OR , MOD , EQ , NE , LE, LT , GE, GT
+
+This goes also for self-operators: and= , *= , eq= , ge= , >= , gt= , le= , <= , lt= , #= , ##= , -= , mod= , ne= , or= , += , ^= , /= , xor=
+
+Math functions etc:
+-------------------
+
+ABS , ACOS , ALOG , ALOG2 , ALOG10 , ASIN , ATAN , CEIL , CONJ , COS , COSH,
+ERF , ERFC , ERFCX , EXP , EXPINT , FINITE , FLOOR , GAMMA , GAUSSINT ,
+IMAGINARY , ISHFT , LNGAMMA , MATRIX_MULTIPLY , MAX, MIN, PRODUCT , ROUND ,SIN ,
+SINH , SQRT , TAN , TANH , TOTAL, VOIGT
+
+BYTSCL , CONVOL , FFT , INTERPOLATE , POLY_2D , TVSCL
+
+INDGEN  and all indexed creators ( CINDGEN etc..),  REPLICATE .
+
+BYTE and all other data conversion routines (FIX, ULONG..)
+
+WHERE, REPLICATE_INPLACE, BYTEORDER , LOGICAL_OR , LOGICAL_AND , LOGICAL_TRUE
+
+
+Geeks corner:
+- setting the OpenMP machinery is time-consuming, and was working in defavour of GDL for small numbers. The solution (probably perfectible) has been
+ to duplicate the code everywhere necessary in a 'if (!parallelize) { ... code ...} else { ... same code, with OMP #pragmas ... }' , with 'parallelize'
+ given by the TPOOL rules. Apparently this solves most of the reported GDL sluggishness.
+
+- some code like where() or interpolate() etc are not with this simple scheme as the section put in parallel is often very long. Usually, for any problem
+  size, the speed is on par or better than IDL. Test reports welcome.
+
+- It is up to the user on mumti-core machines to adapt the values of !CPU (using the 'CPU' command) to get the most of the machine. Remember, one
+  can change the !CPU values at each line of code.
+
+- TRACE_OMP_CALLS (in src/typedefs.hpp) may be used to trace the calls to OpenMP sections.
+
+ 

--- a/resource/randomgenerators_parallel.cpp
+++ b/resource/randomgenerators_parallel.cpp
@@ -61,22 +61,27 @@ namespace lib {
 #include "dSFMT/dSFMT.h"
 #include "dSFMT/dSFMT-params.h"
 #include "dSFMT/dSFMT-common.h"
+//for jumps and parallelism
+#include "dSFMT/dSFMT-jump.h"
+#include "dSFMT/dSFMT-poly.h"
 
 #define GSL_M_E  2.7182818284590452354 /* e */
 
- //RANDOM numbers are not thread-pool commands. This version does not parallelize calculations, and does not use dSFMT_jump.
-
-  // our own struct to keep up things related to parallel seeds.
-  // this one is when this file is used: r is just of one dsfmt_t struture,
-  // since this version does not used parallel threads. The version in
-  // 'randomgenerators_parallel.cpp' keeps the same stucture, but there r is a vector
-  // of seeds, each one with its own copy of the seed,
-  // displaced by 2^128 in the 'future' by the magic of the dSFMT_jump
-  // such as to contain all 128-bit internal state arrays, one per thread.
+  //our own struct to keep up things related to parallel seeds
+  //it will contain all 128-bit internal state arrays, one per thread.
+  //as the number of threads is not known, it will be initialized at start.
   struct DSFMT_STATE {
     dsfmt_t **r; 
  };
  typedef struct DSFMT_STATE dsfmt_state;
+ 
+ //RANDOM numbers are not thread-pool commands. We take the opportunity to use the same mechanism because dsfmt can be parallelized thanks to
+ // 'loooooong jump' in the quasi infinite serie of random numbers rendered possible by dSFMT_jump.
+ // the random seed sequence is initialized to a max of maxNumberOfThreadsForDSFMT() which is capped to a reasonable (8 procs) value.
+ // However, contrary to the use of !CPU.TPOOLxxx that just switch from 'all parallel' to 'no parallel', we need to optimize by using
+ // reasonably sized parallel chunks. I suggest to use CpuTPOOL_MIN_ELTS as the minimum size for a chunk, and 
+#define DEFINE_NCHUNK_FOR_dSFMT  int dsfmt_nthreads = (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) ? maxNumberOfThreadsForDSFMT() : 1;
+ 
 
 // This function could prove to be way faster than the function below, provided the parallelization insures
 // an alignment on _align16 , i.e., 2 doubles = 128 bits = address%16==0
@@ -95,13 +100,48 @@ namespace lib {
   
   int random_uniform(double* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i=0; i<nEl; ++i) res[i] = dsfmt_genrand_close_open(state.r[0]);
+    //no difficulty as we do not use aligned functions here.
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads-1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i=start_index; i<stop_index; ++i) res[i] = dsfmt_genrand_close_open(state.r[thread_id]);
+    }
     return 0;
   }
 
   int random_uniform(float* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i=0; i<nEl; ++i) res[i] = (float) dsfmt_genrand_close_open(state.r[0]);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads-1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i=start_index; i<stop_index; ++i) res[i] = (float) dsfmt_genrand_close_open(state.r[thread_id]);
+    }
     return 0;
   }
 
@@ -171,13 +211,45 @@ namespace lib {
 
   int random_normal(double* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i=0; i<nEl; ++i) res[i] = dsfmt_gauss(state.r[0],1.0);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads-1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i=start_index; i<stop_index; ++i) res[i] = dsfmt_gauss(state.r[thread_id],1.0);
+    }
     return 0;
   }
   
   int random_normal( float* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i=0; i<nEl; ++i) res[i] = (float) dsfmt_gauss(state.r[0],1.0);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads-1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i=start_index; i<stop_index; ++i) res[i] = (float) dsfmt_gauss(state.r[thread_id],1.0);
+    }
     return 0;
   }
  
@@ -404,13 +476,45 @@ namespace lib {
 
   int random_gamma(double* res, dsfmt_state state, SizeT nEl, DLong n)
   {
-    for (SizeT i = 0; i < nEl; ++i) res[i] = dsfmt_ran_gamma_knuth(state.r[0], 1.0 * n, 1.0);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = dsfmt_ran_gamma_knuth(state.r[thread_id], 1.0 * n, 1.0);
+    }
     return 0;
   }
 
   int random_gamma(float* res, dsfmt_state state, SizeT nEl, DLong n)
   {
-    for (SizeT i = 0; i < nEl; ++i) res[i] = (float) dsfmt_ran_gamma_knuth(state.r[0], 1.0 * n, 1.0);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = (float) dsfmt_ran_gamma_knuth(state.r[thread_id], 1.0 * n, 1.0);
+    }
     return 0;
   }
   
@@ -419,7 +523,23 @@ namespace lib {
     //Note: Binomial values are not same IDL.    
     DULong n = (DULong) (*binomialKey)[0];
     DDouble p = (DDouble) (*binomialKey)[1];
-    for (SizeT i = 0; i < nEl; ++i) res[i] = dsfmt_ran_binomial_knuth(state.r[0], p, n);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = dsfmt_ran_binomial_knuth(state.r[thread_id], p, n);
+    }
     return 0;    
   }
   
@@ -428,33 +548,113 @@ namespace lib {
     //Note: Binomial values are not same IDL.    
     DULong n = (DULong) (*binomialKey)[0];
     DDouble p = (DDouble) (*binomialKey)[1];
-    for (SizeT i = 0; i < nEl; ++i) res[i] = (float) dsfmt_ran_binomial_knuth(state.r[0], p, n);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = (float) dsfmt_ran_binomial_knuth(state.r[thread_id], p, n);
+    }
     return 0;    
   }
   
   int random_poisson(double* res, dsfmt_state state, SizeT nEl, DDoubleGDL* poissonKey)
   {
     DDouble mu = (DDouble) (*poissonKey)[0];
-    for (SizeT i = 0; i < nEl; ++i) res[i] = dsfmt_ran_poisson(state.r[0], mu);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = dsfmt_ran_poisson(state.r[thread_id], mu);
+    }
     return 0;
   }
 
   int random_poisson(float* res, dsfmt_state state, SizeT nEl, DDoubleGDL* poissonKey)
   {
     DDouble mu = (DDouble) (*poissonKey)[0];
-    for (SizeT i = 0; i < nEl; ++i) res[i] = (float) dsfmt_ran_poisson(state.r[0], mu);
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads-1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i=start_index; i<stop_index; ++i) res[i] = (float) dsfmt_ran_poisson(state.r[thread_id], mu);
+    }
     return 0;
   }
 
   int random_dlong(DLong* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i = 0; i < nEl; ++i) res[i] = dsfmt_genrand_int31(state.r[0]); //int31 as in [0..2^31-1] 
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = dsfmt_genrand_int31(state.r[thread_id]); //int31 as in [0..2^31-1] 
+    }
     return 0;
   }
 
   int random_dulong(DULong* res, dsfmt_state state, SizeT nEl)
   {
-    for (SizeT i = 0; i < nEl; ++i) res[i] = dsfmt_genrand_uint32(state.r[0]); //int31 as in [0..2^31-1] 
+    DEFINE_NCHUNK_FOR_dSFMT
+    SizeT dsfmt_chunksize = nEl / dsfmt_nthreads;
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(dsfmt_nthreads) if (dsfmt_nthreads > 1)
+    {
+      int thread_id = currentThreadNumber();
+      SizeT start_index, stop_index;
+      start_index = thread_id * dsfmt_chunksize;
+      if (thread_id != dsfmt_nthreads - 1) //robust wrt. use of threads or not.
+      {
+        stop_index = start_index + dsfmt_chunksize;
+      } else {
+        stop_index = nEl;
+      }
+      SizeT i;
+      for (i = start_index; i < stop_index; ++i) res[i] = dsfmt_genrand_uint32(state.r[thread_id]); //int31 as in [0..2^31-1] 
+    }
     return 0;
   }  
   
@@ -465,17 +665,18 @@ namespace lib {
     dsfmt_mem->idx = pos;
   }
 
-  //same as parallel version, but just with 1 thread
   void get_random_state(EnvT* e, dsfmt_state state, const DULong seed)
   {
     if (e->GlobalPar(0)) {
-      DULong64GDL* ret = new DULong64GDL(dimension(1+(DSFMT_N64+1)*1), BaseGDL::NOZERO);
+      DULong64GDL* ret = new DULong64GDL(dimension(1+(DSFMT_N64+1)*maxNumberOfThreadsForDSFMT()), BaseGDL::NOZERO);
       DULong64* newstate = (DULong64*) (ret->DataAddr());
       long k=0;
       newstate[k++] = seed;
-      newstate[k++] = state.r[0]->idx;
-      uint64_t *psfmt64 = &(state.r[0]->status[0].u[0]);
-      for (int j = 0; j < DSFMT_N64; ++j) newstate[k++] = psfmt64[j];
+      for (int ithread=0; ithread < maxNumberOfThreadsForDSFMT() ; ++ithread) {
+        newstate[k++] = state.r[ithread]->idx;
+        uint64_t *psfmt64 = &(state.r[ithread]->status[0].u[0]);
+        for (int j = 0; j < DSFMT_N64; ++j) newstate[k++] = psfmt64[j];
+      }
       e->SetPar(0, ret);
     }
   }
@@ -485,23 +686,43 @@ namespace lib {
   // This is already two to four times faster than IDL.
   // Use of dSFMT depends on the presence of switches (--no-dSFMT), environment variable (GDL_USE_DSFMT)
   // and if Eigen:: is used (because Eigen:: aligns correctly wrt. the requirements of dSFMT)
+
+  // We moreover definitely speed up random number generation for a very large number of
+  // values by parallelizing the code. This is possible within dSFMT, provided one use the dsfmt-jump() function 
+  // written by the authors above. It permits to "jump" the seed to a new state as if 2^{128} 
+  // random numbers had been generated in the meantime. (This in a random series with a period of 2^19937 !).
+  // Note: 2^128 is already way larger than the number of particles in the Universe.
+  // The implementation creates maxNumberOfThreadsForDSFMT() seed states, separated by a 2^{128} state jump,
+  // and may run up to maxNumberOfThreadsForDSFMT() threads in parallell, each continuing with its own seed.
+  // maxNumberOfThreadsForDSFMT() is capped to 8 threads, you do not normally want to see GDL 
+  // intializing 256 seed states on a 256 thread machine.
   
   // The price to pay is that **the produced random numbers are not the same as IDL**.
   // To get values comparable with IDL, but slowly, use the /RAN1 switch (1) (or do not enable dSFMT).  
   // Moreover, the seed arrays are different. Switching from one to another is *NOT* possible as the
-  // types and seed lengths are different. Besides, our dSFMT seed is larger than the IDL one (not a big deal!).
+  // types and seed lengths are different. Besides, our dSFMT seed is, because of the use of parallel threads
+  // to speed up the random generator, approx maxNumberOfThreadsForDSFMT() larger than the IDL one (not a big deal!).
   
   // (1) Why /RAN1? Because this option is present in IDL, and, instead of throwing an error on it,
   // we use it also as a compatibility switch. But in our case the compatibility is with IDL8+
   // results, not with IDL6.
   
+#include "dSFMT/dSFMT-jump.c"
+
  //this initializes parallel states up to min of max_allowed_threads and omp_max_threads.
  //independently of the fact that only a subset of theses thtreads will be used in loops.
  void init_seeds(dsfmt_state state, DULong seed) {
    //populate with seed template state 'temp'
    dsfmt_t temp;   
    dsfmt_init_gen_rand(&temp, seed);
-   memcpy((void*)(state.r[0]),(void*)&temp,sizeof(temp)); //first and only state.
+   //sucessively push by 2^128 and copy to next place
+   //Note: we use the maximum number of threads allowed as this seed can be replayed
+   //after changing the number of threads to be used.
+   memcpy((void*)(state.r[0]),(void*)&temp,sizeof(temp));
+   for (int i=1; i<maxNumberOfThreadsForDSFMT(); ++i) {
+     dSFMT_jump(&temp, poly_128);
+     memcpy((void*)(state.r[i]),(void*)&temp,sizeof(temp));
+   }
  }
   
   BaseGDL* random_fun_dsfmt(EnvT* e)
@@ -530,10 +751,10 @@ namespace lib {
     if (exclusiveKW > 1) e->Throw("Conflicting keywords.");
     
     static dsfmt_state dsfmt_mem;
-    //initialize only once, and for 1 state (this unparallel version)
+    //initialize only once!
     if (dsfmt_mem.r==NULL) {
-      dsfmt_mem.r=(dsfmt_t**)malloc(sizeof(dsfmt_t*));
-      dsfmt_mem.r[0]=(dsfmt_t*)malloc(sizeof(dsfmt_t));
+      dsfmt_mem.r=(dsfmt_t**)malloc(maxNumberOfThreadsForDSFMT()*sizeof(dsfmt_t*));
+      {for (int i=0; i< maxNumberOfThreadsForDSFMT() ; ++i) dsfmt_mem.r[i]=(dsfmt_t*)malloc(sizeof(dsfmt_t));}
     }
 
     SizeT nParam = e->NParam(1);
@@ -553,13 +774,15 @@ namespace lib {
       // plus the memory of the initial seed value.
       if (p0->Type() == GDL_ULONG64) { //good chances we have here a genuine dSFMT seed!
         DULong64GDL* p0L = e->IfDefGetParAs< DULong64GDL>(0);
-        if (p0L->N_Elements() == 1 + (DSFMT_N64 + 1) *1 ) {
+        if (p0L->N_Elements() == 1 + (DSFMT_N64 + 1) * maxNumberOfThreadsForDSFMT()) {
           long k = 0;
-          seed = (*p0L)[k++]; //hopefully it is always compatible with an unisgned int32 as result of a saved previous seed.
-          int pos = (*p0L)[k++];
-          DULong64 sequence[DSFMT_N64];
-          for (int i = 0; i < DSFMT_N64; ++i) sequence[i] = (*p0L)[k++];
-          set_random_state(dsfmt_mem.r[0], sequence, pos); //initialize each thread seed 
+          seed = (*p0L)[k++]; //hopefully it is always compatible with an unisgned int32 as reslut of a saved previous seed.
+          for (int ithread = 0; ithread < maxNumberOfThreadsForDSFMT(); ++ithread) {
+            int pos = (*p0L)[k++];
+            DULong64 sequence[DSFMT_N64];
+            for (int i = 0; i < DSFMT_N64; ++i) sequence[i] = (*p0L)[k++];
+            set_random_state(dsfmt_mem.r[ithread], sequence, pos); //initialize each thread seed 
+          }
           initialized=true;
         } else { // not a seed sequence: take first value as 32 bit UNsigned integer (for dSFMT compatibility).
           DULongGDL* p02L = e->IfDefGetParAs< DULongGDL>(0);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ exists_fun.cpp
 fftw.cpp
 file.cpp
 fmtnode.cpp
+gdlarray.cpp
 gdleventhandler.cpp
 gdlexception.cpp
 gdlgstream.cpp

--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -837,3 +837,4 @@ void GDLDelete( BaseGDL* toDelete)
     delete toDelete;
 }
 
+bool parallelize(SizeT n, int modifier) { return (CpuTPOOL_NTHREADS > 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));}

--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -836,5 +836,14 @@ void GDLDelete( BaseGDL* toDelete)
   if( toDelete != NullGDL::GetSingleInstance())
     delete toDelete;
 }
+int GDL_NTHREADS;
 
-bool parallelize(SizeT n, int modifier) { return (CpuTPOOL_NTHREADS > 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));}
+int parallelize(SizeT n, int modifier) {
+  switch(modifier)
+  {
+  case TP_DEFAULT:
+    return (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))?CpuTPOOL_NTHREADS:1;
+  default:
+    return (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))?2:1;
+  }    
+}

--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -839,11 +839,15 @@ void GDLDelete( BaseGDL* toDelete)
 int GDL_NTHREADS;
 
 int parallelize(SizeT n, int modifier) {
+//below, please modify if you find a way to persuade behaviour of those different cases to be better if they return different number of threads.
   switch(modifier)
   {
-  case TP_DEFAULT:
+  case TP_DEFAULT: //the same as IDL, reserved for routines that use the thread pool, ideally check the special thread pool keywords.
+  case TP_ARRAY_INITIALISATION: // used by GDL array initialisation (new, convert, gdlarray): probably needs som special tuning
+  case TP_MEMORY_ACCESS: // concurrent memory access, probably needs to be capped to preserve bandwidth 
+  case TP_CPU_INTENSIVE:  // benefit from max number of threads
     return (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))?CpuTPOOL_NTHREADS:1;
   default:
-    return (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))?2:1;
+    return 1;
   }    
 }

--- a/src/basegdl.hpp
+++ b/src/basegdl.hpp
@@ -775,7 +775,8 @@ enum ThreadPoolType {
     TP_CPU_INTENSIVE  // benefit from max number of threads
   };
 
-bool parallelize(SizeT n, int modifier=TP_DEFAULT);
+extern  int GDL_NTHREADS;
+int parallelize(SizeT n, int modifier=TP_DEFAULT);
 
 #endif
 

--- a/src/basegdl.hpp
+++ b/src/basegdl.hpp
@@ -767,6 +767,15 @@ struct ForLoopInfoT
 // before NullGDL instance must not be deleted, now this is fine (overloaded operators new and delete)
 // inline void GDLDelete( BaseGDL* toDelete) { delete toDelete;}
 void GDLDelete( BaseGDL* toDelete);
+ 
+enum ThreadPoolType {
+    TP_DEFAULT=0, //the same as IDL, reserved for routines that use the thread pool, ideally check the special thread pool keywords.
+    TP_ARRAY_INITIALISATION, // used by GDL array initialisation (new, convert, gdlarray): probably needs som special tuning
+    TP_MEMORY_ACCESS, // concurrent memory access, probably needs to be capped to preserve bandwidth 
+    TP_CPU_INTENSIVE  // benefit from max number of threads
+  };
+
+bool parallelize(SizeT n, int modifier=TP_DEFAULT);
 
 #endif
 

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1926,9 +1926,7 @@ namespace lib {
   }
 
   BaseGDL* replicate(EnvT* e) {
-    SizeT nParam = e->NParam();
-    if (nParam < 2)
-      e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(2);
     dimension dim;
     arr(e, dim, 1);
 
@@ -6754,6 +6752,8 @@ namespace lib {
   }
 
   BaseGDL* ishft_fun(EnvT* e) {
+    SizeT nParam=e->NParam(2);
+    
     Guard<BaseGDL>guard;
 
     BaseGDL* in = (e->GetParDefined(0));
@@ -7110,6 +7110,7 @@ namespace lib {
   }
 
   BaseGDL* obj_isa(EnvT* e) {
+    e->NParam(2);
     DString className;
     e->AssureScalarPar<DStringGDL>(1, className);
     className = StrUpCase(className);

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1221,7 +1221,7 @@ namespace lib {
     if (re->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
       if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       } else {
@@ -1233,7 +1233,7 @@ namespace lib {
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
       if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else {
@@ -1245,7 +1245,7 @@ namespace lib {
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
       if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
@@ -1257,7 +1257,7 @@ namespace lib {
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
       if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
@@ -1994,7 +1994,7 @@ namespace lib {
 
     SizeT nEl = res->N_Elements();
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (mode == 2) // both
     {
       if (!parallelize) {
@@ -2036,7 +2036,7 @@ namespace lib {
     DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
@@ -2081,7 +2081,7 @@ namespace lib {
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
@@ -2159,7 +2159,7 @@ namespace lib {
       }
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr ) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr ) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nSrcStr)));
     if (!parallelize) {
       for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
@@ -2206,7 +2206,7 @@ namespace lib {
     }
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
@@ -2246,7 +2246,7 @@ namespace lib {
     }
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
@@ -2407,7 +2407,7 @@ namespace lib {
   BaseGDL* total_template_generic(T* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
     typename T::Ty sum = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
@@ -2437,7 +2437,7 @@ namespace lib {
     SizeT nEl = src->N_Elements();
     DFloat sr = 0;
     DFloat si = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!omitNaN) {
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) {
@@ -2485,7 +2485,7 @@ namespace lib {
     SizeT nEl = src->N_Elements();
     DDouble sr = 0;
     DDouble si = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!omitNaN) {
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) {
@@ -2533,7 +2533,7 @@ namespace lib {
   DDoubleGDL* total_template_double(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_double "<<std::endl;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     DDouble sum = 0;
     if (!parallelize) {
       if (!omitNaN) {
@@ -2566,7 +2566,7 @@ namespace lib {
   DFloatGDL* total_template_single(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_single "<<std::endl;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     DDouble sum = 0;
     if (!parallelize) {
       if (!omitNaN) {
@@ -2602,7 +2602,7 @@ namespace lib {
     //   std::cerr<<" total_template_integer "<<std::endl;
     SizeT nEl = src->N_Elements();
     DLong64 sum = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
@@ -2612,26 +2612,6 @@ namespace lib {
     }
     return new DLong64GDL(sum);
   }
-
-  // cumulative over all dims
-
-  //  template<typename T>
-  //  BaseGDL* total_cu_template(T* res, bool omitNaN)
-  //  {
-  //    SizeT nEl = res->N_Elements();
-  //    if (omitNaN) {
-  //      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  //      {
-  //        // #pragma omp for
-  //        for (SizeT i = 0; i < nEl; ++i)
-  //          NaN2Zero((*res)[i]);
-  //      }
-  //    }
-  //    for (SizeT i = 1, ii = 0; i < nEl; ++i, ++ii)
-  //      (*res)[i] += (*res)[ii];
-  //    return res;
-  //  }
-  //this is twice faster than above version, probably by exposing the POD (T1::Ty) to the loop to be optimized by the compiler
 
   template<typename T1, typename T2>
   BaseGDL* total_cu_template(T1* val, bool omitNaN) {
@@ -2665,7 +2645,7 @@ namespace lib {
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * sumStride)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * sumStride)));
     if (!parallelize) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -3320,7 +3300,7 @@ namespace lib {
   BaseGDL* product_template(T* src, bool omitNaN) {
     typename T::Ty prod = 1;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       if (!omitNaN) {
         for (OMPInt i = 0; i < nEl; ++i) {
@@ -3423,7 +3403,7 @@ namespace lib {
     SizeT prodStride = srcDim.Stride(prodDimIx);
     SizeT outerStride = srcDim.Stride(prodDimIx + 1);
     SizeT prodLimit = nProd * prodStride;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * prodStride)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * prodStride)));
     if (!parallelize) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -5414,7 +5394,7 @@ namespace lib {
 
   template <typename Ty> static inline Ty do_mean(const Ty* data, const SizeT sz) {
     Ty mean = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
@@ -5428,7 +5408,7 @@ namespace lib {
   template <typename Ty, typename T2> static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
       for (SizeT i = 0; i < sz; ++i) meani += data[i].imag();
@@ -5449,7 +5429,7 @@ namespace lib {
   template <typename Ty> static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
     Ty mean = 0;
     SizeT n = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty v = data[i];
@@ -5481,7 +5461,7 @@ namespace lib {
     T2 meani = 0;
     SizeT nr = 0;
     SizeT ni = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].real();
@@ -5678,7 +5658,7 @@ namespace lib {
 
     Ty var = 0;
     Ty md = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
@@ -5754,7 +5734,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
@@ -5885,7 +5865,7 @@ namespace lib {
     Ty var = 0;
     Ty md = 0;
     SizeT k = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
@@ -5971,7 +5951,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
@@ -6184,7 +6164,7 @@ namespace lib {
       // resize destDim
       destDim.Remove(momentDim); //will be one dimension less
       SizeT nEl = destDim.NDimElementsConst(); //need to compute that here, before adding last dim.
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       auxiliaryDim = destDim;
 
       destDim << 4; //add 4 as last dim
@@ -6647,7 +6627,7 @@ namespace lib {
   }
 
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-    bool parallelize = ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n));
+    bool parallelize = ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
     if (!parallelize) {
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
@@ -7250,7 +7230,7 @@ namespace lib {
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-    bool parallelize = (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       if (IntType(p0->Type())) {
         //Is a thread pool function

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1,28 +1,28 @@
- /***************************************************************************
-                          basic_fun.cpp  -  basic GDL library function
-                             -------------------
-    begin                : July 22 2002
-    copyright            : (C) 2002 by Marc Schellens (exceptions see below)
-    email                : m_schellens@users.sf.net
+/***************************************************************************
+                         basic_fun.cpp  -  basic GDL library function
+                            -------------------
+   begin                : July 22 2002
+   copyright            : (C) 2002 by Marc Schellens (exceptions see below)
+   email                : m_schellens@users.sf.net
 
- strtok_fun, getenv_fun, tag_names_fun, stregex_fun:
- (C) 2004 by Peter Messmer    
- 
- 20150506 Jacco A. de Zwart, National Institutes of Health, Bethesda, MD, USA
-     Changed behavior of COMPLEX() and DCOMPLEX() called with three arguments,
-     aka where type casting is the expected behavoir. 
+strtok_fun, getenv_fun, tag_names_fun, stregex_fun:
+(C) 2004 by Peter Messmer
 
- 2017 September
-   Greg Jung mods to unbug pointer, object treatments. Also:
-     Updated with new Where(), cosmetics
-     #ifndef _WIN32 replaces #if !defined(_WIN32) || defined(__CYGWIN__)
-     Mods to array_equal() and array_never_equal (new)
-     routine_filepath moved to here.
-     command_line_args uses strings instead of char*
+20150506 Jacco A. de Zwart, National Institutes of Health, Bethesda, MD, USA
+    Changed behavior of COMPLEX() and DCOMPLEX() called with three arguments,
+    aka where type casting is the expected behavoir.
 
- 2017 July gilles-duvert  New version of Where() twice as fast as previous
-***************************************************************************/
-      // AC 2018-feb 
+2017 September
+  Greg Jung mods to unbug pointer, object treatments. Also:
+    Updated with new Where(), cosmetics
+    #ifndef _WIN32 replaces #if !defined(_WIN32) || defined(__CYGWIN__)
+    Mods to array_equal() and array_never_equal (new)
+    routine_filepath moved to here.
+    command_line_args uses strings instead of char*
+
+2017 July gilles-duvert  New version of Where() twice as fast as previous
+ ***************************************************************************/
+// AC 2018-feb
 
 /***************************************************************************
  *                                                                         *
@@ -36,7 +36,7 @@
 #include "includefirst.hpp"
 
 #ifndef _WIN32
-#include <unistd.h> 
+#include <unistd.h>
 #endif
 
 // used to defined GDL_TMPDIR: may have trouble on MSwin, help welcome
@@ -51,8 +51,8 @@
 #include <regex.h> // stregex
 
 #ifdef __APPLE__
-# include <crt_externs.h>
-# define environ (*_NSGetEnviron())
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
 #endif
 
 #if defined(__FreeBSD__) || defined(__sun__) || defined(__OpenBSD__)
@@ -72,7 +72,7 @@ extern "C" char **environ;
 
 
 #ifdef HAVE_LOCALE_H
-# include <locale.h>
+#include <locale.h>
 #endif
 
 /* max regexp error message length */
@@ -85,17 +85,16 @@ extern "C" char **environ;
 #define round(f) floor(f+0.5)
 #endif
 #define std::isfinite(x) std::isfinite((double) x)
-int strncasecmp(const char *s1, const char *s2, size_t n)
-{
+
+int strncasecmp(const char *s1, const char *s2, size_t n) {
   if (n == 0)
     return 0;
-  while (n-- != 0 && tolower(*s1) == tolower(*s2))
-    {
-      if (n == 0 || *s1 == '\0' || *s2 == '\0')
-    break;
-      s1++;
-      s2++;
-    }
+  while (n-- != 0 && tolower(*s1) == tolower(*s2)) {
+    if (n == 0 || *s1 == '\0' || *s2 == '\0')
+      break;
+    s1++;
+    s2++;
+  }
 
   return tolower(*(unsigned char *) s1) - tolower(*(unsigned char *) s2);
 }
@@ -104,33 +103,31 @@ int strncasecmp(const char *s1, const char *s2, size_t n)
 #ifndef _WIN32
 #include <sys/utsname.h>
 #endif
-static DStructGDL* GetObjStruct( BaseGDL* Objptr, EnvT* e)
-  {
-    if( Objptr == 0 || Objptr->Type() != GDL_OBJ)
-      e->Throw( "Objptr not of type OBJECT. Please report.");
-    if( !Objptr->Scalar())
-      e->Throw(  "Objptr must be a scalar. Please report.");
-    DObjGDL* Object = static_cast<DObjGDL*>( Objptr);
-    DObj ID = (*Object)[0];
-    try {
-      return BaseGDL::interpreter->GetObjHeap( ID);
-    }
-    catch( GDLInterpreter::HeapException& hEx)
-    {
-      e->Throw(  "Object ID <"+i2s(ID)+"> not found.");      
-    }
-    assert(false);
-    return NULL;
+
+static DStructGDL* GetObjStruct(BaseGDL* Objptr, EnvT* e) {
+  if (Objptr == 0 || Objptr->Type() != GDL_OBJ)
+    e->Throw("Objptr not of type OBJECT. Please report.");
+  if (!Objptr->Scalar())
+    e->Throw("Objptr must be a scalar. Please report.");
+  DObjGDL* Object = static_cast<DObjGDL*> (Objptr);
+  DObj ID = (*Object)[0];
+  try {
+    return BaseGDL::interpreter->GetObjHeap(ID);
+  } catch (GDLInterpreter::HeapException& hEx) {
+    e->Throw("Object ID <" + i2s(ID) + "> not found.");
   }
+  assert(false);
+  return NULL;
+}
 
 static bool trace_me(false);
 
 namespace lib {
   bool trace_arg();
   bool gdlarg_present(const char* s);
-  SizeT HASH_count( DStructGDL* oStructGDL);
-  SizeT LIST_count( DStructGDL* oStructGDL);
-  
+  SizeT HASH_count(DStructGDL* oStructGDL);
+  SizeT LIST_count(DStructGDL* oStructGDL);
+
   // for use in COMMAND_LINE_ARGS()
   std::vector<std::string> command_line_args;
 
@@ -141,104 +138,102 @@ namespace lib {
   using namespace antlr;
 
   DULong SHA256Constants[] = {
-    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
-    ,0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
-    ,0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
-    ,0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
-    ,0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
-    ,0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070
-    ,0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
-    ,0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2};
- 
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5
+    , 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174
+    , 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da
+    , 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967
+    , 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85
+    , 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070
+    , 0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3
+    , 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+  };
+
   DULong SHAH0[] = {
     0x6a09e667 // H0_0
-    ,0xbb67ae85
-    ,0x3c6ef372
-    ,0xa54ff53a
-    ,0x510e527f
-    ,0x9b05688c
-    ,0x1f83d9ab
-    ,0x5be0cd19 // H0_7
+    , 0xbb67ae85
+    , 0x3c6ef372
+    , 0xa54ff53a
+    , 0x510e527f
+    , 0x9b05688c
+    , 0x1f83d9ab
+    , 0x5be0cd19 // H0_7
   };
 
 
 
   // assumes all parameters from pOffs till end are dim
-  void arr( EnvT* e, dimension& dim, SizeT pOffs=0)
-  {
 
-    int nParam=e->NParam()-pOffs;
+  void arr(EnvT* e, dimension& dim, SizeT pOffs = 0) {
 
-    if( nParam <= 0)
-      e->Throw( "Incorrect number of arguments.");
+    int nParam = e->NParam() - pOffs;
 
-    const string BadDims="Array dimensions must be greater than 0.";
+    if (nParam <= 0)
+      e->Throw("Incorrect number of arguments.");
+
+    const string BadDims = "Array dimensions must be greater than 0.";
 
 
-    if( nParam == 1 ) {
+    if (nParam == 1) {
 
-      BaseGDL* par = e->GetParDefined( pOffs); 
-    
+      BaseGDL* par = e->GetParDefined(pOffs);
+
       SizeT newDim;
-      int ret = par->Scalar2Index( newDim);
+      int ret = par->Scalar2Index(newDim);
 
       if (ret < 0) throw GDLException(BadDims);
 
-      if( ret > 0) {  // single argument
-    if (newDim < 1) throw GDLException(BadDims);
-    dim << newDim;
-    return;
-      } 
-      if( ret == 0) { //  array argument
-    DLongGDL* ind = 
-      static_cast<DLongGDL*>(par->Convert2(GDL_LONG, BaseGDL::COPY));    
-    Guard<DLongGDL> ind_guard( ind);
-    //e->Guard( ind);
-
-    for(SizeT i =0; i < par->N_Elements(); ++i){
-      if  ((*ind)[i] < 1) throw GDLException(BadDims);
-      dim << (*ind)[i];
-    }
-    return;
+      if (ret > 0) { // single argument
+        if (newDim < 1) throw GDLException(BadDims);
+        dim << newDim;
+        return;
       }
-      e->Throw( "arr: should never arrive here.");  
+      if (ret == 0) { //  array argument
+        DLongGDL* ind =
+          static_cast<DLongGDL*> (par->Convert2(GDL_LONG, BaseGDL::COPY));
+        Guard<DLongGDL> ind_guard(ind);
+        //e->Guard( ind);
+
+        for (SizeT i = 0; i < par->N_Elements(); ++i) {
+          if ((*ind)[i] < 1) throw GDLException(BadDims);
+          dim << (*ind)[i];
+        }
+        return;
+      }
+      e->Throw("arr: should never arrive here.");
       return;
     }
 
     // max number checked in interpreter
-    SizeT endIx=nParam+pOffs;
-    for( SizeT i=pOffs; i<endIx; i++)
-      {
-    BaseGDL* par=e->GetParDefined( i);
+    SizeT endIx = nParam + pOffs;
+    for (SizeT i = pOffs; i < endIx; i++) {
+      BaseGDL* par = e->GetParDefined(i);
 
-    SizeT newDim;
-    int ret=par->Scalar2Index( newDim);
-    if( ret < 1 || newDim == 0) throw GDLException(BadDims);
-    dim << newDim;
-      }
+      SizeT newDim;
+      int ret = par->Scalar2Index(newDim);
+      if (ret < 1 || newDim == 0) throw GDLException(BadDims);
+      dim << newDim;
+    }
   }
 
-  BaseGDL* bytarr( EnvT* e)
-  {
+  BaseGDL* bytarr(EnvT* e) {
     dimension dim;
 
-    arr( e, dim);
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DByteGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DByteGDL(dim, BaseGDL::NOZERO);
     return new DByteGDL(dim);
   }
 
-  BaseGDL* intarr( EnvT* e)
-  {
+  BaseGDL* intarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DIntGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DIntGDL(dim, BaseGDL::NOZERO);
     return new DIntGDL(dim);
     //     }
     //     catch( GDLException& ex)
@@ -246,15 +241,15 @@ namespace lib {
     //  e->Throw( "INTARR: "+ex.getMessage());
     //       }
   }
-  BaseGDL* uintarr( EnvT* e)
-  {
+
+  BaseGDL* uintarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DUIntGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DUIntGDL(dim, BaseGDL::NOZERO);
     return new DUIntGDL(dim);
     //     }
     //     catch( GDLException& ex)
@@ -262,15 +257,15 @@ namespace lib {
     //  e->Throw( "UINTARR: "+ex.getMessage());
     //       }
   }
-  BaseGDL* lonarr( EnvT* e)
-  {
+
+  BaseGDL* lonarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DLongGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DLongGDL(dim, BaseGDL::NOZERO);
     return new DLongGDL(dim);
     /*    }
       catch( GDLException& ex)
@@ -278,32 +273,32 @@ namespace lib {
       e->Throw( "LONARR: "+ex.getMessage());
       }*/
   }
-  BaseGDL* ulonarr( EnvT* e)
-  {
+
+  BaseGDL* ulonarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DULongGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DULongGDL(dim, BaseGDL::NOZERO);
     return new DULongGDL(dim);
     /*   }
      catch( GDLException& ex)
      {
      e->Throw( "ULONARR: "+ex.getMessage());
      }
-    */ 
+     */
   }
-  BaseGDL* lon64arr( EnvT* e)
-  {
+
+  BaseGDL* lon64arr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DLong64GDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DLong64GDL(dim, BaseGDL::NOZERO);
     return new DLong64GDL(dim);
     /*    }
       catch( GDLException& ex)
@@ -311,15 +306,15 @@ namespace lib {
       e->Throw( "LON64ARR: "+ex.getMessage());
       }*/
   }
-  BaseGDL* ulon64arr( EnvT* e)
-  {
+
+  BaseGDL* ulon64arr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DULong64GDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DULong64GDL(dim, BaseGDL::NOZERO);
     return new DULong64GDL(dim);
     /*  }
     catch( GDLException& ex)
@@ -327,31 +322,32 @@ namespace lib {
     e->Throw( "ULON64ARR: "+ex.getMessage());
     }*/
   }
-  BaseGDL* fltarr( EnvT* e)
-  {
+
+  BaseGDL* fltarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DFloatGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DFloatGDL(dim, BaseGDL::NOZERO);
     return new DFloatGDL(dim);
     /* }
        catch( GDLException& ex)
        {
        e->Throw( "FLTARR: "+ex.getMessage());
        }
-    */}
-  BaseGDL* dblarr( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* dblarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DDoubleGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DDoubleGDL(dim, BaseGDL::NOZERO);
     return new DDoubleGDL(dim);
     /* }
        catch( GDLException& ex)
@@ -359,464 +355,412 @@ namespace lib {
        e->Throw( "DBLARR: "+ex.getMessage());
        }*/
   }
-  BaseGDL* strarr( EnvT* e)
-  {
+
+  BaseGDL* strarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) 
-      e->Throw( "Keyword parameters not allowed in call.");
+    if (e->KeywordSet(0))
+      e->Throw("Keyword parameters not allowed in call.");
     return new DStringGDL(dim);
     /*   }
      catch( GDLException& ex)
      {
      e->Throw( "STRARR: "+ex.getMessage());
      }
-    */ }
-  BaseGDL* complexarr( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* complexarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
-    if( e->KeywordSet(0)) return new DComplexGDL(dim, BaseGDL::NOZERO);
+    if (e->KeywordSet(0)) return new DComplexGDL(dim, BaseGDL::NOZERO);
     return new DComplexGDL(dim);
     /*}
       catch( GDLException& ex)
       {
       e->Throw( "COMPLEXARR: "+ex.getMessage());
       }
-    */ }
-  BaseGDL* dcomplexarr( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* dcomplexarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
 
-      if( e->KeywordSet(0)) return new DComplexDblGDL(dim, BaseGDL::NOZERO);
+      if (e->KeywordSet(0)) return new DComplexDblGDL(dim, BaseGDL::NOZERO);
     return new DComplexDblGDL(dim);
     /*   }
      catch( GDLException& ex)
      {
      e->Throw( "DCOMPLEXARR: "+ex.getMessage());
      }
-    */ }
-  BaseGDL* ptrarr( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* ptrarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     DPtrGDL* ret;
 
-    if( !e->KeywordSet(0))
+    if (!e->KeywordSet(0))
       return new DPtrGDL(dim);
-    
-    // ALLOCATE_HEAP
-    ret= new DPtrGDL(dim, BaseGDL::NOZERO);
 
-    SizeT nEl=ret->N_Elements();
-    SizeT sIx=e->NewHeap(nEl, NullGDL::GetSingleInstance());
-    // not a thread pool function #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-      // #pragma omp for
-      for( SizeT i=0; i<nEl; i++)  (*ret)[i]=sIx+i;
-    }
+    // ALLOCATE_HEAP
+    ret = new DPtrGDL(dim, BaseGDL::NOZERO);
+
+    SizeT nEl = ret->N_Elements();
+    SizeT sIx = e->NewHeap(nEl, NullGDL::GetSingleInstance());
+    for (SizeT i = 0; i < nEl; i++) (*ret)[i] = sIx + i;
     return ret;
   }
-  BaseGDL* objarr( EnvT* e)
-  {
+
+  BaseGDL* objarr(EnvT* e) {
     dimension dim;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     // reference counting      if( e->KeywordSet(0)) return new DObjGDL(dim, BaseGDL::NOZERO);
     return new DObjGDL(dim);
   }
 
-  BaseGDL* ptr_new( EnvT* e)
-  {
-    int nParam=e->NParam();
-    if( nParam > 0)
-      {
-    BaseGDL* p= e->GetPar( 0);
+  BaseGDL* ptr_new(EnvT* e) {
+    int nParam = e->NParam();
+    if (nParam > 0) {
+      BaseGDL* p = e->GetPar(0);
 
-    // new ptr from undefined variable is allowed as well
-    // this case was discovered by chance by Leva, July 16, 2014
-    // p=ptr_new(), p=ptr_new(!null), p=ptr_new(undef_var) should work
+      // new ptr from undefined variable is allowed as well
+      // this case was discovered by chance by Leva, July 16, 2014
+      // p=ptr_new(), p=ptr_new(!null), p=ptr_new(undef_var) should work
 
-        if ((p == NULL) || (p->Type() == GDL_UNDEF))
+      if ((p == NULL) || (p->Type() == GDL_UNDEF)) {
+        DPtr heapID = e->NewHeap(1, NullGDL::GetSingleInstance()); //same as /ALLOCATE_HEAP
+        return new DPtrGDL(heapID);
+      }
+      static int no_copyIx = e->KeywordIx("NO_COPY");
+      if (e->KeywordSet(no_copyIx)) // NO_COPY
       {
-        DPtr heapID= e->NewHeap(1, NullGDL::GetSingleInstance()); //same as /ALLOCATE_HEAP
-        return new DPtrGDL( heapID);
-      } 
-    static int no_copyIx=e->KeywordIx("NO_COPY");
-    if (e->KeywordSet(no_copyIx)) // NO_COPY
-      {
-        BaseGDL** p= &e->GetPar( 0);
+        BaseGDL** p = &e->GetPar(0);
 
-        DPtr heapID= e->NewHeap( 1, *p);
-        *p=NULL;
-        return new DPtrGDL( heapID);
-      }
-    else
-      {
-        BaseGDL* p= e->GetParDefined( 0);
+        DPtr heapID = e->NewHeap(1, *p);
+        *p = NULL;
+        return new DPtrGDL(heapID);
+      } else {
+        BaseGDL* p = e->GetParDefined(0);
 
-        DPtr heapID= e->NewHeap( 1, p->Dup());
-        return new DPtrGDL( heapID);
+        DPtr heapID = e->NewHeap(1, p->Dup());
+        return new DPtrGDL(heapID);
       }
-      }
-    else
+    } else {
+      if (e->KeywordSet(1)) // ALLOCATE_HEAP
       {
-    if( e->KeywordSet(1)) // ALLOCATE_HEAP
-      {
-        DPtr heapID= e->NewHeap(1, NullGDL::GetSingleInstance()); //allocate a !NULL, not a null ptr!!
-        return new DPtrGDL( heapID);
+        DPtr heapID = e->NewHeap(1, NullGDL::GetSingleInstance()); //allocate a !NULL, not a null ptr!!
+        return new DPtrGDL(heapID);
+      } else {
+        return new DPtrGDL(0); // null ptr
       }
-    else
-      {
-        return new DPtrGDL( 0); // null ptr
-      }
-      }
+    }
   }
 
-  BaseGDL* ptr_valid(EnvT* e)
-  {
-    int nParam = e->NParam( );
-    static int CASTIx = e->KeywordIx( "CAST" );
-    static int COUNTIx = e->KeywordIx( "COUNT" );
-    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx( "GET_HEAP_IDENTIFIER" );
+  BaseGDL* ptr_valid(EnvT* e) {
+    int nParam = e->NParam();
+    static int CASTIx = e->KeywordIx("CAST");
+    static int COUNTIx = e->KeywordIx("COUNT");
+    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx("GET_HEAP_IDENTIFIER");
 
-    if ( e->KeywordPresent( COUNTIx ) )
-      {
-        e->SetKW( COUNTIx, new DLongGDL( e->Interpreter( )->HeapSize( ) ) );
-      }
+    if (e->KeywordPresent(COUNTIx)) {
+      e->SetKW(COUNTIx, new DLongGDL(e->Interpreter()->HeapSize()));
+    }
 
-    if ( nParam == 0 )
-      {
-        return e->Interpreter( )->GetAllHeap( );
-      }
+    if (nParam == 0) {
+      return e->Interpreter()->GetAllHeap();
+    }
 
-    BaseGDL* p = e->GetPar( 0 );
-    if ( p == NULL )
-      {
-        return new DByteGDL( 0 );
-      }
+    BaseGDL* p = e->GetPar(0);
+    if (p == NULL) {
+      return new DByteGDL(0);
+    }
 
-    DType pType = p->Type( );
-    bool isscalar = p->StrictScalar( );
+    DType pType = p->Type();
+    bool isscalar = p->StrictScalar();
 
 
-    GDLInterpreter* interpreter = e->Interpreter( );
+    GDLInterpreter* interpreter = e->Interpreter();
 
     //if called with  CAST return either a new pointer if arg is a pointer, or a pointer to the heap variable whose arg is an index to.
-    if ( e->KeywordSet( CASTIx ) )
-      {
-        if ( pType == GDL_PTR ) return p->Dup( );
-        //else: only integer or array thereof authorized: 
-        DULongGDL* pL = static_cast<DULongGDL*> ( p->Convert2( GDL_ULONG, BaseGDL::COPY ) );
-        Guard<DULongGDL> pL_guard( pL );
-        if ( isscalar )
-          {
-            DULong p0 = ( *pL )[0];
-            if ( interpreter->PtrValid( p0 ) )
-              {
-                interpreter->IncRef( p0 );
-                return new DPtrGDL( p0 );
-              }
-            else return new DPtrGDL( 0 );
+    if (e->KeywordSet(CASTIx)) {
+      if (pType == GDL_PTR) return p->Dup();
+      //else: only integer or array thereof authorized:
+      DULongGDL* pL = static_cast<DULongGDL*> (p->Convert2(GDL_ULONG, BaseGDL::COPY));
+      Guard<DULongGDL> pL_guard(pL);
+      if (isscalar) {
+        DULong p0 = (*pL)[0];
+        if (interpreter->PtrValid(p0)) {
+          interpreter->IncRef(p0);
+          return new DPtrGDL(p0);
+        } else return new DPtrGDL(0);
+      } else {
+        DPtrGDL* ret = new DPtrGDL(pL->Dim());
+        for (SizeT i = 0; i < pL->N_Elements(); ++i)
+          if (interpreter->PtrValid((*pL)[ i])) {
+            interpreter->IncRef((*pL)[ i]);
+            (*ret)[ i] = (*pL)[ i];
           }
-        else
-          {
-            DPtrGDL* ret = new DPtrGDL( pL->Dim( ) );
-            for ( SizeT i = 0; i < pL->N_Elements( ); ++i )
-              if ( interpreter->PtrValid( ( *pL )[ i] ) )
-                {
-                  interpreter->IncRef( ( *pL )[ i] );
-                  ( *ret )[ i] = ( *pL )[ i];
-                }
-            return ret;
-          }
-      }
-    //no CAST. If PTR type, return true of false, or heap index if  GET_HEAP_IDENTIFIER is used.
-    if ( pType == GDL_PTR )
-      {
-        DPtrGDL* pPtr = static_cast<DPtrGDL*> ( p );
-
-        if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx ) )
-          {
-            DULongGDL* pL = new DULongGDL( p->Dim( ) );
-            Guard<DULongGDL> pL_guard( pL );
-            for ( SizeT i = 0; i < pL->N_Elements( ); ++i ) ( *pL ) [i] = ( *pPtr )[i]; //heap indexes
-            if ( isscalar ) return new DULongGDL( ( *pL )[0] );
-            else
-              {
-                pL_guard.release( );
-                return pL;
-              }
-          }
-        else
-          {
-            if ( isscalar )
-              {
-                return new DByteGDL( interpreter->PtrValid( (*pPtr)[ 0] ));
-              }
-            else
-              {
-                DByteGDL* ret= new DByteGDL( p->Dim( ));
-                for (SizeT i=0; i< ret->N_Elements(); ++i) (*ret)[i]=interpreter->PtrValid( (*pPtr)[ i] );
-                return ret;
-              }
-          }
-      }
-    else
-      { // pType!=GDL_PTR: return false = 0 always.
-        if ( isscalar )
-          {
-            if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx )) return new DULongGDL( 0 ); else return new DByteGDL( 0 );
-            }
-        else
-          {
-                 if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx )) return new DULongGDL( p->Dim( ) ); else return new DByteGDL( p->Dim( ) );
-            }
+        return ret;
       }
     }
-//
-// 2018 May 29 G. Jung: Note there is an inordinate separation of  scalar and non-scalar treament.
-//  This was my last line of attempt to quash an error, due to an assert
-// in gdlarray.cpp (line 210) which obj_valid() triggered in Travis tests.
-// I am now convinced that this error is due to the incorrect hack in GDL
-// that, for "SizeT nEl = p->N_Elements();" returns instead the count() of the list
-// so in fact, a list is not a true object. 
-//  Merge "legacy_list" branch to remedy this.
-// 
-  BaseGDL* obj_valid( EnvT* e)
-  {
-    int nParam = e->NParam( );
-    static int CASTIx = e->KeywordIx( "CAST" );
-    static int COUNTIx = e->KeywordIx( "COUNT" );
-    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx( "GET_HEAP_IDENTIFIER" );
+    //no CAST. If PTR type, return true of false, or heap index if  GET_HEAP_IDENTIFIER is used.
+    if (pType == GDL_PTR) {
+      DPtrGDL* pPtr = static_cast<DPtrGDL*> (p);
 
-    if( e->KeywordPresent( COUNTIx)) // COUNT
-      {
-        e->SetKW( COUNTIx, new DLongGDL( e->Interpreter( )->ObjHeapSize() ) );
+      if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) {
+        DULongGDL* pL = new DULongGDL(p->Dim());
+        Guard<DULongGDL> pL_guard(pL);
+        for (SizeT i = 0; i < pL->N_Elements(); ++i) (*pL) [i] = (*pPtr)[i]; //heap indexes
+        if (isscalar) return new DULongGDL((*pL)[0]);
+        else {
+          pL_guard.release();
+          return pL;
+        }
+      } else {
+        if (isscalar) {
+          return new DByteGDL(interpreter->PtrValid((*pPtr)[ 0]));
+        } else {
+          DByteGDL* ret = new DByteGDL(p->Dim());
+          for (SizeT i = 0; i < ret->N_Elements(); ++i) (*ret)[i] = interpreter->PtrValid((*pPtr)[ i]);
+          return ret;
+        }
       }
-
-    if ( nParam == 0 )
-      {
-        return e->Interpreter( )->GetAllObjHeap();
+    } else { // pType!=GDL_PTR: return false = 0 always.
+      if (isscalar) {
+        if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) return new DULongGDL(0);
+        else return new DByteGDL(0);
+      } else {
+        if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) return new DULongGDL(p->Dim());
+        else return new DByteGDL(p->Dim());
       }
+    }
+  }
+  //
+  // 2018 May 29 G. Jung: Note there is an inordinate separation of  scalar and non-scalar treament.
+  //  This was my last line of attempt to quash an error, due to an assert
+  // in gdlarray.cpp (line 210) which obj_valid() triggered in Travis tests.
+  // I am now convinced that this error is due to the incorrect hack in GDL
+  // that, for "SizeT nEl = p->N_Elements();" returns instead the count() of the list
+  // so in fact, a list is not a true object.
+  //  Merge "legacy_list" branch to remedy this.
+  //
 
-    BaseGDL* p = e->GetPar( 0 );
-    if ( p == NULL )
-      {
-        return new DByteGDL( 0 );
-      }
+  BaseGDL* obj_valid(EnvT* e) {
+    int nParam = e->NParam();
+    static int CASTIx = e->KeywordIx("CAST");
+    static int COUNTIx = e->KeywordIx("COUNT");
+    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx("GET_HEAP_IDENTIFIER");
 
-    DType pType = p->Type( );
-    bool isscalar = p->StrictScalar( );
+    if (e->KeywordPresent(COUNTIx)) // COUNT
+    {
+      e->SetKW(COUNTIx, new DLongGDL(e->Interpreter()->ObjHeapSize()));
+    }
 
-    GDLInterpreter* interpreter = e->Interpreter( );
+    if (nParam == 0) {
+      return e->Interpreter()->GetAllObjHeap();
+    }
+
+    BaseGDL* p = e->GetPar(0);
+    if (p == NULL) {
+      return new DByteGDL(0);
+    }
+
+    DType pType = p->Type();
+    bool isscalar = p->StrictScalar();
+
+    GDLInterpreter* interpreter = e->Interpreter();
 
     //if called with  CAST return either a new pointer if arg is a pointer, or a pointer to the ObjHeap variable whose arg is an index to.
-    if ( e->KeywordSet( CASTIx ) )
-      {
-        if ( pType == GDL_OBJ ) return p->Dup( );
-        //else: only integer or array thereof authorized: 
-        DULongGDL* pL = static_cast<DULongGDL*> ( p->Convert2( GDL_ULONG, BaseGDL::COPY ) );
-        Guard<DULongGDL> pL_guard( pL );
-        if ( isscalar ) {
-            DULong p0 = (*pL)[0];
-            if ( interpreter->ObjValid( p0 )) {
-                interpreter->IncRefObj( p0 );
-                return new DObjGDL( p0 );
-              } else return new DObjGDL( 0 );
+    if (e->KeywordSet(CASTIx)) {
+      if (pType == GDL_OBJ) return p->Dup();
+      //else: only integer or array thereof authorized:
+      DULongGDL* pL = static_cast<DULongGDL*> (p->Convert2(GDL_ULONG, BaseGDL::COPY));
+      Guard<DULongGDL> pL_guard(pL);
+      if (isscalar) {
+        DULong p0 = (*pL)[0];
+        if (interpreter->ObjValid(p0)) {
+          interpreter->IncRefObj(p0);
+          return new DObjGDL(p0);
+        } else return new DObjGDL(0);
+      } else {
+        DObjGDL* ret = new DObjGDL(pL->Dim());
+        for (SizeT i = 0; i < pL->N_Elements(); ++i)
+          if (interpreter->ObjValid((*pL)[ i])) {
+            interpreter->IncRefObj((*pL)[ i]);
+            (*ret)[ i] = (*pL)[ i];
           }
-        else
-          {
-            DObjGDL* ret = new DObjGDL( pL->Dim( ) );
-            for ( SizeT i = 0; i < pL->N_Elements( ); ++i )
-              if ( interpreter->ObjValid( ( *pL )[ i] ) ) {
-                  interpreter->IncRefObj( ( *pL )[ i] );
-                  ( *ret )[ i] = ( *pL )[ i];
-                }
-            return ret;
-          }
-      }
-    //no CAST. If OBJ type, return true of false, or ObjHeap index if  GET_HEAP_IDENTIFIER is used.
-    if ( pType == GDL_OBJ )
-      {
-        DObjGDL* pObj = static_cast<DObjGDL*> ( p );
-
-        if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx ) )
-          {
-            DULongGDL* pL = new DULongGDL( p->Dim( ) );
-            Guard<DULongGDL> pL_guard( pL );
-            for ( SizeT i = 0; i < pL->N_Elements( ); ++i ) ( *pL ) [i] = ( *pObj )[i]; //heap indexes
-            if ( isscalar ) return new DULongGDL( ( *pL )[0] );
-            else
-              {
-                pL_guard.release( );
-                return pL;
-              }
-          }
-        else
-          {
-            if ( isscalar )
-              {
-                return new DByteGDL( interpreter->ObjValid( (*pObj)[ 0] ));
-              }
-            else
-              {
-                DByteGDL* ret= new DByteGDL( p->Dim( ));
-                for (SizeT i=0; i< ret->N_Elements(); ++i) (*ret)[i]=interpreter->ObjValid( (*pObj)[ i] );
-                return ret;
-              }
-          }
-      }
-    else
-      { // pType!=GDL_OBJ: return false = 0 always.
-        if ( isscalar )
-          {
-            if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx )) return new DULongGDL( 0 ); else return new DByteGDL( 0 );
-            }
-        else
-          {
-                 if ( e->KeywordSet( GET_HEAP_IDENTIFIERIx )) return new DULongGDL( p->Dim( ) ); else return new DByteGDL( p->Dim( ) );
-            }
+        return ret;
       }
     }
+    //no CAST. If OBJ type, return true of false, or ObjHeap index if  GET_HEAP_IDENTIFIER is used.
+    if (pType == GDL_OBJ) {
+      DObjGDL* pObj = static_cast<DObjGDL*> (p);
 
-
-//  {
-//    int nParam=e->NParam();
-//    static int CASTIx = e->KeywordIx("CAST");
-//    static int COUNTIx = e->KeywordIx("COUNT");
-//    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx("GET_HEAP_IDENTIFIER");
-//    
-//    if( e->KeywordPresent( COUNTIx)) // COUNT
-//      {
-//    e->SetKW( COUNTIx, new DLongGDL( e->Interpreter()->ObjHeapSize()));
-//      }
-//
-//    if( nParam == 0)
-//      {
-//    return e->Interpreter()->GetAllObjHeap();
-//      } 
-//
-//    BaseGDL* p = e->GetPar( 0);
-//    if( p == NULL)
-//      {
-//    return new DByteGDL( 0);
-//      } 
-//
-//    DType pType = p->Type();
-//    bool isscalar = p->StrictScalar();
-//    DLongGDL* pL;
-//    Guard<DLongGDL> pL_guard;
-//
-//    GDLInterpreter* interpreter = e->Interpreter();
-//    if( pType == GDL_OBJ) {
-//        DObjGDL* pObj = static_cast<DObjGDL*>( p);
-//        pL = new DLongGDL( p->Dim());
-//        for( SizeT i=0; i < pL->N_Elements(); ++i) (*pL) [i] = (*pObj)[i];
-//        if( e->KeywordSet( GET_HEAP_IDENTIFIERIx)) {
-//            if(isscalar) return new DLongGDL( (*pL)[0] );
-//                else    return pL; 
-//            }
-//    }
-//    else {          // pType == GDL_OBJ
-//        pL = static_cast<DLongGDL*>(p->Convert2(GDL_LONG,BaseGDL::COPY));
-//        pL_guard.Init( pL);
-//        if( e->KeywordSet( CASTIx))  {
-//            if(isscalar) {
-//                DLong p0 = (*pL)[0];
-//                if(  interpreter->ObjValid( p0 )) {
-//                        interpreter->IncRefObj( p0);
-//                        return new DObjGDL( p0);
-//                } else  return new DObjGDL( 0);
-//            }
-//            DObjGDL* ret = new DObjGDL( pL->Dim());
-//            for( SizeT i=0; i < pL->N_Elements(); ++i)
-//              if( interpreter->ObjValid( (*pL)[ i])) {
-//                  interpreter->IncRefObj((*pL)[ i]);
-//                  (*ret)[ i] = (*pL)[ i];
-//                  }
-//          return ret;
-//          }
-//      }
-//
-//    DByteGDL* ret = new DByteGDL( pL->Dim()); // zero
-//    for( SizeT i=0; i<pL->N_Elements(); ++i)
-//      {
-//    if( interpreter->ObjValid( (*pL)[ i])) 
-//      (*ret)[ i] = 1;
-//      }
-//      
-//    if(isscalar) return new DByteGDL( (*ret)[0] );
-//       else return ret;
-//  }
-
-  BaseGDL* obj_new( EnvT* e)
-  {
-    //     StackGuard<EnvStackT> guard( e->Interpreter()->CallStack());
-    
-    int nParam=e->NParam();
-    
-    if( nParam == 0)
-      {
-    return new DObjGDL( 0);
+      if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) {
+        DULongGDL* pL = new DULongGDL(p->Dim());
+        Guard<DULongGDL> pL_guard(pL);
+        for (SizeT i = 0; i < pL->N_Elements(); ++i) (*pL) [i] = (*pObj)[i]; //heap indexes
+        if (isscalar) return new DULongGDL((*pL)[0]);
+        else {
+          pL_guard.release();
+          return pL;
+        }
+      } else {
+        if (isscalar) {
+          return new DByteGDL(interpreter->ObjValid((*pObj)[ 0]));
+        } else {
+          DByteGDL* ret = new DByteGDL(p->Dim());
+          for (SizeT i = 0; i < ret->N_Elements(); ++i) (*ret)[i] = interpreter->ObjValid((*pObj)[ i]);
+          return ret;
+        }
       }
-    
+    } else { // pType!=GDL_OBJ: return false = 0 always.
+      if (isscalar) {
+        if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) return new DULongGDL(0);
+        else return new DByteGDL(0);
+      } else {
+        if (e->KeywordSet(GET_HEAP_IDENTIFIERIx)) return new DULongGDL(p->Dim());
+        else return new DByteGDL(p->Dim());
+      }
+    }
+  }
+
+
+  //  {
+  //    int nParam=e->NParam();
+  //    static int CASTIx = e->KeywordIx("CAST");
+  //    static int COUNTIx = e->KeywordIx("COUNT");
+  //    static int GET_HEAP_IDENTIFIERIx = e->KeywordIx("GET_HEAP_IDENTIFIER");
+  //
+  //    if( e->KeywordPresent( COUNTIx)) // COUNT
+  //      {
+  //    e->SetKW( COUNTIx, new DLongGDL( e->Interpreter()->ObjHeapSize()));
+  //      }
+  //
+  //    if( nParam == 0)
+  //      {
+  //    return e->Interpreter()->GetAllObjHeap();
+  //      }
+  //
+  //    BaseGDL* p = e->GetPar( 0);
+  //    if( p == NULL)
+  //      {
+  //    return new DByteGDL( 0);
+  //      }
+  //
+  //    DType pType = p->Type();
+  //    bool isscalar = p->StrictScalar();
+  //    DLongGDL* pL;
+  //    Guard<DLongGDL> pL_guard;
+  //
+  //    GDLInterpreter* interpreter = e->Interpreter();
+  //    if( pType == GDL_OBJ) {
+  //        DObjGDL* pObj = static_cast<DObjGDL*>( p);
+  //        pL = new DLongGDL( p->Dim());
+  //        for( SizeT i=0; i < pL->N_Elements(); ++i) (*pL) [i] = (*pObj)[i];
+  //        if( e->KeywordSet( GET_HEAP_IDENTIFIERIx)) {
+  //            if(isscalar) return new DLongGDL( (*pL)[0] );
+  //                else    return pL;
+  //            }
+  //    }
+  //    else {          // pType == GDL_OBJ
+  //        pL = static_cast<DLongGDL*>(p->Convert2(GDL_LONG,BaseGDL::COPY));
+  //        pL_guard.Init( pL);
+  //        if( e->KeywordSet( CASTIx))  {
+  //            if(isscalar) {
+  //                DLong p0 = (*pL)[0];
+  //                if(  interpreter->ObjValid( p0 )) {
+  //                        interpreter->IncRefObj( p0);
+  //                        return new DObjGDL( p0);
+  //                } else  return new DObjGDL( 0);
+  //            }
+  //            DObjGDL* ret = new DObjGDL( pL->Dim());
+  //            for( SizeT i=0; i < pL->N_Elements(); ++i)
+  //              if( interpreter->ObjValid( (*pL)[ i])) {
+  //                  interpreter->IncRefObj((*pL)[ i]);
+  //                  (*ret)[ i] = (*pL)[ i];
+  //                  }
+  //          return ret;
+  //          }
+  //      }
+  //
+  //    DByteGDL* ret = new DByteGDL( pL->Dim()); // zero
+  //    for( SizeT i=0; i<pL->N_Elements(); ++i)
+  //      {
+  //    if( interpreter->ObjValid( (*pL)[ i]))
+  //      (*ret)[ i] = 1;
+  //      }
+  //
+  //    if(isscalar) return new DByteGDL( (*ret)[0] );
+  //       else return ret;
+  //  }
+
+  BaseGDL* obj_new(EnvT* e) {
+    //     StackGuard<EnvStackT> guard( e->Interpreter()->CallStack());
+
+    int nParam = e->NParam();
+
+    if (nParam == 0) {
+      return new DObjGDL(0);
+    }
+
     DString objName;
-    e->AssureScalarPar<DStringGDL>( 0, objName);
+    e->AssureScalarPar<DStringGDL>(0, objName);
 
     // this is a struct name -> convert to UPPERCASE
-    objName=StrUpCase(objName);
-    if( objName == "IDL_OBJECT")
+    objName = StrUpCase(objName);
+    if (objName == "IDL_OBJECT")
       objName = GDL_OBJECT_NAME; // replacement also done in GDLParser
-    else if( objName == "IDL_CONTAINER" )
-       objName = GDL_CONTAINER_NAME;
-    DStructDesc* objDesc=e->Interpreter()->GetStruct( objName, e->CallingNode());
+    else if (objName == "IDL_CONTAINER")
+      objName = GDL_CONTAINER_NAME;
+    DStructDesc* objDesc = e->Interpreter()->GetStruct(objName, e->CallingNode());
 
-    DStructGDL* objStruct= new DStructGDL( objDesc, dimension(1));
+    DStructGDL* objStruct = new DStructGDL(objDesc, dimension(1));
 
-    DObj objID= e->NewObjHeap( 1, objStruct); // owns objStruct
+    DObj objID = e->NewObjHeap(1, objStruct); // owns objStruct
 
-    DObjGDL* newObj = new DObjGDL( objID); // the object
+    DObjGDL* newObj = new DObjGDL(objID); // the object
 
     try {
       // call INIT function
-      DFun* objINIT= objDesc->GetFun( "INIT");
-      if( objINIT != NULL)
-    {
-      StackGuard<EnvStackT> guard( e->Interpreter()->CallStack());
+      DFun* objINIT = objDesc->GetFun("INIT");
+      if (objINIT != NULL) {
+        StackGuard<EnvStackT> guard(e->Interpreter()->CallStack());
 
-      // morph to obj environment and push it onto the stack again
-      e->PushNewEnvUD( objINIT, 1, &newObj);
-    
-      BaseGDL* res=e->Interpreter()->call_fun( objINIT->GetTree());
-    
-      if( res == NULL || (!res->Scalar()) || res->False())
-        {
+        // morph to obj environment and push it onto the stack again
+        e->PushNewEnvUD(objINIT, 1, &newObj);
+
+        BaseGDL* res = e->Interpreter()->call_fun(objINIT->GetTree());
+
+        if (res == NULL || (!res->Scalar()) || res->False()) {
           GDLDelete(res);
-          return new DObjGDL( 0);
+          return new DObjGDL(0);
         }
-      GDLDelete(res);
-    }
-    } catch(...) {
-      e->FreeObjHeap( objID); // newObj might be changed
+        GDLDelete(res);
+      }
+    } catch (...) {
+      e->FreeObjHeap(objID); // newObj might be changed
       GDLDelete(newObj);
       throw;
     }
@@ -824,125 +768,113 @@ namespace lib {
     return newObj;
   }
 
-  BaseGDL* heap_refcount( EnvT* e)
-  {
+  BaseGDL* heap_refcount(EnvT* e) {
     static int DISABLEIx = e->KeywordIx("DISABLE");
     static int ENABLEIx = e->KeywordIx("ENABLE");
     static int IS_ENABLEDIx = e->KeywordIx("IS_ENABLED");
-//    trace_me = trace_arg();
-    int nParam=e->NParam();
-    
+    //    trace_me = trace_arg();
+    int nParam = e->NParam();
+
     GDLInterpreter* interpreter = e->Interpreter();
 
-    if( nParam == 0) {
-    if( e->KeywordSet(DISABLEIx)) {
-      EnableGC(false);
+    if (nParam == 0) {
+      if (e->KeywordSet(DISABLEIx)) {
+        EnableGC(false);
+      } else if (e->KeywordSet(ENABLEIx)) {
+        EnableGC(true);
+        interpreter->EnableAllGC();
       }
-    else if( e->KeywordSet(ENABLEIx)) {
-      EnableGC(true);
-      interpreter->EnableAllGC();
-    }
-    if(e->KeywordPresent(IS_ENABLEDIx)) 
-          e->SetKW( IS_ENABLEDIx,
-            new DByteGDL( IsEnabledGC()) );
-    return new DIntGDL( 0);
+      if (e->KeywordPresent(IS_ENABLEDIx))
+        e->SetKW(IS_ENABLEDIx,
+        new DByteGDL(IsEnabledGC()));
+      return new DIntGDL(0);
     }
 
-    BaseGDL* p = e->GetPar( 0);
-    if( p == NULL)
-      {
-    return new DIntGDL( 0);
-      } 
+    BaseGDL* p = e->GetPar(0);
+    if (p == NULL) {
+      return new DIntGDL(0);
+    }
 
     DIntGDL* ret = new DIntGDL(p->Dim());
     Guard<DIntGDL> ret_guard(ret);
     DType pType = p->Type();
     SizeT nEl = p->N_Elements();
-    if(pType == GDL_OBJ) {
-    DObjGDL* pObj = static_cast<DObjGDL*>( p);
-    for( SizeT i=0; i<nEl; ++i)
-        (*ret)[ i] = interpreter->RefCountHeapObj( (*pObj)[ i]);
-    if( e->KeywordSet(DISABLEIx) or
-        e->KeywordSet(ENABLEIx) ) {
-          bool set = e->KeywordSet(ENABLEIx) ? true: false;
-          interpreter->EnableGCObj( pObj, set);
+    if (pType == GDL_OBJ) {
+      DObjGDL* pObj = static_cast<DObjGDL*> (p);
+      for (SizeT i = 0; i < nEl; ++i)
+        (*ret)[ i] = interpreter->RefCountHeapObj((*pObj)[ i]);
+      if (e->KeywordSet(DISABLEIx) or
+        e->KeywordSet(ENABLEIx)) {
+        bool set = e->KeywordSet(ENABLEIx) ? true : false;
+        interpreter->EnableGCObj(pObj, set);
+      }
+    } else {
+      if (pType == GDL_PTR) {
+
+        DPtrGDL* pPtr = static_cast<DPtrGDL*> (p);
+        for (SizeT i = 0; i < nEl; ++i)
+          (*ret)[ i] = interpreter->RefCountHeap((*pPtr)[ i]);
+        if (e->KeywordSet(DISABLEIx) or
+          e->KeywordSet(ENABLEIx)) {
+          bool set = e->KeywordSet(ENABLEIx) ? true : false;
+          //  if(trace_me) cout <<" GC set? "<<set<<endl;
+          interpreter->EnableGC(pPtr, set);
         }
+      } else {
+        DLongGDL* pL;
+        Guard<DLongGDL> pL_guard(pL);
+        if (pType != GDL_LONG) {
+          pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
+          pL_guard.Init(pL);
+        } else {
+          pL = static_cast<DLongGDL*> (p);
+        }
+        for (SizeT i = 0; i < nEl; ++i)
+          (*ret)[ i] = interpreter->RefCountHeap((*pL)[ i]);
+      }
     }
-    else {
-      if( pType == GDL_PTR) {
-      
-      DPtrGDL* pPtr = static_cast<DPtrGDL*>( p);
-      for( SizeT i=0; i<nEl; ++i)
-          (*ret)[ i] = interpreter->RefCountHeap( (*pPtr)[ i]);
-      if( e->KeywordSet(DISABLEIx) or
-          e->KeywordSet(ENABLEIx) ) {
-        bool set = e->KeywordSet(ENABLEIx) ? true: false;
-//  if(trace_me) cout <<" GC set? "<<set<<endl;
-        interpreter->EnableGC( pPtr, set);
-          }
-    } else {
-      DLongGDL* pL;
-      Guard<DLongGDL> pL_guard(pL);
-      if( pType != GDL_LONG)
-      {
-        pL = static_cast<DLongGDL*>(p->Convert2(GDL_LONG,BaseGDL::COPY)); 
-        pL_guard.Init( pL);
-      }
-      else
-      {
-        pL = static_cast<DLongGDL*>(p);
-      }
-      for( SizeT i=0; i<nEl; ++i)
-          (*ret)[ i] = interpreter->RefCountHeap( (*pL)[ i]);
-    }
-      }
-// #if 1 
-    if(e->KeywordPresent(IS_ENABLEDIx)) {
+    // #if 1
+    if (e->KeywordPresent(IS_ENABLEDIx)) {
       DByteGDL* enabled;
-//      if(trace_me) 
-//  cout << "  heap_refcount( prm, KeywordPresent(IS_ENABLEDIx)) "<< endl;
-      if(pType == GDL_OBJ) {
-    enabled = interpreter->IsEnabledGCObj(static_cast<DObjGDL*>( p));
-    }
-      else {
-      if( pType == GDL_PTR) {
-      enabled = interpreter->IsEnabledGC(static_cast<DPtrGDL*>( p));
-    } else {
-//  if(trace_me) 
-//  cout << " heap_refcount(prm=lonarr, KeywordPresent(IS_ENABLEDIx) "<< endl;
-      DLongGDL* pL;
-      Guard<DLongGDL> pL_guard(pL);
-      if( pType != GDL_LONG)
-      {
-        pL = static_cast<DLongGDL*>(p->Convert2(GDL_LONG,BaseGDL::COPY)); 
-        pL_guard.Init( pL);
-      }
-      else
-      {
-        pL = static_cast<DLongGDL*>(p);
-      }
-      DPtrGDL* ptr = new DPtrGDL( p->Dim());
-      Guard<DPtrGDL> ptr_guard(ptr);
-      for( SizeT i=0; i<nEl; ++i)
+      //      if(trace_me)
+      //  cout << "  heap_refcount( prm, KeywordPresent(IS_ENABLEDIx)) "<< endl;
+      if (pType == GDL_OBJ) {
+        enabled = interpreter->IsEnabledGCObj(static_cast<DObjGDL*> (p));
+      } else {
+        if (pType == GDL_PTR) {
+          enabled = interpreter->IsEnabledGC(static_cast<DPtrGDL*> (p));
+        } else {
+          //  if(trace_me)
+          //  cout << " heap_refcount(prm=lonarr, KeywordPresent(IS_ENABLEDIx) "<< endl;
+          DLongGDL* pL;
+          Guard<DLongGDL> pL_guard(pL);
+          if (pType != GDL_LONG) {
+            pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
+            pL_guard.Init(pL);
+          } else {
+            pL = static_cast<DLongGDL*> (p);
+          }
+          DPtrGDL* ptr = new DPtrGDL(p->Dim());
+          Guard<DPtrGDL> ptr_guard(ptr);
+          for (SizeT i = 0; i < nEl; ++i)
             (*ptr)[ i] = (*pL)[ i];
 
-      enabled = interpreter->IsEnabledGC(ptr);
-    }
+          enabled = interpreter->IsEnabledGC(ptr);
+        }
       }
-      e->SetKW( IS_ENABLEDIx, enabled);
+      e->SetKW(IS_ENABLEDIx, enabled);
     }
-// #endif
+    // #endif
     return ret_guard.release();
   }
-  
-  BaseGDL* bindgen( EnvT* e)
-  {
+
+  BaseGDL* bindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -952,84 +884,107 @@ namespace lib {
        {
        e->Throw( "BINDGEN: "+ex.getMessage());
        }
-    */ }
-  BaseGDL* indgen( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* indgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     DType type = GDL_INT;
 
     static int kwIx1 = e->KeywordIx("BYTE");
-    if (e->KeywordSet(kwIx1)){ type = GDL_BYTE; }
+    if (e->KeywordSet(kwIx1)) {
+      type = GDL_BYTE;
+    }
 
     static int kwIx2 = e->KeywordIx("COMPLEX");
-    if (e->KeywordSet(kwIx2)){ type = GDL_COMPLEX; }
-    
+    if (e->KeywordSet(kwIx2)) {
+      type = GDL_COMPLEX;
+    }
+
     static int kwIx3 = e->KeywordIx("DCOMPLEX");
-    if (e->KeywordSet(kwIx3)){ type = GDL_COMPLEXDBL; }
+    if (e->KeywordSet(kwIx3)) {
+      type = GDL_COMPLEXDBL;
+    }
 
     static int kwIx4 = e->KeywordIx("DOUBLE");
-    if (e->KeywordSet(kwIx4)){ type = GDL_DOUBLE; }
+    if (e->KeywordSet(kwIx4)) {
+      type = GDL_DOUBLE;
+    }
 
     static int kwIx5 = e->KeywordIx("FLOAT");
-    if (e->KeywordSet(kwIx5)){ type = GDL_FLOAT; }
-    
+    if (e->KeywordSet(kwIx5)) {
+      type = GDL_FLOAT;
+    }
+
     static int kwIx6 = e->KeywordIx("L64");
-    if (e->KeywordSet(kwIx6)){ type = GDL_LONG64; }
+    if (e->KeywordSet(kwIx6)) {
+      type = GDL_LONG64;
+    }
 
     static int kwIx7 = e->KeywordIx("LONG");
-    if (e->KeywordSet(kwIx7)){ type = GDL_LONG; }
+    if (e->KeywordSet(kwIx7)) {
+      type = GDL_LONG;
+    }
 
     static int kwIx8 = e->KeywordIx("STRING");
-    if (e->KeywordSet(kwIx8)){ type = GDL_STRING; }
+    if (e->KeywordSet(kwIx8)) {
+      type = GDL_STRING;
+    }
 
     static int kwIx9 = e->KeywordIx("UINT");
-    if (e->KeywordSet(kwIx9)){ type = GDL_UINT; }
+    if (e->KeywordSet(kwIx9)) {
+      type = GDL_UINT;
+    }
 
     static int kwIx10 = e->KeywordIx("UL64");
-    if (e->KeywordSet(kwIx10)){ type = GDL_ULONG64; }
+    if (e->KeywordSet(kwIx10)) {
+      type = GDL_ULONG64;
+    }
 
     static int kwIx11 = e->KeywordIx("ULONG");
-    if (e->KeywordSet(kwIx11)){ type = GDL_ULONG; }
-    
+    if (e->KeywordSet(kwIx11)) {
+      type = GDL_ULONG;
+    }
+
     /*try
       {*/
     // Seeing if the user passed in a TYPE code
     static int kwIx12 = e->KeywordIx("TYPE");
-    if ( e->KeywordPresent(kwIx12)){
+    if (e->KeywordPresent(kwIx12)) {
       DLong temp_long;
       e->AssureLongScalarKW(kwIx12, temp_long);
-      type = static_cast<DType>(temp_long);
+      type = static_cast<DType> (temp_long);
     }
 
     arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
 
-    switch(type)
-      {
-      case GDL_INT:        return new DIntGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_BYTE:       return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_COMPLEX:    return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_COMPLEXDBL: return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_DOUBLE:     return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_FLOAT:      return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_LONG64:     return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_LONG:       return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_STRING: {
-    DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-    return iGen->Convert2(GDL_STRING);
-      }
-      case GDL_UINT:       return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_ULONG64:    return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
-      case GDL_ULONG:      return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-      default:
-    e->Throw( "Invalid type code specified.");
-    break;
-      }
+    switch (type) {
+    case GDL_INT: return new DIntGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_BYTE: return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_COMPLEX: return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_COMPLEXDBL: return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_DOUBLE: return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_FLOAT: return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_LONG64: return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_LONG: return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_STRING:
+    {
+      DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_STRING);
+    }
+    case GDL_UINT: return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_ULONG64: return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_ULONG: return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
+    default:
+      e->Throw("Invalid type code specified.");
+      break;
+    }
     /*      }
         catch( GDLException& ex)
         {
@@ -1039,14 +994,13 @@ namespace lib {
     return NULL;
   }
 
-  BaseGDL* uindgen( EnvT* e)
-  {
+  BaseGDL* uindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1056,34 +1010,35 @@ namespace lib {
        {
        e->Throw( "UINDGEN: "+ex.getMessage());
        }
-    */ }
-  BaseGDL* sindgen( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* sindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-    return iGen->Convert2( GDL_STRING);
+    return iGen->Convert2(GDL_STRING);
     /*    }
       catch( GDLException& ex)
       {
       e->Throw( "SINDGEN: "+ex.getMessage());
       }*/
   }
-  BaseGDL* lindgen( EnvT* e)
-  {
+
+  BaseGDL* lindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1094,14 +1049,14 @@ namespace lib {
       e->Throw( "LINDGEN: "+ex.getMessage());
       }*/
   }
-  BaseGDL* ulindgen( EnvT* e)
-  {
+
+  BaseGDL* ulindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1112,14 +1067,14 @@ namespace lib {
       e->Throw( "ULINDGEN: "+ex.getMessage());
       }*/
   }
-  BaseGDL* l64indgen( EnvT* e)
-  {
+
+  BaseGDL* l64indgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1130,14 +1085,14 @@ namespace lib {
     e->Throw( "L64INDGEN: "+ex.getMessage());
     }*/
   }
-  BaseGDL* ul64indgen( EnvT* e)
-  {
+
+  BaseGDL* ul64indgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1147,15 +1102,16 @@ namespace lib {
      {
      e->Throw( "UL64INDGEN: "+ex.getMessage());
      }
-    */ }
-  BaseGDL* findgen( EnvT* e)
-  {
+     */
+  }
+
+  BaseGDL* findgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1166,14 +1122,14 @@ namespace lib {
     e->Throw( "FINDGEN: "+ex.getMessage());
     }*/
   }
-  BaseGDL* dindgen( EnvT* e)
-  {
+
+  BaseGDL* dindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1184,14 +1140,14 @@ namespace lib {
     e->Throw( "DINDGEN: "+ex.getMessage());
     }*/
   }
-  BaseGDL* cindgen( EnvT* e)
-  {
+
+  BaseGDL* cindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1202,14 +1158,14 @@ namespace lib {
     e->Throw( "CINDGEN: "+ex.getMessage());
     }*/
   }
-  BaseGDL* dcindgen( EnvT* e)
-  {
+
+  BaseGDL* dcindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
     //     try{
-    arr( e, dim); 
+    arr(e, dim);
     if (dim[0] == 0)
-      throw GDLException( "Array dimensions must be greater than 0");
+      throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
@@ -1219,85 +1175,90 @@ namespace lib {
     {
     e->Throw( "DCINDGEN: "+ex.getMessage());
     }
-    */ }
+     */
+  }
 
-  // only called from CALL_FUNCTION 
+  // only called from CALL_FUNCTION
   // otherwise done directly in FCALL_LIB_N_ELEMENTSNode::Eval();
   // (but must be defined anyway for LibInit() for correct parametrization)
   // N_ELEMENTS is special because on error it just returns 0L
   // (the error is just caught and dropped)
-  BaseGDL* n_elements( EnvT* e)
-  {
-    SizeT nParam=e->NParam(1);
 
-    BaseGDL* p0=e->GetPar( 0);
+  BaseGDL* n_elements(EnvT* e) {
+    SizeT nParam = e->NParam(1);
 
-    if( p0 == NULL) 
-      return new DLongGDL( 0);
-    if( p0->IsAssoc())
-      return new DLongGDL( 1);
-    if(p0->Type() == GDL_OBJ) 
-    {
-        DStructGDL* s = GetObjStruct(p0, e);
-        if( s->Desc()->IsParent("LIST"))
-          return new DLongGDL( LIST_count(s));
-        else
-        if( s->Desc()->IsParent("HASH"))
-          return new DLongGDL( HASH_count(s));
+    BaseGDL* p0 = e->GetPar(0);
+
+    if (p0 == NULL)
+      return new DLongGDL(0);
+    if (p0->IsAssoc())
+      return new DLongGDL(1);
+    if (p0->Type() == GDL_OBJ) {
+      DStructGDL* s = GetObjStruct(p0, e);
+      if (s->Desc()->IsParent("LIST"))
+        return new DLongGDL(LIST_count(s));
+      else
+        if (s->Desc()->IsParent("HASH"))
+        return new DLongGDL(HASH_count(s));
     }
-    if (p0->N_Elements() > 2147483647UL) 
-      return new DLong64GDL( p0->N_Elements()); 
-    else 
-      return new DLongGDL( p0->N_Elements()); 
+    if (p0->N_Elements() > 2147483647UL)
+      return new DLong64GDL(p0->N_Elements());
+    else
+      return new DLongGDL(p0->N_Elements());
   }
 
-// GD Rewrote complex_fun_template_twopar for gain speed > 10.
-// compiler optimization, including openmp inner loops, depends terribly on the knowledge at the compilation time
-// of the exact nature of every value --- typenames do not help if they do not quickly resolve to known PODs.
-// the following construction has speeds on par with IDL's C . Note the test to avoid completely the openmp loop,
-// which seems to gain some time (?) and the use of auto and decltype() in std::complex.
+  // GD Rewrote complex_fun_template_twopar for gain speed > 10.
+  // compiler optimization, including openmp inner loops, depends terribly on the knowledge at the compilation time
+  // of the exact nature of every value --- typenames do not help if they do not quickly resolve to known PODs.
+  // the following construction has speeds on par with IDL's C . Note the test to avoid completely the openmp loop,
+  // which seems to gain some time (?) and the use of auto and decltype() in std::complex.
+
   template< typename TypOutGDL, typename TypInGDL>
   BaseGDL* complex_fun_template_twopar(EnvT* e) {
-    TypInGDL* re=e->GetParAs<TypInGDL>(0);
-    TypInGDL* im=e->GetParAs<TypInGDL>(1);
-    auto t=(*re)[0]; //a Float or Double
+    TypInGDL* re = e->GetParAs<TypInGDL>(0);
+    TypInGDL* im = e->GetParAs<TypInGDL>(1);
+    auto t = (*re)[0]; //a Float or Double
     if (re->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
-      } else 
-        for (SizeT i = 0; i < nE; i++)  (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
+      } else
+        for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       return res;
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
-      return res; 
+      return res;
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
-      } else 
-        for (SizeT i = 0; i < nE; i++)  (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+      } else
+        for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       return res;
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       return res;
@@ -1315,7 +1276,7 @@ namespace lib {
 
     dimension dim;
 
-    if (nParam > 2)  arr(e, dim, 2);
+    if (nParam > 2) arr(e, dim, 2);
 
     TargetClass* res = new TargetClass(dim, BaseGDL::NOZERO);
 
@@ -1343,12 +1304,12 @@ namespace lib {
     BaseGDL* p0 = e->GetParDefined(0);
 
     assert(dynamic_cast<EnvUDT*> (e->Caller()) != NULL);
- 
+
     // type_fun( expr) just convert
     if (static_cast<EnvUDT*> (e->Caller())->GetIOError() != NULL)
       return p0->Convert2(TargetClass::t,
       BaseGDL::COPY_THROWIOERROR);
-      // SA: see tracker item no. 3151760 
+      // SA: see tracker item no. 3151760
     else if (TargetClass::t == p0->Type() && e->GlobalPar(0))
       // HERE THE INPUT VARIABLE IS RETURNED
     {
@@ -1357,79 +1318,78 @@ namespace lib {
     } else
       return p0->Convert2(TargetClass::t, BaseGDL::COPY);
     throw;
-  } 
+  }
 
-  BaseGDL* byte_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DByteGDL>( e);
-    return type_fun<DByteGDL>( e);
+  BaseGDL* byte_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DByteGDL>(e);
+    return type_fun<DByteGDL>(e);
   }
-  BaseGDL* int_fun( EnvT* e) //not registered, use FIX instead.
+
+  BaseGDL* int_fun(EnvT* e) //not registered, use FIX instead.
   {
-    if (e->NParam()==1) return type_fun_single<DIntGDL>( e);
-    return type_fun<DIntGDL>( e);
+    if (e->NParam() == 1) return type_fun_single<DIntGDL>(e);
+    return type_fun<DIntGDL>(e);
   }
-  BaseGDL* uint_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DUIntGDL>( e);
-    return type_fun<DUIntGDL>( e);
+
+  BaseGDL* uint_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DUIntGDL>(e);
+    return type_fun<DUIntGDL>(e);
   }
-  BaseGDL* long_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DLongGDL>( e);
-    return type_fun<DLongGDL>( e);
+
+  BaseGDL* long_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DLongGDL>(e);
+    return type_fun<DLongGDL>(e);
   }
-  BaseGDL* ulong_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DULongGDL>( e);
-    return type_fun<DULongGDL>( e);
+
+  BaseGDL* ulong_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DULongGDL>(e);
+    return type_fun<DULongGDL>(e);
   }
-  BaseGDL* long64_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DLong64GDL>( e);
-    return type_fun<DLong64GDL>( e);
+
+  BaseGDL* long64_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DLong64GDL>(e);
+    return type_fun<DLong64GDL>(e);
   }
-  BaseGDL* ulong64_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DULong64GDL>( e);
-    return type_fun<DULong64GDL>( e);
+
+  BaseGDL* ulong64_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DULong64GDL>(e);
+    return type_fun<DULong64GDL>(e);
   }
-  BaseGDL* float_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DFloatGDL>( e);
-    return type_fun<DFloatGDL>( e);
+
+  BaseGDL* float_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DFloatGDL>(e);
+    return type_fun<DFloatGDL>(e);
   }
-  BaseGDL* double_fun( EnvT* e)
-  {
-    if (e->NParam()==1) return type_fun_single<DDoubleGDL>( e);
-    return type_fun<DDoubleGDL>( e);
+
+  BaseGDL* double_fun(EnvT* e) {
+    if (e->NParam() == 1) return type_fun_single<DDoubleGDL>(e);
+    return type_fun<DDoubleGDL>(e);
   }
 
   BaseGDL* complex_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
     static int doubleIx = e->KeywordIx("DOUBLE");
-    bool noDouble=(!e->KeywordSet(doubleIx));
+    bool noDouble = (!e->KeywordSet(doubleIx));
     if (noDouble) {
-      if (nParam==1) return type_fun_single<DComplexGDL>( e);
-      if (nParam == 2) return complex_fun_template_twopar< DComplexGDL, DFloatGDL>(e); 
-      return type_fun<DComplexGDL>( e);
+      if (nParam == 1) return type_fun_single<DComplexGDL>(e);
+      if (nParam == 2) return complex_fun_template_twopar< DComplexGDL, DFloatGDL>(e);
+      return type_fun<DComplexGDL>(e);
     } else {
-      if (nParam==1) return type_fun_single<DComplexDblGDL>( e);
+      if (nParam == 1) return type_fun_single<DComplexDblGDL>(e);
       if (nParam == 2) return complex_fun_template_twopar< DComplexDblGDL, DDoubleGDL>(e);
-      return type_fun<DComplexDblGDL>( e);      
+      return type_fun<DComplexDblGDL>(e);
     }
   }
-  
+
   BaseGDL* dcomplex_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
-    if (nParam==1) return type_fun_single<DComplexDblGDL>( e);
+    if (nParam == 1) return type_fun_single<DComplexDblGDL>(e);
     if (nParam == 2) return complex_fun_template_twopar< DComplexDblGDL, DDoubleGDL>(e);
     return type_fun<DComplexDblGDL>(e);
   }
   // STRING function behaves different
 
-  BaseGDL* string_fun(EnvT* e)
-  {
+  BaseGDL* string_fun(EnvT* e) {
     SizeT nParam = e->NParam();
 
     if (nParam == 0)
@@ -1512,7 +1472,7 @@ namespace lib {
       if (nParam == 1) // nParam == 1 -> conversion
       {
         BaseGDL* p0 = e->GetParDefined(0);
-        // SA: see tracker item no. 3151760 
+        // SA: see tracker item no. 3151760
 
         // HERE INPUT VARIABLE IS RETURNED
         if (p0->Type() == GDL_STRING && e->GlobalPar(0)) {
@@ -1540,17 +1500,16 @@ namespace lib {
     }
   }
 
-  BaseGDL* fix_fun( EnvT* e)
-  {
-    SizeT np=e->NParam(1);
+  BaseGDL* fix_fun(EnvT* e) {
+    SizeT np = e->NParam(1);
 
     DIntGDL* type = e->IfDefGetKWAs<DIntGDL>(0); //"TYPE" keyword
-    
-    int typ=0;
+
+    int typ = 0;
     if (type != NULL) { //see IDL's behaviour.
       typ = (*type)[0];
-      if (typ > 15) typ=0;
-      if (typ < 0) typ=0;
+      if (typ > 15) typ = 0;
+      if (typ < 0) typ = 0;
     }
     if (typ > 0) {
       if (typ == GDL_INT) return int_fun(e);
@@ -1570,21 +1529,21 @@ namespace lib {
       if (typ == GDL_BYTE) {
         static int printIx = e->KeywordIx("PRINT");
         if (e->KeywordSet(printIx) && e->GetPar(0)->Type() == GDL_STRING) {
-          DLong64GDL* temp=static_cast<DLong64GDL*>(e->GetPar(0)->Convert2(GDL_LONG64,BaseGDL::COPY));
-          SizeT nEl=temp->N_Elements();
-          DByteGDL* ret=new DByteGDL(dimension(nEl));
-          for (SizeT i=0; i< nEl; ++i) {
-              (*ret)[i]=(*temp)[i];
+          DLong64GDL* temp = static_cast<DLong64GDL*> (e->GetPar(0)->Convert2(GDL_LONG64, BaseGDL::COPY));
+          SizeT nEl = temp->N_Elements();
+          DByteGDL* ret = new DByteGDL(dimension(nEl));
+          for (SizeT i = 0; i < nEl; ++i) {
+            (*ret)[i] = (*temp)[i];
           }
-          (static_cast<BaseGDL*>(ret))->SetDim(e->GetPar(0)->Dim());
+          (static_cast<BaseGDL*> (ret))->SetDim(e->GetPar(0)->Dim());
           GDLDelete(temp);
           return ret;
-          } else
-              return byte_fun(e);
+        } else
+          return byte_fun(e);
       }
-      if(typ == GDL_STRUCT) e->Throw("Unable to convert variable to type struct.");
-      if(typ == GDL_PTR) e->Throw("Unable to convert variable to type pointer.");
-      if(typ == GDL_OBJ) e->Throw("Unable to convert variable to type object reference.");
+      if (typ == GDL_STRUCT) e->Throw("Unable to convert variable to type struct.");
+      if (typ == GDL_PTR) e->Throw("Unable to convert variable to type pointer.");
+      if (typ == GDL_OBJ) e->Throw("Unable to convert variable to type object reference.");
 
       if (typ == GDL_STRING) {
         // SA: calling GDL_STRING() with correct parameters
@@ -1599,8 +1558,8 @@ namespace lib {
 
         static int printIx = e->KeywordIx("PRINT");
 
-        if (e->KeywordSet(printIx) && e->GetPar(0)->Type() == GDL_BYTE){
-            newEnv->SetKeyword("PRINT", new DIntGDL(1));
+        if (e->KeywordSet(printIx) && e->GetPar(0)->Type() == GDL_BYTE) {
+          newEnv->SetKeyword("PRINT", new DIntGDL(1));
         }
 
         return static_cast<DLibFun*> (newEnv->GetPro())->Fun()(newEnv);
@@ -1609,439 +1568,387 @@ namespace lib {
     return int_fun(e);
   }
 
-  BaseGDL* call_function( EnvT* e)
-  {
-    int nParam=e->NParam();
-    if( nParam == 0)
-      e->Throw( "No function specified.");
-    
+  BaseGDL* call_function(EnvT* e) {
+    int nParam = e->NParam();
+    if (nParam == 0)
+      e->Throw("No function specified.");
+
     DString callF;
-    e->AssureScalarPar<DStringGDL>( 0, callF);
+    e->AssureScalarPar<DStringGDL>(0, callF);
 
     // this is a function name -> convert to UPPERCASE
-    callF = StrUpCase( callF);
+    callF = StrUpCase(callF);
 
     // first search library funcedures
-    int funIx=LibFunIx( callF);
-    if( funIx != -1)
-      {
-    //  e->PushNewEnv( libFunList[ funIx], 1);
-    // make the call
-    //  EnvT* newEnv = static_cast<EnvT*>(e->Interpreter()->CallStack().back());
+    int funIx = LibFunIx(callF);
+    if (funIx != -1) {
+      //  e->PushNewEnv( libFunList[ funIx], 1);
+      // make the call
+      //  EnvT* newEnv = static_cast<EnvT*>(e->Interpreter()->CallStack().back());
 
-    // handle direct call functions 
-    if( libFunList[ funIx]->DirectCall())
-      {
+      // handle direct call functions
+      if (libFunList[ funIx]->DirectCall()) {
         BaseGDL* directCallParameter = e->GetParDefined(1);
-        BaseGDL* res = 
-          static_cast<DLibFunDirect*>(libFunList[ funIx])->FunDirect()(directCallParameter, true /*isReference*/);
+        BaseGDL* res =
+          static_cast<DLibFunDirect*> (libFunList[ funIx])->FunDirect()(directCallParameter, true /*isReference*/);
+        return res;
+      } else {
+        EnvT* newEnv = e->NewEnv(libFunList[ funIx], 1);
+        Guard<EnvT> guard(newEnv);
+        BaseGDL* res = static_cast<DLibFun*> (newEnv->GetPro())->Fun()(newEnv);
+        e->SetPtrToReturnValue(newEnv->GetPtrToReturnValue());
         return res;
       }
-    else
-      {
-        EnvT* newEnv = e->NewEnv( libFunList[ funIx], 1);
-        Guard<EnvT> guard( newEnv);
-        BaseGDL* res = static_cast<DLibFun*>(newEnv->GetPro())->Fun()(newEnv);
-        e->SetPtrToReturnValue( newEnv->GetPtrToReturnValue());
-        return res;
-      }
-      }
-    else
-      {
-    // no direct call here
-    
-    funIx = GDLInterpreter::GetFunIx( callF);
-    
-    StackGuard<EnvStackT> guard( e->Interpreter()->CallStack());
+    } else {
+      // no direct call here
 
-    EnvUDT* newEnv = e->PushNewEnvUD( funList[ funIx], 1);
-    
-    // make the call
-    //  EnvUDT* newEnv = static_cast<EnvUDT*>(e->Interpreter()->CallStack().back());
-    //GD: changed LRFUNCTION to RFUNCTION and removed e->SetPtrToReturnValue() below.
-    //this solved bug #706
-    newEnv->SetCallContext( EnvUDT::RFUNCTION);
-    BaseGDL* res = e->Interpreter()->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
-//GD: removed   e->SetPtrToReturnValue( newEnv->GetPtrToReturnValue());
-    //  BaseGDL* ppp = res->Dup();
-    //  cout << " res = " << res << "  p to res = " << newEnv->GetPtrToReturnValue() << endl;
-    return res;
-      }
+      funIx = GDLInterpreter::GetFunIx(callF);
+
+      StackGuard<EnvStackT> guard(e->Interpreter()->CallStack());
+
+      EnvUDT* newEnv = e->PushNewEnvUD(funList[ funIx], 1);
+
+      // make the call
+      //  EnvUDT* newEnv = static_cast<EnvUDT*>(e->Interpreter()->CallStack().back());
+      //GD: changed LRFUNCTION to RFUNCTION and removed e->SetPtrToReturnValue() below.
+      //this solved bug #706
+      newEnv->SetCallContext(EnvUDT::RFUNCTION);
+      BaseGDL* res = e->Interpreter()->call_fun(static_cast<DSubUD*> (newEnv->GetPro())->GetTree());
+      //GD: removed   e->SetPtrToReturnValue( newEnv->GetPtrToReturnValue());
+      //  BaseGDL* ppp = res->Dup();
+      //  cout << " res = " << res << "  p to res = " << newEnv->GetPtrToReturnValue() << endl;
+      return res;
+    }
   }
 
-  BaseGDL* call_method_function( EnvT* e)
-  {
-    int nParam=e->NParam();
-    if( nParam < 2)
-      e->Throw(  "Name and object reference must be specified.");
-    
+  BaseGDL* call_method_function(EnvT* e) {
+    int nParam = e->NParam();
+    if (nParam < 2)
+      e->Throw("Name and object reference must be specified.");
+
     DString callP;
-    e->AssureScalarPar<DStringGDL>( 0, callP);
+    e->AssureScalarPar<DStringGDL>(0, callP);
 
     // this is a procedure name -> convert to UPPERCASE
-    callP = StrUpCase( callP);
-    
-    DStructGDL* oStruct = e->GetObjectPar( 1);
+    callP = StrUpCase(callP);
 
-    DFun* method= oStruct->Desc()->GetFun( callP);
+    DStructGDL* oStruct = e->GetObjectPar(1);
 
-    if( method == NULL)
-      e->Throw( "Method not found: "+callP);
+    DFun* method = oStruct->Desc()->GetFun(callP);
 
-    StackGuard<EnvStackT> guard( e->Interpreter()->CallStack());
+    if (method == NULL)
+      e->Throw("Method not found: " + callP);
 
-    EnvUDT* newEnv = e->PushNewEnvUD( method, 2, (DObjGDL**) &e->GetPar( 1));
-    
+    StackGuard<EnvStackT> guard(e->Interpreter()->CallStack());
+
+    EnvUDT* newEnv = e->PushNewEnvUD(method, 2, (DObjGDL**) & e->GetPar(1));
+
     // make the call
     //     return e->Interpreter()->call_fun( method->GetTree());
-    newEnv->SetCallContext( EnvUDT::LRFUNCTION);
-    BaseGDL* res = e->Interpreter()->call_fun( method->GetTree());
-    e->SetPtrToReturnValue( newEnv->GetPtrToReturnValue());
+    newEnv->SetCallContext(EnvUDT::LRFUNCTION);
+    BaseGDL* res = e->Interpreter()->call_fun(method->GetTree());
+    e->SetPtrToReturnValue(newEnv->GetPtrToReturnValue());
     return res;
   }
 
-
-
-  BaseGDL* execute_fun( EnvT* e)
-  {
-    int nParam=e->NParam( 1);
+  BaseGDL* execute_fun(EnvT* e) {
+    int nParam = e->NParam(1);
 
     bool compileFlags = false;
-    if( nParam >= 2)
-      {
-    BaseGDL* p1 = e->GetParDefined( 1);
+    if (nParam >= 2) {
+      BaseGDL* p1 = e->GetParDefined(1);
 
-    if( !p1->Scalar())
-      e->Throw( "Expression must be scalar in this context: "+
-            e->GetParString(1));
+      if (!p1->Scalar())
+        e->Throw("Expression must be scalar in this context: " +
+        e->GetParString(1));
 
-    // we do not enforce the case of Implied Print, then only 2 states
-    compileFlags = p1->LogTrue();
-      }
+      // we do not enforce the case of Implied Print, then only 2 states
+      compileFlags = p1->LogTrue();
+    }
 
     bool quietExecution = false;
-    if( nParam == 3)
-      {
-    BaseGDL* p2 = e->GetParDefined( 2);
+    if (nParam == 3) {
+      BaseGDL* p2 = e->GetParDefined(2);
 
-    if( !p2->Scalar())
-      e->Throw( "Expression must be scalar in this context: "+
-            e->GetParString(2));
+      if (!p2->Scalar())
+        e->Throw("Expression must be scalar in this context: " +
+        e->GetParString(2));
 
-    quietExecution = p2->LogTrue();
-    Warning("The QuietExecution argument of execute() is not yet supported by GDL.");
-      }
+      quietExecution = p2->LogTrue();
+      Warning("The QuietExecution argument of execute() is not yet supported by GDL.");
+    }
 
     if (e->GetParDefined(0)->Rank() != 0)
-      e->Throw("Expression must be scalar in this context: "+e->GetParString(0));
-    
+      e->Throw("Expression must be scalar in this context: " + e->GetParString(0));
+
     DString line;
-    e->AssureScalarPar<DStringGDL>( 0, line);
+    e->AssureScalarPar<DStringGDL>(0, line);
 
     // remove current environment (own one)
-    assert( dynamic_cast<EnvUDT*>(e->Caller()) != NULL);
-    EnvUDT* caller = static_cast<EnvUDT*>(e->Caller());
+    assert(dynamic_cast<EnvUDT*> (e->Caller()) != NULL);
+    EnvUDT* caller = static_cast<EnvUDT*> (e->Caller());
     //     e->Interpreter()->CallStack().pop_back();
 
-    // wrong: e is guarded, do not delete it here   
+    // wrong: e is guarded, do not delete it here
     //  delete e;
 
-    istringstream istr(line+"\n");
+    istringstream istr(line + "\n");
 
     RefDNode theAST;
-    try {  
-      GDLLexer   lexer(istr, "", caller->CompileOpt());
-      GDLParser& parser=lexer.Parser();
-    
+    try {
+      GDLLexer lexer(istr, "", caller->CompileOpt());
+      GDLParser& parser = lexer.Parser();
+
       parser.interactive();
-    
-      theAST=parser.getAST();
+
+      theAST = parser.getAST();
+    }    catch (GDLException& ex) {
+      if (!compileFlags) GDLInterpreter::ReportCompileError(ex);
+      return new DIntGDL(0);
+    }    catch (ANTLRException& ex) {
+      if (!compileFlags) cerr << "EXECUTE: Lexer/Parser exception: " <<
+        ex.getMessage() << endl;
+      return new DIntGDL(0);
     }
-    catch( GDLException& ex)
-      {
-    if( !compileFlags) GDLInterpreter::ReportCompileError( ex);
-    return new DIntGDL( 0);
-      }
-    catch( ANTLRException& ex)
-      {
-    if( !compileFlags) cerr << "EXECUTE: Lexer/Parser exception: " <<  
-                 ex.getMessage() << endl;
-    return new DIntGDL( 0);
-      }
-    
-    if( theAST == NULL) return new DIntGDL( 1);
+
+    if (theAST == NULL) return new DIntGDL(1);
 
     RefDNode trAST;
-    try
-      {
-    GDLTreeParser treeParser( caller);
-      
-    treeParser.interactive(theAST);
+    try {
+      GDLTreeParser treeParser(caller);
 
-    trAST=treeParser.getAST();
-      }
-    catch( GDLException& ex)
-      {
-    if( !compileFlags) GDLInterpreter::ReportCompileError( ex);
-    return new DIntGDL( 0);
-      }
+      treeParser.interactive(theAST);
 
-    catch( ANTLRException& ex)
-      {
-    if( !compileFlags) cerr << "EXECUTE: Compiler exception: " <<  
-                 ex.getMessage() << endl;
-    return new DIntGDL( 0);
-      }
-      
-    if( trAST == NULL) return new DIntGDL( 1);
+      trAST = treeParser.getAST();
+    }    catch (GDLException& ex) {
+      if (!compileFlags) GDLInterpreter::ReportCompileError(ex);
+      return new DIntGDL(0);
+    } catch (ANTLRException& ex) {
+      if (!compileFlags) cerr << "EXECUTE: Compiler exception: " <<
+        ex.getMessage() << endl;
+      return new DIntGDL(0);
+    }
+
+    if (trAST == NULL) return new DIntGDL(1);
 
     int nForLoopsIn = caller->NForLoops();
-    try
-      {
-    ProgNodeP progAST = ProgNode::NewProgNode( trAST);
-    Guard< ProgNode> progAST_guard( progAST);
+    try {
+      ProgNodeP progAST = ProgNode::NewProgNode(trAST);
+      Guard< ProgNode> progAST_guard(progAST);
 
-    int nForLoops = ProgNode::NumberForLoops( progAST, nForLoopsIn);
-    caller->ResizeForLoops( nForLoops);
+      int nForLoops = ProgNode::NumberForLoops(progAST, nForLoopsIn);
+      caller->ResizeForLoops(nForLoops);
 
-    progAST->setLine( e->GetLineNumber());
+      progAST->setLine(e->GetLineNumber());
 
-    // AC 2016-02-26 : bug report #692 always verbose in EXECUTE()
-    // Do we have a way not to *always* issue a message here 
-    // in case of problem ???
-    RetCode retCode = caller->Interpreter()->execute( progAST); 
+      // AC 2016-02-26 : bug report #692 always verbose in EXECUTE()
+      // Do we have a way not to *always* issue a message here
+      // in case of problem ???
+      RetCode retCode = caller->Interpreter()->execute(progAST);
 
-    caller->ResizeForLoops( nForLoopsIn);
+      caller->ResizeForLoops(nForLoopsIn);
 
-    if( retCode == RC_OK)
-      return new DIntGDL( 1);
-    else
-      return new DIntGDL( 0);
-      }
-    catch( GDLException& ex)
-      {
-    caller->ResizeForLoops( nForLoopsIn);
-    // are we throwing to target environment?
-    //      if( ex.GetTargetEnv() == NULL)
-    if( !compileFlags) cerr << "EXECUTE: " <<
-                 ex.getMessage() << endl;
-    return new DIntGDL( 0);
-      }
-    catch( ANTLRException& ex)
-      {
-    caller->ResizeForLoops( nForLoopsIn);
-        
-    if( !compileFlags) cerr << "EXECUTE: Interpreter exception: " <<
-                 ex.getMessage() << endl;
-    return new DIntGDL( 0);
-      }
+      if (retCode == RC_OK)
+        return new DIntGDL(1);
+      else
+        return new DIntGDL(0);
+    }    catch (GDLException& ex) {
+      caller->ResizeForLoops(nForLoopsIn);
+      // are we throwing to target environment?
+      //      if( ex.GetTargetEnv() == NULL)
+      if (!compileFlags) cerr << "EXECUTE: " <<
+        ex.getMessage() << endl;
+      return new DIntGDL(0);
+    }    catch (ANTLRException& ex) {
+      caller->ResizeForLoops(nForLoopsIn);
 
-    return new DIntGDL( 0); // control flow cannot reach here - compiler shut up
+      if (!compileFlags) cerr << "EXECUTE: Interpreter exception: " <<
+        ex.getMessage() << endl;
+      return new DIntGDL(0);
+    }
+
+    return new DIntGDL(0); // control flow cannot reach here - compiler shut up
   }
 
-  BaseGDL* assoc( EnvT* e)
-  {
-    SizeT nParam=e->NParam( 2);
+  BaseGDL* assoc(EnvT* e) {
+    SizeT nParam = e->NParam(2);
 
     DLong lun;
-    e->AssureLongScalarPar( 0, lun);
+    e->AssureLongScalarPar(0, lun);
 
-    bool stdLun = check_lun( e, lun);
-    if( stdLun)
-      e->Throw( "File unit does not allow"
-        " this operation. Unit: "+i2s( lun));
+    bool stdLun = check_lun(e, lun);
+    if (stdLun)
+      e->Throw("File unit does not allow"
+      " this operation. Unit: " + i2s(lun));
 
     DLong offset = 0;
-    if( nParam >= 3) e->AssureLongScalarPar( 2, offset);
-    
-    BaseGDL* arr = e->GetParDefined( 1);
-    
-    if( arr->StrictScalar())
-      e->Throw( "Scalar variable not allowed in this"
-        " context: "+e->GetParString(1));
-    
-    return arr->AssocVar( lun, offset);
+    if (nParam >= 3) e->AssureLongScalarPar(2, offset);
+
+    BaseGDL* arr = e->GetParDefined(1);
+
+    if (arr->StrictScalar())
+      e->Throw("Scalar variable not allowed in this"
+      " context: " + e->GetParString(1));
+
+    return arr->AssocVar(lun, offset);
   }
 
   // gdl_ naming because of weired namespace problem in MSVC
-  BaseGDL* gdl_logical_and( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
-    if( nParam != 2)
-      e->Throw(
-           "Incorrect number of arguments.");
 
-    BaseGDL* e1=e->GetParDefined( 0);//, "LOGICAL_AND");
-    BaseGDL* e2=e->GetParDefined( 1);//, "LOGICAL_AND");
+  BaseGDL* gdl_logical_and(EnvT* e) {
+    SizeT nParam = e->NParam();
+    if (nParam != 2)
+      e->Throw(
+      "Incorrect number of arguments.");
+
+    BaseGDL* e1 = e->GetParDefined(0); //, "LOGICAL_AND");
+    BaseGDL* e2 = e->GetParDefined(1); //, "LOGICAL_AND");
 
     ULong nEl1 = e1->N_Elements();
     ULong nEl2 = e2->N_Elements();
 
     Data_<SpDByte>* res;
 
-    if( e1->Scalar()) 
-      {
-    if( e1->LogTrue(0)) 
-      {
-        res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
+    if (e1->Scalar()) {
+      if (e1->LogTrue(0)) {
+        res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
         {
-          for( SizeT i=0; i < nEl2; i++)
-        (*res)[i] = e2->LogTrue( i) ? 1 : 0;
+          for (SizeT i = 0; i < nEl2; i++)
+            (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         }
+      } else {
+        return new Data_<SpDByte>(e2->Dim());
       }
-    else
-      {
-        return new Data_<SpDByte>( e2->Dim());
-      }
-      }
-    else if( e2->Scalar()) 
-      {
-    if( e2->LogTrue(0)) 
-      {
-        res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
+    } else if (e2->Scalar()) {
+      if (e2->LogTrue(0)) {
+        res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
         {
-          for( SizeT i=0; i < nEl1; i++)
-        (*res)[i] = e1->LogTrue( i) ? 1 : 0;
+          for (SizeT i = 0; i < nEl1; i++)
+            (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         }
+      } else {
+        return new Data_<SpDByte>(e1->Dim());
       }
-    else
+    } else if (nEl2 <= nEl1) {
+      res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
       {
-        return new Data_<SpDByte>( e1->Dim());
+        for (SizeT i = 0; i < nEl2; i++)
+          (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       }
-      }
-    else if( nEl2 <= nEl1) 
-      {
-    res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
+    } else // ( nEl2 > nEl1)
     {
-      for( SizeT i=0; i < nEl2; i++)
-        (*res)[i] = (e1->LogTrue( i) && e2->LogTrue( i)) ? 1 : 0;
-    }
-      }
-    else // ( nEl2 > nEl1)
+      res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
       {
-    res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-    {
-      for( SizeT i=0; i < nEl1; i++)
-        (*res)[i] = (e1->LogTrue( i) && e2->LogTrue( i)) ? 1 : 0;
-    }
+        for (SizeT i = 0; i < nEl1; i++)
+          (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       }
+    }
     return res;
   }
 
   // gdl_ naming because of weired namespace problem in MSVC
-  BaseGDL* gdl_logical_or( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
-    if( nParam != 2)
-      e->Throw(
-           "Incorrect number of arguments.");
 
-    BaseGDL* e1=e->GetParDefined( 0);//, "LOGICAL_OR");
-    BaseGDL* e2=e->GetParDefined( 1);//, "LOGICAL_OR");
+  BaseGDL* gdl_logical_or(EnvT* e) {
+    SizeT nParam = e->NParam();
+    if (nParam != 2)
+      e->Throw(
+      "Incorrect number of arguments.");
+
+    BaseGDL* e1 = e->GetParDefined(0); //, "LOGICAL_OR");
+    BaseGDL* e2 = e->GetParDefined(1); //, "LOGICAL_OR");
 
     ULong nEl1 = e1->N_Elements();
     ULong nEl2 = e2->N_Elements();
 
     Data_<SpDByte>* res;
 
-    if( e1->Scalar()) 
-      {
-    if( e1->LogTrue(0)) 
-      {
-        res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
+    if (e1->Scalar()) {
+      if (e1->LogTrue(0)) {
+        res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
         {
-          for( SizeT i=0; i < nEl2; i++)
-        (*res)[i] = 1;
+          for (SizeT i = 0; i < nEl2; i++)
+            (*res)[i] = 1;
+        }
+      } else {
+        res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
+        {
+          for (SizeT i = 0; i < nEl2; i++)
+            (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         }
       }
-    else
-      {
-        res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
+    } else if (e2->Scalar()) {
+      if (e2->LogTrue(0)) {
+        res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
         {
-          for( SizeT i=0; i < nEl2; i++)
-        (*res)[i] = e2->LogTrue( i) ? 1 : 0;
+          for (SizeT i = 0; i < nEl1; i++)
+            (*res)[i] = 1;
+        }
+      } else {
+        res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
+        {
+          for (SizeT i = 0; i < nEl1; i++)
+            (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         }
       }
-      }
-    else if( e2->Scalar()) 
+    } else if (nEl2 < nEl1) {
+      res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
       {
-    if( e2->LogTrue(0)) 
-      {
-        res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-        {
-          for( SizeT i=0; i < nEl1; i++)
-        (*res)[i] = 1;
-        }
+        for (SizeT i = 0; i < nEl2; i++)
+          (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       }
-    else
-      {
-        res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-        {
-          for( SizeT i=0; i < nEl1; i++)
-        (*res)[i] = e1->LogTrue( i) ? 1 : 0;
-        }
-      }
-      }
-    else if( nEl2 < nEl1) 
-      {
-    res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
+    } else // ( nEl2 >= nEl1)
     {
-      for( SizeT i=0; i < nEl2; i++)
-        (*res)[i] = (e1->LogTrue( i) || e2->LogTrue( i)) ? 1 : 0;
-    }
-      }
-    else // ( nEl2 >= nEl1)
+      res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
       {
-    res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-    {
-      for( SizeT i=0; i < nEl1; i++)
-        (*res)[i] = (e1->LogTrue( i) || e2->LogTrue( i)) ? 1 : 0;
-    }
+        for (SizeT i = 0; i < nEl1; i++)
+          (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       }
+    }
     return res;
   }
 
-  BaseGDL* logical_true( BaseGDL* e1, bool isReference)//( EnvT* e);
+  BaseGDL* logical_true(BaseGDL* e1, bool isReference)//( EnvT* e);
   {
-    if (e1->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    if (e1->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
 
     ULong nEl1 = e1->N_Elements();
 
-    Data_<SpDByte>* res = new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
+    Data_<SpDByte>* res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
     {
-      for( SizeT i=0; i < nEl1; i++)
-    (*res)[i] = e1->LogTrue( i) ? 1 : 0;
-    }    
+      for (SizeT i = 0; i < nEl1; i++)
+        (*res)[i] = e1->LogTrue(i) ? 1 : 0;
+    }
     return res;
   }
 
-  BaseGDL* replicate( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
-    if( nParam < 2)
-      e->Throw( "Incorrect number of arguments.");
+  BaseGDL* replicate(EnvT* e) {
+    SizeT nParam = e->NParam();
+    if (nParam < 2)
+      e->Throw("Incorrect number of arguments.");
     dimension dim;
-    arr( e, dim, 1);
+    arr(e, dim, 1);
 
-    BaseGDL* p0=e->GetParDefined( 0);//, "REPLICATE");
-    if( !p0->Scalar())
-      e->Throw( "Expression must be a scalar in this context: "+
-        e->GetParString(0));
+    BaseGDL* p0 = e->GetParDefined(0); //, "REPLICATE");
+    if (!p0->Scalar())
+      e->Throw("Expression must be a scalar in this context: " +
+      e->GetParString(0));
 
-    return p0->New( dim, BaseGDL::INIT);
+    return p0->New(dim, BaseGDL::INIT);
   }
-static const std::string trimmable(" \t");
+  static const std::string trimmable(" \t");
 
- 
+
   //leading blanks
+
   inline void trim1(std::string &s) {
     std::size_t found = s.find_first_not_of(trimmable);
     if (found != std::string::npos)
-      s.erase(0,found);
+      s.erase(0, found);
     else
       s.clear();
   }
   //trailing blanks
+
   inline void trim0(std::string &s) {
     std::size_t found = s.find_last_not_of(trimmable);
     if (found != std::string::npos)
@@ -2049,7 +1956,8 @@ static const std::string trimmable(" \t");
     else
       s.clear();
   }
- inline void trim2(std::string &s) {
+
+  inline void trim2(std::string &s) {
     trim0(s);
     trim1(s);
   }
@@ -2058,11 +1966,11 @@ static const std::string trimmable(" \t");
     SizeT nParam = e->NParam(1); //, "STRTRIM");
 
     BaseGDL* p0 = e->GetPar(0);
-    if (p0 == NULL)   e->Throw("Variable is undefined: " + e->GetParString(0));
+    if (p0 == NULL) e->Throw("Variable is undefined: " + e->GetParString(0));
 
     DLong mode = 0;
     if (nParam == 2) {
-      e->AssureLongScalarPar(1,mode);
+      e->AssureLongScalarPar(1, mode);
 
       if (mode < 0 || mode > 2) {
         ostringstream os;
@@ -2071,39 +1979,42 @@ static const std::string trimmable(" \t");
           ")> is out of allowed range.");
       }
     }
-    
+
     DStringGDL* res;
 
     if (p0->Type() == GDL_STRING)
-      res = static_cast<DStringGDL*>(p0->Dup());
+      res = static_cast<DStringGDL*> (p0->Dup());
     else {
       res = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
     }
-    
+
     SizeT nEl = res->N_Elements();
-    
+
     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (mode == 2) // both
     {
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
+          for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       }
     } else if (mode == 1) // leading
     {
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
+          for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       }
     } else // trailing
     {
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
+          for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       }
@@ -2125,59 +2036,58 @@ static const std::string trimmable(" \t");
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-      for (OMPInt i = 0; i < nEl; ++i) {
+        for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
       }
     }
     return res;
   }
 
-  BaseGDL* strpos( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 2);//, "STRPOS");
+  BaseGDL* strpos(EnvT* e) {
+    SizeT nParam = e->NParam(2); //, "STRPOS");
 
-    bool reverseOffset =  e->KeywordSet(0); // REVERSE_OFFSET
-    bool reverseSearch =  e->KeywordSet(1); // REVERSE_SEARCH
+    bool reverseOffset = e->KeywordSet(0); // REVERSE_OFFSET
+    bool reverseSearch = e->KeywordSet(1); // REVERSE_SEARCH
 
-    DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
+    DStringGDL* p0S = e->GetParAs<DStringGDL>(0);
 
     DString searchString;
     //     e->AssureScalarPar<DStringGDL>( 1, searchString);
-    DStringGDL* sStr = e->GetParAs<DStringGDL>( 1);
-    if( !sStr->Scalar( searchString))
-      e->Throw( "Search string must be a scalar or one element array: "+
-        e->GetParString( 1));
+    DStringGDL* sStr = e->GetParAs<DStringGDL>(1);
+    if (!sStr->Scalar(searchString))
+      e->Throw("Search string must be a scalar or one element array: " +
+      e->GetParString(1));
 
     long pos = -1; //string::npos
-    if( nParam > 2)
-      {
-    BaseGDL* p2 = e->GetParDefined(2);
-    const SizeT pIx = 2;
-    BaseGDL* p = e->GetParDefined( pIx);
-    DLongGDL* lp = static_cast<DLongGDL*>(p->Convert2( GDL_LONG, BaseGDL::COPY));
-    Guard<DLongGDL> guard_lp( lp);
-    DLong scalar;
-    if( !lp->Scalar( scalar))
-      throw GDLException("Parameter must be a scalar in this context: "+
-                 e->GetParString(pIx));
-    pos = scalar;
-      }
+    if (nParam > 2) {
+      BaseGDL* p2 = e->GetParDefined(2);
+      const SizeT pIx = 2;
+      BaseGDL* p = e->GetParDefined(pIx);
+      DLongGDL* lp = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
+      Guard<DLongGDL> guard_lp(lp);
+      DLong scalar;
+      if (!lp->Scalar(scalar))
+        throw GDLException("Parameter must be a scalar in this context: " +
+        e->GetParString(pIx));
+      pos = scalar;
+    }
 
-    DLongGDL* res = new DLongGDL( p0S->Dim(), BaseGDL::NOZERO);
+    DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
-      }      
+      }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-    for( OMPInt i=0; i<nEl; ++i)
-      {
-        (*res)[ i] = StrPos((*p0S)[ i], searchString, pos,  reverseOffset, reverseSearch);
-      } 
+        for (OMPInt i = 0; i < nEl; ++i) {
+        (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
+      }
     }
     return res;
   }
@@ -2245,7 +2155,7 @@ static const std::string trimmable(" \t");
       }
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr * 10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr * 10)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr ) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr)));
     if (!parallelize) {
       for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
@@ -2259,8 +2169,9 @@ static const std::string trimmable(" \t");
         }
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) default( shared)
-      for (OMPInt i = 0; i < nSrcStr; ++i) {
+        for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
           DLong actFirst = (sc1) ? scVal1 : (*p1L)[ destIx % nEl1];
@@ -2287,7 +2198,7 @@ static const std::string trimmable(" \t");
     else {
       p0S = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
       guard.Reset(p0S);
-      isReference=true;
+      isReference = true;
     }
 
     SizeT nEl = p0S->N_Elements();
@@ -2296,16 +2207,18 @@ static const std::string trimmable(" \t");
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
+          for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       }
@@ -2334,23 +2247,25 @@ static const std::string trimmable(" \t");
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
       if (parallelize) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
+          for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       } else {
         for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       }
     }
     return res;
   }
-  
+
   BaseGDL* strlen(BaseGDL* p0, bool isReference)//( EnvT* e)
   {
     if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
@@ -2365,7 +2280,7 @@ static const std::string trimmable(" \t");
     }
 
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
-//no use to parallelize, fast enough (on par)
+    //no use to parallelize, fast enough (on par)
     SizeT nEl = p0S->N_Elements();
     for (SizeT i = 0; i < nEl; ++i) {
       (*res)[ i] = (*p0S)[ i].length();
@@ -2373,128 +2288,112 @@ static const std::string trimmable(" \t");
     return res;
   }
 
-  BaseGDL* strjoin( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 1);
+  BaseGDL* strjoin(EnvT* e) {
+    SizeT nParam = e->NParam(1);
 
-    DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
+    DStringGDL* p0S = e->GetParAs<DStringGDL>(0);
     SizeT nEl = p0S->N_Elements();
 
     DString delim = "";
-    if( nParam > 1)
-      e->AssureStringScalarPar( 1, delim);
-    
-    bool single = e->KeywordSet( 0); // SINGLE
+    if (nParam > 1)
+      e->AssureStringScalarPar(1, delim);
 
-    if( single)
-      {
-    DStringGDL* res = new DStringGDL( (*p0S)[0]);
-    DString&    scl = (*res)[0];
+    bool single = e->KeywordSet(0); // SINGLE
 
-    for( SizeT i=1; i<nEl; ++i)
-      scl += delim + (*p0S)[i];
+    if (single) {
+      DStringGDL* res = new DStringGDL((*p0S)[0]);
+      DString& scl = (*res)[0];
 
-    return res;
-      }
+      for (SizeT i = 1; i < nEl; ++i)
+        scl += delim + (*p0S)[i];
 
-    dimension resDim( p0S->Dim());
+      return res;
+    }
+
+    dimension resDim(p0S->Dim());
     resDim.Purge();
-    
-    SizeT stride = resDim.Stride( 1);
 
-    resDim.Remove( 0);
+    SizeT stride = resDim.Stride(1);
 
-    DStringGDL* res = new DStringGDL( resDim, BaseGDL::NOZERO);
-    for( SizeT src=0, dst=0; src<nEl; ++dst)
-      {
-    (*res)[ dst] = (*p0S)[ src++];
-    for(SizeT l=1; l<stride; ++l)
-      (*res)[ dst] += delim + (*p0S)[ src++];
-      }
-    
+    resDim.Remove(0);
+
+    DStringGDL* res = new DStringGDL(resDim, BaseGDL::NOZERO);
+    for (SizeT src = 0, dst = 0; src < nEl; ++dst) {
+      (*res)[ dst] = (*p0S)[ src++];
+      for (SizeT l = 1; l < stride; ++l)
+        (*res)[ dst] += delim + (*p0S)[ src++];
+    }
+
     return res;
   }
 
-
-  BaseGDL* n_params( EnvT* e) 
-  {
-    EnvUDT* caller = static_cast<EnvUDT*>(e->Caller());
-    if( caller == NULL) return new DLongGDL( 0);
+  BaseGDL* n_params(EnvT* e) {
+    EnvUDT* caller = static_cast<EnvUDT*> (e->Caller());
+    if (caller == NULL) return new DLongGDL(0);
     DLong nP = caller->NParam();
-    if( caller->IsObject()) 
-      return new DLongGDL( nP-1); // "self" is not counted
-    return new DLongGDL( nP);
+    if (caller->IsObject())
+      return new DLongGDL(nP - 1); // "self" is not counted
+    return new DLongGDL(nP);
   }
-//keyword_set returns 1 (true) if:
-//
-//    Expression is a scalar or 1-element array with a non-zero value.
-//    Expression is a structure or a n-element array, n>1 
-//    Expression is an ASSOC file variable.  ---> not done?
-//
-//KEYWORD_SET returns 0 (false) if:
-//
-//    Expression is undefined.
-//    Expression is a scalar or 1-element array with a zero value.
+  //keyword_set returns 1 (true) if:
+  //
+  //    Expression is a scalar or 1-element array with a non-zero value.
+  //    Expression is a structure or a n-element array, n>1
+  //    Expression is an ASSOC file variable.  ---> not done?
+  //
+  //KEYWORD_SET returns 0 (false) if:
+  //
+  //    Expression is undefined.
+  //    Expression is a scalar or 1-element array with a zero value.
 
-  BaseGDL* keyword_set( EnvT* e)
-  {
-    e->NParam( 1);//, "KEYWORD_SET");
+  BaseGDL* keyword_set(EnvT* e) {
+    e->NParam(1); //, "KEYWORD_SET");
 
-    BaseGDL* p0 = e->GetPar( 0);
-    if( p0 == NULL) return new DIntGDL( 0);
-    if( p0->Type() == GDL_UNDEF) return new DIntGDL( 0);
-    if( !p0->Scalar()) return new DIntGDL( 1);
-    if( p0->Type() == GDL_STRUCT) return new DIntGDL( 1);
-    if( p0->LogTrue()) return new DIntGDL( 1);
-    return new DIntGDL( 0);
+    BaseGDL* p0 = e->GetPar(0);
+    if (p0 == NULL) return new DIntGDL(0);
+    if (p0->Type() == GDL_UNDEF) return new DIntGDL(0);
+    if (!p0->Scalar()) return new DIntGDL(1);
+    if (p0->Type() == GDL_STRUCT) return new DIntGDL(1);
+    if (p0->LogTrue()) return new DIntGDL(1);
+    return new DIntGDL(0);
   }
 
-  // passing 2nd argument by value is slightly better for float and double, 
+  // passing 2nd argument by value is slightly better for float and double,
   // but incur some overhead for the complex class.
 
-  template<class T> inline void AddOmitNaN(T& dest, T value)
-  {
+  template<class T> inline void AddOmitNaN(T& dest, T value) {
     if (std::isfinite(value)) {
-      // #pragma omp atomic
       dest += value;
     }
   }
 
-  template<class T> inline void AddOmitNaNCpx(T& dest, T value)
-  {
-    // #pragma omp atomic
+  template<class T> inline void AddOmitNaNCpx(T& dest, T value) {
     dest += T(std::isfinite(value.real()) ? value.real() : 0,
-        std::isfinite(value.imag()) ? value.imag() : 0);
+      std::isfinite(value.imag()) ? value.imag() : 0);
   }
 
-  template<> inline void AddOmitNaN(DComplex& dest, DComplex value)
-  {
+  template<> inline void AddOmitNaN(DComplex& dest, DComplex value) {
     AddOmitNaNCpx<DComplex>(dest, value);
   }
 
-  template<> inline void AddOmitNaN(DComplexDbl& dest, DComplexDbl value)
-  {
+  template<> inline void AddOmitNaN(DComplexDbl& dest, DComplexDbl value) {
     AddOmitNaNCpx<DComplexDbl>(dest, value);
   }
 
-  template<class T> inline void NaN2Zero(T& value)
-  {
+  template<class T> inline void NaN2Zero(T& value) {
     if (!std::isfinite(value)) value = 0;
   }
 
-  template<class T> inline void NaN2ZeroCpx(T& value)
-  {
+  template<class T> inline void NaN2ZeroCpx(T& value) {
     value = T(std::isfinite(value.real()) ? value.real() : 0,
-        std::isfinite(value.imag()) ? value.imag() : 0);
+      std::isfinite(value.imag()) ? value.imag() : 0);
   }
 
-  template<> inline void NaN2Zero(DComplex& value)
-  {
+  template<> inline void NaN2Zero(DComplex& value) {
     NaN2ZeroCpx< DComplex>(value);
   }
 
-  template<> inline void NaN2Zero(DComplexDbl& value)
-  {
+  template<> inline void NaN2Zero(DComplexDbl& value) {
     NaN2ZeroCpx< DComplexDbl>(value);
   }
 
@@ -2509,14 +2408,16 @@ static const std::string trimmable(" \t");
       if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
     } else {
-        if (!omitNaN) {
+      if (!omitNaN) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for reduction(+:sum) num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+          for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           typename T::Ty localsum = 0;
-#pragma omp for  
+#pragma omp for
           for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) localsum += (*src)[ i];
 #pragma omp atomic
           sum += localsum;
@@ -2540,8 +2441,9 @@ static const std::string trimmable(" \t");
           si += (*src)[i].imag();
         }
       } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
-        for (SizeT i = 0; i < nEl; ++i) {
+          for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
@@ -2553,6 +2455,8 @@ static const std::string trimmable(" \t");
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
         }
       } else {
+
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           DFloat lsr = 0;
@@ -2572,8 +2476,7 @@ static const std::string trimmable(" \t");
   }
 
   template<>
-  BaseGDL* total_template_generic(DComplexDblGDL* src, bool omitNaN)
-  {
+  BaseGDL* total_template_generic(DComplexDblGDL* src, bool omitNaN) {
     //    std::cerr << " total_template_generic_DcomplexGDlDbl " << std::endl;
     SizeT nEl = src->N_Elements();
     DDouble sr = 0;
@@ -2586,8 +2489,9 @@ static const std::string trimmable(" \t");
           si += (*src)[i].imag();
         }
       } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
-        for (SizeT i = 0; i < nEl; ++i) {
+          for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
@@ -2599,6 +2503,8 @@ static const std::string trimmable(" \t");
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
         }
       } else {
+
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           DDouble lsr = 0;
@@ -2617,7 +2523,7 @@ static const std::string trimmable(" \t");
     return new DComplexDblGDL(std::complex<double>(sr, si));
   }
 
-  // total over all elements, done on Double. Avoids costly convert! 
+  // total over all elements, done on Double. Avoids costly convert!
 
   template<class T>
   DDoubleGDL* total_template_double(T* src, bool omitNaN) {
@@ -2633,10 +2539,13 @@ static const std::string trimmable(" \t");
       }
     } else {
       if (!omitNaN) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
-        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+          for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           DDouble localsum = 0;
 #pragma omp for nowait
@@ -2663,10 +2572,13 @@ static const std::string trimmable(" \t");
       }
     } else {
       if (!omitNaN) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
-        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+          for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           DDouble localsum = 0;
 #pragma omp for nowait
@@ -2690,43 +2602,44 @@ static const std::string trimmable(" \t");
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
-      for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     }
     return new DLong64GDL(sum);
   }
 
   // cumulative over all dims
 
-//  template<typename T>
-//  BaseGDL* total_cu_template(T* res, bool omitNaN)
-//  {
-//    SizeT nEl = res->N_Elements();
-//    if (omitNaN) {
-//      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-//      {
-//        // #pragma omp for
-//        for (SizeT i = 0; i < nEl; ++i)
-//          NaN2Zero((*res)[i]);
-//      }
-//    }
-//    for (SizeT i = 1, ii = 0; i < nEl; ++i, ++ii)
-//      (*res)[i] += (*res)[ii];
-//    return res;
-//  }
-//this is twice faster than above version, probably by exposing the POD (T1::Ty) to the loop to be optimized by the compiler  
+  //  template<typename T>
+  //  BaseGDL* total_cu_template(T* res, bool omitNaN)
+  //  {
+  //    SizeT nEl = res->N_Elements();
+  //    if (omitNaN) {
+  //      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  //      {
+  //        // #pragma omp for
+  //        for (SizeT i = 0; i < nEl; ++i)
+  //          NaN2Zero((*res)[i]);
+  //      }
+  //    }
+  //    for (SizeT i = 1, ii = 0; i < nEl; ++i, ++ii)
+  //      (*res)[i] += (*res)[ii];
+  //    return res;
+  //  }
+  //this is twice faster than above version, probably by exposing the POD (T1::Ty) to the loop to be optimized by the compiler
+
   template<typename T1, typename T2>
-  BaseGDL* total_cu_template(T1* val, bool omitNaN)
-  {
+  BaseGDL* total_cu_template(T1* val, bool omitNaN) {
     typename T1::Ty *res;
-    SizeT nEl=val->N_Elements();
-    res=static_cast<T2*>(val->DataAddr());
+    SizeT nEl = val->N_Elements();
+    res = static_cast<T2*> (val->DataAddr());
     if (omitNaN) {
       for (SizeT i = 0; i < nEl; ++i) NaN2Zero(res[i]);
     }
     //this formulation is slightly faster on my machine
-    for (SizeT i = 1, ii = 0; i < nEl; ++i, ++ii)  res[i] += res[ii];
-//      for (SizeT i = 1; i < nEl; ++i) res[i] += res[i-1];
+    for (SizeT i = 1, ii = 0; i < nEl; ++i, ++ii) res[i] += res[ii];
+    //      for (SizeT i = 1; i < nEl; ++i) res[i] += res[i-1];
     return val;
   }
 
@@ -2734,9 +2647,8 @@ static const std::string trimmable(" \t");
 
   template< typename T>
   BaseGDL* total_over_dim_template(T* src,
-      const dimension& srcDim,
-      SizeT sumDimIx, bool omitNaN)
-  {
+    const dimension& srcDim,
+    SizeT sumDimIx, bool omitNaN) {
     SizeT nEl = src->N_Elements();
 
     // get dest dim and number of summations
@@ -2749,7 +2661,7 @@ static const std::string trimmable(" \t");
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl/outerStride)*sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*sumStride)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * sumStride)));
     if (!parallelize) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -2773,9 +2685,10 @@ static const std::string trimmable(" \t");
         }
       }
     } else {
-    if (omitNaN) {
+      if (omitNaN) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT o = 0; o < nEl; o += outerStride) {
+          for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
             SizeT oi = o + i;
@@ -2784,9 +2697,10 @@ static const std::string trimmable(" \t");
             ++rIx;
           }
         }
-    } else {
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT o = 0; o < nEl; o += outerStride) {
+          for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
             SizeT oi = o + i;
@@ -2795,7 +2709,7 @@ static const std::string trimmable(" \t");
             ++rIx;
           }
         }
-    }
+      }
     }
     return res;
   }
@@ -2804,12 +2718,11 @@ static const std::string trimmable(" \t");
 
   template< typename T1, typename T2>
   BaseGDL* total_over_dim_cu_template(T1* val,
-      SizeT sumDimIx,
-      bool omitNaN)
-  {
+    SizeT sumDimIx,
+    bool omitNaN) {
     SizeT nEl = val->N_Elements();
     typename T1::Ty *res;
-    res=static_cast<T2*>(val->DataAddr());
+    res = static_cast<T2*> (val->DataAddr());
     const dimension& valDim = val->Dim();
     if (omitNaN) {
       for (SizeT i = 0; i < nEl; ++i)
@@ -2825,8 +2738,7 @@ static const std::string trimmable(" \t");
     return val;
   }
 
-  BaseGDL* total_fun(EnvT* e)
-  {
+  BaseGDL* total_fun(EnvT* e) {
 
     // Integer parts initially by Erin Sheldon
 
@@ -2840,7 +2752,7 @@ static const std::string trimmable(" \t");
 
     if (p0->Type() == GDL_STRING)
       e->Throw("String expression not allowed "
-        "in this context: " + e->GetParString(0));
+      "in this context: " + e->GetParString(0));
 
     static int cumIx = e->KeywordIx("CUMULATIVE");
     static int intIx = e->KeywordIx("INTEGER");
@@ -2852,15 +2764,15 @@ static const std::string trimmable(" \t");
     bool useIntegerArithmetic = e->KeywordSet(intIx);
     // if double is set to ZERO, then DOUBLE things are converted IN THE END to SINGLE
     // if double is set to 1, SINGLE things are converted to double before summing, then total is reconverted to single:
-    // DL> a=FINDGEN(10LL^7) & z=total(a) & help,z                
+    // DL> a=FINDGEN(10LL^7) & z=total(a) & help,z
     // Z               FLOAT     =   4.98246e+13
-    // DL> a=FINDGEN(10LL^7) & z=total(a,/doub) & help,z 
+    // DL> a=FINDGEN(10LL^7) & z=total(a,/doub) & help,z
     // Z               DOUBLE    =    4.9999995e+13
-    // DL> a=DINDGEN(10LL^7) & z=total(a,doub=0) & help,z  
+    // DL> a=DINDGEN(10LL^7) & z=total(a,doub=0) & help,z
     // Z               FLOAT     =   5.00000e+13
 
     // PRESERVE takes precedence.
-    // Next, INTEGER arithmetic takes precedence, and floats are individually converted to integers: 
+    // Next, INTEGER arithmetic takes precedence, and floats are individually converted to integers:
     // 1) ULONG64 are treated "as is" and result is like "preserve"
     // 2) Others are converted to LONG64 and result is LONG64. Complex values uses only real part.
     // /double converts individually values to doubles before summing and double=0 converts THE RESULT ONLY to single.
@@ -2901,17 +2813,17 @@ static const std::string trimmable(" \t");
           }
         } else {
           switch (p0->Type()) {
-          case GDL_BYTE: return total_cu_template<DByteGDL,DByte>(static_cast<DByteGDL*> (p0->Dup()), false);
-          case GDL_INT: return total_cu_template<DIntGDL,DInt>(static_cast<DIntGDL*> (p0->Dup()), false);
-          case GDL_UINT: return total_cu_template<DUIntGDL,DUInt>(static_cast<DUIntGDL*> (p0->Dup()), false);
-          case GDL_LONG: return total_cu_template<DLongGDL,DLong>(static_cast<DLongGDL*> (p0->Dup()), false);
-          case GDL_ULONG: return total_cu_template<DULongGDL,DULong>(static_cast<DULongGDL*> (p0->Dup()), false);
-          case GDL_LONG64: return total_cu_template<DLong64GDL,DLong64>(static_cast<DLong64GDL*> (p0->Dup()), false);
-          case GDL_ULONG64: return total_cu_template<DULong64GDL,DULong64>(static_cast<DULong64GDL*> (p0->Dup()), false);
-          case GDL_FLOAT: return total_cu_template<DFloatGDL,DFloat>(static_cast<DFloatGDL*> (p0->Dup()), nan);
-          case GDL_DOUBLE: return total_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
-          case GDL_COMPLEX: return total_cu_template<DComplexGDL,DComplex>(static_cast<DComplexGDL*> (p0->Dup()), nan);
-          case GDL_COMPLEXDBL: return total_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
+          case GDL_BYTE: return total_cu_template<DByteGDL, DByte>(static_cast<DByteGDL*> (p0->Dup()), false);
+          case GDL_INT: return total_cu_template<DIntGDL, DInt>(static_cast<DIntGDL*> (p0->Dup()), false);
+          case GDL_UINT: return total_cu_template<DUIntGDL, DUInt>(static_cast<DUIntGDL*> (p0->Dup()), false);
+          case GDL_LONG: return total_cu_template<DLongGDL, DLong>(static_cast<DLongGDL*> (p0->Dup()), false);
+          case GDL_ULONG: return total_cu_template<DULongGDL, DULong>(static_cast<DULongGDL*> (p0->Dup()), false);
+          case GDL_LONG64: return total_cu_template<DLong64GDL, DLong64>(static_cast<DLong64GDL*> (p0->Dup()), false);
+          case GDL_ULONG64: return total_cu_template<DULong64GDL, DULong64>(static_cast<DULong64GDL*> (p0->Dup()), false);
+          case GDL_FLOAT: return total_cu_template<DFloatGDL, DFloat>(static_cast<DFloatGDL*> (p0->Dup()), nan);
+          case GDL_DOUBLE: return total_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
+          case GDL_COMPLEX: return total_cu_template<DComplexGDL, DComplex>(static_cast<DComplexGDL*> (p0->Dup()), nan);
+          case GDL_COMPLEXDBL: return total_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
           default: assert(false);
           }
         }
@@ -2944,8 +2856,8 @@ static const std::string trimmable(" \t");
 
         } else {
           switch (p0->Type()) {
-          case GDL_ULONG64: return total_cu_template<DULong64GDL,DULong64>(static_cast<DULong64GDL*> (p0->Dup()), false);
-          case GDL_LONG64: return total_cu_template<DLong64GDL,DLong64>(static_cast<DLong64GDL*> (p0->Dup()), false);
+          case GDL_ULONG64: return total_cu_template<DULong64GDL, DULong64>(static_cast<DULong64GDL*> (p0->Dup()), false);
+          case GDL_LONG64: return total_cu_template<DLong64GDL, DLong64>(static_cast<DLong64GDL*> (p0->Dup()), false);
           case GDL_BYTE:
           case GDL_INT:
           case GDL_UINT:
@@ -2957,7 +2869,7 @@ static const std::string trimmable(" \t");
           case GDL_COMPLEXDBL:
           {
             DLong64GDL* p0L64 = static_cast<DLong64GDL*> (p0->Convert2(GDL_LONG64, BaseGDL::COPY));
-            return total_cu_template<DLong64GDL,DLong64>(p0L64, false);
+            return total_cu_template<DLong64GDL, DLong64>(p0L64, false);
           }
           default: assert(false);
           }
@@ -2997,14 +2909,14 @@ static const std::string trimmable(" \t");
           }
         } else {
           switch (p0->Type()) {
-          case GDL_DOUBLE: return total_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
-          case GDL_COMPLEXDBL: return total_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
+          case GDL_DOUBLE: return total_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
+          case GDL_COMPLEXDBL: return total_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
             // We use GDL_DOUBLE for others
           case GDL_FLOAT:
             // Conver to Double
           {
             DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
-            return total_cu_template<DDoubleGDL,DDouble>(p0Double, nan);
+            return total_cu_template<DDoubleGDL, DDouble>(p0Double, nan);
           }
           case GDL_ULONG64:
           case GDL_LONG64:
@@ -3016,18 +2928,17 @@ static const std::string trimmable(" \t");
             // Conver to Double
           {
             DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
-            return total_cu_template<DDoubleGDL,DDouble>(p0Double, false);
+            return total_cu_template<DDoubleGDL, DDouble>(p0Double, false);
           }
           case GDL_COMPLEX:
           {
             DComplexDblGDL* p0Double = static_cast<DComplexDblGDL*> (p0->Convert2(GDL_COMPLEXDBL, BaseGDL::COPY));
-            return total_cu_template<DComplexDblGDL,DComplexDbl>(p0Double, nan);
+            return total_cu_template<DComplexDblGDL, DComplexDbl>(p0Double, nan);
           }
           default: assert(false);
           }
         }
-      }
-      else { //does not promote, but eventually downgrade double results if downgradeDoubleResult is true
+      } else { //does not promote, but eventually downgrade double results if downgradeDoubleResult is true
         // note integer conversion is in doubles, not floats (verified).
         if (!cumulative) {
           switch (p0->Type()) {
@@ -3072,34 +2983,34 @@ static const std::string trimmable(" \t");
           }
         } else {
           switch (p0->Type()) {
-          case GDL_FLOAT: return total_cu_template<DFloatGDL,DFloat>(static_cast<DFloatGDL*> (p0->Dup()), nan);
+          case GDL_FLOAT: return total_cu_template<DFloatGDL, DFloat>(static_cast<DFloatGDL*> (p0->Dup()), nan);
           case GDL_DOUBLE:
           {
             if (downgradeDoubleResult) {
-              DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (total_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan));
+              DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (total_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan));
               Guard<DDoubleGDL> guard(p0Double);
               return (p0Double)->Convert2(GDL_FLOAT, BaseGDL::COPY);
             } else
-              return total_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
-            }
-          case GDL_COMPLEX: return total_cu_template<DComplexGDL,DComplex>(static_cast<DComplexGDL*> (p0->Dup()), nan);
+              return total_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), nan);
+          }
+          case GDL_COMPLEX: return total_cu_template<DComplexGDL, DComplex>(static_cast<DComplexGDL*> (p0->Dup()), nan);
           case GDL_COMPLEXDBL: if (downgradeDoubleResult) {
-              DComplexGDL* p0Cpx = static_cast<DComplexGDL*> (total_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan));
+              DComplexGDL* p0Cpx = static_cast<DComplexGDL*> (total_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan));
               Guard<DComplexGDL> guard(p0Cpx);
               return (p0Cpx)->Convert2(GDL_COMPLEX, BaseGDL::COPY);
             } else
-              return total_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
+              return total_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), nan);
             // convert to double, total then return double or float...
           case GDL_ULONG64:
           case GDL_LONG64:
           {
             DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
             if (downgradeDoubleResult) {
-              DDoubleGDL* tmp = static_cast<DDoubleGDL*> (total_cu_template<DDoubleGDL,DDouble>(p0Double, false));
+              DDoubleGDL* tmp = static_cast<DDoubleGDL*> (total_cu_template<DDoubleGDL, DDouble>(p0Double, false));
               Guard<DDoubleGDL> guard(tmp);
               return (tmp)->Convert2(GDL_FLOAT, BaseGDL::COPY);
             } else
-              return total_cu_template<DDoubleGDL,DDouble>(p0Double, false);
+              return total_cu_template<DDoubleGDL, DDouble>(p0Double, false);
           }
             // We use GDL_FLOAT for others
           case GDL_BYTE:
@@ -3109,7 +3020,7 @@ static const std::string trimmable(" \t");
           case GDL_ULONG:
           {
             DFloatGDL* p0Single = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-            return total_cu_template<DFloatGDL,DFloat>(p0Single, false);
+            return total_cu_template<DFloatGDL, DFloat>(p0Single, false);
           }
           default: assert(false);
           }
@@ -3126,8 +3037,8 @@ static const std::string trimmable(" \t");
 
     if (sumDim < 1 || sumDim > srcRank)
       e->Throw(
-        "Array must have " + i2s(sumDim) +
-        " dimensions: " + e->GetParString(0));
+      "Array must have " + i2s(sumDim) +
+      " dimensions: " + e->GetParString(0));
 
     // Preserve , fast , has preference .
     if (preserve) {
@@ -3148,17 +3059,17 @@ static const std::string trimmable(" \t");
         }
       } else {
         switch (p0->Type()) {
-        case GDL_BYTE: return total_over_dim_cu_template<DByteGDL,DByte>(static_cast<DByteGDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_INT: return total_over_dim_cu_template<DIntGDL,DInt>(static_cast<DIntGDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_UINT: return total_over_dim_cu_template<DUIntGDL,DUInt>(static_cast<DUIntGDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_LONG: return total_over_dim_cu_template<DLongGDL,DLong>(static_cast<DLongGDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_ULONG: return total_over_dim_cu_template<DULongGDL,DULong>(static_cast<DULongGDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_LONG64: return total_over_dim_cu_template<DLong64GDL,DLong64>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_ULONG64: return total_over_dim_cu_template<DULong64GDL,DULong64>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_FLOAT: return total_over_dim_cu_template<DFloatGDL,DFloat>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, nan);
-        case GDL_DOUBLE: return total_over_dim_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
-        case GDL_COMPLEX: return total_over_dim_cu_template<DComplexGDL,DComplex>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, nan);
-        case GDL_COMPLEXDBL: return total_over_dim_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_BYTE: return total_over_dim_cu_template<DByteGDL, DByte>(static_cast<DByteGDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_INT: return total_over_dim_cu_template<DIntGDL, DInt>(static_cast<DIntGDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_UINT: return total_over_dim_cu_template<DUIntGDL, DUInt>(static_cast<DUIntGDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_LONG: return total_over_dim_cu_template<DLongGDL, DLong>(static_cast<DLongGDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_ULONG: return total_over_dim_cu_template<DULongGDL, DULong>(static_cast<DULongGDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_LONG64: return total_over_dim_cu_template<DLong64GDL, DLong64>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_ULONG64: return total_over_dim_cu_template<DULong64GDL, DULong64>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_FLOAT: return total_over_dim_cu_template<DFloatGDL, DFloat>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_DOUBLE: return total_over_dim_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_COMPLEX: return total_over_dim_cu_template<DComplexGDL, DComplex>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_COMPLEXDBL: return total_over_dim_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
         default: assert(false);
         }
       }
@@ -3190,8 +3101,8 @@ static const std::string trimmable(" \t");
 
       } else {
         switch (p0->Type()) {
-        case GDL_ULONG64: return total_over_dim_cu_template<DULong64GDL,DULong64>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, false);
-        case GDL_LONG64: return total_over_dim_cu_template<DLong64GDL,DLong64>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_ULONG64: return total_over_dim_cu_template<DULong64GDL, DULong64>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, false);
+        case GDL_LONG64: return total_over_dim_cu_template<DLong64GDL, DLong64>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, false);
         case GDL_BYTE:
         case GDL_INT:
         case GDL_UINT:
@@ -3203,7 +3114,7 @@ static const std::string trimmable(" \t");
         case GDL_COMPLEXDBL:
         {
           DLong64GDL* p0L64 = static_cast<DLong64GDL*> (p0->Convert2(GDL_LONG64, BaseGDL::COPY));
-          return total_over_dim_cu_template<DLong64GDL,DLong64>(p0L64, sumDim - 1, false);
+          return total_over_dim_cu_template<DLong64GDL, DLong64>(p0L64, sumDim - 1, false);
         }
         default: assert(false);
         }
@@ -3215,7 +3126,7 @@ static const std::string trimmable(" \t");
       if (!cumulative) {
         switch (p0->Type()) {
         case GDL_DOUBLE: return total_over_dim_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0), srcDim, sumDim - 1, nan);
-	case GDL_COMPLEXDBL: return total_over_dim_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), srcDim, sumDim - 1, nan);
+        case GDL_COMPLEXDBL: return total_over_dim_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), srcDim, sumDim - 1, nan);
           // We use GDL_DOUBLE for others
         case GDL_FLOAT:
           // Conver to Double
@@ -3247,14 +3158,14 @@ static const std::string trimmable(" \t");
         }
       } else {
         switch (p0->Type()) {
-        case GDL_DOUBLE: return total_over_dim_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
-        case GDL_COMPLEXDBL: return total_over_dim_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_DOUBLE: return total_over_dim_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_COMPLEXDBL: return total_over_dim_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
           // We use GDL_DOUBLE for others
         case GDL_FLOAT:
           // Conver to Double
         {
           DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
-          return total_over_dim_cu_template<DDoubleGDL,DDouble>(p0Double, sumDim - 1, nan);
+          return total_over_dim_cu_template<DDoubleGDL, DDouble>(p0Double, sumDim - 1, nan);
         }
         case GDL_ULONG64:
         case GDL_LONG64:
@@ -3266,17 +3177,17 @@ static const std::string trimmable(" \t");
           // Conver to Double
         {
           DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
-          return total_over_dim_cu_template<DDoubleGDL,DDouble>(p0Double, sumDim - 1, false);
+          return total_over_dim_cu_template<DDoubleGDL, DDouble>(p0Double, sumDim - 1, false);
         }
         case GDL_COMPLEX:
         {
           DComplexDblGDL* p0Cpx = static_cast<DComplexDblGDL*> (p0->Convert2(GDL_COMPLEXDBL, BaseGDL::COPY));
-          return total_over_dim_cu_template<DComplexDblGDL,DComplexDbl>(p0Cpx, sumDim - 1, nan);
+          return total_over_dim_cu_template<DComplexDblGDL, DComplexDbl>(p0Cpx, sumDim - 1, nan);
         }
         default: assert(false);
         }
       }
-    }// promote to double 
+    }// promote to double
     else { //does not promote, but eventually downgrade double results if downgradeDoubleResult is true
       if (!cumulative) {
         switch (p0->Type()) {
@@ -3316,21 +3227,21 @@ static const std::string trimmable(" \t");
         }
       } else {
         switch (p0->Type()) {
-        case GDL_FLOAT: return total_over_dim_cu_template<DFloatGDL,DFloat>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_FLOAT: return total_over_dim_cu_template<DFloatGDL, DFloat>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, nan);
         case GDL_DOUBLE:
         {
           if (downgradeDoubleResult) {
-            DDoubleGDL* tmp = static_cast<DDoubleGDL*> (total_over_dim_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan));
+            DDoubleGDL* tmp = static_cast<DDoubleGDL*> (total_over_dim_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan));
             Guard<DDoubleGDL> guard(tmp);
             return tmp->Convert2(GDL_FLOAT, BaseGDL::COPY);
-          } else return total_over_dim_cu_template<DDoubleGDL,DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
+          } else return total_over_dim_cu_template<DDoubleGDL, DDouble>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, nan);
         }
-        case GDL_COMPLEX: return total_over_dim_cu_template<DComplexGDL,DComplex>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, nan);
+        case GDL_COMPLEX: return total_over_dim_cu_template<DComplexGDL, DComplex>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, nan);
         case GDL_COMPLEXDBL: if (downgradeDoubleResult) {
-            DComplexDblGDL* tmp = static_cast<DComplexDblGDL*> (total_over_dim_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan));
+            DComplexDblGDL* tmp = static_cast<DComplexDblGDL*> (total_over_dim_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan));
             Guard<DComplexDblGDL> guard(tmp);
             return tmp->Convert2(GDL_COMPLEX, BaseGDL::COPY);
-          } else return total_over_dim_cu_template<DComplexDblGDL,DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
+          } else return total_over_dim_cu_template<DComplexDblGDL, DComplexDbl>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, nan);
           // convert to double, total_over_dim then return double or float...
         case GDL_ULONG64:
         case GDL_LONG64:
@@ -3338,8 +3249,8 @@ static const std::string trimmable(" \t");
           DDoubleGDL* p0Double = static_cast<DDoubleGDL*> (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
           if (downgradeDoubleResult) {
             Guard<DDoubleGDL> guard(p0Double);
-            return (total_over_dim_cu_template<DDoubleGDL,DDouble>(p0Double, sumDim - 1, false))->Convert2(GDL_FLOAT, BaseGDL::COPY);
-          } else return total_over_dim_cu_template<DDoubleGDL,DDouble>(p0Double, sumDim - 1, false);
+            return (total_over_dim_cu_template<DDoubleGDL, DDouble>(p0Double, sumDim - 1, false))->Convert2(GDL_FLOAT, BaseGDL::COPY);
+          } else return total_over_dim_cu_template<DDoubleGDL, DDouble>(p0Double, sumDim - 1, false);
         }
           // We use GDL_FLOAT for others
         case GDL_BYTE:
@@ -3349,7 +3260,7 @@ static const std::string trimmable(" \t");
         case GDL_ULONG:
         {
           DFloatGDL* p0Single = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-          return total_over_dim_cu_template<DFloatGDL,DFloat>(p0Single, sumDim - 1, false);
+          return total_over_dim_cu_template<DFloatGDL, DFloat>(p0Single, sumDim - 1, false);
         }
         default: assert(false);
         }
@@ -3360,37 +3271,43 @@ static const std::string trimmable(" \t");
   }
 
 
-  // passing 2nd argument by value is slightly better for float and double, 
+  // passing 2nd argument by value is slightly better for float and double,
   // but incur some overhead for the complex class.
-  template<class T> inline void MultOmitNaN(T& dest, T value)
-  { 
-    if (std::isfinite(value)) 
-      {
-    // #pragma omp atomic
-    dest *= value; 
-      }
-  }
-  template<class T> inline void MultOmitNaNCpx(T& dest, T value)
-  {
-    dest *= T(std::isfinite(value.real())? value.real() : 1,
-          std::isfinite(value.imag())? value.imag() : 1);
-  }
-  template<> inline void MultOmitNaN(DComplex& dest, DComplex value)
-  { MultOmitNaNCpx<DComplex>(dest, value); }
-  template<> inline void MultOmitNaN(DComplexDbl& dest, DComplexDbl value)
-  { MultOmitNaNCpx<DComplexDbl>(dest, value); }
 
-  template<class T> inline void Nan2One(T& value)
-  { if (!std::isfinite(value)) value = 1; }
-  template<class T> inline void Nan2OneCpx(T& value)
-  {
-    value = T(std::isfinite(value.real())? value.real() : 1, 
-              std::isfinite(value.imag())? value.imag() : 1);
+  template<class T> inline void MultOmitNaN(T& dest, T value) {
+    if (std::isfinite(value)) {
+      dest *= value;
+    }
   }
-  template<> inline void Nan2One(DComplex& value)
-  { Nan2OneCpx< DComplex>(value); }
-  template<> inline void Nan2One(DComplexDbl& value)
-  { Nan2OneCpx< DComplexDbl>(value);
+
+  template<class T> inline void MultOmitNaNCpx(T& dest, T value) {
+    dest *= T(std::isfinite(value.real()) ? value.real() : 1,
+      std::isfinite(value.imag()) ? value.imag() : 1);
+  }
+
+  template<> inline void MultOmitNaN(DComplex& dest, DComplex value) {
+    MultOmitNaNCpx<DComplex>(dest, value);
+  }
+
+  template<> inline void MultOmitNaN(DComplexDbl& dest, DComplexDbl value) {
+    MultOmitNaNCpx<DComplexDbl>(dest, value);
+  }
+
+  template<class T> inline void Nan2One(T& value) {
+    if (!std::isfinite(value)) value = 1;
+  }
+
+  template<class T> inline void Nan2OneCpx(T& value) {
+    value = T(std::isfinite(value.real()) ? value.real() : 1,
+      std::isfinite(value.imag()) ? value.imag() : 1);
+  }
+
+  template<> inline void Nan2One(DComplex& value) {
+    Nan2OneCpx< DComplex>(value);
+  }
+
+  template<> inline void Nan2One(DComplexDbl& value) {
+    Nan2OneCpx< DComplexDbl>(value);
   }
 
   // product over all elements
@@ -3413,6 +3330,8 @@ static const std::string trimmable(" \t");
     } else {
 
       if (!omitNaN) {
+
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
         {
 #pragma omp for reduction(*:prod)
@@ -3421,6 +3340,8 @@ static const std::string trimmable(" \t");
           }
         }
       } else {
+
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
         {
 #pragma omp for reduction(*:prod)
@@ -3432,9 +3353,9 @@ static const std::string trimmable(" \t");
     }
     return new T(prod);
   }
-  
+
   template<>
-  BaseGDL* product_template( DComplexGDL* src, bool omitNaN) {
+  BaseGDL* product_template(DComplexGDL* src, bool omitNaN) {
     DComplexGDL::Ty prod = 1;
     SizeT nEl = src->N_Elements();
     if (!omitNaN) {
@@ -3448,9 +3369,9 @@ static const std::string trimmable(" \t");
     }
     return new DComplexGDL(prod);
   }
-  
+
   template<>
-  BaseGDL* product_template( DComplexDblGDL* src, bool omitNaN) {
+  BaseGDL* product_template(DComplexDblGDL* src, bool omitNaN) {
     DComplexDblGDL::Ty prod = 1;
     SizeT nEl = src->N_Elements();
     if (!omitNaN) {
@@ -3464,10 +3385,11 @@ static const std::string trimmable(" \t");
     }
     return new DComplexDblGDL(prod);
   }
-  
+
   // cumulative over all dims
+
   template<typename T>
-  BaseGDL* product_cu_template( T* res, bool omitNaN) {
+  BaseGDL* product_cu_template(T* res, bool omitNaN) {
     SizeT nEl = res->N_Elements();
     if (omitNaN) {
       for (SizeT i = 0; i < nEl; ++i)
@@ -3524,8 +3446,9 @@ static const std::string trimmable(" \t");
       }
     } else {
       if (omitNaN) {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT o = 0; o < nEl; o += outerStride) {
+          for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
             (*res)[ rIx] = 1;
@@ -3536,8 +3459,9 @@ static const std::string trimmable(" \t");
           }
         }
       } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-        for (SizeT o = 0; o < nEl; o += outerStride) {
+          for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
             (*res)[ rIx] = 1;
@@ -3553,10 +3477,11 @@ static const std::string trimmable(" \t");
   }
 
   // cumulative over one dim
+
   template< typename T>
-  BaseGDL* product_over_dim_cu_template( T* res, 
-                     SizeT sumDimIx,
-                     bool omitNaN) {
+  BaseGDL* product_over_dim_cu_template(T* res,
+    SizeT sumDimIx,
+    bool omitNaN) {
     SizeT nEl = res->N_Elements();
     const dimension& resDim = res->Dim();
     if (omitNaN) {
@@ -3573,7 +3498,7 @@ static const std::string trimmable(" \t");
     return res;
   }
 
-  BaseGDL* product_fun( EnvT* e) {
+  BaseGDL* product_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
 
     BaseGDL* p0 = e->GetParDefined(0);
@@ -3604,23 +3529,23 @@ static const std::string trimmable(" \t");
       if (!KwCumul) {
         if (KwPre) {
           switch (p0->Type()) {
-            case GDL_BYTE: return product_template<DByteGDL>(static_cast<DByteGDL*> (p0), nanInt);
-            case GDL_INT: return product_template<DIntGDL>(static_cast<DIntGDL*> (p0), nanInt);
-            case GDL_UINT: return product_template<DUIntGDL>(static_cast<DUIntGDL*> (p0), nanInt);
-            case GDL_LONG: return product_template<DLongGDL>(static_cast<DLongGDL*> (p0), nanInt);
-            case GDL_ULONG: return product_template<DULongGDL>(static_cast<DULongGDL*> (p0), nanInt);
-            case GDL_LONG64: return product_template<DLong64GDL>(static_cast<DLong64GDL*> (p0), nanInt);
-            case GDL_ULONG64: return product_template<DULong64GDL>(static_cast<DULong64GDL*> (p0), nanInt);
-            case GDL_FLOAT: return product_template<DFloatGDL>(static_cast<DFloatGDL*> (p0), KwNaN);
-            case GDL_DOUBLE: return product_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0), KwNaN);
-            case GDL_COMPLEX: return product_template<DComplexGDL>(static_cast<DComplexGDL*> (p0), KwNaN);
-            case GDL_COMPLEXDBL: return product_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), KwNaN);
-            default: assert(false);
+          case GDL_BYTE: return product_template<DByteGDL>(static_cast<DByteGDL*> (p0), nanInt);
+          case GDL_INT: return product_template<DIntGDL>(static_cast<DIntGDL*> (p0), nanInt);
+          case GDL_UINT: return product_template<DUIntGDL>(static_cast<DUIntGDL*> (p0), nanInt);
+          case GDL_LONG: return product_template<DLongGDL>(static_cast<DLongGDL*> (p0), nanInt);
+          case GDL_ULONG: return product_template<DULongGDL>(static_cast<DULongGDL*> (p0), nanInt);
+          case GDL_LONG64: return product_template<DLong64GDL>(static_cast<DLong64GDL*> (p0), nanInt);
+          case GDL_ULONG64: return product_template<DULong64GDL>(static_cast<DULong64GDL*> (p0), nanInt);
+          case GDL_FLOAT: return product_template<DFloatGDL>(static_cast<DFloatGDL*> (p0), KwNaN);
+          case GDL_DOUBLE: return product_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0), KwNaN);
+          case GDL_COMPLEX: return product_template<DComplexGDL>(static_cast<DComplexGDL*> (p0), KwNaN);
+          case GDL_COMPLEXDBL: return product_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), KwNaN);
+          default: assert(false);
           }
         }
 
         // Integer parts derivated from Total code by Erin Sheldon
-        // In IDL PRODUCT(), the INTEGER keyword takes precedence 
+        // In IDL PRODUCT(), the INTEGER keyword takes precedence
         if (KwInt) {
           // We use GDL_LONG64 unless the input is GDL_ULONG64
           if ((p0->Type() == GDL_LONG64) && (!KwNaN)) {
@@ -3668,28 +3593,27 @@ static const std::string trimmable(" \t");
         Guard<DDoubleGDL> p0D_guard(p0D);
         //      p0D_guard.Reset( p0D);
         return product_template<DDoubleGDL>(p0D, KwNaN);
-      }
-      else { // KwCumul
+      } else { // KwCumul
 
         if (KwPre) {
           switch (p0->Type()) {
-            case GDL_BYTE: return product_cu_template<DByteGDL>(static_cast<DByteGDL*> (p0->Dup()), nanInt);
-            case GDL_INT: return product_cu_template<DIntGDL>(static_cast<DIntGDL*> (p0->Dup()), nanInt);
-            case GDL_UINT: return product_cu_template<DUIntGDL>(static_cast<DUIntGDL*> (p0->Dup()), nanInt);
-            case GDL_LONG: return product_cu_template<DLongGDL>(static_cast<DLongGDL*> (p0->Dup()), nanInt);
-            case GDL_ULONG: return product_cu_template<DULongGDL>(static_cast<DULongGDL*> (p0->Dup()), nanInt);
-            case GDL_LONG64: return product_cu_template<DLong64GDL>(static_cast<DLong64GDL*> (p0->Dup()), nanInt);
-            case GDL_ULONG64: return product_cu_template<DULong64GDL>(static_cast<DULong64GDL*> (p0->Dup()), nanInt);
-            case GDL_FLOAT: return product_cu_template<DFloatGDL>(static_cast<DFloatGDL*> (p0->Dup()), KwNaN);
-            case GDL_DOUBLE: return product_cu_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0->Dup()), KwNaN);
-            case GDL_COMPLEX: return product_cu_template<DComplexGDL>(static_cast<DComplexGDL*> (p0->Dup()), KwNaN);
-            case GDL_COMPLEXDBL: return product_cu_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0->Dup()), KwNaN);
-            default: assert(false);
+          case GDL_BYTE: return product_cu_template<DByteGDL>(static_cast<DByteGDL*> (p0->Dup()), nanInt);
+          case GDL_INT: return product_cu_template<DIntGDL>(static_cast<DIntGDL*> (p0->Dup()), nanInt);
+          case GDL_UINT: return product_cu_template<DUIntGDL>(static_cast<DUIntGDL*> (p0->Dup()), nanInt);
+          case GDL_LONG: return product_cu_template<DLongGDL>(static_cast<DLongGDL*> (p0->Dup()), nanInt);
+          case GDL_ULONG: return product_cu_template<DULongGDL>(static_cast<DULongGDL*> (p0->Dup()), nanInt);
+          case GDL_LONG64: return product_cu_template<DLong64GDL>(static_cast<DLong64GDL*> (p0->Dup()), nanInt);
+          case GDL_ULONG64: return product_cu_template<DULong64GDL>(static_cast<DULong64GDL*> (p0->Dup()), nanInt);
+          case GDL_FLOAT: return product_cu_template<DFloatGDL>(static_cast<DFloatGDL*> (p0->Dup()), KwNaN);
+          case GDL_DOUBLE: return product_cu_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0->Dup()), KwNaN);
+          case GDL_COMPLEX: return product_cu_template<DComplexGDL>(static_cast<DComplexGDL*> (p0->Dup()), KwNaN);
+          case GDL_COMPLEXDBL: return product_cu_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0->Dup()), KwNaN);
+          default: assert(false);
           }
         }
 
         // Integer parts derivated from Total code by Erin Sheldon
-        // In IDL PRODUCT(), the INTEGER keyword takes precedence 
+        // In IDL PRODUCT(), the INTEGER keyword takes precedence
         if (KwInt) {
           // We use GDL_LONG64 unless the input is GDL_ULONG64
           if ((p0->Type() == GDL_LONG64) && (!KwNaN)) {
@@ -3748,23 +3672,23 @@ static const std::string trimmable(" \t");
 
       if (KwPre) {
         switch (p0->Type()) {
-          case GDL_BYTE: return product_over_dim_template<DByteGDL>(static_cast<DByteGDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_INT: return product_over_dim_template<DIntGDL>(static_cast<DIntGDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_UINT: return product_over_dim_template<DUIntGDL>(static_cast<DUIntGDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_LONG: return product_over_dim_template<DLongGDL>(static_cast<DLongGDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_ULONG: return product_over_dim_template<DULongGDL>(static_cast<DULongGDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_LONG64: return product_over_dim_template<DLong64GDL>(static_cast<DLong64GDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_ULONG64: return product_over_dim_template<DULong64GDL>(static_cast<DULong64GDL*> (p0), srcDim, sumDim - 1, nanInt);
-          case GDL_FLOAT: return product_over_dim_template<DFloatGDL>(static_cast<DFloatGDL*> (p0), srcDim, sumDim - 1, KwNaN);
-          case GDL_DOUBLE: return product_over_dim_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0), srcDim, sumDim - 1, KwNaN);
-          case GDL_COMPLEX: return product_over_dim_template<DComplexGDL>(static_cast<DComplexGDL*> (p0), srcDim, sumDim - 1, KwNaN);
-          case GDL_COMPLEXDBL: return product_over_dim_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), srcDim, sumDim - 1, KwNaN);
-          default: assert(false);
+        case GDL_BYTE: return product_over_dim_template<DByteGDL>(static_cast<DByteGDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_INT: return product_over_dim_template<DIntGDL>(static_cast<DIntGDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_UINT: return product_over_dim_template<DUIntGDL>(static_cast<DUIntGDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_LONG: return product_over_dim_template<DLongGDL>(static_cast<DLongGDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_ULONG: return product_over_dim_template<DULongGDL>(static_cast<DULongGDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_LONG64: return product_over_dim_template<DLong64GDL>(static_cast<DLong64GDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_ULONG64: return product_over_dim_template<DULong64GDL>(static_cast<DULong64GDL*> (p0), srcDim, sumDim - 1, nanInt);
+        case GDL_FLOAT: return product_over_dim_template<DFloatGDL>(static_cast<DFloatGDL*> (p0), srcDim, sumDim - 1, KwNaN);
+        case GDL_DOUBLE: return product_over_dim_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0), srcDim, sumDim - 1, KwNaN);
+        case GDL_COMPLEX: return product_over_dim_template<DComplexGDL>(static_cast<DComplexGDL*> (p0), srcDim, sumDim - 1, KwNaN);
+        case GDL_COMPLEXDBL: return product_over_dim_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0), srcDim, sumDim - 1, KwNaN);
+        default: assert(false);
         }
       }
 
       // Integer parts derivated from Total code by Erin Sheldon
-      // In IDL PRODUCT(), the INTEGER keyword takes precedence 
+      // In IDL PRODUCT(), the INTEGER keyword takes precedence
       if (KwInt) {
         // We use GDL_LONG64 unless the input is GDL_ULONG64
         if ((p0->Type() == GDL_LONG64) && (!KwNaN)) {
@@ -3815,28 +3739,27 @@ static const std::string trimmable(" \t");
       //p0D_guard.Reset( p0D);
       return product_over_dim_template< DDoubleGDL>
         (p0D, srcDim, sumDim - 1, KwNaN);
-    }
-    else { // KwCumul
+    } else { // KwCumul
 
       if (KwPre) {
         switch (p0->Type()) {
-          case GDL_BYTE: return product_over_dim_cu_template<DByteGDL>(static_cast<DByteGDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_INT: return product_over_dim_cu_template<DIntGDL>(static_cast<DIntGDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_UINT: return product_over_dim_cu_template<DUIntGDL>(static_cast<DUIntGDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_LONG: return product_over_dim_cu_template<DLongGDL>(static_cast<DLongGDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_ULONG: return product_over_dim_cu_template<DULongGDL>(static_cast<DULongGDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_LONG64: return product_over_dim_cu_template<DLong64GDL>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_ULONG64: return product_over_dim_cu_template<DULong64GDL>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, nanInt);
-          case GDL_FLOAT: return product_over_dim_cu_template<DFloatGDL>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, KwNaN);
-          case GDL_DOUBLE: return product_over_dim_cu_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, KwNaN);
-          case GDL_COMPLEX: return product_over_dim_cu_template<DComplexGDL>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, KwNaN);
-          case GDL_COMPLEXDBL: return product_over_dim_cu_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, KwNaN);
-          default: assert(false);
+        case GDL_BYTE: return product_over_dim_cu_template<DByteGDL>(static_cast<DByteGDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_INT: return product_over_dim_cu_template<DIntGDL>(static_cast<DIntGDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_UINT: return product_over_dim_cu_template<DUIntGDL>(static_cast<DUIntGDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_LONG: return product_over_dim_cu_template<DLongGDL>(static_cast<DLongGDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_ULONG: return product_over_dim_cu_template<DULongGDL>(static_cast<DULongGDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_LONG64: return product_over_dim_cu_template<DLong64GDL>(static_cast<DLong64GDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_ULONG64: return product_over_dim_cu_template<DULong64GDL>(static_cast<DULong64GDL*> (p0->Dup()), sumDim - 1, nanInt);
+        case GDL_FLOAT: return product_over_dim_cu_template<DFloatGDL>(static_cast<DFloatGDL*> (p0->Dup()), sumDim - 1, KwNaN);
+        case GDL_DOUBLE: return product_over_dim_cu_template<DDoubleGDL>(static_cast<DDoubleGDL*> (p0->Dup()), sumDim - 1, KwNaN);
+        case GDL_COMPLEX: return product_over_dim_cu_template<DComplexGDL>(static_cast<DComplexGDL*> (p0->Dup()), sumDim - 1, KwNaN);
+        case GDL_COMPLEXDBL: return product_over_dim_cu_template<DComplexDblGDL>(static_cast<DComplexDblGDL*> (p0->Dup()), sumDim - 1, KwNaN);
+        default: assert(false);
         }
       }
 
       // Integer parts derivated from Total code by Erin Sheldon
-      // In IDL PRODUCT(), the INTEGER keyword takes precedence 
+      // In IDL PRODUCT(), the INTEGER keyword takes precedence
       if (KwInt) {
         // We use GDL_LONG64 unless the input is GDL_ULONG64
         if ((p0->Type() == GDL_LONG64) && (!KwNaN)) {
@@ -3885,14 +3808,14 @@ static const std::string trimmable(" \t");
         (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY)), sumDim - 1, KwNaN);
     }
   }
-//  servicing array_equal and also gdl_container::equals
-  bool array_equal_bool( BaseGDL* p0, BaseGDL* p1,
-    bool notypeconv=false, bool not_equal=false,
-    bool quiet=true)
-   {
+  //  servicing array_equal and also gdl_container::equals
 
-      if( p0 == p1) return true;
-      if( p0==0 or p1==0) return false;
+  bool array_equal_bool(BaseGDL* p0, BaseGDL* p1,
+    bool notypeconv = false, bool not_equal = false,
+    bool quiet = true) {
+
+    if (p0 == p1) return true;
+    if (p0 == 0 or p1 == 0) return false;
     SizeT nEl0 = p0->N_Elements();
     SizeT nEl1 = p1->N_Elements();
 
@@ -3904,53 +3827,46 @@ static const std::string trimmable(" \t");
     // ARRAY_EQUAL(1,[1,1]) True, ARRAY_EQUAL([1],[1,1]) False !!
     if (nEl0 != nEl1) {
       if (nEl0 == 1 && nEl1 != 1) {
-    if (!p0->StrictScalar()) return false;
+        if (!p0->StrictScalar()) return false;
       }
       if (nEl0 != 1 && nEl1 == 1) {
-    if (!p1->StrictScalar()) return false;
+        if (!p1->StrictScalar()) return false;
       }
     }
 
     //cout << "pO "<< p0->Dim() << " p1 "<< p1->Dim() << endl;
     //cout << "pO "<< p0->StrictScalar() << " p1 "<< p1->StrictScalar() << endl;
-    DType aTy=p0->Type();
-    DType bTy=p1->Type();
+    DType aTy = p0->Type();
+    DType bTy = p1->Type();
 
-    if( aTy==GDL_STRUCT or bTy==GDL_STRUCT) {
-      if(quiet) return false;
+    if (aTy == GDL_STRUCT or bTy == GDL_STRUCT) {
+      if (quiet) return false;
       throw GDLException("array_equal: inconvertable GDL_STRUCT");
-      }
+    }
 
     Guard<BaseGDL> p0_guard;
     Guard<BaseGDL> p1_guard;
-    
-    if( ( aTy==GDL_PTR and bTy==GDL_PTR) or
-    ( aTy==GDL_OBJ and bTy==GDL_OBJ) ) {
-    Data_<SpDULong64>* p0t =
-          static_cast<Data_<SpDULong64>* >( p0);
-    if( not_equal) return p0t->ArrayNeverEqual( p1);
-    else       return p0t->ArrayEqual( p1);
-    }
-    else if( aTy==GDL_PTR or bTy==GDL_PTR) {
-      if(quiet) return false;
+
+    if ((aTy == GDL_PTR and bTy == GDL_PTR) or
+      ( aTy == GDL_OBJ and bTy == GDL_OBJ)) {
+      Data_<SpDULong64>* p0t =
+        static_cast<Data_<SpDULong64>*> (p0);
+      if (not_equal) return p0t->ArrayNeverEqual(p1);
+      else return p0t->ArrayEqual(p1);
+    } else if (aTy == GDL_PTR or bTy == GDL_PTR) {
+      if (quiet) return false;
       throw GDLException("array_equal: GDL_PTR only with PTR");
-      }
-    else if( aTy==GDL_OBJ or bTy==GDL_OBJ) {
-      if(quiet) return false;
+    } else if (aTy == GDL_OBJ or bTy == GDL_OBJ) {
+      if (quiet) return false;
       throw GDLException("array_equal: GDL_OBJ only with OBJ");
-      }
-    else if( aTy != bTy)
-      {
-    if( notypeconv) // NO_TYPECONV
-      return false;
-    else
-      {
-        if( !ConvertableType( aTy) or !ConvertableType( bTy)) {
-          if(quiet) return false;
+    } else if (aTy != bTy) {
+      if (notypeconv) // NO_TYPECONV
+        return false;
+      else {
+        if (!ConvertableType(aTy) or !ConvertableType(bTy)) {
+          if (quiet) return false;
           throw GDLException("array_equal: inconvertable type");
-          }
-        else if( DTypeOrder[aTy] >= DTypeOrder[bTy])
-          {
+        } else if (DTypeOrder[aTy] >= DTypeOrder[bTy]) {
           p1 = p1->Convert2(aTy, BaseGDL::COPY);
           p1_guard.Reset(p1);
         } else {
@@ -3959,29 +3875,28 @@ static const std::string trimmable(" \t");
         }
       }
     }
-    if( not_equal) return p0->ArrayNeverEqual( p1);
-    else       return p0->ArrayEqual( p1);
+    if (not_equal) return p0->ArrayNeverEqual(p1);
+    else return p0->ArrayEqual(p1);
   }
 
-  BaseGDL* array_equal( EnvT* e)
-  {
-    e->NParam( 2);
- //   trace_me = trace_arg();
+  BaseGDL* array_equal(EnvT* e) {
+    e->NParam(2);
+    //   trace_me = trace_arg();
     static int notypeconvIx = e->KeywordIx("NO_TYPECONV");
     static int notequalIx = e->KeywordIx("NOT_EQUAL");
     static int quietIx = e->KeywordIx("QUIET");
-  //  if(trace_me) cout << " array=? ";
-    BaseGDL* p0 = e->GetParDefined( 0);
-    BaseGDL* p1 = e->GetParDefined( 1);
+    //  if(trace_me) cout << " array=? ";
+    BaseGDL* p0 = e->GetParDefined(0);
+    BaseGDL* p1 = e->GetParDefined(1);
 
     bool result = array_equal_bool(p0, p1,
-      e->KeywordSet( notypeconvIx), e->KeywordSet( notequalIx),
-      e->KeywordSet( quietIx));
- //   if(trace_me) cout << result<< endl;
-    return new DByteGDL( result ? 1 : 0 );
+      e->KeywordSet(notypeconvIx), e->KeywordSet(notequalIx),
+      e->KeywordSet(quietIx));
+    //   if(trace_me) cout << result<< endl;
+    return new DByteGDL(result ? 1 : 0);
   }
 
-  BaseGDL* min_fun( EnvT* e) {
+  BaseGDL* min_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
     BaseGDL* searchArr = e->GetParDefined(0);
 
@@ -3997,7 +3912,7 @@ static const std::string trimmable(" \t");
     static int maxIx = e->KeywordIx("MAX");
     bool maxSet = e->WriteableKeywordPresent(maxIx); //insure the output variable exist and is of 'good' type
 
-    static int absIx= e->KeywordIx("ABSOLUTE");
+    static int absIx = e->KeywordIx("ABSOLUTE");
     bool absSet = e->KeywordSet(absIx); // not KeywordPresent as it should be ignored if not set.
 
     DLong searchDim;
@@ -4021,7 +3936,7 @@ static const std::string trimmable(" \t");
 
       // memory allocation
       BaseGDL *maxVal, *resArr = searchArr->New(destDim, BaseGDL::NOZERO);
-      DLongGDL *minElArr=NULL, *maxElArr=NULL;
+      DLongGDL *minElArr = NULL, *maxElArr = NULL;
 
       if (maxSet) {
         maxVal = searchArr->New(destDim, BaseGDL::NOZERO);
@@ -4055,8 +3970,7 @@ static const std::string trimmable(" \t");
       if (maxSet) e->SetKW(maxIx, maxVal);
 
       return resArr;
-    }
-    else {
+    } else {
       DLong minEl;
       BaseGDL* res;
 
@@ -4083,7 +3997,7 @@ static const std::string trimmable(" \t");
     }
   }
 
-  BaseGDL* max_fun( EnvT* e) {
+  BaseGDL* max_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
     BaseGDL* searchArr = e->GetParDefined(0);
 
@@ -4099,7 +4013,7 @@ static const std::string trimmable(" \t");
     static int minIx = e->KeywordIx("MIN");
     bool minSet = e->WriteableKeywordPresent(minIx);
 
-    static int absIx= e->KeywordIx("ABSOLUTE");
+    static int absIx = e->KeywordIx("ABSOLUTE");
     bool absSet = e->KeywordSet(absIx); // not KeywordPresent as it should be ignored if not set.
 
     DLong searchDim;
@@ -4123,7 +4037,7 @@ static const std::string trimmable(" \t");
 
       // memory allocation
       BaseGDL *minVal, *resArr = searchArr->New(destDim, BaseGDL::NOZERO);
-      DLongGDL *minElArr=NULL, *maxElArr=NULL;
+      DLongGDL *minElArr = NULL, *maxElArr = NULL;
 
       if (minSet) {
         minVal = searchArr->New(destDim, BaseGDL::NOZERO);
@@ -4138,7 +4052,7 @@ static const std::string trimmable(" \t");
         maxElArr = new DLongGDL(destDim);
       }
       for (SizeT o = 0; o < nEl; o += outerStride) {
-        SizeT rIx = (o/outerStride)*searchStride;
+        SizeT rIx = (o / outerStride) * searchStride;
         for (SizeT i = 0; i < searchStride; ++i) {
           searchArr->MinMax(
             (subMin ? &((*minElArr)[rIx]) : NULL),
@@ -4162,7 +4076,7 @@ static const std::string trimmable(" \t");
       if (minSet) // MIN keyword given
       {
         e->AssureGlobalKW(0);
-        GDLDelete(e->GetTheKW(0));//TheKW to keep old behaviour, OK since GlobalPar is assured.
+        GDLDelete(e->GetTheKW(0)); //TheKW to keep old behaviour, OK since GlobalPar is assured.
         DLong minEl;
         searchArr->MinMax(&minEl, &maxEl, &e->GetTheKW(0), &res, omitNaN, 0, 0, 1, -1, absSet);
         if (subMin) e->SetKW(subIx, new DLongGDL(minEl));
@@ -4181,80 +4095,77 @@ static const std::string trimmable(" \t");
       return res;
     }
   }
- 
-  BaseGDL* transpose( EnvT* e)
-  {
-    SizeT nParam=e->NParam( 1); 
 
-    BaseGDL* p0 = e->GetParDefined( 0);
-    if( p0->Type() == GDL_STRUCT)
-      e->Throw("Struct expression not allowed in this context: "+
-           e->GetParString(0));
-    
+  BaseGDL* transpose(EnvT* e) {
+    SizeT nParam = e->NParam(1);
+
+    BaseGDL* p0 = e->GetParDefined(0);
+    if (p0->Type() == GDL_STRUCT)
+      e->Throw("Struct expression not allowed in this context: " +
+      e->GetParString(0));
+
     SizeT rank = p0->Rank();
-    if( rank == 0)
-      e->Throw( "Expression must be an array "
-        "in this context: "+ e->GetParString(0));
-    
-    if( nParam == 2) 
-      {
- 
-    BaseGDL* p1 = e->GetParDefined( 1);
-    if( p1->N_Elements() != rank)
-      e->Throw("Incorrect number of elements in permutation.");
+    if (rank == 0)
+      e->Throw("Expression must be an array "
+      "in this context: " + e->GetParString(0));
 
-    DUInt* perm = new DUInt[rank];
-    ArrayGuard<DUInt> perm_guard( perm);
+    if (nParam == 2) {
 
-    DUIntGDL* p1L = static_cast<DUIntGDL*>
-      (p1->Convert2( GDL_UINT, BaseGDL::COPY));
-    for( SizeT i=0; i<rank; ++i) perm[i] = (*p1L)[ i];
-    GDLDelete(p1L);
+      BaseGDL* p1 = e->GetParDefined(1);
+      if (p1->N_Elements() != rank)
+        e->Throw("Incorrect number of elements in permutation.");
 
-    // check permutation vector
-    for( SizeT i=0; i<rank; ++i) 
-      {
+      DUInt* perm = new DUInt[rank];
+      ArrayGuard<DUInt> perm_guard(perm);
+
+      DUIntGDL* p1L = static_cast<DUIntGDL*>
+        (p1->Convert2(GDL_UINT, BaseGDL::COPY));
+      for (SizeT i = 0; i < rank; ++i) perm[i] = (*p1L)[ i];
+      GDLDelete(p1L);
+
+      // check permutation vector
+      for (SizeT i = 0; i < rank; ++i) {
         DUInt j;
-        for( j=0; j<rank; ++j) if( perm[j] == i) break;
+        for (j = 0; j < rank; ++j) if (perm[j] == i) break;
         if (j == rank)
-          e->Throw( "Incorrect permutation vector.");
+          e->Throw("Incorrect permutation vector.");
       }
-    return p0->Transpose( perm);
-      }
+      return p0->Transpose(perm);
+    }
 
-    return p0->Transpose( NULL);
+    return p0->Transpose(NULL);
   }
 
 
   // BaseGDL* matrix_multiply( EnvT* e)
   //   {
-  //     SizeT nParam=e->NParam( 2); 
-  // 
+  //     SizeT nParam=e->NParam( 2);
+  //
   //     BaseGDL* a = e->GetNumericArrayParDefined( 0);
   //     BaseGDL* b = e->GetNumericArrayParDefined( 1);
-  //     
+  //
   //     static int aTIx = e->KeywordIx("ATRANSPOSE");
   //     bool aT = e->KeywordPresent(aTIx);
   //     static int bTIx = e->KeywordIx("BTRANSPOSE");
   //     bool bT = e->KeywordPresent(bTIx);
-  //     
+  //
   //     static int strassenIx = e->KeywordIx("STRASSEN_ALGORITHM");
   //     bool strassen = e->KeywordPresent(strassenIx);
-  // 
-  //     
+  //
+  //
   //     if( p1->N_Elements() != rank)
   //      e->Throw("Incorrect number of elements in permutation.");
-  // 
+  //
   //    DUInt* perm = new DUInt[rank];
   //    Guard<DUInt> perm_guard( perm);
-  // 
+  //
   //    DUIntGDL* p1L = static_cast<DUIntGDL*>
   //      (p1->Convert2( GDL_UINT, BaseGDL::COPY));
   //    for( SizeT i=0; i<rank; ++i) perm[i] = (*p1L)[ i];
   //    delete p1L;
-  // 
+  //
   //    // check permutaion vector
-  //    for( SizeT i=0; i<rank; ++i) 
+  //    for( SizeT i=0; i<rank; ++i)
   //      {
   //        DUInt j;
   //        for( j=0; j<rank; ++j) if( perm[j] == i) break;
@@ -4263,17 +4174,17 @@ static const std::string trimmable(" \t");
   //      }
   //    return p0->Transpose( perm);
   //       }
-  // 
+  //
   //     return a->Transpose( NULL);
   //   }
 
   // helper function for sort_fun, recursive
   // optimized version
+
   template< typename IndexT>
-  void MergeSortOpt( BaseGDL* p0, IndexT* hhS, IndexT* h1, IndexT* h2,
-             SizeT len) 
-  {
-    if( len <= 1) return;       
+  void MergeSortOpt(BaseGDL* p0, IndexT* hhS, IndexT* h1, IndexT* h2,
+    SizeT len) {
+    if (len <= 1) return;
 
     SizeT h1N = len / 2;
     SizeT h2N = len - h1N;
@@ -4282,58 +4193,58 @@ static const std::string trimmable(" \t");
     MergeSortOpt(p0, hhS, h1, h2, h1N);
 
     // 2nd half
-    IndexT* hhM = &hhS[h1N]; 
+    IndexT* hhM = &hhS[h1N];
     MergeSortOpt(p0, hhM, h1, h2, h2N);
 
     SizeT i;
-    for(i=0; i<h1N; ++i) h1[i] = hhS[ i];
-    for(i=0; i<h2N; ++i) h2[i] = hhM[ i];
+    for (i = 0; i < h1N; ++i) h1[i] = hhS[ i];
+    for (i = 0; i < h2N; ++i) h2[i] = hhM[ i];
 
-    SizeT  h1Ix = 0;
-    SizeT  h2Ix = 0;
-    for( i=0; (h1Ix < h1N) && (h2Ix < h2N); ++i) 
-      {
-    // the actual comparisson
-    if( p0->Greater( h1[h1Ix], h2[h2Ix])) 
-      hhS[ i] = h2[ h2Ix++];
-    else
-      hhS[ i] = h1[ h1Ix++];
-      }
-    for(; h1Ix < h1N; ++i) hhS[ i] = h1[ h1Ix++];
-    for(; h2Ix < h2N; ++i) hhS[ i] = h2[ h2Ix++];
+    SizeT h1Ix = 0;
+    SizeT h2Ix = 0;
+    for (i = 0; (h1Ix < h1N) && (h2Ix < h2N); ++i) {
+      // the actual comparisson
+      if (p0->Greater(h1[h1Ix], h2[h2Ix]))
+        hhS[ i] = h2[ h2Ix++];
+      else
+        hhS[ i] = h1[ h1Ix++];
+    }
+    for (; h1Ix < h1N; ++i) hhS[ i] = h1[ h1Ix++];
+    for (; h2Ix < h2N; ++i) hhS[ i] = h2[ h2Ix++];
   }
 
   // start of highly-optimized median code. 1D and 2D fast medians are in medianfilter.cpp, gathered from
   // recent sources. see the include file for explanations & copyrights.
-#include "medianfilter.cpp"  
-/*
- *  Following routines are variants of the algorithm described in
- *  "Numerical recipes in C", Second Edition,
- *  Cambridge University Press, 1992, Section 8.5, ISBN 0-521-43108-5
- *  Original code by Nicolas Devillard - 1998. Public domain.
- *  Modified by G. Duvert, 2017, for NaN/INF handling and correction of Nicolas's code
- *  which gave erroneous results when two or more elements were identical. 
- */
+#include "medianfilter.cpp"
+  /*
+   *  Following routines are variants of the algorithm described in
+   *  "Numerical recipes in C", Second Edition,
+   *  Cambridge University Press, 1992, Section 8.5, ISBN 0-521-43108-5
+   *  Original code by Nicolas Devillard - 1998. Public domain.
+   *  Modified by G. Duvert, 2017, for NaN/INF handling and correction of Nicolas's code
+   *  which gave erroneous results when two or more elements were identical.
+   */
 #define ELEM_SWAP(a,b) { DDouble t=(a);(a)=(b);(b)=t; }
-  
+
   DDouble quick_select_d(DDouble array[], SizeT arraySize, int even) {
 
-    if (arraySize==1) return array[0];
+    if (arraySize == 1) return array[0];
 
     SizeT high, low, middle;
-    SizeT median=(arraySize)/2; 
+    SizeT median = (arraySize) / 2;
     SizeT ll, hh;
     DDouble pivot;
     low = 0;
-    high = arraySize-1;
+    high = arraySize - 1;
     for (;;) {
       if (high <= low + 1) {
         if (high == low + 1 && array[high] < array[low]) {
           ELEM_SWAP(array[low], array[high])
         }
-        if (even) return 0.5*(array[median]+array[median-1]); else return array[median]; 
+        if (even) return 0.5 * (array[median] + array[median - 1]);
+        else return array[median];
       } else {
-        middle = (low + high) /2 ;
+        middle = (low + high) / 2;
         ELEM_SWAP(array[middle], array[low + 1])
         if (array[low] > array[high]) {
           ELEM_SWAP(array[low], array[high])
@@ -4364,25 +4275,26 @@ static const std::string trimmable(" \t");
 
 #undef ELEM_SWAP
 #define ELEM_SWAP(a,b) { DFloat t=(a);(a)=(b);(b)=t; }
-  
+
   DFloat quick_select_f(DFloat array[], SizeT arraySize, int even) {
 
-    if (arraySize==1) return array[0];
+    if (arraySize == 1) return array[0];
 
     SizeT high, low, middle;
-    SizeT median=(arraySize)/2; 
+    SizeT median = (arraySize) / 2;
     SizeT ll, hh;
     DFloat pivot;
     low = 0;
-    high = arraySize-1;
+    high = arraySize - 1;
     for (;;) {
       if (high <= low + 1) {
         if (high == low + 1 && array[high] < array[low]) {
           ELEM_SWAP(array[low], array[high])
         }
-        if (even) return 0.5*(array[median]+array[median-1]); else return array[median]; 
+        if (even) return 0.5 * (array[median] + array[median - 1]);
+        else return array[median];
       } else {
-        middle = (low + high) /2 ;
+        middle = (low + high) / 2;
         ELEM_SWAP(array[middle], array[low + 1])
         if (array[low] > array[high]) {
           ELEM_SWAP(array[low], array[high])
@@ -4413,22 +4325,25 @@ static const std::string trimmable(" \t");
 
 #undef ELEM_SWAP
   //input-protected versions of above
-   DFloat quick_select_f_protect_input(const DFloat data[], SizeT arraySize, int even) { 
-    DFloat * array=(DFloat*)malloc(arraySize*sizeof(DFloat));
-    for (SizeT i = 0; i < arraySize; ++i) array[i]=data[i];
-    DFloat res=quick_select_f(array, arraySize, even);
+
+  DFloat quick_select_f_protect_input(const DFloat data[], SizeT arraySize, int even) {
+    DFloat * array = (DFloat*) malloc(arraySize * sizeof (DFloat));
+    for (SizeT i = 0; i < arraySize; ++i) array[i] = data[i];
+    DFloat res = quick_select_f(array, arraySize, even);
     free(array);
     return res;
-   } 
-   DDouble quick_select_d_protect_input(const DDouble data[], SizeT arraySize, int even) {
-    DDouble * array=(DDouble*)malloc(arraySize*sizeof(DDouble));
-    for (SizeT i = 0; i < arraySize; ++i) array[i]=data[i];
-    DDouble res=quick_select_d(array, arraySize, even);
+  }
+
+  DDouble quick_select_d_protect_input(const DDouble data[], SizeT arraySize, int even) {
+    DDouble * array = (DDouble*) malloc(arraySize * sizeof (DDouble));
+    for (SizeT i = 0; i < arraySize; ++i) array[i] = data[i];
+    DDouble res = quick_select_d(array, arraySize, even);
     free(array);
     return res;
-   }
-  
+  }
+
   //simple median for double arrays with no NaNs.
+
   inline BaseGDL* mymedian_d(EnvT* e) {
     DDoubleGDL* array = e->GetParAs<DDoubleGDL>(0)->Dup(); //original array is protected
     SizeT nEl = array->N_Elements();
@@ -4440,15 +4355,16 @@ static const std::string trimmable(" \t");
 
     return res;
   }
-  
+
   //simple median for double arrays whith NaNs. Remove the Nans before doing the median.
+
   inline BaseGDL* mymedian_d_nan(EnvT* e) {
     DDoubleGDL* data = e->GetParAs<DDoubleGDL>(0); //original array is protected
     SizeT nEl = data->N_Elements();
     DLong iEl = 0;
-    DDouble * array=(DDouble*)malloc(nEl*sizeof(DDouble));
+    DDouble * array = (DDouble*) malloc(nEl * sizeof (DDouble));
     for (SizeT i = 0; i < data->N_Elements(); ++i) {
-      if(!isnan( (*data)[i]) ) {
+      if (!isnan((*data)[i])) {
         array[iEl] = (*data)[i];
         iEl++;
       }
@@ -4464,11 +4380,12 @@ static const std::string trimmable(" \t");
     return res;
   }
   //simple median for double arrays whith NaNs. Remove the Nans before doing the median.
-  inline DDouble quick_select_d_filter_nan( const DDouble* arr, SizeT nEl, int even) {
+
+  inline DDouble quick_select_d_filter_nan(const DDouble* arr, SizeT nEl, int even) {
     DLong iEl = 0;
-    DDouble* array=(DDouble*)malloc(nEl*sizeof(DDouble));
+    DDouble* array = (DDouble*) malloc(nEl * sizeof (DDouble));
     for (SizeT i = 0; i < nEl; ++i) {
-      if (!isnan( arr[i]) ) {
+      if (!isnan(arr[i])) {
         array[iEl] = arr[i];
         iEl++;
       }
@@ -4477,41 +4394,41 @@ static const std::string trimmable(" \t");
       free(array);
       return std::numeric_limits<double>::quiet_NaN();
     }
-    DDouble res=quick_select_d(array, iEl, even);
+    DDouble res = quick_select_d(array, iEl, even);
     free(array);
     return res;
   }
 
-  inline bool hasnan_d( DDouble* arr, SizeT nEl) {
-    for (SizeT i=0; i< nEl; ++i) if (isnan( arr[i])) return true;
+  inline bool hasnan_d(DDouble* arr, SizeT nEl) {
+    for (SizeT i = 0; i < nEl; ++i) if (isnan(arr[i])) return true;
     return false;
   }
-  
- inline BaseGDL* mymedian_f(EnvT* e) {
+
+  inline BaseGDL* mymedian_f(EnvT* e) {
     DFloatGDL* array = e->GetParAs<DFloatGDL>(0)->Dup(); //original array is protected
     SizeT nEl = array->N_Elements();
 
     static int evenIx = e->KeywordIx("EVEN");
-    int iseven=((nEl % 2) == 0 && e->KeywordSet(evenIx));
+    int iseven = ((nEl % 2) == 0 && e->KeywordSet(evenIx));
     BaseGDL *res = new DFloatGDL(quick_select_f((DFloat*) array->DataAddr(), nEl, iseven));
 
     delete array;
 
     return res;
- }
- 
+  }
+
   inline BaseGDL* mymedian_f_nan(EnvT* e) {
     DFloatGDL* data = e->GetParAs<DFloatGDL>(0); //original array is protected
     SizeT nEl = data->N_Elements();
     DLong iEl = 0;
-    DFloat * array=(DFloat*)malloc(nEl*sizeof(DFloat));
+    DFloat * array = (DFloat*) malloc(nEl * sizeof (DFloat));
     for (SizeT i = 0; i < data->N_Elements(); ++i) {
-      if (!isnan( (*data)[i]) ) {
+      if (!isnan((*data)[i])) {
         array[iEl] = (*data)[i];
         iEl++;
       }
     }
-    if (iEl == 0) { 
+    if (iEl == 0) {
       free(array);
       return new DFloatGDL(std::numeric_limits<float>::quiet_NaN());
     }
@@ -4521,17 +4438,17 @@ static const std::string trimmable(" \t");
     free(array);
     return res;
   }
-  
-  inline DFloat quick_select_f_filter_nan(const DFloat* arr, SizeT nEl, int even){
+
+  inline DFloat quick_select_f_filter_nan(const DFloat* arr, SizeT nEl, int even) {
     DLong iEl = 0;
-    DFloat * array=(DFloat*)malloc(nEl*sizeof(DFloat));
+    DFloat * array = (DFloat*) malloc(nEl * sizeof (DFloat));
     for (SizeT i = 0; i < nEl; ++i) {
-      if (!isnan( arr[i]) ) {
+      if (!isnan(arr[i])) {
         array[iEl] = arr[i];
         iEl++;
       }
     }
-    if (iEl == 0) { 
+    if (iEl == 0) {
       free(array);
       return std::numeric_limits<float>::quiet_NaN();
     }
@@ -4544,7 +4461,7 @@ static const std::string trimmable(" \t");
     for (SizeT i = 0; i < nEl; ++i) if (isnan(arr[i])) return true;
     return false;
   }
-  
+
   BaseGDL* SlowReliableMedian(EnvT* e); //see below.
 
   BaseGDL* median(EnvT* e) {
@@ -4567,9 +4484,9 @@ static const std::string trimmable(" \t");
       p0->Type() == GDL_COMPLEXDBL ||
       e->KeywordSet(doubleIx));
     //contrary to doc (?) EVEN is useable everywhere, 1D or 2D.
-    
+
     static int evenIx = e->KeywordIx("EVEN");
-    
+
     if (nParam == 1) {
       // Check conversion to real or double:
 
@@ -4580,7 +4497,7 @@ static const std::string trimmable(" \t");
         p0->Type() == GDL_COMPLEX ||
         p0->Type() == GDL_COMPLEXDBL);
 
-      //DIMENSION Kw  
+      //DIMENSION Kw
       static int dimIx = e->KeywordIx("DIMENSION");
       bool dimSet = e->KeywordSet(dimIx);
 
@@ -4626,8 +4543,6 @@ static const std::string trimmable(" \t");
               clean_array = true;
             }
             DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
-//            //probably overkill to start multithreading in some easy cases. TBD.
-//#pragma omp for private(i,hasnan)
             for (SizeT i = 0; i < nEl; ++i) {
               if (hasnan_d(&(*input)[i * stride], stride)) (*res)[i] = quick_select_d_filter_nan(&(*input)[i * stride], stride, iseven); //special if nan.
               else (*res)[i] = quick_select_d_protect_input(&(*input)[i * stride], stride, iseven);
@@ -4641,11 +4556,10 @@ static const std::string trimmable(" \t");
               clean_array = true;
             }
             DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
-//            //probably overkill to start multithreading in some easy cases. TBD.
-//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) {
               if (hasnan_f(&(*input)[i * stride], stride)) (*res)[i] = quick_select_f_filter_nan(&(*input)[i * stride], stride, iseven); //special if nan.
-              else (*res)[i] = quick_select_f_protect_input(&(*input)[i * stride], stride, iseven);            }
+              else (*res)[i] = quick_select_f_protect_input(&(*input)[i * stride], stride, iseven);
+            }
             if (clean_array) delete input;
             return res;
           }
@@ -4657,7 +4571,6 @@ static const std::string trimmable(" \t");
               clean_array = true;
             }
             DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
-//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = quick_select_d_protect_input(&(*input)[i * stride], stride, iseven);
             if (clean_array) delete input;
             return res;
@@ -4668,7 +4581,6 @@ static const std::string trimmable(" \t");
               clean_array = true;
             }
             DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
-//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = quick_select_f_protect_input(&(*input)[i * stride], stride, iseven);
             if (clean_array) delete input;
             return res;
@@ -4677,9 +4589,9 @@ static const std::string trimmable(" \t");
       } else {
         if (possibleNaN) {
           if (dbl) {
-              return mymedian_d_nan(e);
+            return mymedian_d_nan(e);
           } else {
-              return mymedian_f_nan(e);
+            return mymedian_f_nan(e);
           }
         } else {
           if (dbl) return mymedian_d(e);
@@ -4693,7 +4605,7 @@ static const std::string trimmable(" \t");
       //rank is important as fast algos are different!
       bool twoD = (p0->Rank() == 2);
 
-      // basic checks on "width" input      
+      // basic checks on "width" input
       DDoubleGDL* p1d = e->GetParAs<DDoubleGDL>(1);
 
       if (p1d->N_Elements() > 1 || (*p1d)[0] <= 0)
@@ -4713,14 +4625,14 @@ static const std::string trimmable(" \t");
       int width = p0->Dim(0);
       int height = twoD ? p0->Dim(1) : 1;
       int size = (*p1)[0];
-      int radius = (size-1) / 2;
+      int radius = (size - 1) / 2;
       bool oddsize = (size % 2 == 1);
-      
+
       bool iseven = ((size % 2) == 0 && e->KeywordSet(evenIx));
 
       if (p0->Type() == GDL_BYTE && twoD && oddsize) {
         // for this special case we apply the constant-time algorithm described in Perreault et al,
-        // Published in the September 2007 issue of IEEE Transactions on Image Processing. DOI: 10.1109/TIP.2007.902329 
+        // Published in the September 2007 issue of IEEE Transactions on Image Processing. DOI: 10.1109/TIP.2007.902329
         DByteGDL* data = e->GetParAs<DByteGDL>(0);
         BaseGDL* res = new DByteGDL(data->Dim(), BaseGDL::NOZERO);
         fastmedian::ctmf(
@@ -4734,26 +4646,26 @@ static const std::string trimmable(" \t");
         if (dbl) {
           DDoubleGDL* data = e->GetParAs<DDoubleGDL>(0);
           if (twoD) {
-            if (oddsize) { //2D fast routines are programmed with odd sizes (2*radius+1) 
+            if (oddsize) { //2D fast routines are programmed with odd sizes (2*radius+1)
               BaseGDL* res = new DDoubleGDL(data->Dim(), BaseGDL::NOZERO);
               fastmedian::median_filter_2d(width, height, radius, radius, 0, (DDouble*) data->DataAddr(), (DDouble*) res->DataAddr());
               return res;
             } else { //for quite a large number of pixels (100=10^2), use the next ODD value. Results are compatible within 1% for random values.
               //to be tested, but should be better for natural values.
               if (size > 10) {
-                radius=size/2; //1 more
+                radius = size / 2; //1 more
                 BaseGDL* res = new DDoubleGDL(data->Dim(), BaseGDL::NOZERO);
                 fastmedian::median_filter_2d(width, height, radius, radius, 0, (DDouble*) data->DataAddr(), (DDouble*) res->DataAddr());
                 if (p0->Type() == GDL_BYTE) return res->Convert2(GDL_BYTE, BaseGDL::CONVERT);
                 else return res;
               } else return SlowReliableMedian(e); //until we rewrite a fast non-odd 2 d filter.
             }
-          } else { 
+          } else {
             if (oddsize) {
               BaseGDL* res = new DDoubleGDL(data->Dim(), BaseGDL::NOZERO);
               fastmedian::median_filter_1d(width, radius, 0, (DDouble*) data->DataAddr(), (DDouble*) res->DataAddr());
               return res;
-            } else { //this oneD fast routine accepts odd and even sizes, but is slower than Jukka's 
+            } else { //this oneD fast routine accepts odd and even sizes, but is slower than Jukka's
               BaseGDL* res = data->Dup();
               fastmedian::filter((DDouble*) res->DataAddr(), width, size, iseven);
               return res;
@@ -4762,21 +4674,21 @@ static const std::string trimmable(" \t");
         } else {
           DFloatGDL* data = e->GetParAs<DFloatGDL>(0);
           if (twoD) {
-            if (oddsize) { //2D fast routines are programmed with odd sizes (2*radius+1). 
+            if (oddsize) { //2D fast routines are programmed with odd sizes (2*radius+1).
               BaseGDL* res = new DFloatGDL(data->Dim(), BaseGDL::NOZERO);
               fastmedian::median_filter_2d(width, height, radius, radius, 0, (DFloat*) data->DataAddr(), (DFloat*) res->DataAddr());
               return res;
             } else { //for quite a large number of pixels (100=10^2), use the next ODD value. Results are compatible within 1% for random values.
               //to be tested, but should be better for natural values.
               if (size > 10) {
-                radius=size/2; //1 more
+                radius = size / 2; //1 more
                 BaseGDL* res = new DFloatGDL(data->Dim(), BaseGDL::NOZERO);
                 fastmedian::median_filter_2d(width, height, radius, radius, 0, (DFloat*) data->DataAddr(), (DFloat*) res->DataAddr());
                 if (p0->Type() == GDL_BYTE) return res->Convert2(GDL_BYTE, BaseGDL::CONVERT);
                 else return res;
               } else return SlowReliableMedian(e); //until we rewrite a fast non-odd 2 d filter.
             }
-          } else { 
+          } else {
             if (oddsize) { //Jukka's version is faster.
               BaseGDL* res = new DFloatGDL(data->Dim(), BaseGDL::NOZERO);
               fastmedian::median_filter_1d(width, radius, 0, (DFloat*) data->DataAddr(), (DFloat*) res->DataAddr());
@@ -4793,7 +4705,7 @@ static const std::string trimmable(" \t");
     }
     return NULL; //pacifies dumm compilers.
   }
-// uses MergeSort
+  // uses MergeSort
   // 2 parts in the code: without "width" or with "width" (limited to 1D and 2D)
 
   BaseGDL* SlowReliableMedian(EnvT* e) {
@@ -4814,7 +4726,7 @@ static const std::string trimmable(" \t");
     SizeT nEl = p0->N_Elements();
 
     // "f_nan" and "d_nan" used by both parts ...
-    DStructGDL *Values = SysVar::Values(); //MUST NOT BE STATIC, due to .reset 
+    DStructGDL *Values = SysVar::Values(); //MUST NOT BE STATIC, due to .reset
     DFloat f_nan = (*static_cast<DFloatGDL*> (Values->GetTag(Values->Desc()->TagIndex("F_NAN"), 0)))[0];
     DDouble d_nan = (*static_cast<DDoubleGDL*> (Values->GetTag(Values->Desc()->TagIndex("D_NAN"), 0)))[0];
 
@@ -4987,7 +4899,7 @@ static const std::string trimmable(" \t");
           if (dbl) (*static_cast<DDoubleGDL*> (res))[k] = d_nan;
           else (*static_cast<DFloatGDL*> (res))[k] = f_nan;
         } else {
-          //cout << k << "" << (*static_cast<DFloatGDL*>(p0))[medEl] << " " 
+          //cout << k << "" << (*static_cast<DFloatGDL*>(p0))[medEl] << " "
           //     << (*static_cast<DFloatGDL*>(p0))[medEl_1] << endl;
           //cout << "k :" << k << endl;
           if ((nEl % 2) == 1 || !e->KeywordSet(evenIx)) {
@@ -5044,13 +4956,13 @@ static const std::string trimmable(" \t");
       //  such as histogram algorithms.
       // Copyright: (C) 2008 by Nicolas Galmiche
 
-      // basic checks on "vector/array" input   
+      // basic checks on "vector/array" input
       DDoubleGDL* p0 = e->GetParAs<DDoubleGDL>(0);
 
       if (p0->Rank() > 2)
         e->Throw("Only 1 or 2 dimensions allowed: " + e->GetParString(0));
 
-      // basic checks on "width" input      
+      // basic checks on "width" input
       DDoubleGDL* p1d = e->GetParAs<DDoubleGDL>(1);
 
       if (p1d->N_Elements() > 1 || (*p1d)[0] <= 0)
@@ -5087,7 +4999,7 @@ static const std::string trimmable(" \t");
 
       static int evenIx = e->KeywordIx("EVEN");
       static int doubleIx = e->KeywordIx("DOUBLE");
-      DStructGDL *Values = SysVar::Values(); //MUST NOT BE STATIC, due to .reset                                             
+      DStructGDL *Values = SysVar::Values(); //MUST NOT BE STATIC, due to .reset
       DDouble d_nan = (*static_cast<DDoubleGDL*> (Values->GetTag(Values->Desc()->TagIndex("D_NAN"), 0)))[0];
       DDouble d_infinity = (*static_cast<DDoubleGDL*> (Values->GetTag(Values->Desc()->TagIndex("D_INFINITY"), 0)))[0];
 
@@ -5297,8 +5209,7 @@ static const std::string trimmable(" \t");
                   delete[]h2bis;
                   delete[]h1bis;
                 }
-              }
-              else {
+              } else {
                 BaseGDL* besort = static_cast<BaseGDL*> (Mask1D);
                 MergeSortOpt<DLong>(besort, hh, h1, h2, width); // call the sort routine
 
@@ -5306,7 +5217,7 @@ static const std::string trimmable(" \t");
 
                   (*tamp)[col] = ((*Mask1D)[hh[ width / 2]]+(*Mask1D)[hh[ (width - 1) / 2]]) / 2;
                 else
-                  (*tamp)[col] = (*Mask1D)[hh[ width / 2]]; // replace value by Mask median 
+                  (*tamp)[col] = (*Mask1D)[hh[ width / 2]]; // replace value by Mask median
               }
             }
 
@@ -5354,8 +5265,7 @@ static const std::string trimmable(" \t");
                     delete[]h2b;
                     delete[]h1b;
                   }
-                }
-                else {
+                } else {
                   BaseGDL* besort = static_cast<BaseGDL*> (Mask);
                   MergeSortOpt<DLong>(besort, hh, h1, h2, N_MaskElem); // call the sort routine
                   if (e->KeywordSet(evenIx))
@@ -5366,10 +5276,9 @@ static const std::string trimmable(" \t");
               }
             }
           }
-        }
-        else {
+        } else {
           if (p0->Rank() == 1)//------------------------  For a vector with odd width -------------------
- {
+          {
             for (SizeT col = lim; col < larg - lim; ++col) {
               SizeT kk = 0;
               SizeT ctl_NaN = 0;
@@ -5400,16 +5309,14 @@ static const std::string trimmable(" \t");
                   delete[]h2bis;
                   delete[]h1bis;
                 }
-              }
-              else {
+              } else {
                 BaseGDL* besort = static_cast<BaseGDL*> (Mask1D);
                 MergeSortOpt<DLong>(besort, hh, h1, h2, width); // call the sort routine
-                (*tamp)[col] = (*Mask1D)[hh[ (width) / 2]]; // replace value by Mask median 
+                (*tamp)[col] = (*Mask1D)[hh[ (width) / 2]]; // replace value by Mask median
               }
             }
 
-          }
-          else //-----------------------------  For an array with odd width ---------------------------------
+          } else //-----------------------------  For an array with odd width ---------------------------------
           {
             SizeT jj;
             for (SizeT i = 0; i < haut - 2 * lim; ++i) // lines to replace
@@ -5472,11 +5379,10 @@ static const std::string trimmable(" \t");
                     delete[]h2b;
                     delete[]h1b;
                   }
-                }
-                else {
+                } else {
                   BaseGDL* besort = static_cast<BaseGDL*> (Mask);
                   MergeSortOpt<DLong>(besort, hh, h1, h2, N_MaskElem); // call the sort routine
-                  (*tamp)[j] = (*Mask)[hh[ (N_MaskElem) / 2]]; // replace value by Mask median 
+                  (*tamp)[j] = (*Mask)[hh[ (N_MaskElem) / 2]]; // replace value by Mask median
                 }
               }
             }
@@ -5508,8 +5414,9 @@ static const std::string trimmable(" \t");
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:mean)
-      for (SizeT i = 0; i < sz; ++i) mean += data[i];
+        for (SizeT i = 0; i < sz; ++i) mean += data[i];
     }
     return mean / sz;
   }
@@ -5522,6 +5429,8 @@ static const std::string trimmable(" \t");
       for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
       for (SizeT i = 0; i < sz; ++i) meani += data[i].imag();
     } else {
+
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       {
 #pragma omp for reduction(+:meanr)
@@ -5546,7 +5455,9 @@ static const std::string trimmable(" \t");
         }
       }
     } else {
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       {
 #pragma omp for reduction(+:mean,n)
         for (SizeT i = 0; i < sz; ++i) {
@@ -5583,6 +5494,8 @@ static const std::string trimmable(" \t");
         }
       }
     } else {
+
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       {
 #pragma omp for reduction(+:meanr,nr)
@@ -5631,7 +5544,7 @@ static const std::string trimmable(" \t");
       p0->Type() == GDL_COMPLEXDBL);
     bool omitNaN = (e->KeywordPresent(nanIx) && possibleNaN);
 
-    //DIMENSION Kw  
+    //DIMENSION Kw
     static int dimIx = e->KeywordIx("DIMENSION");
     bool dimSet = e->KeywordSet(dimIx);
 
@@ -5645,7 +5558,7 @@ static const std::string trimmable(" \t");
     if (dimSet && p0->Rank() > 1) {
       meanDim -= 1; // user-supplied dimensions start with 1!
 
-    // output dimension: copy srcDim to destDim
+      // output dimension: copy srcDim to destDim
       dimension destDim = p0->Dim();
       // make array of dims for transpose
       DUInt* perm = new DUInt[p0->Rank()];
@@ -5674,9 +5587,9 @@ static const std::string trimmable(" \t");
         }
         DComplexDblGDL* res = new DComplexDblGDL(destDim, BaseGDL::NOZERO);
         if (omitNaN) {
-            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride);
         } else {
-            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplexDbl, double>(&(*input)[i * stride], stride);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplexDbl, double>(&(*input)[i * stride], stride);
         }
         if (clean_array) delete input;
         return res;
@@ -5688,9 +5601,9 @@ static const std::string trimmable(" \t");
         }
         DComplexGDL* res = new DComplexGDL(destDim, BaseGDL::NOZERO);
         if (omitNaN) {
-            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplex, float>(&(*input)[i * stride], stride);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplex, float>(&(*input)[i * stride], stride);
         } else {
-            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplex, float>(&(*input)[i * stride], stride);
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplex, float>(&(*input)[i * stride], stride);
         }
         if (clean_array) delete input;
         return res;
@@ -5703,9 +5616,9 @@ static const std::string trimmable(" \t");
           }
           DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
           if (omitNaN) {
-              for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
+            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
           } else {
-              for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
+            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
           }
           if (clean_array) delete input;
           return res;
@@ -5718,9 +5631,9 @@ static const std::string trimmable(" \t");
           }
           DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
           if (omitNaN) {
-              for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
+            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
           } else {
-              for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
+            for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
           }
           if (clean_array) delete input;
           return res;
@@ -5769,8 +5682,9 @@ static const std::string trimmable(" \t");
         md += fabs(cdata);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
         md += fabs(cdata);
@@ -5792,8 +5706,9 @@ static const std::string trimmable(" \t");
         skew += (cdata * cdata * cdata) / (var * sdev);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
       }
@@ -5810,8 +5725,9 @@ static const std::string trimmable(" \t");
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
@@ -5845,8 +5761,9 @@ static const std::string trimmable(" \t");
         mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -5885,8 +5802,9 @@ static const std::string trimmable(" \t");
           exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -5927,8 +5845,9 @@ static const std::string trimmable(" \t");
           4.0 * varr * varr * vari * vari);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -5973,8 +5892,9 @@ static const std::string trimmable(" \t");
         }
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md,k)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
           var += cdata*cdata;
@@ -6002,8 +5922,9 @@ static const std::string trimmable(" \t");
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
       }
@@ -6020,8 +5941,9 @@ static const std::string trimmable(" \t");
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
@@ -6062,8 +5984,9 @@ static const std::string trimmable(" \t");
         if (std::isfinite(cdatar)) mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr,kr,ki)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -6108,8 +6031,9 @@ static const std::string trimmable(" \t");
           exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -6150,8 +6074,9 @@ static const std::string trimmable(" \t");
           4.0 * varr * varr * vari * vari);
       }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
-      for (SizeT i = 0; i < sz; ++i) {
+        for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
         T2 cdatai = cdata.imag();
@@ -6171,7 +6096,7 @@ static const std::string trimmable(" \t");
     }
     kurtosis = std::complex<T2>((kurtr / kr) - 3, (kurti / kr) - 3);
   }
-  
+
   BaseGDL* moment_fun(EnvT* e) {
     BaseGDL* p0 = e->GetParDefined(0);
 
@@ -6197,38 +6122,38 @@ static const std::string trimmable(" \t");
       p0->Type() == GDL_COMPLEXDBL);
     bool omitNaN = (e->KeywordPresent(nanIx) && possibleNaN);
 
-    //DIMENSION Kw  
+    //DIMENSION Kw
     static int dimIx = e->KeywordIx("DIMENSION");
     bool dimSet = e->KeywordSet(dimIx);
 
     //MAXMOMENT Kw. It limits the computation, even if a modifying kw of higher moment, such as "kurtosis" is present
-    
+
     static int maxmIx = e->KeywordIx("MAXMOMENT");
     DLong maxmoment = 4;
     if (e->KeywordPresent(maxmIx)) e->AssureLongScalarKW(maxmIx, maxmoment);
-    if (maxmoment > 4) maxmoment=4;
-    if (maxmoment < 1) maxmoment=4;
-    
+    if (maxmoment > 4) maxmoment = 4;
+    if (maxmoment < 1) maxmoment = 4;
+
     //MEAN Kw
     static int meanIx = e->KeywordIx("MEAN");
     int domean = e->KeywordPresent(meanIx);
-        //KURTOSIS Kw
+    //KURTOSIS Kw
     static int kurtIx = e->KeywordIx("KURTOSIS");
     int dokurt = e->KeywordPresent(kurtIx);
-        //SDEV Kw
+    //SDEV Kw
     static int sdevIx = e->KeywordIx("SDEV");
     int dosdev = e->KeywordPresent(sdevIx);
-        //MDEV Kw
+    //MDEV Kw
     static int mdevIx = e->KeywordIx("MDEV");
     int domdev = e->KeywordPresent(mdevIx);
-        //VARIANCE Kw
+    //VARIANCE Kw
     static int varIx = e->KeywordIx("VARIANCE");
     int dovar = e->KeywordPresent(varIx);
-        //SKEWNESS Kw
+    //SKEWNESS Kw
     static int skewIx = e->KeywordIx("SKEWNESS");
-    int doskew = e->KeywordPresent(skewIx);    
+    int doskew = e->KeywordPresent(skewIx);
 
-    
+
     DLong momentDim;
     if (dimSet) {
       e->AssureLongScalarKW(dimIx, momentDim);
@@ -6256,9 +6181,9 @@ static const std::string trimmable(" \t");
       destDim.Remove(momentDim); //will be one dimension less
       SizeT nEl = destDim.NDimElementsConst(); //need to compute that here, before adding last dim.
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
-      auxiliaryDim=destDim;
-      
-      destDim<<4; //add 4 as last dim
+      auxiliaryDim = destDim;
+
+      destDim << 4; //add 4 as last dim
       //compute stride and number of elements of result:
       SizeT stride = p0->Dim(momentDim);
 
@@ -6279,7 +6204,7 @@ static const std::string trimmable(" \t");
         DComplexDblGDL* sdev;
         DDoubleGDL* mdev;
         if (domean) mean = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
-        if (dovar)   var = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
+        if (dovar) var = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (doskew) skew = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (dokurt) kurt = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (dosdev) sdev = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
@@ -6296,19 +6221,20 @@ static const std::string trimmable(" \t");
               if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
               if (dosdev) (*sdev)[i] = sdevl;
               if (domdev) (*mdev)[i] = mdevl;
-            }            
+            }
           } else {
+            TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-            for (SizeT i = 0; i < nEl; ++i) {
+              for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
-              do_moment_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
+              do_moment_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
             }
           }
         } else {
@@ -6316,36 +6242,37 @@ static const std::string trimmable(" \t");
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
-              do_moment_cpx<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
-            }                      
+              do_moment_cpx<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
+            }
           } else {
+            TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-            for (SizeT i = 0; i < nEl; ++i) {
+              for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
-              do_moment_cpx<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
+              do_moment_cpx<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
             }
           }
         }
         if (clean_array) delete input;
-        if (domean) e->SetKW( meanIx, mean );
-        if (dovar ) e->SetKW( varIx, var );
-        if (doskew) e->SetKW( skewIx, skew );
-        if (dokurt) e->SetKW( kurtIx, kurt );
-        if (dosdev) e->SetKW( sdevIx, sdev );
-        if (domdev) e->SetKW( mdevIx, mdev );
+        if (domean) e->SetKW(meanIx, mean);
+        if (dovar) e->SetKW(varIx, var);
+        if (doskew) e->SetKW(skewIx, skew);
+        if (dokurt) e->SetKW(kurtIx, kurt);
+        if (dosdev) e->SetKW(sdevIx, sdev);
+        if (domdev) e->SetKW(mdevIx, mdev);
         return res;
       } else if (p0->Type() == GDL_COMPLEX) {
         DComplexGDL* input = e->GetParAs<DComplexGDL>(0);
@@ -6361,7 +6288,7 @@ static const std::string trimmable(" \t");
         DComplexGDL* sdev;
         DFloatGDL* mdev;
         if (domean) mean = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
-        if (dovar)   var = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
+        if (dovar) var = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (doskew) skew = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (dokurt) kurt = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (dosdev) sdev = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
@@ -6371,26 +6298,27 @@ static const std::string trimmable(" \t");
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
-              do_moment_cpx_nan<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
-            }            
+              do_moment_cpx_nan<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
+            }
           } else {
+            TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-            for (SizeT i = 0; i < nEl; ++i) {
+              for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
-              do_moment_cpx_nan<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
+              do_moment_cpx_nan<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
             }
           }
         } else {
@@ -6398,37 +6326,38 @@ static const std::string trimmable(" \t");
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
-              do_moment_cpx<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
+              do_moment_cpx<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
             }
           } else {
+            TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-            for (SizeT i = 0; i < nEl; ++i) {
+              for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
-              do_moment_cpx<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-              if (domean) (*mean)[i]=(*res)[i];
-              if (dovar ) (*var )[i]=(*res)[i+nEl];
-              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-              if (dosdev) (*sdev)[i]=sdevl;
-              if (domdev) (*mdev)[i]=mdevl;
+              do_moment_cpx<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
             }
           }
         }
         if (clean_array) delete input;
-        if (domean) e->SetKW( meanIx, mean );
-        if (dovar ) e->SetKW( varIx, var );
-        if (doskew) e->SetKW( skewIx, skew );
-        if (dokurt) e->SetKW( kurtIx, kurt );
-        if (dosdev) e->SetKW( sdevIx, sdev );
-        if (domdev) e->SetKW( mdevIx, mdev );
-        return res;        
+        if (domean) e->SetKW(meanIx, mean);
+        if (dovar) e->SetKW(varIx, var);
+        if (doskew) e->SetKW(skewIx, skew);
+        if (dokurt) e->SetKW(kurtIx, kurt);
+        if (dosdev) e->SetKW(sdevIx, sdev);
+        if (domdev) e->SetKW(mdevIx, mdev);
+        return res;
       } else {
         if (dbl) {
           DDoubleGDL* input = e->GetParAs<DDoubleGDL>(0);
@@ -6444,7 +6373,7 @@ static const std::string trimmable(" \t");
           DDoubleGDL* sdev;
           DDoubleGDL* mdev;
           if (domean) mean = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
-          if (dovar)   var = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
+          if (dovar) var = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (doskew) skew = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (dokurt) kurt = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (dosdev) sdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
@@ -6454,28 +6383,29 @@ static const std::string trimmable(" \t");
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
-                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
-              }              
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
+              }
             } else {
+              TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-              for (SizeT i = 0; i < nEl; ++i) {
+                for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
-                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             }
           } else {
@@ -6483,38 +6413,39 @@ static const std::string trimmable(" \t");
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
-                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
-              }              
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
+              }
             } else {
+              TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-              for (SizeT i = 0; i < nEl; ++i) {
+                for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
-                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             }
           }
           if (clean_array) delete input;
-          if (domean) e->SetKW( meanIx, mean );
-          if (dovar ) e->SetKW( varIx, var );
-          if (doskew) e->SetKW( skewIx, skew );
-          if (dokurt) e->SetKW( kurtIx, kurt );
-          if (dosdev) e->SetKW( sdevIx, sdev );
-          if (domdev) e->SetKW( mdevIx, mdev );
+          if (domean) e->SetKW(meanIx, mean);
+          if (dovar) e->SetKW(varIx, var);
+          if (doskew) e->SetKW(skewIx, skew);
+          if (dokurt) e->SetKW(kurtIx, kurt);
+          if (dosdev) e->SetKW(sdevIx, sdev);
+          if (domdev) e->SetKW(mdevIx, mdev);
           return res;
         } else {
           DFloatGDL* input = e->GetParAs<DFloatGDL>(0);
@@ -6530,7 +6461,7 @@ static const std::string trimmable(" \t");
           DFloatGDL* sdev;
           DFloatGDL* mdev;
           if (domean) mean = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
-          if (dovar)   var = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
+          if (dovar) var = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (doskew) skew = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (dokurt) kurt = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (dosdev) sdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
@@ -6540,28 +6471,29 @@ static const std::string trimmable(" \t");
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
-                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             } else {
+              TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-              for (SizeT i = 0; i < nEl; ++i) {
+                for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
-                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             }
           } else {
@@ -6569,38 +6501,39 @@ static const std::string trimmable(" \t");
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
-                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             } else {
+              TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-              for (SizeT i = 0; i < nEl; ++i) {
+                for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
-                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
-                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
-                if (domean) (*mean)[i]=(*res)[i];
-                if (dovar ) (*var )[i]=(*res)[i+nEl];
-                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
-                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
-                if (dosdev) (*sdev)[i]=sdevl;
-                if (domdev) (*mdev)[i]=mdevl;
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl],
+                  (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i] = (*res)[i];
+                if (dovar) (*var)[i] = (*res)[i + nEl];
+                if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+                if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+                if (dosdev) (*sdev)[i] = sdevl;
+                if (domdev) (*mdev)[i] = mdevl;
               }
             }
           }
           if (clean_array) delete input;
-          if (domean) e->SetKW( meanIx, mean );
-          if (dovar ) e->SetKW( varIx, var );
-          if (doskew) e->SetKW( skewIx, skew );
-          if (dokurt) e->SetKW( kurtIx, kurt );
-          if (dosdev) e->SetKW( sdevIx, sdev );
-          if (domdev) e->SetKW( mdevIx, mdev );
+          if (domean) e->SetKW(meanIx, mean);
+          if (dovar) e->SetKW(varIx, var);
+          if (doskew) e->SetKW(skewIx, skew);
+          if (dokurt) e->SetKW(kurtIx, kurt);
+          if (dosdev) e->SetKW(sdevIx, sdev);
+          if (domdev) e->SetKW(mdevIx, mdev);
           return res;
         }
       }
@@ -6614,18 +6547,18 @@ static const std::string trimmable(" \t");
         DComplexDbl sdev;
         DDouble mdev;
         if (omitNaN) do_moment_cpx_nan<DComplexDbl, double>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-        else  do_moment_cpx<DComplexDbl, double>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-        if (domean) e->SetKW( meanIx,new DComplexDblGDL( mean) );
-        if (dovar ) e->SetKW( varIx, new DComplexDblGDL( var ) );
-        if (doskew) e->SetKW( skewIx,new DComplexDblGDL( skew) );
-        if (dokurt) e->SetKW( kurtIx,new DComplexDblGDL( kurt) );
-        if (dosdev) e->SetKW( sdevIx,new DComplexDblGDL( sdev) );
-        if (domdev) e->SetKW( mdevIx,new DDoubleGDL( mdev) );
+        else do_moment_cpx<DComplexDbl, double>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
+        if (domean) e->SetKW(meanIx, new DComplexDblGDL(mean));
+        if (dovar) e->SetKW(varIx, new DComplexDblGDL(var));
+        if (doskew) e->SetKW(skewIx, new DComplexDblGDL(skew));
+        if (dokurt) e->SetKW(kurtIx, new DComplexDblGDL(kurt));
+        if (dosdev) e->SetKW(sdevIx, new DComplexDblGDL(sdev));
+        if (domdev) e->SetKW(mdevIx, new DDoubleGDL(mdev));
         DComplexDblGDL* res = new DComplexDblGDL(4, BaseGDL::NOZERO);
-        (*res)[0]=mean;
-        (*res)[1]=var;
-        (*res)[2]=skew;
-        (*res)[3]=kurt;
+        (*res)[0] = mean;
+        (*res)[1] = var;
+        (*res)[2] = skew;
+        (*res)[3] = kurt;
         return res;
       } else if (p0->Type() == GDL_COMPLEX) {
         DComplexGDL* input = e->GetParAs<DComplexGDL>(0);
@@ -6636,18 +6569,18 @@ static const std::string trimmable(" \t");
         DComplex sdev;
         DFloat mdev;
         if (omitNaN) do_moment_cpx_nan<DComplex, float>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-        else  do_moment_cpx<DComplex, float>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-        if (domean) e->SetKW( meanIx,new DComplexGDL( mean) );
-        if (dovar ) e->SetKW( varIx, new DComplexGDL( var ) );
-        if (doskew) e->SetKW( skewIx,new DComplexGDL( skew) );
-        if (dokurt) e->SetKW( kurtIx,new DComplexGDL( kurt) );
-        if (dosdev) e->SetKW( sdevIx,new DComplexGDL( sdev) );
-        if (domdev) e->SetKW( mdevIx,new DFloatGDL( mdev) );
+        else do_moment_cpx<DComplex, float>(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
+        if (domean) e->SetKW(meanIx, new DComplexGDL(mean));
+        if (dovar) e->SetKW(varIx, new DComplexGDL(var));
+        if (doskew) e->SetKW(skewIx, new DComplexGDL(skew));
+        if (dokurt) e->SetKW(kurtIx, new DComplexGDL(kurt));
+        if (dosdev) e->SetKW(sdevIx, new DComplexGDL(sdev));
+        if (domdev) e->SetKW(mdevIx, new DFloatGDL(mdev));
         DComplexGDL* res = new DComplexGDL(4, BaseGDL::NOZERO);
-        (*res)[0]=mean;
-        (*res)[1]=var;
-        (*res)[2]=skew;
-        (*res)[3]=kurt;
+        (*res)[0] = mean;
+        (*res)[1] = var;
+        (*res)[2] = skew;
+        (*res)[3] = kurt;
         return res;
       } else {
         if (dbl) {
@@ -6659,18 +6592,18 @@ static const std::string trimmable(" \t");
           DDouble sdev;
           DDouble mdev;
           if (omitNaN) do_moment_nan(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-          else  do_moment(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-          if (domean) e->SetKW( meanIx,new DDoubleGDL( mean) );
-          if (dovar ) e->SetKW( varIx, new DDoubleGDL( var ) );
-          if (doskew) e->SetKW( skewIx,new DDoubleGDL( skew) );
-          if (dokurt) e->SetKW( kurtIx,new DDoubleGDL( kurt) );
-          if (dosdev) e->SetKW( sdevIx,new DDoubleGDL( sdev) );
-          if (domdev) e->SetKW( mdevIx,new DDoubleGDL( mdev) );
+          else do_moment(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
+          if (domean) e->SetKW(meanIx, new DDoubleGDL(mean));
+          if (dovar) e->SetKW(varIx, new DDoubleGDL(var));
+          if (doskew) e->SetKW(skewIx, new DDoubleGDL(skew));
+          if (dokurt) e->SetKW(kurtIx, new DDoubleGDL(kurt));
+          if (dosdev) e->SetKW(sdevIx, new DDoubleGDL(sdev));
+          if (domdev) e->SetKW(mdevIx, new DDoubleGDL(mdev));
           DDoubleGDL* res = new DDoubleGDL(4, BaseGDL::NOZERO);
-          (*res)[0]=mean;
-          (*res)[1]=var;
-          (*res)[2]=skew;
-          (*res)[3]=kurt;
+          (*res)[0] = mean;
+          (*res)[1] = var;
+          (*res)[2] = skew;
+          (*res)[3] = kurt;
           return res;
         } else {
           DFloatGDL* input = e->GetParAs<DFloatGDL>(0);
@@ -6681,91 +6614,101 @@ static const std::string trimmable(" \t");
           DFloat sdev;
           DFloat mdev;
           if (omitNaN) do_moment_nan(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-          else  do_moment(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
-          if (domean) e->SetKW( meanIx,new DFloatGDL( mean) );
-          if (dovar ) e->SetKW( varIx, new DFloatGDL( var ) );
-          if (doskew) e->SetKW( skewIx,new DFloatGDL( skew) );
-          if (dokurt) e->SetKW( kurtIx,new DFloatGDL( kurt) );
-          if (dosdev) e->SetKW( sdevIx,new DFloatGDL( sdev) );
-          if (domdev) e->SetKW( mdevIx,new DFloatGDL( mdev) );
+          else do_moment(&(*input)[0], input->N_Elements(), mean, var, skew, kurt, mdev, sdev, maxmoment);
+          if (domean) e->SetKW(meanIx, new DFloatGDL(mean));
+          if (dovar) e->SetKW(varIx, new DFloatGDL(var));
+          if (doskew) e->SetKW(skewIx, new DFloatGDL(skew));
+          if (dokurt) e->SetKW(kurtIx, new DFloatGDL(kurt));
+          if (dosdev) e->SetKW(sdevIx, new DFloatGDL(sdev));
+          if (domdev) e->SetKW(mdevIx, new DFloatGDL(mdev));
           DFloatGDL* res = new DFloatGDL(4, BaseGDL::NOZERO);
-          (*res)[0]=mean;
-          (*res)[1]=var;
-          (*res)[2]=skew;
-          (*res)[3]=kurt;
+          (*res)[0] = mean;
+          (*res)[1] = var;
+          (*res)[2] = skew;
+          (*res)[3] = kurt;
           return res;
         }
       }
     }
   }
+
   template<typename T> void pos_ishft_s(T* out, const SizeT n, const char s) {
-// parallelization is marginally useful as the loop is well paralleized by compiler.
-      for (SizeT i=0; i < n; ++i) out[i] <<= s;
+    // parallelization is marginally useful as the loop is well paralleized by compiler.
+    for (SizeT i = 0; i < n; ++i) out[i] <<= s;
   }
 
   template<typename T> void neg_ishft_s(T* out, const SizeT n, const char s) {
-// parallelization is marginally useful as the loop is well paralleized by compiler.
-      for (SizeT i = 0; i < n; ++i) out[i] >>= s;
+    // parallelization is marginally useful as the loop is well paralleized by compiler.
+    for (SizeT i = 0; i < n; ++i) out[i] >>= s;
   }
-  
+
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-    bool parallelize=((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n));
+    bool parallelize = ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n));
     if (!parallelize) {
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
-      }      
+      }
     } else {
+      TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-      for (SizeT i = 0; i < n; ++i) {
-        if (s[i] >= 0 ) out[i] <<= s[i]; else out[i] >>= s[i];
+        for (SizeT i = 0; i < n; ++i) {
+        if (s[i] >= 0) out[i] <<= s[i];
+        else out[i] >>= s[i];
       }
     }
   }
-  
+
   BaseGDL* ishft_single(BaseGDL* in, SizeT n, char s, bool pos) {
     BaseGDL* out = in->Dup();
     switch (in->Type()) {
     case GDL_BYTE:
     {
       DByte* _out = static_cast<DByte*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_UINT:
     {
       DUInt* _out = static_cast<DUInt*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s( _out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_INT:
     {
       DInt* _out = static_cast<DInt*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_LONG:
     {
       DLong* _out = static_cast<DLong*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_ULONG:
     {
       DULong* _out = static_cast<DULong*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_LONG64:
     {
       DULong64* _out = static_cast<DULong64*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     case GDL_ULONG64:
     {
       DLong64* _out = static_cast<DLong64*> (out->DataAddr());
-      if (pos) pos_ishft_s(_out, n, s); else neg_ishft_s(_out, n, s);
+      if (pos) pos_ishft_s(_out, n, s);
+      else neg_ishft_s(_out, n, s);
     }
       break;
     default:
@@ -6776,7 +6719,7 @@ static const std::string trimmable(" \t");
 
   BaseGDL* ishft_multiple(BaseGDL* in, DLongGDL* _s, SizeT n) {
     BaseGDL* out = in->Dup(); //New(n, BaseGDL::NOZERO);
-    DLong* s=static_cast<DLong*> (_s->DataAddr());
+    DLong* s = static_cast<DLong*> (_s->DataAddr());
     switch (in->Type()) {
     case GDL_BYTE:
     {
@@ -6787,7 +6730,7 @@ static const std::string trimmable(" \t");
     case GDL_UINT:
     {
       DUInt* _out = static_cast<DUInt*> (out->DataAddr());
-      ishft_m( _out, n, s);
+      ishft_m(_out, n, s);
     }
       break;
     case GDL_INT:
@@ -6826,10 +6769,10 @@ static const std::string trimmable(" \t");
     return out;
   }
 
-    BaseGDL* ishft_fun(EnvT* e) {
+  BaseGDL* ishft_fun(EnvT* e) {
     Guard<BaseGDL>guard;
-    
-    BaseGDL* in=(e->GetParDefined(0));
+
+    BaseGDL* in = (e->GetParDefined(0));
     DType typ = in->Type();
     //types are normally correct, so do not loose time looking for wrong types
     if (IntType(typ)) {
@@ -6856,27 +6799,32 @@ static const std::string trimmable(" \t");
       }
       //note: res is always 0's type:
       //fill shift, using a large type Long as apparently IDL does
-      DLongGDL* sss=e->GetParAs<DLongGDL>(1);
+      DLongGDL* sss = e->GetParAs<DLongGDL>(1);
       //if sss is a singleton, or not:
       if (sss->N_Elements() == 1) {
         char shift;
-        if ((*sss)[0] ==0) return in->Dup(); 
+        if ((*sss)[0] == 0) return in->Dup();
         else if ((*sss)[0] > 0) {
-          if ((*sss)[0] > 254) shift = -1; else shift = (*sss)[0];
+          if ((*sss)[0] > 254) shift = -1;
+          else shift = (*sss)[0];
           return ishft_single(in, finalN, shift, true);
         } else {
-          if ( (*sss)[0] < -254 ) shift = -1; else shift = -(*sss)[0];
+          if ((*sss)[0] < -254) shift = -1;
+          else shift = -(*sss)[0];
           return ishft_single(in, finalN, shift, false);
         }
       } else {
-        if (in->Scalar()) {in=in->New( finalN, BaseGDL::INIT); guard.Reset(in);} //expand to return element size, for parallel processing
+        if (in->Scalar()) {
+          in = in->New(finalN, BaseGDL::INIT);
+          guard.Reset(in);
+        } //expand to return element size, for parallel processing
         return ishft_multiple(in, sss, finalN);
       }
     } else e->Throw("Operand must be integer:" + e->GetParString(0));
     return NULL; //pacify dumb compilers.
-    }
-  
-  BaseGDL* shift_fun( EnvT* e) {
+  }
+
+  BaseGDL* shift_fun(EnvT* e) {
     SizeT nParam = e->NParam(2);
 
     BaseGDL* p0 = e->GetParDefined(0);
@@ -6921,51 +6869,49 @@ static const std::string trimmable(" \t");
     return p0->CShift(sIx);
   }
 
-  BaseGDL* arg_present( EnvT* e)
-  {
-    e->NParam( 1);
-    
-    if( !e->GlobalPar( 0))
-      return new DIntGDL( 0);
+  BaseGDL* arg_present(EnvT* e) {
+    e->NParam(1);
+
+    if (!e->GlobalPar(0))
+      return new DIntGDL(0);
 
     EnvBaseT* caller = e->Caller();
-    if( caller == NULL)
-      return new DIntGDL( 0);
+    if (caller == NULL)
+      return new DIntGDL(0);
 
-    BaseGDL** pp0 = &e->GetPar( 0);
-    
-    int ix = caller->FindGlobalKW( pp0);
-    if( ix == -1)
-      return new DIntGDL( 0);
+    BaseGDL** pp0 = &e->GetPar(0);
 
-    return new DIntGDL( 1);
+    int ix = caller->FindGlobalKW(pp0);
+    if (ix == -1)
+      return new DIntGDL(0);
+
+    return new DIntGDL(1);
   }
 
-  BaseGDL* eof_fun( EnvT* e)
-  {
-    e->NParam( 1);
+  BaseGDL* eof_fun(EnvT* e) {
+    e->NParam(1);
 
     DLong lun;
-    e->AssureLongScalarPar( 0, lun);
+    e->AssureLongScalarPar(0, lun);
 
-    bool stdLun = check_lun( e, lun);
-    if( stdLun)
-      return new DIntGDL( 0);
+    bool stdLun = check_lun(e, lun);
+    if (stdLun)
+      return new DIntGDL(0);
 
     // nicer error message (Disregard if socket)
-    if ( fileUnits[ lun-1].SockNum() == -1) {
-      if( !fileUnits[ lun-1].IsOpen())
-    throw GDLIOException( e->CallingNode(), "File unit is not open: "+i2s( lun)+".");
+    if (fileUnits[ lun - 1].SockNum() == -1) {
+      if (!fileUnits[ lun - 1].IsOpen())
+        throw GDLIOException(e->CallingNode(), "File unit is not open: " + i2s(lun) + ".");
 
-      if( fileUnits[ lun-1].Eof())
-    return new DIntGDL( 1);
+      if (fileUnits[ lun - 1].Eof())
+        return new DIntGDL(1);
     } else {
       // Socket
-      string *recvBuf = &fileUnits[ lun-1].RecvBuf();
+      string *recvBuf = &fileUnits[ lun - 1].RecvBuf();
       if (recvBuf->size() == 0)
-    return new DIntGDL( 1);
+        return new DIntGDL(1);
     }
-    return new DIntGDL( 0);
+    return new DIntGDL(0);
   }
 
   BaseGDL* rebin_fun(EnvT* e) {
@@ -7019,8 +6965,7 @@ static const std::string trimmable(" \t");
     return p0->Rebin(resDim, sample);
   }
 
-  BaseGDL* obj_class(EnvT* e)
-  {
+  BaseGDL* obj_class(EnvT* e) {
     SizeT nParam = e->NParam();
 
     static int countIx = e->KeywordIx("COUNT");
@@ -7070,7 +7015,7 @@ static const std::string trimmable(" \t");
         DStructGDL* oStruct;
         try {
           oStruct = e->GetObjHeap(objRef);
-        }        catch (GDLInterpreter::HeapException&) { // non valid object
+        } catch (GDLInterpreter::HeapException&) { // non valid object
           if (count)
             e->SetKW(countIx, new DLongGDL(0));
           return new DStringGDL("");
@@ -7127,79 +7072,77 @@ static const std::string trimmable(" \t");
     } else return new DStringGDL("");
 
   }
- BaseGDL* obj_hasmethod( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 2);
-            //trace_me = trace_arg();
-    BaseGDL*& p0 = e->GetPar( 0);
-    if( p0 == NULL || p0->Type() != GDL_OBJ)
-      e->Throw( "Object reference type required in this context: "+
-        e->GetParString(0));
 
-    BaseGDL* p1 = e->GetParDefined( 1);
-    if( p1->Type() != GDL_STRING)
-              e->Throw( "Methods can be referenced only with names (strings)");
-    DStringGDL* p1S =  static_cast<DStringGDL*>( p1);
-    DObjGDL* pObj = static_cast<DObjGDL*>( p0);
+  BaseGDL* obj_hasmethod(EnvT* e) {
+    SizeT nParam = e->NParam(2);
+    //trace_me = trace_arg();
+    BaseGDL*& p0 = e->GetPar(0);
+    if (p0 == NULL || p0->Type() != GDL_OBJ)
+      e->Throw("Object reference type required in this context: " +
+      e->GetParString(0));
+
+    BaseGDL* p1 = e->GetParDefined(1);
+    if (p1->Type() != GDL_STRING)
+      e->Throw("Methods can be referenced only with names (strings)");
+    DStringGDL* p1S = static_cast<DStringGDL*> (p1);
+    DObjGDL* pObj = static_cast<DObjGDL*> (p0);
     SizeT nObj = p0->StrictScalar() ? 1 : p0->N_Elements();
-    DByteGDL* res = new DByteGDL( dimension(nObj));
+    DByteGDL* res = new DByteGDL(dimension(nObj));
     Guard<DByteGDL> res_guard(res);
-    DByteGDL* altres = new DByteGDL( dimension(nObj));
+    DByteGDL* altres = new DByteGDL(dimension(nObj));
     Guard<DByteGDL> altres_guard(altres);
     GDLInterpreter* interpreter = e->Interpreter();
-    
-    for( SizeT iobj=0; iobj<nObj; ++iobj)
-      {
-        if( ((*res)[iobj] != 0) || ((*altres)[iobj] != 0)) continue; 
-            DObj s = (*static_cast<DObjGDL*>( p0))[iobj];
-        if( s != 0)
-        {
-//          DStructGDL* oStruct = e->GetObjHeap( (*pObj)[iobj]);
-            DStructGDL* oStruct = e->GetObjHeap( s);        
-            //if(trace_me) std::cout << " oStruct";
-            DStructDesc* odesc = oStruct->Desc();
-            int passed = 1;
-            for( SizeT m=0; m<p1->N_Elements(); m++)
-            {
-                DString method = StrUpCase((*p1S)[m]);
-    //          if(trace_me) std::cout << method;
-                if( odesc->GetFun( method) != NULL) continue;
-                if( odesc->GetPro( method) != NULL) continue;
-                passed = 0; break;
+
+    for (SizeT iobj = 0; iobj < nObj; ++iobj) {
+      if (((*res)[iobj] != 0) || ((*altres)[iobj] != 0)) continue;
+      DObj s = (*static_cast<DObjGDL*> (p0))[iobj];
+      if (s != 0) {
+        //          DStructGDL* oStruct = e->GetObjHeap( (*pObj)[iobj]);
+        DStructGDL* oStruct = e->GetObjHeap(s);
+        //if(trace_me) std::cout << " oStruct";
+        DStructDesc* odesc = oStruct->Desc();
+        int passed = 1;
+        for (SizeT m = 0; m < p1->N_Elements(); m++) {
+          DString method = StrUpCase((*p1S)[m]);
+          //          if(trace_me) std::cout << method;
+          if (odesc->GetFun(method) != NULL) continue;
+          if (odesc->GetPro(method) != NULL) continue;
+          passed = 0;
+          break;
+        }
+        (*res)[iobj] = passed;
+        for (SizeT i = iobj + 1; i < nObj; ++i) {
+          if (interpreter->ObjValid((*pObj)[ i]))
+            if (e->GetObjHeap((*pObj)[i])->Desc() == odesc) {
+              (*res)[i] = passed;
+              (*altres)[i] = 1 - passed;
             }
-            (*res)[iobj] = passed;
-            for( SizeT i=iobj+1; i<nObj; ++i) {
-                if( interpreter->ObjValid( (*pObj)[ i])) 
-                    if( e->GetObjHeap( (*pObj)[i])->Desc() == odesc) {
-                             (*res)[i] = passed;
-                             (*altres)[i] = 1-passed;
-                         }
-                 }
-        } // else if(trace_me) std::cout << " 0 ";
-      }
-    if( p0->StrictScalar())
-             return new DByteGDL((*res)[0]);
-    else     return res_guard.release();
+        }
+      } // else if(trace_me) std::cout << " 0 ";
+    }
+    if (p0->StrictScalar())
+      return new DByteGDL((*res)[0]);
+    else return res_guard.release();
   }
 
   BaseGDL* obj_isa(EnvT* e) {
     DString className;
     e->AssureScalarPar<DStringGDL>(1, className);
     className = StrUpCase(className);
-     if( className == "IDL_OBJECT")
-       className = GDL_OBJECT_NAME;
-    else if( className == "IDL_CONTAINER" )
-       className = GDL_CONTAINER_NAME;
+    if (className == "IDL_OBJECT")
+      className = GDL_OBJECT_NAME;
+    else if (className == "IDL_CONTAINER")
+      className = GDL_CONTAINER_NAME;
     BaseGDL* p0 = e->GetPar(0);
     //nObjects is the number of objects or strings passed in array format.
     SizeT nElem = p0->N_Elements();
 
-    DByteGDL* res = new DByteGDL(p0->Dim()); // zero 
+    DByteGDL* res = new DByteGDL(p0->Dim()); // zero
 
     if (p0->Type() == GDL_OBJ) {
       DObjGDL* pObj = static_cast<DObjGDL*> (p0);
       if (pObj) { //pObj protection probably overkill.
-        for (SizeT i = 0; i < nElem; ++i) { 
+        for (SizeT i = 0; i < nElem; ++i) {
           if (e->Interpreter()->ObjValid((*pObj)[ i])) {
             DStructGDL* oStruct = e->GetObjHeap((*pObj)[i]);
             if (oStruct->Desc()->IsParent(className))
@@ -7214,36 +7157,36 @@ static const std::string trimmable(" \t");
         (*res)[i] = 0;
       }
       return res;
-    } else e->Throw("Object reference type required in this context: " + e->GetParString(0)); return NULL;
+    } else e->Throw("Object reference type required in this context: " + e->GetParString(0));
+    return NULL;
   }
 
-  BaseGDL* n_tags( EnvT* e)
-  {
-    e->NParam( 1);
+  BaseGDL* n_tags(EnvT* e) {
+    e->NParam(1);
 
-    BaseGDL* p0 = e->GetPar( 0);
-    if( p0 == NULL)
-      return new DLongGDL( 0);
-    
-    if( p0->Type() != GDL_STRUCT)
-      return new DLongGDL( 0);
-    
-    DStructGDL* s = static_cast<DStructGDL*>( p0);
+    BaseGDL* p0 = e->GetPar(0);
+    if (p0 == NULL)
+      return new DLongGDL(0);
+
+    if (p0->Type() != GDL_STRUCT)
+      return new DLongGDL(0);
+
+    DStructGDL* s = static_cast<DStructGDL*> (p0);
 
     //static int lengthIx = e->KeywordIx( "DATA_LENGTH");
     //bool length = e->KeywordSet( lengthIx);
-    
-    // we don't know now how to distinguish the 2 following cases
-    static int datalengthIx=e->KeywordIx("DATA_LENGTH");
-    static int lengthIx=e->KeywordIx("LENGTH");
-    
-    if(e->KeywordSet(datalengthIx))
-      return new DLongGDL( s->SizeofTags());
-    
-    if(e->KeywordSet(lengthIx))
-      return new DLongGDL( s->Sizeof());
 
-    return new DLongGDL( s->Desc()->NTags());
+    // we don't know now how to distinguish the 2 following cases
+    static int datalengthIx = e->KeywordIx("DATA_LENGTH");
+    static int lengthIx = e->KeywordIx("LENGTH");
+
+    if (e->KeywordSet(datalengthIx))
+      return new DLongGDL(s->SizeofTags());
+
+    if (e->KeywordSet(lengthIx))
+      return new DLongGDL(s->Sizeof());
+
+    return new DLongGDL(s->Desc()->NTags());
   }
 
   BaseGDL* bytscl(EnvT* e) {
@@ -7268,14 +7211,13 @@ static const std::string trimmable(" \t");
 
     DDouble min;
     bool minSet = false;
-    // SA: handling 3 parameters to emulate undocumented IDL behaviour 
+    // SA: handling 3 parameters to emulate undocumented IDL behaviour
     //     of translating second and third arguments to MIN and MAX, respectively
     //     (parameters have precedence over keywords)
     if (nParam >= 2) {
       e->AssureDoubleScalarPar(1, min);
       minSet = true;
-    }
-    else if (e->GetKW(minIx) != NULL) {
+    } else if (e->GetKW(minIx) != NULL) {
       e->AssureDoubleScalarKW(minIx, min);
       minSet = true;
     }
@@ -7304,7 +7246,7 @@ static const std::string trimmable(" \t");
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-    bool parallelize=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (!parallelize) {
       if (IntType(p0->Type())) {
         //Is a thread pool function
@@ -7329,12 +7271,13 @@ static const std::string trimmable(" \t");
             (*dRes)[ i] = floor(((dTop + .9999)*(d - min)) / (max - min));
           }
         }
-      }     
+      }
     } else {
-    if (IntType(p0->Type())) {
+      if (IntType(p0->Type())) {
         //Is a thread pool function
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
-        for (SizeT i = 0; i < nEl; ++i) {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+          for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
           else if (d <= min) (*dRes)[ i] = 0;
@@ -7345,22 +7288,23 @@ static const std::string trimmable(" \t");
           }
         }
       } else {
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
-        for (SizeT i = 0; i < nEl; ++i) {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+          for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
           else if (d <= min) (*dRes)[ i] = 0;
           else if (d >= max) (*dRes)[ i] = dTop;
           else {
-              // SA (?): here floor is used (instead of round) to simulate IDL behaviour
-            (*dRes)[ i] = floor(((dTop + .9999)*(d - min)) / (max - min) );
+            // SA (?): here floor is used (instead of round) to simulate IDL behaviour
+            (*dRes)[ i] = floor(((dTop + .9999)*(d - min)) / (max - min));
           }
         }
       }
     }
     return dRes->Convert2(GDL_BYTE);
-  } 
-  
+  }
+
   BaseGDL* strtok_fun(EnvT* e) {
     SizeT nParam = e->NParam(1);
 
@@ -7372,14 +7316,14 @@ static const std::string trimmable(" \t");
       e->AssureStringScalarPar(1, pattern);
     }
 
-    static int extractIx = e->KeywordIx( "EXTRACT");
-    bool extract = e->KeywordSet( extractIx);
+    static int extractIx = e->KeywordIx("EXTRACT");
+    bool extract = e->KeywordSet(extractIx);
 
-    static int countIx = e->KeywordIx( "COUNT");
-    bool countPresent = e->KeywordPresent( countIx);
-     
-    static int lengthIx = e->KeywordIx( "LENGTH");
-    bool lengthPresent = e->KeywordPresent( lengthIx);
+    static int countIx = e->KeywordIx("COUNT");
+    bool countPresent = e->KeywordPresent(countIx);
+
+    static int lengthIx = e->KeywordIx("LENGTH");
+    bool lengthPresent = e->KeywordPresent(lengthIx);
 
     static int pre0Ix = e->KeywordIx("PRESERVE_NULL");
     bool pre0 = e->KeywordSet(pre0Ix);
@@ -7389,10 +7333,10 @@ static const std::string trimmable(" \t");
     char err_msg[MAX_REGEXPERR_LENGTH];
     regex_t regexp;
 
-    static int foldCaseIx = e->KeywordIx( "FOLD_CASE" );
-    bool foldCaseKW = e->KeywordSet( foldCaseIx );
+    static int foldCaseIx = e->KeywordIx("FOLD_CASE");
+    bool foldCaseKW = e->KeywordSet(foldCaseIx);
     //FOLD_CASE can only be specified if the REGEX keyword is set
-    if (!regex && foldCaseKW)   e->Throw("Conflicting keywords.");
+    if (!regex && foldCaseKW) e->Throw("Conflicting keywords.");
 
     vector<long> tokenStart;
     vector<long> tokenLen;
@@ -7400,11 +7344,11 @@ static const std::string trimmable(" \t");
     int strLen = stringIn.length();
 
     DString escape = "";
-    static int ESCAPEIx=e->KeywordIx("ESCAPE");
-    
+    static int ESCAPEIx = e->KeywordIx("ESCAPE");
+
     //ESCAPE cannot be specified with the FOLD_CASE or REGEX keywords.
-    if (regex && e->KeywordPresent(ESCAPEIx))   e->Throw("Conflicting keywords.");
-    if (foldCaseKW && e->KeywordPresent(ESCAPEIx))   e->Throw("Conflicting keywords.");
+    if (regex && e->KeywordPresent(ESCAPEIx)) e->Throw("Conflicting keywords.");
+    if (foldCaseKW && e->KeywordPresent(ESCAPEIx)) e->Throw("Conflicting keywords.");
 
     e->AssureStringScalarKWIfPresent(ESCAPEIx, escape);
     vector<long> escList;
@@ -7424,19 +7368,20 @@ static const std::string trimmable(" \t");
     long nextE = 0;
     long actLen;
     //special case: pattern void string
-    if (pattern.size()==0) {
+    if (pattern.size() == 0) {
       if (lengthPresent) {
         e->AssureGlobalKW(lengthIx);
         e->SetKW(lengthIx, new DLongGDL(0));
       }
-     if (countPresent) {
+      if (countPresent) {
         e->AssureGlobalKW(countIx);
         e->SetKW(countIx, new DLongGDL(0));
-      }   
-      if (!extract) return new DLongGDL(0); else return new DStringGDL("");
+      }
+      if (!extract) return new DLongGDL(0);
+      else return new DStringGDL("");
     }
-      
-    // If regex then compile regex. 
+
+    // If regex then compile regex.
     // set the compile flags to use the REG_ICASE facility in case /FOLD_CASE is given.
     int cflags = REG_EXTENDED;
     if (foldCaseKW)
@@ -7448,12 +7393,12 @@ static const std::string trimmable(" \t");
       if (compRes) {
         regerror(compRes, &regexp, err_msg, MAX_REGEXPERR_LENGTH);
         e->Throw("Error processing regular expression: " +
-         pattern + "\n           " + string(err_msg) + ".");
+          pattern + "\n           " + string(err_msg) + ".");
       }
     }
 
     if (foldCaseKW && !regex) { //duplicate pattern with ascii chars upcased
-      pattern=pattern+StrUpCase(pattern);
+      pattern = pattern + StrUpCase(pattern);
     }
     for (;;) {
       regmatch_t pmatch[1];
@@ -7491,30 +7436,30 @@ static const std::string trimmable(" \t");
 
     SizeT nTok = tokenStart.size();
     if (countPresent) {
-        e->AssureGlobalKW(countIx);
-         if (nTok > 0) {
-          DLongGDL* count = new DLongGDL(nTok);
-          e->SetKW(countIx, count);
-        } else {
-          e->SetKW(countIx, new DLongGDL(0));
-        }
+      e->AssureGlobalKW(countIx);
+      if (nTok > 0) {
+        DLongGDL* count = new DLongGDL(nTok);
+        e->SetKW(countIx, count);
+      } else {
+        e->SetKW(countIx, new DLongGDL(0));
       }
-     
-      if (lengthPresent) {
-        e->AssureGlobalKW(lengthIx);
+    }
 
-        if (nTok > 0) {
-          dimension dim(nTok);
-          DLongGDL* len = new DLongGDL(dim);
-          for (int i = 0; i < nTok; i++)
-            (*len)[i] = tokenLen[i];
+    if (lengthPresent) {
+      e->AssureGlobalKW(lengthIx);
 
-          e->SetKW(lengthIx, len);
-        } else {
-          e->SetKW(lengthIx, new DLongGDL(0));
-        }
+      if (nTok > 0) {
+        dimension dim(nTok);
+        DLongGDL* len = new DLongGDL(dim);
+        for (int i = 0; i < nTok; i++)
+          (*len)[i] = tokenLen[i];
+
+        e->SetKW(lengthIx, len);
+      } else {
+        e->SetKW(lengthIx, new DLongGDL(0));
       }
-    
+    }
+
     if (!extract) {
 
       if (nTok == 0) return new DLongGDL(0);
@@ -7526,185 +7471,176 @@ static const std::string trimmable(" \t");
       return d;
     } else {
 
-    // EXTRACT
-    if (nTok == 0) return new DStringGDL("");
+      // EXTRACT
+      if (nTok == 0) return new DStringGDL("");
 
-    dimension dim(nTok);
-    DStringGDL *d = new DStringGDL(dim);
-    for (int i = 0; i < nTok; i++) {
-      (*d)[i] = stringIn.substr(tokenStart[i], tokenLen[i]);
+      dimension dim(nTok);
+      DStringGDL *d = new DStringGDL(dim);
+      for (int i = 0; i < nTok; i++) {
+        (*d)[i] = stringIn.substr(tokenStart[i], tokenLen[i]);
 
-      // remove escape
-      DString& act = (*d)[i];
-      long escPos = act.find_first_of(escape, 0);
-      while (escPos != string::npos) {
-        act = act.substr(0, escPos) + act.substr(escPos + 1);
-        escPos = act.find_first_of(escape, escPos + 1);
+        // remove escape
+        DString& act = (*d)[i];
+        long escPos = act.find_first_of(escape, 0);
+        while (escPos != string::npos) {
+          act = act.substr(0, escPos) + act.substr(escPos + 1);
+          escPos = act.find_first_of(escape, escPos + 1);
+        }
       }
-    }
-    return d;
+      return d;
     }
   }
 
-  BaseGDL* getenv_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
+  BaseGDL* getenv_fun(EnvT* e) {
+    SizeT nParam = e->NParam();
 
-    static int environmentIx = e->KeywordIx( "ENVIRONMENT" );
-    bool environment = e->KeywordSet( environmentIx );
-  
-    SizeT nEnv; 
+    static int environmentIx = e->KeywordIx("ENVIRONMENT");
+    bool environment = e->KeywordSet(environmentIx);
+
+    SizeT nEnv;
     DStringGDL* env;
 
-    if( environment) {
+    if (environment) {
 
-      if(nParam != 0) 
-        e->Throw( "Incorrect number of arguments.");
+      if (nParam != 0)
+        e->Throw("Incorrect number of arguments.");
 
       // determine number of environment entries
-      for(nEnv = 0; environ[nEnv] != NULL  ; ++nEnv);
+      for (nEnv = 0; environ[nEnv] != NULL; ++nEnv);
 
-      dimension dim( nEnv );
+      dimension dim(nEnv);
       env = new DStringGDL(dim);
 
       // copy stuff into local string array
-      for(SizeT i=0; i < nEnv ; ++i)
+      for (SizeT i = 0; i < nEnv; ++i)
         (*env)[i] = environ[i];
 
     } else {
 
-      if(nParam != 1) 
-        e->Throw( "Incorrect number of arguments.");
+      if (nParam != 1)
+        e->Throw("Incorrect number of arguments.");
 
       DStringGDL* name = e->GetParAs<DStringGDL>(0);
       nEnv = name->N_Elements();
 
-      env = new DStringGDL( name->Dim());
- 
+      env = new DStringGDL(name->Dim());
+
       // copy the stuff into local string only if param found
       char *resPtr;
-      for(SizeT i=0; i < nEnv ; ++i)
-    {
-      // handle special environment variables
-      // GDL_TMPDIR, IDL_TMPDIR
-      if( (*name)[i] == "GDL_TMPDIR" || (*name)[i] == "IDL_TMPDIR")
-        {
+      for (SizeT i = 0; i < nEnv; ++i) {
+        // handle special environment variables
+        // GDL_TMPDIR, IDL_TMPDIR
+        if ((*name)[i] == "GDL_TMPDIR" || (*name)[i] == "IDL_TMPDIR") {
           resPtr = getenv((*name)[i].c_str());
 
-          if (resPtr != NULL)
-        {
-          (*env)[i] = resPtr;
-        }
-          else
-        {
-          //        (*env)[i] = SysVar::Dir();
+          if (resPtr != NULL) {
+            (*env)[i] = resPtr;
+          } else {
+            //        (*env)[i] = SysVar::Dir();
 #ifdef _WIN32
-          WCHAR tmpBuf[MAX_PATH];
-          GetTempPathW(MAX_PATH, tmpBuf);
-          char c_tmpBuf[MAX_PATH];
-          WideCharToMultiByte(CP_ACP, 0, tmpBuf, MAX_PATH, c_tmpBuf, MAX_PATH, NULL, NULL);
-          (*env)[i] = c_tmpBuf;
+            WCHAR tmpBuf[MAX_PATH];
+            GetTempPathW(MAX_PATH, tmpBuf);
+            char c_tmpBuf[MAX_PATH];
+            WideCharToMultiByte(CP_ACP, 0, tmpBuf, MAX_PATH, c_tmpBuf, MAX_PATH, NULL, NULL);
+            (*env)[i] = c_tmpBuf;
 #else
-          // AC 2017/10/19 : why _PATH_VARTMP_, not just _PATH_TMP_
-          (*env)[i] = _PATH_TMP ;
+            // AC 2017/10/19 : why _PATH_VARTMP_, not just _PATH_TMP_
+            (*env)[i] = _PATH_TMP;
 #endif
-        }
-        AppendIfNeeded( (*env)[i], lib::PathSeparator());
-        }
-      else // normal environment variables
-        if( (resPtr = getenv((*name)[i].c_str())) ) 
+          }
+          AppendIfNeeded((*env)[i], lib::PathSeparator());
+        } else // normal environment variables
+          if ((resPtr = getenv((*name)[i].c_str())))
           (*env)[i] = resPtr;
+      }
     }
-    }
-    
+
     return env;
   }
 
-  BaseGDL* tag_names_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
+  BaseGDL* tag_names_fun(EnvT* e) {
+    SizeT nParam = e->NParam();
     BaseGDL* p = e->GetParDefined(0);
     DStructGDL* struc = nullptr;
-    if( p->Type() == DObjGDL::t ) {
-        DObjGDL* obj = static_cast<DObjGDL*>( p);
-        DObj objRef;
-        if( obj && obj->Scalar( objRef ) ) {
+    if (p->Type() == DObjGDL::t) {
+      DObjGDL* obj = static_cast<DObjGDL*> (p);
+      DObj objRef;
+      if (obj && obj->Scalar(objRef)) {
         try {
-            struc = e->GetObjHeap( objRef );
-        } catch ( GDLInterpreter::HeapException& ) { }
+          struc = e->GetObjHeap(objRef);
+        } catch (GDLInterpreter::HeapException&) {
         }
-    } else if( p->Type() == DStructGDL::t ) {
-       struc = static_cast<DStructGDL*>( p);
+      }
+    } else if (p->Type() == DStructGDL::t) {
+      struc = static_cast<DStructGDL*> (p);
     }
 
-    if( !struc ) {
-        e->Throw( "Error: Failed to obtain structure. Input type: " + p->TypeStr() );
+    if (!struc) {
+      e->Throw("Error: Failed to obtain structure. Input type: " + p->TypeStr());
     }
 
-    static int structureNameIx = e->KeywordIx( "STRUCTURE_NAME" );
-    bool structureName = e->KeywordSet( structureNameIx );
+    static int structureNameIx = e->KeywordIx("STRUCTURE_NAME");
+    bool structureName = e->KeywordSet(structureNameIx);
 
     DStringGDL* tagNames;
 
-    if(structureName){
-        
+    if (structureName) {
+
       if ((*struc).Desc()->Name() != "$truct") {
-        tagNames =  new DStringGDL((*struc).Desc()->Name());
+        tagNames = new DStringGDL((*struc).Desc()->Name());
       } else {
-        tagNames =  new DStringGDL("");
+        tagNames = new DStringGDL("");
       }
     } else {
       SizeT nTags = (*struc).Desc()->NTags();
       tagNames = new DStringGDL(dimension(nTags));
-      for(int i=0; i < nTags; ++i) {
+      for (int i = 0; i < nTags; ++i) {
         (*tagNames)[i] = (*struc).Desc()->TagName(i);
       }
     }
 
     return tagNames;
-      
+
   }
 
   // AC 12-Oc-2011: better version for: len=len, /Extract and /Sub
   // but it is still not perfect
 
-  BaseGDL* stregex_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam( 2);
-    
-    DStringGDL* stringExpr= e->GetParAs<DStringGDL>(0);
+  BaseGDL* stregex_fun(EnvT* e) {
+    SizeT nParam = e->NParam(2);
+
+    DStringGDL* stringExpr = e->GetParAs<DStringGDL>(0);
     dimension dim = stringExpr->Dim();
 
     DString pattern;
     e->AssureStringScalarPar(1, pattern);
-    if (pattern.size() <= 0)
-      {
-    e->Throw( "Error processing regular expression: "+pattern+
-          "\n           empty (sub)expression");
-      }
+    if (pattern.size() <= 0) {
+      e->Throw("Error processing regular expression: " + pattern +
+        "\n           empty (sub)expression");
+    }
 
-    static int booleanIx = e->KeywordIx( "BOOLEAN" );
-    bool booleanKW = e->KeywordSet( booleanIx );
+    static int booleanIx = e->KeywordIx("BOOLEAN");
+    bool booleanKW = e->KeywordSet(booleanIx);
 
-    static int extractIx = e->KeywordIx( "EXTRACT" );
-    bool extractKW = e->KeywordSet( extractIx );
+    static int extractIx = e->KeywordIx("EXTRACT");
+    bool extractKW = e->KeywordSet(extractIx);
 
-    static int foldCaseIx = e->KeywordIx( "FOLD_CASE" );
-    bool foldCaseKW = e->KeywordSet( foldCaseIx );
+    static int foldCaseIx = e->KeywordIx("FOLD_CASE");
+    bool foldCaseKW = e->KeywordSet(foldCaseIx);
 
     //XXXpch: this is wrong, should check arg_present
-    static int lengthIx = e->KeywordIx( "LENGTH" );
-    bool lengthKW = e->KeywordPresent( lengthIx );
-   
-    static int subexprIx = e->KeywordIx( "SUBEXPR" );
-    bool subexprKW = e->KeywordSet( subexprIx );
- 
-    if( booleanKW && (subexprKW || extractKW || lengthKW))
-      e->Throw( "Conflicting keywords.");
-  
+    static int lengthIx = e->KeywordIx("LENGTH");
+    bool lengthKW = e->KeywordPresent(lengthIx);
+
+    static int subexprIx = e->KeywordIx("SUBEXPR");
+    bool subexprKW = e->KeywordSet(subexprIx);
+
+    if (booleanKW && (subexprKW || extractKW || lengthKW))
+      e->Throw("Conflicting keywords.");
+
     char err_msg[MAX_REGEXPERR_LENGTH];
 
-    // set the compile flags 
+    // set the compile flags
     int cflags = REG_EXTENDED;
     if (foldCaseKW)
       cflags |= REG_ICASE;
@@ -7713,443 +7649,413 @@ static const std::string trimmable(" \t");
 
     // compile the regular expression
     regex_t regexp;
-    int compRes = regcomp( &regexp, pattern.c_str(), cflags);
+    int compRes = regcomp(&regexp, pattern.c_str(), cflags);
     SizeT nSubExpr = regexp.re_nsub + 1;
-    
+
     //    cout << regexp.re_nsub << endl;
 
     if (compRes) {
       regerror(compRes, &regexp, err_msg, MAX_REGEXPERR_LENGTH);
-      e->Throw( "Error processing regular expression: "+
-        pattern+"\n           "+string(err_msg)+".");
+      e->Throw("Error processing regular expression: " +
+        pattern + "\n           " + string(err_msg) + ".");
     }
 
     BaseGDL* result;
 
-    if( booleanKW) 
+    if (booleanKW)
       result = new DByteGDL(dim);
-    else if( extractKW && !subexprKW)
-      {
-    //  cout << "my pb ! ? dim= " << dim << endl;
-    result = new DStringGDL(dim);
-      }
-    else if( subexprKW)
-      {
-    //  cout << "my pb 2 ? dim= " << dim << endl;
-    dimension subExprDim = dim;
-    subExprDim >> nSubExpr; // m_schellens: commented in, needed
-    if( extractKW)
-      result = new DStringGDL(subExprDim);
-    else
-      result = new DLongGDL(subExprDim);
-      }
-    else 
-      result = new DLongGDL(dim); 
-
-    DLongGDL* len = NULL;
-    if( lengthKW) {
-      e->AssureGlobalKW( lengthIx);
-      if( subexprKW)
-    {
+    else if (extractKW && !subexprKW) {
+      //  cout << "my pb ! ? dim= " << dim << endl;
+      result = new DStringGDL(dim);
+    } else if (subexprKW) {
+      //  cout << "my pb 2 ? dim= " << dim << endl;
       dimension subExprDim = dim;
       subExprDim >> nSubExpr; // m_schellens: commented in, needed
-      len = new DLongGDL(subExprDim);
-    }
+      if (extractKW)
+        result = new DStringGDL(subExprDim);
       else
-    {
-      len = new DLongGDL(dim);
+        result = new DLongGDL(subExprDim);
+    } else
+      result = new DLongGDL(dim);
+
+    DLongGDL* len = NULL;
+    if (lengthKW) {
+      e->AssureGlobalKW(lengthIx);
+      if (subexprKW) {
+        dimension subExprDim = dim;
+        subExprDim >> nSubExpr; // m_schellens: commented in, needed
+        len = new DLongGDL(subExprDim);
+      } else {
+        len = new DLongGDL(dim);
+      }
+      for (SizeT i = 0; i < len->N_Elements(); ++i)
+        (*len)[i] = -1;
     }
-      for( SizeT i=0; i<len->N_Elements(); ++i)
-    (*len)[i]= -1;
-    } 
-    
+
     int nmatch = 1;
-    if( subexprKW) nmatch = nSubExpr;
+    if (subexprKW) nmatch = nSubExpr;
 
     regmatch_t* pmatch = new regmatch_t[nSubExpr];
-    ArrayGuard<regmatch_t> pmatchGuard( pmatch);
+    ArrayGuard<regmatch_t> pmatchGuard(pmatch);
 
-    //    cout << "dim " << dim.NDimElements() << endl;     
-    for( SizeT s=0; s<dim.NDimElements(); ++s)
-      {
-    int eflags = 0; 
+    //    cout << "dim " << dim.NDimElements() << endl;
+    for (SizeT s = 0; s < dim.NDimElements(); ++s) {
+      int eflags = 0;
 
-    for( SizeT sE=0; sE<nSubExpr; ++sE)
-      pmatch[sE].rm_so = -1;
+      for (SizeT sE = 0; sE < nSubExpr; ++sE)
+        pmatch[sE].rm_so = -1;
 
-    // now match towards the string
-    int matchres = regexec( &regexp, (*stringExpr)[s].c_str(),  nmatch, pmatch, eflags);
+      // now match towards the string
+      int matchres = regexec(&regexp, (*stringExpr)[s].c_str(), nmatch, pmatch, eflags);
 
-    // subexpressions
-    if ( extractKW && subexprKW) {
+      // subexpressions
+      if (extractKW && subexprKW) {
 
-      // Loop through subexpressions & fill output array
-      for( SizeT i = 0; i<nSubExpr; ++i) {
-        if (pmatch[i].rm_so != -1)
-          (*static_cast<DStringGDL*>(result))[i+s*nSubExpr] =
-        (*stringExpr)[s].substr( pmatch[i].rm_so,  pmatch[i].rm_eo - pmatch[i].rm_so);
-        //          (*stringExpr)[i+s*nSubExpr].substr( pmatch[i].rm_so,  pmatch[i].rm_eo - pmatch[i].rm_so);
-        if( lengthKW)
-          (*len)[i+s*nSubExpr] = pmatch[i].rm_so != -1 ? pmatch[i].rm_eo - pmatch[i].rm_so : -1;
-        //            (*len)[i+s*nSubExpr] = pmatch[i].rm_eo - pmatch[i].rm_so;
-      }
-    }
-    else  if ( subexprKW) 
-      {
+        // Loop through subexpressions & fill output array
+        for (SizeT i = 0; i < nSubExpr; ++i) {
+          if (pmatch[i].rm_so != -1)
+            (*static_cast<DStringGDL*> (result))[i + s * nSubExpr] =
+            (*stringExpr)[s].substr(pmatch[i].rm_so, pmatch[i].rm_eo - pmatch[i].rm_so);
+          //          (*stringExpr)[i+s*nSubExpr].substr( pmatch[i].rm_so,  pmatch[i].rm_eo - pmatch[i].rm_so);
+          if (lengthKW)
+            (*len)[i + s * nSubExpr] = pmatch[i].rm_so != -1 ? pmatch[i].rm_eo - pmatch[i].rm_so : -1;
+          //            (*len)[i+s*nSubExpr] = pmatch[i].rm_eo - pmatch[i].rm_so;
+        }
+      } else if (subexprKW) {
         //      cout << "je ne comprends pas v2: "<< nSubExpr << endl;
 
         // Loop through subexpressions & fill output array
-        for( SizeT i = 0; i<nSubExpr; ++i) {
-          (* static_cast<DLongGDL*>(result))[i+s*nSubExpr] =  pmatch[i].rm_so;
-          if( lengthKW)
-        (*len)[i+s*nSubExpr] = pmatch[i].rm_so != -1 ? pmatch[i].rm_eo - pmatch[i].rm_so : -1;
+        for (SizeT i = 0; i < nSubExpr; ++i) {
+          (* static_cast<DLongGDL*> (result))[i + s * nSubExpr] = pmatch[i].rm_so;
+          if (lengthKW)
+            (*len)[i + s * nSubExpr] = pmatch[i].rm_so != -1 ? pmatch[i].rm_eo - pmatch[i].rm_so : -1;
         }
-      }
-    else
-      {
-        if( booleanKW)
-          (* static_cast<DByteGDL*>(result))[s] = (matchres == 0);
-        else if ( extractKW) // !subExprKW
-          {
-        if( matchres == 0)
-          (* static_cast<DStringGDL*>(result))[s] = 
-            (*stringExpr)[s].substr( pmatch[0].rm_so, 
-                         pmatch[0].rm_eo - pmatch[0].rm_so);
-          }
-        else
-          (*static_cast<DLongGDL*>(result))[s] = matchres ? -1 : pmatch[0].rm_so;
+      } else {
+        if (booleanKW)
+          (* static_cast<DByteGDL*> (result))[s] = (matchres == 0);
+        else if (extractKW) // !subExprKW
+        {
+          if (matchres == 0)
+            (* static_cast<DStringGDL*> (result))[s] =
+            (*stringExpr)[s].substr(pmatch[0].rm_so,
+            pmatch[0].rm_eo - pmatch[0].rm_so);
+        } else
+          (*static_cast<DLongGDL*> (result))[s] = matchres ? -1 : pmatch[0].rm_so;
       }
 
-    if( lengthKW && !subexprKW)
-      //(*len)[s] = pmatch[0].rm_eo - pmatch[0].rm_so;
-      (*len)[s] = pmatch[0].rm_so != -1 ? pmatch[0].rm_eo - pmatch[0].rm_so : -1;
+      if (lengthKW && !subexprKW)
+        //(*len)[s] = pmatch[0].rm_eo - pmatch[0].rm_so;
+        (*len)[s] = pmatch[0].rm_so != -1 ? pmatch[0].rm_eo - pmatch[0].rm_so : -1;
 
-      }
+    }
 
-    regfree( &regexp);
+    regfree(&regexp);
 
-    if( lengthKW)
-      e->SetKW( lengthIx, len);    
+    if (lengthKW)
+      e->SetKW(lengthIx, len);
 
     return result;
   }
 
-BaseGDL* routine_filepath( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
+  BaseGDL* routine_filepath(EnvT* e) {
+    SizeT nParam = e->NParam();
     DStringGDL* p0S;
     Guard<DStringGDL> p0S_guard;
     if (nParam > 1) e->Throw("Incorrect number of arguments.");
-    if( nParam > 0)  {
-        BaseGDL* p0 = e->GetParDefined( 0);
-        if( p0->Type() != GDL_STRING)
+    if (nParam > 0) {
+      BaseGDL* p0 = e->GetParDefined(0);
+      if (p0->Type() != GDL_STRING)
         e->Throw("String expression required in this context: " + e->GetParString(0));
-        p0S = static_cast<DStringGDL*>( p0);
-    } else {          // routine_filepath()
-        p0S = new DStringGDL( dynamic_cast<DSubUD*>((e->Caller())->GetPro())->ObjectName() );
-        p0S_guard.Init(p0S);
+      p0S = static_cast<DStringGDL*> (p0);
+    } else { // routine_filepath()
+      p0S = new DStringGDL(dynamic_cast<DSubUD*> ((e->Caller())->GetPro())->ObjectName());
+      p0S_guard.Init(p0S);
     }
 
-    static int is_functionIx = e->KeywordIx( "IS_FUNCTION" );
-    bool is_functionKW = e->KeywordSet( is_functionIx );
-    static int eitherIx = e->KeywordIx( "EITHER" );
-    bool eitherKW = e->KeywordSet( eitherIx );
-    
+    static int is_functionIx = e->KeywordIx("IS_FUNCTION");
+    bool is_functionKW = e->KeywordSet(is_functionIx);
+    static int eitherIx = e->KeywordIx("EITHER");
+    bool eitherKW = e->KeywordSet(eitherIx);
+
     SizeT nPath = p0S->N_Elements();
     DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
     Guard<DStringGDL> res_guard(res);
 
     DString name;
     string FullFileName;
-    for(int i = 0; i < nPath; i++) {
+    for (int i = 0; i < nPath; i++) {
 
-        name = StrUpCase((*p0S)[i]);
+      name = StrUpCase((*p0S)[i]);
 
-        bool found=false;
-        FullFileName = "";
-        
-        size_t pos(0);
-        if( (pos=name.find("::")) != DString::npos ) {
-            DString struct_tag = name.substr( 0, pos );
-            DString method_name = name.substr( pos+2 );
-            for( auto& s: structList ) {
-                if( s && (s->Name() != struct_tag) ) continue;
-                if( eitherKW || !is_functionKW ) {
-                    DPro* pp = s->FindInProList(method_name);
-                    if( pp ) {
-                        found = true;
-                        FullFileName = pp->GetFilename();
-                        break;
-                    }
-                }
-                if( !found && (is_functionKW || eitherKW) ) {
-                    DFun* fp = s->FindInFunList(method_name);
-                    if( fp ) {
-                        found = true;
-                        FullFileName = fp->GetFilename();
-                        break;
-                    }
-                }
+      bool found = false;
+      FullFileName = "";
+
+      size_t pos(0);
+      if ((pos = name.find("::")) != DString::npos) {
+        DString struct_tag = name.substr(0, pos);
+        DString method_name = name.substr(pos + 2);
+        for (auto& s : structList) {
+          if (s && (s->Name() != struct_tag)) continue;
+          if (eitherKW || !is_functionKW) {
+            DPro* pp = s->FindInProList(method_name);
+            if (pp) {
+              found = true;
+              FullFileName = pp->GetFilename();
+              break;
             }
-        } else {
-            if( eitherKW || !is_functionKW) {
-                for(ProListT::iterator i=proList.begin();
-                                        i != proList.end(); ++i)
-                if ((*i)->ObjectName() == name) {
-                    found=true;
-                    FullFileName=(*i)->GetFilename();
-                    break;
-                }
+          }
+          if (!found && (is_functionKW || eitherKW)) {
+            DFun* fp = s->FindInFunList(method_name);
+            if (fp) {
+              found = true;
+              FullFileName = fp->GetFilename();
+              break;
             }
-            if (!found && (is_functionKW || eitherKW)) {
-                for(FunListT::iterator i=funList.begin();
-                                        i != funList.end(); ++i)
-                if ((*i)->ObjectName() == name) {
-                    found=true;
-                    FullFileName=(*i)->GetFilename();
-                    break;
-                }
-            } 
+          }
         }
-        
-        (*res)[i] = FullFileName;
+      } else {
+        if (eitherKW || !is_functionKW) {
+          for (ProListT::iterator i = proList.begin();
+            i != proList.end(); ++i)
+            if ((*i)->ObjectName() == name) {
+              found = true;
+              FullFileName = (*i)->GetFilename();
+              break;
+            }
+        }
+        if (!found && (is_functionKW || eitherKW)) {
+          for (FunListT::iterator i = funList.begin();
+            i != funList.end(); ++i)
+            if ((*i)->ObjectName() == name) {
+              found = true;
+              FullFileName = (*i)->GetFilename();
+              break;
+            }
+        }
+      }
+
+      (*res)[i] = FullFileName;
     }
-//    if(nParam == 0) return new DStringGDL(FullFileName);
+    //    if(nParam == 0) return new DStringGDL(FullFileName);
     return res_guard.release();
   }
 
   //AC 2019 (see "routine_name.pro". Here another way to catch the name ...)
-  BaseGDL* routine_name_fun( EnvT* e)
-  {
+
+  BaseGDL* routine_name_fun(EnvT* e) {
     EnvStackT& callStack = e->Interpreter()->CallStack();
-    string name=callStack.back()->GetProName();
+    string name = callStack.back()->GetProName();
     return new DStringGDL(name);
   }
 
-  BaseGDL* routine_info( EnvT* e)
-  {
-    SizeT nParam=e->NParam();
+  BaseGDL* routine_info(EnvT* e) {
+    SizeT nParam = e->NParam();
     if (nParam > 1) e->Throw("Incorrect number of arguments.");
 
-    static int functionsIx = e->KeywordIx( "FUNCTIONS" );
-    bool functionsKW = e->KeywordSet( functionsIx );
-    static int systemIx = e->KeywordIx( "SYSTEM" );
-    bool systemKW = e->KeywordSet( systemIx );
-    static int disabledIx = e->KeywordIx( "DISABLED" );
-    bool disabledKW = e->KeywordSet( disabledIx );
-    static int parametersIx = e->KeywordIx( "PARAMETERS" );
-    bool parametersKW = e->KeywordSet( parametersIx );
-    static int sourceIx = e->KeywordIx( "SOURCE" );
-    bool sourceKW = e->KeywordSet(sourceIx );
+    static int functionsIx = e->KeywordIx("FUNCTIONS");
+    bool functionsKW = e->KeywordSet(functionsIx);
+    static int systemIx = e->KeywordIx("SYSTEM");
+    bool systemKW = e->KeywordSet(systemIx);
+    static int disabledIx = e->KeywordIx("DISABLED");
+    bool disabledKW = e->KeywordSet(disabledIx);
+    static int parametersIx = e->KeywordIx("PARAMETERS");
+    bool parametersKW = e->KeywordSet(parametersIx);
+    static int sourceIx = e->KeywordIx("SOURCE");
+    bool sourceKW = e->KeywordSet(sourceIx);
 
-    if ( sourceKW ) {
+    if (sourceKW) {
 
       // sanity checks
-      if ( systemKW ) e->Throw( "Conflicting keywords." );
+      if (systemKW) e->Throw("Conflicting keywords.");
 
       DString raw_name, name;
       string FullFileName;
       bool found = FALSE;
       DStructGDL* stru;
       DStructDesc* stru_desc;
-      
-        
-      if ( nParam == 1 ) {
+
+
+      if (nParam == 1) {
         // getting the routine name from the first parameter (must be a singleton)
         e->AssureScalarPar<DStringGDL>(0, raw_name);
-        name = StrUpCase( raw_name );
-        if ( functionsKW ) {
-          for ( FunListT::iterator i = funList.begin( ); i != funList.end( ); ++i ) {
-            if ( (*i)->ObjectName( ) == name ) {
+        name = StrUpCase(raw_name);
+        if (functionsKW) {
+          for (FunListT::iterator i = funList.begin(); i != funList.end(); ++i) {
+            if ((*i)->ObjectName() == name) {
               found = true;
-              FullFileName = (*i)->GetFilename( );
+              FullFileName = (*i)->GetFilename();
               break;
             }
           }
-          if ( !found ) e->Throw( "% Attempt to call undefined/not compiled function: '" + raw_name + "'" );
+          if (!found) e->Throw("% Attempt to call undefined/not compiled function: '" + raw_name + "'");
         } else {
-          for ( ProListT::iterator i = proList.begin( ); i != proList.end( ); ++i ) {
-            if ( (*i)->ObjectName( ) == name ) {
+          for (ProListT::iterator i = proList.begin(); i != proList.end(); ++i) {
+            if ((*i)->ObjectName() == name) {
               found = true;
-              FullFileName = (*i)->GetFilename( );
+              FullFileName = (*i)->GetFilename();
               break;
             }
           }
-          if ( !found ) e->Throw( "% Attempt to call undefined/not compiled procedure: '" + raw_name + "'" );
+          if (!found) e->Throw("% Attempt to call undefined/not compiled procedure: '" + raw_name + "'");
         }
 
         // creating the output anonymous structure
-        stru_desc = new DStructDesc( "$truct" );
+        stru_desc = new DStructDesc("$truct");
         SpDString aString;
-        stru_desc->AddTag( "NAME", &aString );
-        stru_desc->AddTag( "PATH", &aString );
-        stru = new DStructGDL( stru_desc, dimension( ) );
+        stru_desc->AddTag("NAME", &aString);
+        stru_desc->AddTag("PATH", &aString);
+        stru = new DStructGDL(stru_desc, dimension());
 
-        // filling the structure with information about the routine 
-        stru->InitTag( "NAME", DStringGDL( name ) );
-        stru->InitTag( "PATH", DStringGDL( FullFileName ) );
+        // filling the structure with information about the routine
+        stru->InitTag("NAME", DStringGDL(name));
+        stru->InitTag("PATH", DStringGDL(FullFileName));
         return stru;
-        
+
       } else {
         // creating the output anonymous structure
-        stru_desc = new DStructDesc( "$truct" );
+        stru_desc = new DStructDesc("$truct");
         SpDString aString;
-        stru_desc->AddTag( "NAME", &aString );
-        stru_desc->AddTag( "PATH", &aString );
-        
-//always starts with $MAIN$
-        SizeT N=(functionsKW)?funList.size()+1:proList.size()+1;
-        stru = new DStructGDL( stru_desc, dimension(N) );
-        (*static_cast<DStringGDL*>(stru->GetTag((SizeT)0, 0)))[0]="$MAIN$";
+        stru_desc->AddTag("NAME", &aString);
+        stru_desc->AddTag("PATH", &aString);
 
-        if ( functionsKW ) {
-          SizeT ii=1;
-          for ( FunListT::iterator i = funList.begin( ); i != funList.end( ); ++i ) {
-        (*static_cast<DStringGDL*>(stru->GetTag((SizeT)0, ii)))[0]=(*i)->ObjectName( );
-        (*static_cast<DStringGDL*>(stru->GetTag((SizeT)1, ii)))[0]=(*i)->GetFilename( );
-        ii++;
-      }
+        //always starts with $MAIN$
+        SizeT N = (functionsKW) ? funList.size() + 1 : proList.size() + 1;
+        stru = new DStructGDL(stru_desc, dimension(N));
+        (*static_cast<DStringGDL*> (stru->GetTag((SizeT) 0, 0)))[0] = "$MAIN$";
+
+        if (functionsKW) {
+          SizeT ii = 1;
+          for (FunListT::iterator i = funList.begin(); i != funList.end(); ++i) {
+            (*static_cast<DStringGDL*> (stru->GetTag((SizeT) 0, ii)))[0] = (*i)->ObjectName();
+            (*static_cast<DStringGDL*> (stru->GetTag((SizeT) 1, ii)))[0] = (*i)->GetFilename();
+            ii++;
+          }
         } else {
-          SizeT ii=1;
-          for ( ProListT::iterator i = proList.begin( ); i != proList.end( ); ++i ) {
-        (*static_cast<DStringGDL*>(stru->GetTag((SizeT)0, ii)))[0]=(*i)->ObjectName( );
-        (*static_cast<DStringGDL*>(stru->GetTag((SizeT)1, ii)))[0]=(*i)->GetFilename( );
-        ii++;
+          SizeT ii = 1;
+          for (ProListT::iterator i = proList.begin(); i != proList.end(); ++i) {
+            (*static_cast<DStringGDL*> (stru->GetTag((SizeT) 0, ii)))[0] = (*i)->ObjectName();
+            (*static_cast<DStringGDL*> (stru->GetTag((SizeT) 1, ii)))[0] = (*i)->GetFilename();
+            ii++;
           }
         }
         return stru;
       }
     }
 
-    if (parametersKW)
-      {
-    // sanity checks
-    if (systemKW || disabledKW) e->Throw("Conflicting keywords.");
+    if (parametersKW) {
+      // sanity checks
+      if (systemKW || disabledKW) e->Throw("Conflicting keywords.");
 
-    // getting the routine name from the first parameter
-    DString name;
-    e->AssureScalarPar<DStringGDL>(0, name);
-    name = StrUpCase(name);
-        
-    DSubUD* routine = functionsKW 
-      ? static_cast<DSubUD*>(funList[GDLInterpreter::GetFunIx(name)])
-      : static_cast<DSubUD*>(proList[GDLInterpreter::GetProIx(name)]);
-    SizeT np = routine->NPar(), nk = routine->NKey();
+      // getting the routine name from the first parameter
+      DString name;
+      e->AssureScalarPar<DStringGDL>(0, name);
+      name = StrUpCase(name);
 
-    // creating the output anonymous structure
-    DStructDesc* stru_desc = new DStructDesc("$truct");
-    SpDLong aLong;
-    stru_desc->AddTag("NUM_ARGS", &aLong);
-    stru_desc->AddTag("NUM_KW_ARGS", &aLong);
-    if (np > 0) 
-      {
-        SpDString aStringArr(dimension((int)np));
+      DSubUD* routine = functionsKW
+        ? static_cast<DSubUD*> (funList[GDLInterpreter::GetFunIx(name)])
+        : static_cast<DSubUD*> (proList[GDLInterpreter::GetProIx(name)]);
+      SizeT np = routine->NPar(), nk = routine->NKey();
+
+      // creating the output anonymous structure
+      DStructDesc* stru_desc = new DStructDesc("$truct");
+      SpDLong aLong;
+      stru_desc->AddTag("NUM_ARGS", &aLong);
+      stru_desc->AddTag("NUM_KW_ARGS", &aLong);
+      if (np > 0) {
+        SpDString aStringArr(dimension((int) np));
         stru_desc->AddTag("ARGS", &aStringArr);
       }
-    if (nk > 0) 
-      {
-        SpDString aStringArr(dimension((int)nk));
+      if (nk > 0) {
+        SpDString aStringArr(dimension((int) nk));
         stru_desc->AddTag("KW_ARGS", &aStringArr);
       }
-    DStructGDL* stru = new DStructGDL(stru_desc, dimension());
+      DStructGDL* stru = new DStructGDL(stru_desc, dimension());
 
-    // filling the structure with information about the routine 
-    stru->InitTag("NUM_ARGS", DLongGDL(np));
-    stru->InitTag("NUM_KW_ARGS", DLongGDL(nk));
-    if (np > 0)
-      {
+      // filling the structure with information about the routine
+      stru->InitTag("NUM_ARGS", DLongGDL(np));
+      stru->InitTag("NUM_KW_ARGS", DLongGDL(nk));
+      if (np > 0) {
         DStringGDL *pnames = new DStringGDL(dimension(np));
-        for (SizeT p = 0; p < np; ++p) (*pnames)[p] = routine->GetVarName(nk + p); 
+        for (SizeT p = 0; p < np; ++p) (*pnames)[p] = routine->GetVarName(nk + p);
         stru->InitTag("ARGS", *pnames);
         GDLDelete(pnames);
       }
-    if (nk > 0)
-      {
+      if (nk > 0) {
         DStringGDL *knames = new DStringGDL(dimension(nk));
-        for (SizeT k = 0; k < nk; ++k) (*knames)[k] = routine->GetKWName(k); 
+        for (SizeT k = 0; k < nk; ++k) (*knames)[k] = routine->GetKWName(k);
         stru->InitTag("KW_ARGS", *knames);
         GDLDelete(knames);
       }
 
-    // returning
-    return stru;
-      }
+      // returning
+      return stru;
+    }
 
     // GDL does not have disabled routines
-    if( disabledKW) return new DStringGDL("");
+    if (disabledKW) return new DStringGDL("");
 
     //    if( functionsKW || systemKW || nParam == 0)
     //      {
     vector<DString> subList;
-        
-    if( functionsKW)
-      {
-    if( systemKW)
-      {
-        SizeT n = libFunList.size();
-        if( n == 0) return new DStringGDL("");
 
-        DStringGDL* res = new DStringGDL( dimension( n), BaseGDL::NOZERO);
-        for( SizeT i = 0; i<n; ++i)
+    if (functionsKW) {
+      if (systemKW) {
+        SizeT n = libFunList.size();
+        if (n == 0) return new DStringGDL("");
+
+        DStringGDL* res = new DStringGDL(dimension(n), BaseGDL::NOZERO);
+        for (SizeT i = 0; i < n; ++i)
           (*res)[i] = libFunList[ i]->ObjectName();
 
         return res;
-      }
-    else
-      {
+      } else {
         SizeT n = funList.size();
-        if( n == 0) {
+        if (n == 0) {
           Message("No FUNCTIONS compiled yet !");
           return new DStringGDL("");
         }
-        for( SizeT i = 0; i<n; ++i)
-          subList.push_back( funList[ i]->ObjectName());
+        for (SizeT i = 0; i < n; ++i)
+          subList.push_back(funList[ i]->ObjectName());
       }
-      }
-    else
-      {
-    if( systemKW)
-      {
+    } else {
+      if (systemKW) {
         SizeT n = libProList.size();
-        if( n == 0) return new DStringGDL("");
+        if (n == 0) return new DStringGDL("");
 
-        DStringGDL* res = new DStringGDL( dimension( n), BaseGDL::NOZERO);
-        for( SizeT i = 0; i<n; ++i)
+        DStringGDL* res = new DStringGDL(dimension(n), BaseGDL::NOZERO);
+        for (SizeT i = 0; i < n; ++i)
           (*res)[i] = libProList[ i]->ObjectName();
 
         return res;
-      }
-    else
-      {
+      } else {
         SizeT n = proList.size();
-        if( n == 0) {
+        if (n == 0) {
           Message("No PROCEDURES compiled yet !");
           DStringGDL* res = new DStringGDL(1, BaseGDL::NOZERO);
-          (*res)[0]="$MAIN$";
+          (*res)[0] = "$MAIN$";
           return res;
         }
         subList.push_back("$MAIN$");
-        for( SizeT i = 0; i<n; ++i)
-          subList.push_back( proList[ i]->ObjectName());
+        for (SizeT i = 0; i < n; ++i)
+          subList.push_back(proList[ i]->ObjectName());
       }
-      }
-    
-    sort( subList.begin(), subList.end());
+    }
+
+    sort(subList.begin(), subList.end());
     SizeT nS = subList.size();
 
-    DStringGDL* res = new DStringGDL( dimension( nS), BaseGDL::NOZERO);
-    for( SizeT s=0; s<nS; ++s)
+    DStringGDL* res = new DStringGDL(dimension(nS), BaseGDL::NOZERO);
+    for (SizeT s = 0; s < nS; ++s)
       (*res)[ s] = subList[ s];
 
     return res;
     //      }
   }
 
-  BaseGDL* temporary_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam(1);
+  BaseGDL* temporary_fun(EnvT* e) {
+    SizeT nParam = e->NParam(1);
 
-    BaseGDL** p0 = &e->GetParDefined( 0);
+    BaseGDL** p0 = &e->GetParDefined(0);
 
     BaseGDL* ret = *p0;
 
@@ -8157,506 +8063,424 @@ BaseGDL* routine_filepath( EnvT* e)
     return ret;
   }
 
-  BaseGDL* memory_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam( 0); 
+  BaseGDL* memory_fun(EnvT* e) {
+    SizeT nParam = e->NParam(0);
 
     BaseGDL* ret;
     static int kw_l64_Ix = e->KeywordIx("L64");
     bool kw_l64 = e->KeywordSet(kw_l64_Ix);
     // TODO: IDL-doc mentions about automatically switching to L64 if needed
 
-    static int structureIx=e->KeywordIx("STRUCTURE");
-    if (e->KeywordSet(structureIx))
-      {
-    // returning structure
-    if (kw_l64) 
-      {
+    static int structureIx = e->KeywordIx("STRUCTURE");
+    if (e->KeywordSet(structureIx)) {
+      // returning structure
+      if (kw_l64) {
         ret = new DStructGDL("IDL_MEMORY64");
-        DStructGDL* retStru = static_cast<DStructGDL*>(ret);
-        (retStru->GetTag(retStru->Desc()->TagIndex("CURRENT")))->InitFrom( DLong64GDL(MemStats::GetCurrent()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_ALLOC")))->InitFrom( DLong64GDL(MemStats::GetNumAlloc()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_FREE")))->InitFrom( DLong64GDL(MemStats::GetNumFree()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("HIGHWATER")))->InitFrom( DLong64GDL(MemStats::GetHighWater()));
-      }
-    else 
-      {
+        DStructGDL* retStru = static_cast<DStructGDL*> (ret);
+        (retStru->GetTag(retStru->Desc()->TagIndex("CURRENT")))->InitFrom(DLong64GDL(MemStats::GetCurrent()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_ALLOC")))->InitFrom(DLong64GDL(MemStats::GetNumAlloc()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_FREE")))->InitFrom(DLong64GDL(MemStats::GetNumFree()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("HIGHWATER")))->InitFrom(DLong64GDL(MemStats::GetHighWater()));
+      } else {
         ret = new DStructGDL("IDL_MEMORY");
-        DStructGDL* retStru = static_cast<DStructGDL*>(ret);
-        (retStru->GetTag(retStru->Desc()->TagIndex("CURRENT")))->InitFrom( DLongGDL(MemStats::GetCurrent()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_ALLOC")))->InitFrom( DLongGDL(MemStats::GetNumAlloc()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_FREE")))->InitFrom( DLongGDL(MemStats::GetNumFree()));
-        (retStru->GetTag(retStru->Desc()->TagIndex("HIGHWATER")))->InitFrom( DLongGDL(MemStats::GetHighWater()));
+        DStructGDL* retStru = static_cast<DStructGDL*> (ret);
+        (retStru->GetTag(retStru->Desc()->TagIndex("CURRENT")))->InitFrom(DLongGDL(MemStats::GetCurrent()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_ALLOC")))->InitFrom(DLongGDL(MemStats::GetNumAlloc()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("NUM_FREE")))->InitFrom(DLongGDL(MemStats::GetNumFree()));
+        (retStru->GetTag(retStru->Desc()->TagIndex("HIGHWATER")))->InitFrom(DLongGDL(MemStats::GetHighWater()));
       }
-      }
-    else 
-      {
-    static int Ix_kw_current   = e->KeywordIx("CURRENT");
-    static int Ix_kw_num_alloc = e->KeywordIx("NUM_ALLOC");
-    static int Ix_kw_num_free  = e->KeywordIx("NUM_FREE");
-    static int Ix_kw_highwater = e->KeywordIx("HIGHWATER");
+    } else {
+      static int Ix_kw_current = e->KeywordIx("CURRENT");
+      static int Ix_kw_num_alloc = e->KeywordIx("NUM_ALLOC");
+      static int Ix_kw_num_free = e->KeywordIx("NUM_FREE");
+      static int Ix_kw_highwater = e->KeywordIx("HIGHWATER");
 
-    bool kw_current =   e->KeywordSet( Ix_kw_current  );
-    bool kw_num_alloc = e->KeywordSet( Ix_kw_num_alloc);
-    bool kw_num_free =  e->KeywordSet( Ix_kw_num_free );
-    bool kw_highwater = e->KeywordSet( Ix_kw_highwater);
+      bool kw_current = e->KeywordSet(Ix_kw_current);
+      bool kw_num_alloc = e->KeywordSet(Ix_kw_num_alloc);
+      bool kw_num_free = e->KeywordSet(Ix_kw_num_free);
+      bool kw_highwater = e->KeywordSet(Ix_kw_highwater);
 
-    // Following the IDL documentation: mutually exclusive keywords
-    // IDL behaves different, incl. segfaults with selected kw combinations
-    if (kw_current + kw_num_alloc + kw_num_free + kw_highwater > 1) 
-      e->Throw("CURRENT, NUM_ALLOC, NUM_FREE & HIGHWATER keywords"
-           " are mutually exclusive");
+      // Following the IDL documentation: mutually exclusive keywords
+      // IDL behaves different, incl. segfaults with selected kw combinations
+      if (kw_current + kw_num_alloc + kw_num_free + kw_highwater > 1)
+        e->Throw("CURRENT, NUM_ALLOC, NUM_FREE & HIGHWATER keywords"
+        " are mutually exclusive");
 
-    if (kw_current)
-      {
+      if (kw_current) {
         if (kw_l64) ret = new DLong64GDL(MemStats::GetCurrent());
         else ret = new DLongGDL(MemStats::GetCurrent());
-      } 
-    else if (kw_num_alloc)
-      {
+      }
+      else if (kw_num_alloc) {
         if (kw_l64) ret = new DLong64GDL(MemStats::GetNumAlloc());
         else ret = new DLongGDL(MemStats::GetNumAlloc());
-      }
-    else if (kw_num_free)
-      {
+      } else if (kw_num_free) {
         if (kw_l64) ret = new DLong64GDL(MemStats::GetNumFree());
         else ret = new DLongGDL(MemStats::GetNumFree());
-      }
-    else if (kw_highwater)
-      {
+      } else if (kw_highwater) {
         if (kw_l64) ret = new DLong64GDL(MemStats::GetHighWater());
         else ret = new DLongGDL(MemStats::GetHighWater());
+      } else {
+        // returning 4-element array
+        if (kw_l64) {
+          ret = new DLong64GDL(dimension(4));
+          (*static_cast<DLong64GDL*> (ret))[0] = MemStats::GetCurrent();
+          (*static_cast<DLong64GDL*> (ret))[1] = MemStats::GetNumAlloc();
+          (*static_cast<DLong64GDL*> (ret))[2] = MemStats::GetNumFree();
+          (*static_cast<DLong64GDL*> (ret))[3] = MemStats::GetHighWater();
+        } else {
+          ret = new DLongGDL(dimension(4));
+          (*static_cast<DLongGDL*> (ret))[0] = MemStats::GetCurrent();
+          (*static_cast<DLongGDL*> (ret))[1] = MemStats::GetNumAlloc();
+          (*static_cast<DLongGDL*> (ret))[2] = MemStats::GetNumFree();
+          (*static_cast<DLongGDL*> (ret))[3] = MemStats::GetHighWater();
+        }
       }
-    else 
-      {
-        // returning 4-element array 
-        if (kw_l64) 
-          {
-        ret = new DLong64GDL(dimension(4));
-        (*static_cast<DLong64GDL*>(ret))[0] = MemStats::GetCurrent();
-        (*static_cast<DLong64GDL*>(ret))[1] = MemStats::GetNumAlloc();
-        (*static_cast<DLong64GDL*>(ret))[2] = MemStats::GetNumFree();
-        (*static_cast<DLong64GDL*>(ret))[3] = MemStats::GetHighWater();
-          }
-        else 
-          {
-        ret = new DLongGDL(dimension(4));
-        (*static_cast<DLongGDL*>(ret))[0] = MemStats::GetCurrent();
-        (*static_cast<DLongGDL*>(ret))[1] = MemStats::GetNumAlloc();
-        (*static_cast<DLongGDL*>(ret))[2] = MemStats::GetNumFree();
-        (*static_cast<DLongGDL*>(ret))[3] = MemStats::GetHighWater();
-          }
-      }
-      }
+    }
 
     return ret;
   }
 
-  inline DByte StrCmp( const string& s1, const string& s2, DLong n)
-  {
-    if( n <= 0) return 1;
-    if( s1.substr(0,n) == s2.substr(0,n)) return 1;
-    return 0;
-  }
-  inline DByte StrCmp( const string& s1, const string& s2)
-  {
-    if( s1 == s2) return 1;
-    return 0;
-  }
-  inline DByte StrCmpFold( const string& s1, const string& s2, DLong n)
-  {
-    if( n <= 0) return 1;
-    if( StrUpCase( s1.substr(0,n)) == StrUpCase(s2.substr(0,n))) return 1;
-    return 0;
-  }
-  inline DByte StrCmpFold( const string& s1, const string& s2)
-  {
-    if( StrUpCase( s1) == StrUpCase(s2)) return 1;
+  inline DByte StrCmp(const string& s1, const string& s2, DLong n) {
+    if (n <= 0) return 1;
+    if (s1.substr(0, n) == s2.substr(0, n)) return 1;
     return 0;
   }
 
-  BaseGDL* strcmp_fun( EnvT* e)
-  {
-    SizeT nParam=e->NParam(2);
+  inline DByte StrCmp(const string& s1, const string& s2) {
+    if (s1 == s2) return 1;
+    return 0;
+  }
 
-    DStringGDL* s0 = static_cast<DStringGDL*>( e->GetParAs< DStringGDL>( 0));
-    DStringGDL* s1 = static_cast<DStringGDL*>( e->GetParAs< DStringGDL>( 1));
+  inline DByte StrCmpFold(const string& s1, const string& s2, DLong n) {
+    if (n <= 0) return 1;
+    if (StrUpCase(s1.substr(0, n)) == StrUpCase(s2.substr(0, n))) return 1;
+    return 0;
+  }
+
+  inline DByte StrCmpFold(const string& s1, const string& s2) {
+    if (StrUpCase(s1) == StrUpCase(s2)) return 1;
+    return 0;
+  }
+
+  BaseGDL* strcmp_fun(EnvT* e) {
+    SizeT nParam = e->NParam(2);
+
+    DStringGDL* s0 = static_cast<DStringGDL*> (e->GetParAs< DStringGDL>(0));
+    DStringGDL* s1 = static_cast<DStringGDL*> (e->GetParAs< DStringGDL>(1));
 
     DLongGDL* l2 = NULL;
-    if( nParam > 2)
-      {
-    l2 = static_cast<DLongGDL*>( e->GetParAs< DLongGDL>( 2));
-      }
+    if (nParam > 2) {
+      l2 = static_cast<DLongGDL*> (e->GetParAs< DLongGDL>(2));
+    }
 
-    static int foldIx = e->KeywordIx( "FOLD_CASE");
-    bool fold = e->KeywordSet( foldIx );
-    
-    if( s0->Scalar() && s1->Scalar())
-      {
-    if( l2 == NULL)
-      {
-        if( fold)
-          return new DByteGDL( StrCmpFold( (*s0)[0], (*s1)[0]));
+    static int foldIx = e->KeywordIx("FOLD_CASE");
+    bool fold = e->KeywordSet(foldIx);
+
+    if (s0->Scalar() && s1->Scalar()) {
+      if (l2 == NULL) {
+        if (fold)
+          return new DByteGDL(StrCmpFold((*s0)[0], (*s1)[0]));
         else
-          return new DByteGDL( StrCmp( (*s0)[0], (*s1)[0]));
-      }
-    else
-      {
-        DByteGDL* res = new DByteGDL( l2->Dim(), BaseGDL::NOZERO);
+          return new DByteGDL(StrCmp((*s0)[0], (*s1)[0]));
+      } else {
+        DByteGDL* res = new DByteGDL(l2->Dim(), BaseGDL::NOZERO);
         SizeT nEl = l2->N_Elements();
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-        (*res)[i] = StrCmpFold( (*s0)[0], (*s1)[0], (*l2)[i]);
+        if (fold)
+          for (SizeT i = 0; i < nEl; ++i)
+            (*res)[i] = StrCmpFold((*s0)[0], (*s1)[0], (*l2)[i]);
         else
-          for( SizeT i=0; i<nEl; ++i)
-        (*res)[i] = StrCmp( (*s0)[0], (*s1)[0], (*l2)[i]);
+          for (SizeT i = 0; i < nEl; ++i)
+            (*res)[i] = StrCmp((*s0)[0], (*s1)[0], (*l2)[i]);
         return res;
       }
-      }
-    else // at least one array
-      {
-    if( l2 == NULL)
-      {
-        if( s0->Scalar())
-          {
-        DByteGDL* res = new DByteGDL( s1->Dim(), BaseGDL::NOZERO);
-        SizeT nEl = s1->N_Elements();
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[0], (*s1)[i]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[0], (*s1)[i]);
-        return res;
-          }
-        else if( s1->Scalar())
-          {
-        DByteGDL* res = new DByteGDL( s0->Dim(), BaseGDL::NOZERO);
-        SizeT nEl = s0->N_Elements();
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[i], (*s1)[0]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[i], (*s1)[0]);
-        return res;
-          }
-        else // both arrays
-          {
-        DByteGDL* res;
-        SizeT    nEl;
-        if( s0->N_Elements() <= s1->N_Elements())
-          {
-            res = new DByteGDL( s0->Dim(), BaseGDL::NOZERO);
+    } else // at least one array
+    {
+      if (l2 == NULL) {
+        if (s0->Scalar()) {
+          DByteGDL* res = new DByteGDL(s1->Dim(), BaseGDL::NOZERO);
+          SizeT nEl = s1->N_Elements();
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[0], (*s1)[i]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[0], (*s1)[i]);
+          return res;
+        } else if (s1->Scalar()) {
+          DByteGDL* res = new DByteGDL(s0->Dim(), BaseGDL::NOZERO);
+          SizeT nEl = s0->N_Elements();
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[i], (*s1)[0]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[i], (*s1)[0]);
+          return res;
+        } else // both arrays
+        {
+          DByteGDL* res;
+          SizeT nEl;
+          if (s0->N_Elements() <= s1->N_Elements()) {
+            res = new DByteGDL(s0->Dim(), BaseGDL::NOZERO);
             nEl = s0->N_Elements();
-          }
-        else              
-          {
-            res = new DByteGDL( s1->Dim(), BaseGDL::NOZERO);
+          } else {
+            res = new DByteGDL(s1->Dim(), BaseGDL::NOZERO);
             nEl = s1->N_Elements();
           }
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[i], (*s1)[i]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[i], (*s1)[i]);
-        return res;
-          }
-      }
-    else // l2 != NULL
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[i], (*s1)[i]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[i], (*s1)[i]);
+          return res;
+        }
+      } else // l2 != NULL
       {
         DByteGDL* res;
-        SizeT    nEl;
+        SizeT nEl;
         bool l2Scalar = l2->Scalar();
-        if( s0->Scalar())
-          {
-        if( l2Scalar || s1->N_Elements() <= l2->N_Elements())
-          {
-            res = new DByteGDL( s1->Dim(), BaseGDL::NOZERO);
+        if (s0->Scalar()) {
+          if (l2Scalar || s1->N_Elements() <= l2->N_Elements()) {
+            res = new DByteGDL(s1->Dim(), BaseGDL::NOZERO);
             nEl = s1->N_Elements();
-          }
-        else
-          {
-            res = new DByteGDL( l2->Dim(), BaseGDL::NOZERO);
+          } else {
+            res = new DByteGDL(l2->Dim(), BaseGDL::NOZERO);
             nEl = l2->N_Elements();
           }
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[0], (*s1)[i], (*l2)[l2Scalar?0:i]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[0], (*s1)[i], (*l2)[l2Scalar?0:i]);
-        return res;
-          }
-        else if( s1->Scalar())
-          {
-        if( l2Scalar || s0->N_Elements() <= l2->N_Elements())
-          {
-            res = new DByteGDL( s0->Dim(), BaseGDL::NOZERO);
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[0], (*s1)[i], (*l2)[l2Scalar ? 0 : i]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[0], (*s1)[i], (*l2)[l2Scalar ? 0 : i]);
+          return res;
+        } else if (s1->Scalar()) {
+          if (l2Scalar || s0->N_Elements() <= l2->N_Elements()) {
+            res = new DByteGDL(s0->Dim(), BaseGDL::NOZERO);
             nEl = s0->N_Elements();
-          }
-        else
-          {
-            res = new DByteGDL( l2->Dim(), BaseGDL::NOZERO);
+          } else {
+            res = new DByteGDL(l2->Dim(), BaseGDL::NOZERO);
             nEl = l2->N_Elements();
           }
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[i], (*s1)[0], (*l2)[l2Scalar?0:i]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[i], (*s1)[0], (*l2)[l2Scalar?0:i]);
-        return res;
-          }
-        else // s1 and s2 are arrays
-          {
-        if( l2Scalar)
-          if( s0->N_Elements() <= s1->N_Elements())
-            {
-              res = new DByteGDL( s0->Dim(), BaseGDL::NOZERO);
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[i], (*s1)[0], (*l2)[l2Scalar ? 0 : i]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[i], (*s1)[0], (*l2)[l2Scalar ? 0 : i]);
+          return res;
+        } else // s1 and s2 are arrays
+        {
+          if (l2Scalar)
+            if (s0->N_Elements() <= s1->N_Elements()) {
+              res = new DByteGDL(s0->Dim(), BaseGDL::NOZERO);
               nEl = s0->N_Elements();
-            }
-          else 
-            {
-              res = new DByteGDL( s1->Dim(), BaseGDL::NOZERO);
+            } else {
+              res = new DByteGDL(s1->Dim(), BaseGDL::NOZERO);
               nEl = s1->N_Elements();
-            }
-        else 
-          {
-            if( s0->N_Elements() <= s1->N_Elements())
-              if( s0->N_Elements() <= l2->N_Elements())
-            {
-              res = new DByteGDL( s0->Dim(), BaseGDL::NOZERO);
-              nEl = s0->N_Elements();
-            }
-              else
-            {
-              res = new DByteGDL( l2->Dim(), BaseGDL::NOZERO);
-              nEl = l2->N_Elements();
-            }
-            else
-              if( s1->N_Elements() <= l2->N_Elements())
-            {
-              res = new DByteGDL( s1->Dim(), BaseGDL::NOZERO);
+            } else {
+            if (s0->N_Elements() <= s1->N_Elements())
+              if (s0->N_Elements() <= l2->N_Elements()) {
+                res = new DByteGDL(s0->Dim(), BaseGDL::NOZERO);
+                nEl = s0->N_Elements();
+              } else {
+                res = new DByteGDL(l2->Dim(), BaseGDL::NOZERO);
+                nEl = l2->N_Elements();
+              } else
+              if (s1->N_Elements() <= l2->N_Elements()) {
+              res = new DByteGDL(s1->Dim(), BaseGDL::NOZERO);
               nEl = s1->N_Elements();
-            }
-              else
-            {
-              res = new DByteGDL( l2->Dim(), BaseGDL::NOZERO);
+            } else {
+              res = new DByteGDL(l2->Dim(), BaseGDL::NOZERO);
               nEl = l2->N_Elements();
             }
           }
-        if( fold)
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmpFold( (*s0)[i], (*s1)[i], (*l2)[l2Scalar?0:i]);
-        else
-          for( SizeT i=0; i<nEl; ++i)
-            (*res)[i] = StrCmp( (*s0)[i], (*s1)[i], (*l2)[l2Scalar?0:i]);
-        return res;
-          }
+          if (fold)
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmpFold((*s0)[i], (*s1)[i], (*l2)[l2Scalar ? 0 : i]);
+          else
+            for (SizeT i = 0; i < nEl; ++i)
+              (*res)[i] = StrCmp((*s0)[i], (*s1)[i], (*l2)[l2Scalar ? 0 : i]);
+          return res;
+        }
       }
-      }
-    assert( false);
+    }
+    assert(false);
   }
 
-  string TagName( EnvT* e, const string& name)
-  {
-    string n = StrUpCase( name);
+  string TagName(EnvT* e, const string& name) {
+    string n = StrUpCase(name);
     SizeT len = n.size();
-    if( n[0] != '_' && n[0] != '!' && (n[0] < 'A' || n[0] > 'Z'))
-      e->Throw( "Illegal tag name: "+name+".");
-    for( SizeT i=1; i<len; ++i)
-      {
-    if( n[i] == ' ')
-      n[i] = '_';
-    else 
-      if( n[i] != '_' && n[i] != '$' && //n[0] != '!' &&
-          (n[i] < 'A' || n[i] > 'Z') &&
-          (n[i] < '0' || n[i] > '9'))
-        e->Throw( "Illegal tag name: "+name+".");
-      }
+    if (n[0] != '_' && n[0] != '!' && (n[0] < 'A' || n[0] > 'Z'))
+      e->Throw("Illegal tag name: " + name + ".");
+    for (SizeT i = 1; i < len; ++i) {
+      if (n[i] == ' ')
+        n[i] = '_';
+      else
+        if (n[i] != '_' && n[i] != '$' && //n[0] != '!' &&
+        (n[i] < 'A' || n[i] > 'Z') &&
+        (n[i] < '0' || n[i] > '9'))
+        e->Throw("Illegal tag name: " + name + ".");
+    }
     return n;
   }
 
-  BaseGDL* create_struct( EnvT* e)
-  {
-    static int nameIx = e->KeywordIx( "NAME" );
+  BaseGDL* create_struct(EnvT* e) {
+    static int nameIx = e->KeywordIx("NAME");
     DString name = "$truct";
-    if( e->KeywordPresent( nameIx)) {
+    if (e->KeywordPresent(nameIx)) {
       // Check if name exists, if not then treat as unnamed
-      if (e->GetKW( nameIx) != NULL)
-    e->AssureStringScalarKW( nameIx, name);
+      if (e->GetKW(nameIx) != NULL)
+        e->AssureStringScalarKW(nameIx, name);
     }
 
-    if( name != "$truct") // named struct
-      {
-    name = StrUpCase( name);
-    
-    SizeT nParam=e->NParam();
+    if (name != "$truct") // named struct
+    {
+      name = StrUpCase(name);
 
-    if( nParam == 0)
-      {
-        DStructDesc* desc = 
-          e->Interpreter()->GetStruct( name, e->CallingNode());
-       
-        dimension dim( 1);
-        return new DStructGDL( desc, dim);
+      SizeT nParam = e->NParam();
+
+      if (nParam == 0) {
+        DStructDesc* desc =
+          e->Interpreter()->GetStruct(name, e->CallingNode());
+
+        dimension dim(1);
+        return new DStructGDL(desc, dim);
       }
 
-    DStructDesc*          nStructDesc;
-    Guard<DStructDesc> nStructDescGuard;
-    
-    DStructDesc* oStructDesc=
-      FindInStructList( structList, name);
-    
-    if( oStructDesc == NULL || oStructDesc->NTags() > 0)
-      {
+      DStructDesc* nStructDesc;
+      Guard<DStructDesc> nStructDescGuard;
+
+      DStructDesc* oStructDesc =
+        FindInStructList(structList, name);
+
+      if (oStructDesc == NULL || oStructDesc->NTags() > 0) {
         // not defined at all yet (-> define now)
         // or completely defined  (-> define now and check equality)
-        nStructDesc= new DStructDesc( name);
-                    
+        nStructDesc = new DStructDesc(name);
+
         // guard it
-        nStructDescGuard.Reset( nStructDesc); 
-      }
-    else
-      {   
+        nStructDescGuard.Reset(nStructDesc);
+      } else {
         // NTags() == 0
         // not completely defined (only name in list)
-        nStructDesc= oStructDesc;
-      }
-                
-    // the instance variable
-    //  dimension dim( 1);
-    //  DStructGDL* instance = new DStructGDL( nStructDesc, dim);
-    DStructGDL* instance = new DStructGDL( nStructDesc);
-    Guard<DStructGDL> instance_guard(instance);
-
-    for( SizeT p=0; p<nParam; ++p)
-      {
-        BaseGDL* par = e->GetParDefined( p);
-        if( par->Type() == GDL_STRUCT)
-          {
-        DStructGDL* parStruct = static_cast<DStructGDL*>( par);
-        // add struct
-        if( !parStruct->Scalar())
-          e->Throw("Expression must be a scalar in this context: "+
-               e->GetParString( p));
-        
-        DStructDesc* desc = parStruct->Desc();
-        for( SizeT t=0; t< desc->NTags(); ++t)
-          {
-            instance->NewTag( desc->TagName( t), 
-                      parStruct->GetTag( t)->Dup());
-          }
-          }
-        else
-          {
-        // add tag value pair
-        DStringGDL* tagNames = e->GetParAs<DStringGDL>( p);
-        SizeT nTags = tagNames->N_Elements();
-
-        SizeT tagStart = p+1;
-        SizeT tagEnd   = p+nTags;
-        if( tagEnd >= nParam)
-          e->Throw( "Incorrect number of arguments.");
-
-        do{
-          ++p;
-          BaseGDL* value = e->GetParDefined( p);
-            
-          // add 
-          instance->NewTag( TagName( e, (*tagNames)[ p-tagStart]),
-                    value->Dup());
-        } 
-        while( p<tagEnd);
-          }
+        nStructDesc = oStructDesc;
       }
 
-    if( oStructDesc != NULL)
-      {
-        if( oStructDesc != nStructDesc)
-          {
-        oStructDesc->AssureIdentical(nStructDesc);
-        instance->DStructGDL::SetDesc(oStructDesc);
-        //delete nStructDesc; // auto_ptr
+      // the instance variable
+      //  dimension dim( 1);
+      //  DStructGDL* instance = new DStructGDL( nStructDesc, dim);
+      DStructGDL* instance = new DStructGDL(nStructDesc);
+      Guard<DStructGDL> instance_guard(instance);
+
+      for (SizeT p = 0; p < nParam; ++p) {
+        BaseGDL* par = e->GetParDefined(p);
+        if (par->Type() == GDL_STRUCT) {
+          DStructGDL* parStruct = static_cast<DStructGDL*> (par);
+          // add struct
+          if (!parStruct->Scalar())
+            e->Throw("Expression must be a scalar in this context: " +
+            e->GetParString(p));
+
+          DStructDesc* desc = parStruct->Desc();
+          for (SizeT t = 0; t < desc->NTags(); ++t) {
+            instance->NewTag(desc->TagName(t),
+              parStruct->GetTag(t)->Dup());
           }
+        } else {
+          // add tag value pair
+          DStringGDL* tagNames = e->GetParAs<DStringGDL>(p);
+          SizeT nTags = tagNames->N_Elements();
+
+          SizeT tagStart = p + 1;
+          SizeT tagEnd = p + nTags;
+          if (tagEnd >= nParam)
+            e->Throw("Incorrect number of arguments.");
+
+          do {
+            ++p;
+            BaseGDL* value = e->GetParDefined(p);
+
+            // add
+            instance->NewTag(TagName(e, (*tagNames)[ p - tagStart]),
+              value->Dup());
+          } while (p < tagEnd);
+        }
       }
-    else
-      {
+
+      if (oStructDesc != NULL) {
+        if (oStructDesc != nStructDesc) {
+          oStructDesc->AssureIdentical(nStructDesc);
+          instance->DStructGDL::SetDesc(oStructDesc);
+          //delete nStructDesc; // auto_ptr
+        }
+      } else {
         // release from guard (if not NULL)
         nStructDescGuard.release();
-        // insert into struct list 
+        // insert into struct list
         structList.push_back(nStructDesc);
       }
-    
-    instance_guard.release();
-    return instance;
-      }
-    else 
-      { // unnamed struc
 
-    // Handle case of single structure parameter
-    SizeT nParam;
-    nParam = e->NParam(1);
-    BaseGDL* par = e->GetParDefined( 0);
-    //  DStructGDL* parStruct = dynamic_cast<DStructGDL*>( par);
-    if (nParam != 1 || par->Type() != GDL_STRUCT)// == NULL)
-      nParam=e->NParam(2);
+      instance_guard.release();
+      return instance;
+    } else { // unnamed struc
 
-    DStructDesc*          nStructDesc = new DStructDesc( "$truct");
-    // instance takes care of nStructDesc since it is unnamed
-    //  dimension dim( 1);
-    //  DStructGDL* instance = new DStructGDL( nStructDesc, dim);
-    DStructGDL* instance = new DStructGDL( nStructDesc);
-    Guard<DStructGDL> instance_guard(instance);
+      // Handle case of single structure parameter
+      SizeT nParam;
+      nParam = e->NParam(1);
+      BaseGDL* par = e->GetParDefined(0);
+      //  DStructGDL* parStruct = dynamic_cast<DStructGDL*>( par);
+      if (nParam != 1 || par->Type() != GDL_STRUCT)// == NULL)
+        nParam = e->NParam(2);
 
-    for( SizeT p=0; p<nParam;)
-      {
-        BaseGDL* par = e->GetParDefined( p);
+      DStructDesc* nStructDesc = new DStructDesc("$truct");
+      // instance takes care of nStructDesc since it is unnamed
+      //  dimension dim( 1);
+      //  DStructGDL* instance = new DStructGDL( nStructDesc, dim);
+      DStructGDL* instance = new DStructGDL(nStructDesc);
+      Guard<DStructGDL> instance_guard(instance);
+
+      for (SizeT p = 0; p < nParam;) {
+        BaseGDL* par = e->GetParDefined(p);
         //      DStructGDL* parStruct = dynamic_cast<DStructGDL*>( par);
         //      if( parStruct != NULL)
-        if( par->Type() == GDL_STRUCT)
-          {
-        // add struct
-        DStructGDL* parStruct = static_cast<DStructGDL*>( par);
-        if( !parStruct->Scalar())
-          e->Throw("Expression must be a scalar in this context: "+
-               e->GetParString( p));
-        
-        DStructDesc* desc = parStruct->Desc();
-        for( SizeT t=0; t< desc->NTags(); ++t)
-          {
-            instance->NewTag( desc->TagName( t), 
-                      parStruct->GetTag( t)->Dup());
-          }
-        ++p;
-          }
-        else
-          {
-        // add tag value pair
-        DStringGDL* tagNames = e->GetParAs<DStringGDL>( p);
-        SizeT nTags = tagNames->N_Elements();
+        if (par->Type() == GDL_STRUCT) {
+          // add struct
+          DStructGDL* parStruct = static_cast<DStructGDL*> (par);
+          if (!parStruct->Scalar())
+            e->Throw("Expression must be a scalar in this context: " +
+            e->GetParString(p));
 
-        SizeT tagStart = p+1;
-        SizeT tagEnd   = p+nTags;
-        if( tagEnd >= nParam)
-          e->Throw( "Incorrect number of arguments.");
-
-        for(++p; p<=tagEnd; ++p)
-          {
-            BaseGDL* value = e->GetParDefined( p);
-
-            // add 
-            instance->NewTag( TagName( e, (*tagNames)[ p-tagStart]),
-                      value->Dup());
+          DStructDesc* desc = parStruct->Desc();
+          for (SizeT t = 0; t < desc->NTags(); ++t) {
+            instance->NewTag(desc->TagName(t),
+              parStruct->GetTag(t)->Dup());
           }
+          ++p;
+        } else {
+          // add tag value pair
+          DStringGDL* tagNames = e->GetParAs<DStringGDL>(p);
+          SizeT nTags = tagNames->N_Elements();
+
+          SizeT tagStart = p + 1;
+          SizeT tagEnd = p + nTags;
+          if (tagEnd >= nParam)
+            e->Throw("Incorrect number of arguments.");
+
+          for (++p; p <= tagEnd; ++p) {
+            BaseGDL* value = e->GetParDefined(p);
+
+            // add
+            instance->NewTag(TagName(e, (*tagNames)[ p - tagStart]),
+              value->Dup());
           }
+        }
       }
-    
-    instance_guard.release();
-    return instance;
-      }
+
+      instance_guard.release();
+      return instance;
+    }
   }
 
   BaseGDL* rotate(EnvT* e) {
@@ -8693,14 +8517,14 @@ BaseGDL* routine_filepath( EnvT* e)
       e->Throw("Subscript_index must be positive and less than or equal to number of dimensions.");
 
     BaseGDL* ret;
-    // IDL doc states that OVERWRITE is ignored for one- or two-dim. arrays 
+    // IDL doc states that OVERWRITE is ignored for one- or two-dim. arrays
     // but it seems to behave differently
     // if (p0->Rank() > 2 && e->KeywordSet("OVERWRITE") && e->GlobalPar(0))
     static int overwriteIx = e->KeywordIx("OVERWRITE");
     if (e->KeywordSet(overwriteIx)) {
       p0->Reverse(dim - 1);
       bool stolen = e->StealLocalPar(0);
-      //    if( !stolen) 
+      //    if( !stolen)
       //    e->GetPar(0) = NULL;
       if (!stolen)
         e->SetPtrToReturnValue(&e->GetPar(0));
@@ -8711,26 +8535,25 @@ BaseGDL* routine_filepath( EnvT* e)
   }
 
   // PARSE_URL based on the IDL parse_url function behaviour and documentation
-  
-BaseGDL* parse_url( EnvT* env)
-  {
+
+  BaseGDL* parse_url(EnvT* env) {
     // sanity check for number of parameters
     SizeT nParam = env->NParam();
 
     // 1-nd argument : the url string
-    DString url; 
-    env->AssureScalarPar<DStringGDL>(0, url); 
+    DString url;
+    env->AssureScalarPar<DStringGDL>(0, url);
 
     // creating the output anonymous structure
     DStructDesc* urlstru_desc = new DStructDesc("$truct");
     SpDString aString;
-    urlstru_desc->AddTag("SCHEME",   &aString);
+    urlstru_desc->AddTag("SCHEME", &aString);
     urlstru_desc->AddTag("USERNAME", &aString);
     urlstru_desc->AddTag("PASSWORD", &aString);
-    urlstru_desc->AddTag("HOST",     &aString);
-    urlstru_desc->AddTag("PORT",     &aString);
-    urlstru_desc->AddTag("PATH",     &aString);
-    urlstru_desc->AddTag("QUERY",    &aString);
+    urlstru_desc->AddTag("HOST", &aString);
+    urlstru_desc->AddTag("PORT", &aString);
+    urlstru_desc->AddTag("PATH", &aString);
+    urlstru_desc->AddTag("QUERY", &aString);
     DStructGDL* urlstru = new DStructGDL(urlstru_desc, dimension());
     Guard<DStructGDL> urlstru_guard(urlstru);
 
@@ -8740,12 +8563,12 @@ BaseGDL* parse_url( EnvT* env)
 
     // initialise PORT at 80
     urlstru->InitTag("PORT", DStringGDL("80"));
-   
+
     //searching for the scheme and exciting if not found
     pStart = str;
-    if (!(pEnd = std::strstr(str, "://"))){
-        urlstru_guard.release();
-        return (urlstru);
+    if (!(pEnd = std::strstr(str, "://"))) {
+      urlstru_guard.release();
+      return (urlstru);
     }
     urlstru->InitTag("SCHEME", DStringGDL(pStart < pEnd ? string(pStart, pEnd - pStart) : ""));
 
@@ -8754,49 +8577,48 @@ BaseGDL* parse_url( EnvT* env)
     pStart = pEnd;
 
     //searching for the username and password (':' & '@')
-    if (std::strchr(pStart, '@')){
-        pEnd = std::strchr(pStart, '@');
-        if (!(pMid = std::strchr(pStart, ':')))
-            pMid = pEnd;
-        if (pMid && pMid < pEnd)
-            urlstru->InitTag("PASSWORD", DStringGDL(pMid + 1 < pEnd ? string(pMid + 1, pEnd - (pMid + 1)) : ""));
-        urlstru->InitTag("USERNAME", DStringGDL(pStart < pMid ? string(pStart, pMid - pStart) : ""));
-        pStart = pEnd + 1;
+    if (std::strchr(pStart, '@')) {
+      pEnd = std::strchr(pStart, '@');
+      if (!(pMid = std::strchr(pStart, ':')))
+        pMid = pEnd;
+      if (pMid && pMid < pEnd)
+        urlstru->InitTag("PASSWORD", DStringGDL(pMid + 1 < pEnd ? string(pMid + 1, pEnd - (pMid + 1)) : ""));
+      urlstru->InitTag("USERNAME", DStringGDL(pStart < pMid ? string(pStart, pMid - pStart) : ""));
+      pStart = pEnd + 1;
     }
-    
+
     // setting pEnd at the first '/' found or at the end if not found
-    if (std::strchr(pStart, '/')){
-        pEnd = std::strchr(pStart, '/');
+    if (std::strchr(pStart, '/')) {
+      pEnd = std::strchr(pStart, '/');
     } else {
-        pEnd = pStart + std::strlen(pStart);
+      pEnd = pStart + std::strlen(pStart);
     }
-    
+
     // setting pMid at the first ':' found or at the end if not found
     // if found : InitTag "PORT" from pMid + 1 (after ':') to pEnd ('/' or END)
-    if (std::strchr(pStart, ':')){
-        pMid = std::strchr(pStart, ':');
-        urlstru->InitTag("PORT", DStringGDL(pMid + 1 < pEnd ? string(pMid + 1, pEnd - (pMid + 1)) : ""));
+    if (std::strchr(pStart, ':')) {
+      pMid = std::strchr(pStart, ':');
+      urlstru->InitTag("PORT", DStringGDL(pMid + 1 < pEnd ? string(pMid + 1, pEnd - (pMid + 1)) : ""));
     } else {
-        pMid = pEnd;
+      pMid = pEnd;
     }
     // InitTag "PORT" from pStart(after "://" or '@') to pMid (':' or '/' or END)
     urlstru->InitTag("HOST", DStringGDL(pStart < pMid ? string(pStart, pMid - pStart) : ""));
     pStart = pEnd + 1;
     // Searching for a query ('?')
     // if found : InitTag "QUERY" from pEnd + 1 (after '?') to the end
-    if ((pEnd = strchr(pMid, '?'))){
-        urlstru->InitTag("QUERY", DStringGDL(std::strlen(pEnd + 1) > 0 ? string(pEnd + 1, std::strlen(pEnd + 1)) : ""));
+    if ((pEnd = strchr(pMid, '?'))) {
+      urlstru->InitTag("QUERY", DStringGDL(std::strlen(pEnd + 1) > 0 ? string(pEnd + 1, std::strlen(pEnd + 1)) : ""));
     } else {
-        pEnd = pMid + std::strlen(pMid);
+      pEnd = pMid + std::strlen(pMid);
     }
     // InitTag "PATH" from pStart (after '/') to the end
-    urlstru->InitTag("PATH", DStringGDL(pStart < pEnd ? string(pStart, pEnd - pStart) : ""));   
+    urlstru->InitTag("PATH", DStringGDL(pStart < pEnd ? string(pStart, pEnd - pStart) : ""));
     urlstru_guard.release();
     return urlstru;
   }
 
-  BaseGDL* locale_get(EnvT* e)
-  {
+  BaseGDL* locale_get(EnvT* e) {
 #ifdef HAVE_LOCALE_H
 
     // make GDL inherit the calling process locale
@@ -8814,51 +8636,47 @@ BaseGDL* parse_url( EnvT* env)
 
   // SA: relies on the contents of the lib::command_line_args vector
   //     defined and filled with data (pointers) in gdl.cpp
-  BaseGDL* command_line_args_fun(EnvT* e)
-  {
+
+  BaseGDL* command_line_args_fun(EnvT* e) {
     static int countIx = e->KeywordIx("COUNT");
     static int resetIx = e->KeywordIx("RESET");
     static int setIx = e->KeywordIx("SET");
-// resetting the command_line_args
-    if( e->KeywordSet(resetIx) ) command_line_args.clear();
+    // resetting the command_line_args
+    if (e->KeywordSet(resetIx)) command_line_args.clear();
 
     BaseGDL* setKW = e->GetKW(setIx);
-    if( setKW != NULL) 
-    {
-        if(setKW->Type() != GDL_STRING) 
-                e->Throw(" SET string values only allowed ");
-        DString setp;
-        for(SizeT i = 0; i < setKW->N_Elements(); i++)
-        {
-            setp = (*static_cast<DStringGDL*>(setKW))[i] ;
-            command_line_args.push_back( setp);
-        }
-//          printf(" SET: %s \n", (*static_cast<DStringGDL*>(setKW))[i] )
-//          command_line_args.push_back( ( (*static_cast<DStringGDL*>(setKW))[i] );
+    if (setKW != NULL) {
+      if (setKW->Type() != GDL_STRING)
+        e->Throw(" SET string values only allowed ");
+      DString setp;
+      for (SizeT i = 0; i < setKW->N_Elements(); i++) {
+        setp = (*static_cast<DStringGDL*> (setKW))[i];
+        command_line_args.push_back(setp);
+      }
+      //          printf(" SET: %s \n", (*static_cast<DStringGDL*>(setKW))[i] )
+      //          command_line_args.push_back( ( (*static_cast<DStringGDL*>(setKW))[i] );
 
     }
     // setting the COUNT keyword value
-    if (e->KeywordPresent(countIx))
-      {
-    e->AssureGlobalKW(countIx);
-    e->SetKW(countIx, new DLongGDL(command_line_args.size()));
-      }
+    if (e->KeywordPresent(countIx)) {
+      e->AssureGlobalKW(countIx);
+      e->SetKW(countIx, new DLongGDL(command_line_args.size()));
+    }
 
     // returning empty string or an array of arguments
     if (command_line_args.empty()) return new DStringGDL("");
-    else
-      {
-    BaseGDL* ret = new DStringGDL(dimension(command_line_args.size()));   
-    for (size_t i = 0; i < command_line_args.size(); i++)
-      (*static_cast<DStringGDL*>(ret))[i] = command_line_args[i];
-    return ret;
-      }
+    else {
+      BaseGDL* ret = new DStringGDL(dimension(command_line_args.size()));
+      for (size_t i = 0; i < command_line_args.size(); i++)
+        (*static_cast<DStringGDL*> (ret))[i] = command_line_args[i];
+      return ret;
+    }
   }
 
   // SA: relies in the uname() from libc (must be there if POSIX)
-  BaseGDL* get_login_info( EnvT* e)
-  {
-    // getting the info 
+
+  BaseGDL* get_login_info(EnvT* e) {
+    // getting the info
 #ifdef _WIN32
 #define MAX_WCHAR_BUF 256
 
@@ -8874,7 +8692,7 @@ BaseGDL* parse_url( EnvT* env)
     WideCharToMultiByte(CP_ACP, 0, w_buf, N_WCHAR, info, N_WCHAR, NULL, NULL);
 #else
     char* login = getlogin();
-    if (login == NULL) e->Throw("Failed to get user name from the OS"); 
+    if (login == NULL) e->Throw("Failed to get user name from the OS");
     struct utsname info;
     if (0 != uname(&info)) e->Throw("Failed to get machine name from the OS");
 #endif
@@ -8885,7 +8703,7 @@ BaseGDL* parse_url( EnvT* env)
     stru_desc->AddTag("USER_NAME", &aString);
     DStructGDL* stru = new DStructGDL(stru_desc, dimension());
 
-    // returning the info 
+    // returning the info
     stru->InitTag("USER_NAME", DStringGDL(login));
 #ifdef _WIN32
     stru->InitTag("MACHINE_NAME", DStringGDL(info));
@@ -8896,69 +8714,62 @@ BaseGDL* parse_url( EnvT* env)
   }
 
   // SA: base64 logic in base64.hpp, based on code by Bob Withers (consult base64.hpp)
-  BaseGDL* idl_base64(EnvT* e)
-  {
-    BaseGDL* p0 = e->GetPar(0);    
-    if (p0 != NULL)
-      { 
-    if (p0->Rank() == 0 && p0->Type() == GDL_STRING)
-      {
+
+  BaseGDL* idl_base64(EnvT* e) {
+    BaseGDL* p0 = e->GetPar(0);
+    if (p0 != NULL) {
+      if (p0->Rank() == 0 && p0->Type() == GDL_STRING) {
         // decoding
-        string* str = &((*static_cast<DStringGDL*>(p0))[0]);
+        string* str = &((*static_cast<DStringGDL*> (p0))[0]);
         if (str->length() == 0) return new DByteGDL(0);
-        if (str->length() % 4 != 0) 
+        if (str->length() % 4 != 0)
           e->Throw("Input string length must be a multiple of 4");
         unsigned int retlen = base64::decodeSize(*str);
         if (retlen == 0 || retlen > str->length()) e->Throw("No data in the input string");
         DByteGDL* ret = new DByteGDL(dimension(retlen));
-        if (!base64::decode(*str, (char*)&((*ret)[0]), ret->N_Elements()))
-          {
-        delete ret;
-        e->Throw("Base64 decoder failed"); 
-        return NULL;
-          }
+        if (!base64::decode(*str, (char*) &((*ret)[0]), ret->N_Elements())) {
+          delete ret;
+          e->Throw("Base64 decoder failed");
+          return NULL;
+        }
         return ret;
       }
-    if (p0->Rank() >= 1 && p0->Type() == GDL_BYTE)
-      {
+      if (p0->Rank() >= 1 && p0->Type() == GDL_BYTE) {
         // encoding
         return new DStringGDL(
-                  base64::encode((char*)&(*static_cast<DByteGDL*>(p0))[0], p0->N_Elements())
-                  );
-      } 
+          base64::encode((char*) &(*static_cast<DByteGDL*> (p0))[0], p0->N_Elements())
+          );
       }
+    }
     e->Throw("Expecting string or byte array as a first parameter");
     return NULL; //pacify dumb compilers
   }
 
-  BaseGDL* get_drive_list(EnvT* e)
-  {
+  BaseGDL* get_drive_list(EnvT* e) {
     if (e->KeywordPresent(0)) e->SetKW(0, new DLongGDL(0));
     return new DStringGDL("");
   }
 
-  BaseGDL* scope_level( EnvT* e) 
-  {
-    SizeT nParam=e->NParam();
-    if ( nParam > 0 ) e->Throw("Incorrect number of arguments.");
+  BaseGDL* scope_level(EnvT* e) {
+    SizeT nParam = e->NParam();
+    if (nParam > 0) e->Throw("Incorrect number of arguments.");
     EnvStackT& callStack = e->Interpreter()->CallStack();
     return new DLongGDL(callStack.size());
   }
-  
+
   // based on void SimpleDumpStack(EnvT* e) used in "basic_pro.cpp"
 
-  BaseGDL* scope_traceback( EnvT* e)
-  {
+  BaseGDL* scope_traceback(EnvT* e) {
     static int structureIx = e->KeywordIx("STRUCTURE");
     bool structureKW = e->KeywordSet(structureIx);
- 
+
     static int systemIx = e->KeywordIx("SYSTEM");
     bool systemKW = e->KeywordSet(systemIx);
     if (systemKW) {
       Warning("keyword SYSTEM is not ready here, please contribute !");
     }
 
-    int debug=0;
+    int debug = 0;
 
     EnvStackT& callStack = e->Interpreter()->CallStack();
     long actIx = callStack.size();
@@ -8970,75 +8781,72 @@ BaseGDL* parse_url( EnvT* env)
 
     if (!structureKW) {
 
-      DStringGDL* res;    
-      res = new DStringGDL(dimension(actIx) , BaseGDL::NOZERO);
+      DStringGDL* res;
+      res = new DStringGDL(dimension(actIx), BaseGDL::NOZERO);
 
-      for( SizeT i=0; i<actIx; ++i)
-    {
-      EnvStackT::pointer_type upEnv = callStack[i]; 
-      tmp= upEnv->GetProName();
-      filename=upEnv->GetFilename();
-      if( filename != "")
-        {              
+      for (SizeT i = 0; i < actIx; ++i) {
+        EnvStackT::pointer_type upEnv = callStack[i];
+        tmp = upEnv->GetProName();
+        filename = upEnv->GetFilename();
+        if (filename != "") {
           lineNumber = upEnv->GetLineNumber();
-          if( lineNumber != 0)
-        {
-          tmp=tmp+" <"+filename+"("+i2s(lineNumber)+")>";
+          if (lineNumber != 0) {
+            tmp = tmp + " <" + filename + "(" + i2s(lineNumber) + ")>";
+          }
         }
-        }
-      if (debug) cout << tmp << endl;
-      (*res)[i]=tmp;
-    }
-      
+        if (debug) cout << tmp << endl;
+        (*res)[i] = tmp;
+      }
+
       return res;
     }
 
     if (structureKW) {
       DStructGDL* res = new DStructGDL(
-                       FindInStructList(structList, "IDL_TRACEBACK"),
-                       dimension(actIx));
+        FindInStructList(structList, "IDL_TRACEBACK"),
+        dimension(actIx));
 
       int tRoutine, tFilename, tLine, tLevel, tFunction;
-      int tMethod=0, tRestored=0, tSystem=0;
+      int tMethod = 0, tRestored = 0, tSystem = 0;
 
-      for( SizeT i=0; i<actIx; ++i) {
-    
-    EnvStackT::pointer_type upEnv = callStack[i]; 
-    tmp= upEnv->GetProName();
-    filename=upEnv->GetFilename();
-    if (filename.length() == 0) filename=" ";
-    lineNumber = upEnv->GetLineNumber();
-    
-    tRoutine = res->Desc()->TagIndex("ROUTINE"); 
-    tFilename= res->Desc()->TagIndex("FILENAME"); 
-    tLine= res->Desc()->TagIndex("LINE"); 
-    tLevel= res->Desc()->TagIndex("LEVEL"); 
-    tFunction= res->Desc()->TagIndex("IS_FUNCTION"); 
-    tMethod= res->Desc()->TagIndex("METHOD"); 
-    tRestored= res->Desc()->TagIndex("RESTORED"); 
-    tSystem= res->Desc()->TagIndex("SYSTEM"); 
+      for (SizeT i = 0; i < actIx; ++i) {
 
-    *(res->GetTag(tRoutine, i)) = DStringGDL(tmp);
-    *(res->GetTag(tFilename, i)) = DStringGDL(filename);
-    *(res->GetTag(tLine, i)) = DLongGDL(lineNumber);
-    *(res->GetTag(tLevel, i)) = DLongGDL(i);
+        EnvStackT::pointer_type upEnv = callStack[i];
+        tmp = upEnv->GetProName();
+        filename = upEnv->GetFilename();
+        if (filename.length() == 0) filename = " ";
+        lineNumber = upEnv->GetLineNumber();
 
-    // AC 2015/03/03 : HELP WELCOME
-    // I don't know how to know if we use Pro or Func
-    // we do have a long way in "dinterpreter.cpp" with 
-    // if( firstChar == "#")
-    bool isFunc = false;
-      for (FunListT::iterator ifunc = funList.begin(); ifunc != funList.end(); ++ifunc) {
-        if (StrUpCase(tmp).find((*ifunc)->ObjectName()) != std::string::npos) {
-          isFunc = true;
-          break;
+        tRoutine = res->Desc()->TagIndex("ROUTINE");
+        tFilename = res->Desc()->TagIndex("FILENAME");
+        tLine = res->Desc()->TagIndex("LINE");
+        tLevel = res->Desc()->TagIndex("LEVEL");
+        tFunction = res->Desc()->TagIndex("IS_FUNCTION");
+        tMethod = res->Desc()->TagIndex("METHOD");
+        tRestored = res->Desc()->TagIndex("RESTORED");
+        tSystem = res->Desc()->TagIndex("SYSTEM");
+
+        *(res->GetTag(tRoutine, i)) = DStringGDL(tmp);
+        *(res->GetTag(tFilename, i)) = DStringGDL(filename);
+        *(res->GetTag(tLine, i)) = DLongGDL(lineNumber);
+        *(res->GetTag(tLevel, i)) = DLongGDL(i);
+
+        // AC 2015/03/03 : HELP WELCOME
+        // I don't know how to know if we use Pro or Func
+        // we do have a long way in "dinterpreter.cpp" with
+        // if( firstChar == "#")
+        bool isFunc = false;
+        for (FunListT::iterator ifunc = funList.begin(); ifunc != funList.end(); ++ifunc) {
+          if (StrUpCase(tmp).find((*ifunc)->ObjectName()) != std::string::npos) {
+            isFunc = true;
+            break;
+          }
         }
-      }
-    *(res->GetTag(tFunction, i)) = (isFunc)?DByteGDL(1):DByteGDL(0);
-//all others 0 for the time being
-    *(res->GetTag(tMethod, i)) = DByteGDL(0);
-    *(res->GetTag(tRestored, i)) = DByteGDL(0);
-    *(res->GetTag(tSystem, i)) = DByteGDL(0);
+        *(res->GetTag(tFunction, i)) = (isFunc) ? DByteGDL(1) : DByteGDL(0);
+        //all others 0 for the time being
+        *(res->GetTag(tMethod, i)) = DByteGDL(0);
+        *(res->GetTag(tRestored, i)) = DByteGDL(0);
+        *(res->GetTag(tSystem, i)) = DByteGDL(0);
       }
       return res;
     }
@@ -9075,7 +8883,7 @@ BaseGDL* parse_url( EnvT* env)
 
     DSubUD* pro = static_cast<DSubUD*> (callStack[desiredlevnum - 1]->GetPro());
 
-    SizeT nVar = pro->Size(); // # var in GDL for desired level 
+    SizeT nVar = pro->Size(); // # var in GDL for desired level
     int nKey = pro->NKey();
 
     DString varName;
@@ -9084,8 +8892,7 @@ BaseGDL* parse_url( EnvT* env)
     varName = StrUpCase(varName);
 
     int xI = pro->FindVar(varName);
-    if (xI != -1)
-    {
+    if (xI != -1) {
       //       BaseGDL*& par = ((EnvT*)(callStack[desiredlevnum-1]))->GetPar( xI);
       BaseGDL*& par = callStack[desiredlevnum - 1]->GetTheKW(xI);
 
@@ -9093,8 +8900,7 @@ BaseGDL* parse_url( EnvT* env)
         e->Throw("Variable is undefined: " + varName);
 
       return par->Dup();
-    } else if (acceptNew)
-    {
+    } else if (acceptNew) {
       SizeT u = pro->AddVar(varName);
       SizeT s = callStack[desiredlevnum - 1]->AddEnv();
       BaseGDL*& par = ((EnvT*) (callStack[desiredlevnum - 1]))->GetPar(s - nKey);
@@ -9133,7 +8939,7 @@ BaseGDL* parse_url( EnvT* env)
 
     DSubUD* pro = static_cast<DSubUD*> (callStack[desiredlevnum - 1]->GetPro());
 
-    SizeT nVar = pro->Size(); // # var in GDL for desired level 
+    SizeT nVar = pro->Size(); // # var in GDL for desired level
     int nKey = pro->NKey();
 
     DString varName;
@@ -9141,8 +8947,7 @@ BaseGDL* parse_url( EnvT* env)
     e->AssureScalarPar<DStringGDL>(0, varName);
     varName = StrUpCase(varName);
     int xI = pro->FindVar(varName);
-    if (xI != -1)
-    {
+    if (xI != -1) {
       //       BaseGDL*& par = ((EnvT*)(callStack[desiredlevnum-1]))->GetPar( xI);
       BaseGDL*& par = callStack[desiredlevnum - 1]->GetTheKW(xI);
 
@@ -9150,8 +8955,7 @@ BaseGDL* parse_url( EnvT* env)
       //    e->Throw( "Variable is undefined: " + varName);
 
       return &par;
-    } else if (acceptNew)
-    {
+    } else if (acceptNew) {
       SizeT u = pro->AddVar(varName);
       SizeT s = callStack[desiredlevnum - 1]->AddEnv();
       BaseGDL*& par = ((EnvT*) (callStack[desiredlevnum - 1]))->GetPar(s - nKey);
@@ -9161,155 +8965,132 @@ BaseGDL* parse_url( EnvT* env)
     return NULL; // compiler shut-up
   }
 
-  BaseGDL* scope_varname_fun(EnvT* e)
-  {
+  BaseGDL* scope_varname_fun(EnvT* e) {
 
-    SizeT nParam = e->NParam( );
+    SizeT nParam = e->NParam();
 
-    EnvStackT& callStack = e->Interpreter( )->CallStack( );
+    EnvStackT& callStack = e->Interpreter()->CallStack();
 
-    DLong currentLvl = callStack.size( );
+    DLong currentLvl = callStack.size();
     DLong level = currentLvl; // default to current level
 
     DStringGDL* retVal = nullptr;
-    SizeT count( 0 );
+    SizeT count(0);
 
-    static int commonIx = e->KeywordIx( "COMMON" );
-    static int countIx = e->KeywordIx( "COUNT" );
-    static int levelIx = e->KeywordIx( "LEVEL" );
+    static int commonIx = e->KeywordIx("COMMON");
+    static int countIx = e->KeywordIx("COUNT");
+    static int levelIx = e->KeywordIx("LEVEL");
 
-    if ( e->KeywordSet( commonIx ) )
-      {
+    if (e->KeywordSet(commonIx)) {
 
-        if ( e->KeywordSet( levelIx ) ) e->Throw( "Conflicting keywords." );
+      if (e->KeywordSet(levelIx)) e->Throw("Conflicting keywords.");
 
-        DString commonName = "";
-        e->AssureStringScalarKW( commonIx, commonName );
-        DSubUD* pro = static_cast<DSubUD*> ( e->Caller( )->GetPro( ) );
-        DCommon* common = pro->Common( StrUpCase( commonName ) );
-        if ( common == NULL ) e->Throw( "Common block does not exist: " + commonName );
-        bool passed_list = true;
-        SizeT nComm = common->NVar( );
-        if ( nParam < 1 )
-          {
-            nParam = nComm;
-            passed_list = false;
-          }
-        count=nParam;
-        retVal = new DStringGDL( dimension( count ), BaseGDL::NOZERO );
-        for ( SizeT i( 0 ); i < count; ++i )
-          {
-            DLong ipar = i;
-            if ( passed_list ) e->AssureLongScalarPar( i, ipar );
-            if ( ( ipar >= 0 ) && ( ipar < nComm ) )
-              {
-                ( *retVal )[i] = common->VarName( ipar );
-              }
-            else ( *retVal )[i] = "";
-          }
+      DString commonName = "";
+      e->AssureStringScalarKW(commonIx, commonName);
+      DSubUD* pro = static_cast<DSubUD*> (e->Caller()->GetPro());
+      DCommon* common = pro->Common(StrUpCase(commonName));
+      if (common == NULL) e->Throw("Common block does not exist: " + commonName);
+      bool passed_list = true;
+      SizeT nComm = common->NVar();
+      if (nParam < 1) {
+        nParam = nComm;
+        passed_list = false;
       }
-    else
-      {
-
-        DLongGDL* kwLvl = e->IfDefGetKWAs<DLongGDL>( levelIx );
-        if ( kwLvl )
-          {
-            DLong tmp = ( *kwLvl )[0];
-            if ( tmp > 0 ) level = tmp;
-            else level += tmp;
-            level = std::max( std::min( level, currentLvl ), 1 );
-          }
-
-
-
-        if ( nParam == 0 )
-          { // Just list and return all defined parameters at the requested level.
-            EnvT* requestedScope = (EnvT*) callStack[level - 1];
-            DSubUD* scope_pro = static_cast<DSubUD*> ( requestedScope->GetPro( ) );
-            SizeT scope_nVar = scope_pro->Size( );
-            SizeT scope_nComm = scope_pro->CommonsSize( );
-            count = scope_nVar + scope_nComm;
-            if ( !count )
-              {
-                retVal = new DStringGDL( "" );
-              }
-            else
-              { // N.B. Order doesn't matter since the result is lexically sorted.
-                vector<string> names( count );
-                for ( SizeT i( 0 ); i < scope_nVar; ++i )
-                  {
-                    names[ i ] = scope_pro->GetVarName( i );
-                    if ( names[ i ].empty( ) ) names[ i ] = "*";
-                  }
-                if ( scope_nComm )
-                  {
-                    DStringGDL* list = static_cast<DStringGDL*> ( scope_pro->GetCommonVarNameList( ) );
-                    for ( SizeT i( 0 ); i < list->N_Elements( ); ++i )
-                      {
-                        names[ scope_nVar + i ] = ( *list )[i];
-                      }
-                  }
-                std::sort( names.begin( ), names.end( ) );
-                retVal = new DStringGDL( dimension( count ), BaseGDL::NOZERO );
-                for ( SizeT i( 0 ); i < count; ++i )
-                  {
-                    ( *retVal )[i] = names[i];
-                  }
-              }
-          }
-        else
-          {
-            EnvT* requestedScope = (EnvT*) callStack[level - 1];
-            DSubUD* scope_pro = static_cast<DSubUD*> ( requestedScope->GetPro( ) );
-            SizeT scope_nVar = scope_pro->Size( );
-            SizeT scope_nComm = scope_pro->CommonsSize( );
-            count = nParam;
-            retVal = new DStringGDL( dimension( nParam ), BaseGDL::NOZERO );
-            //retrieve each variable at current level, fetch name at desired level
-            for ( SizeT i( 0 ); i < nParam; ++i )
-              {
-                ( *retVal )[i] = ""; // not found
-                BaseGDL*& par = e->GetPar( i );
-                std::string tmp_name;
-                bool undefineOnExit = false;
-                 //DANGEROUS trick to get parameter name, not <undefined> : avoid to have par=0x0 = NULL
-                if (par==NULL) {
-                    e->SetPar(i, NullGDL::GetSingleInstance()); //make it something not meaningful
-                    par = e->GetPar (i);       
-                    undefineOnExit=true;
-                  }
-                if ( scope_pro->GetCommonVarName( par, tmp_name ) )
-                  { // Variable found in common-block, so use that name first.
-                    ( *retVal )[i] = tmp_name;
-
-                    if ( undefineOnExit ) {
-                        par=NULL;  //PROBABLY WILL CREATE PROBLEM SOMEWHERE ELSE 
-                      };
-                    continue;
-                  }
-                // not defined in common, can only be local.
-                if ( level == currentLvl )
-                  { // For current level we need to resolve using e, but return empty string if not a named variable (ex: expression)
-                    tmp_name = e->GetParString( i );
-                    if ( tmp_name.find( '>' ) == std::string::npos ) ( *retVal )[i] = tmp_name;
-                    if ( undefineOnExit ) {
-                        par=NULL; //PROBABLY WILL CREATE PROBLEM SOMEWHERE ELSE 
-                      };
-                  } else {
-                    tmp_name = requestedScope->GetString (par);
-                    if ( tmp_name.find( '>' ) == std::string::npos ) ( *retVal )[i] = tmp_name;
-                  }
-              }
-          }
-
+      count = nParam;
+      retVal = new DStringGDL(dimension(count), BaseGDL::NOZERO);
+      for (SizeT i(0); i < count; ++i) {
+        DLong ipar = i;
+        if (passed_list) e->AssureLongScalarPar(i, ipar);
+        if ((ipar >= 0) && (ipar < nComm)) {
+          (*retVal)[i] = common->VarName(ipar);
+        } else ( *retVal)[i] = "";
       }
+    } else {
+
+      DLongGDL* kwLvl = e->IfDefGetKWAs<DLongGDL>(levelIx);
+      if (kwLvl) {
+        DLong tmp = (*kwLvl)[0];
+        if (tmp > 0) level = tmp;
+        else level += tmp;
+        level = std::max(std::min(level, currentLvl), 1);
+      }
+
+
+
+      if (nParam == 0) { // Just list and return all defined parameters at the requested level.
+        EnvT* requestedScope = (EnvT*) callStack[level - 1];
+        DSubUD* scope_pro = static_cast<DSubUD*> (requestedScope->GetPro());
+        SizeT scope_nVar = scope_pro->Size();
+        SizeT scope_nComm = scope_pro->CommonsSize();
+        count = scope_nVar + scope_nComm;
+        if (!count) {
+          retVal = new DStringGDL("");
+        } else { // N.B. Order doesn't matter since the result is lexically sorted.
+          vector<string> names(count);
+          for (SizeT i(0); i < scope_nVar; ++i) {
+            names[ i ] = scope_pro->GetVarName(i);
+            if (names[ i ].empty()) names[ i ] = "*";
+          }
+          if (scope_nComm) {
+            DStringGDL* list = static_cast<DStringGDL*> (scope_pro->GetCommonVarNameList());
+            for (SizeT i(0); i < list->N_Elements(); ++i) {
+              names[ scope_nVar + i ] = (*list)[i];
+            }
+          }
+          std::sort(names.begin(), names.end());
+          retVal = new DStringGDL(dimension(count), BaseGDL::NOZERO);
+          for (SizeT i(0); i < count; ++i) {
+            (*retVal)[i] = names[i];
+          }
+        }
+      } else {
+        EnvT* requestedScope = (EnvT*) callStack[level - 1];
+        DSubUD* scope_pro = static_cast<DSubUD*> (requestedScope->GetPro());
+        SizeT scope_nVar = scope_pro->Size();
+        SizeT scope_nComm = scope_pro->CommonsSize();
+        count = nParam;
+        retVal = new DStringGDL(dimension(nParam), BaseGDL::NOZERO);
+        //retrieve each variable at current level, fetch name at desired level
+        for (SizeT i(0); i < nParam; ++i) {
+          (*retVal)[i] = ""; // not found
+          BaseGDL*& par = e->GetPar(i);
+          std::string tmp_name;
+          bool undefineOnExit = false;
+          //DANGEROUS trick to get parameter name, not <undefined> : avoid to have par=0x0 = NULL
+          if (par == NULL) {
+            e->SetPar(i, NullGDL::GetSingleInstance()); //make it something not meaningful
+            par = e->GetPar(i);
+            undefineOnExit = true;
+          }
+          if (scope_pro->GetCommonVarName(par, tmp_name)) { // Variable found in common-block, so use that name first.
+            (*retVal)[i] = tmp_name;
+
+            if (undefineOnExit) {
+              par = NULL; //PROBABLY WILL CREATE PROBLEM SOMEWHERE ELSE
+            };
+            continue;
+          }
+          // not defined in common, can only be local.
+          if (level == currentLvl) { // For current level we need to resolve using e, but return empty string if not a named variable (ex: expression)
+            tmp_name = e->GetParString(i);
+            if (tmp_name.find('>') == std::string::npos) (*retVal)[i] = tmp_name;
+            if (undefineOnExit) {
+              par = NULL; //PROBABLY WILL CREATE PROBLEM SOMEWHERE ELSE
+            };
+          } else {
+            tmp_name = requestedScope->GetString(par);
+            if (tmp_name.find('>') == std::string::npos) (*retVal)[i] = tmp_name;
+          }
+        }
+      }
+
+    }
 
     // set the COUNT keyword
-    if ( e->KeywordPresent( countIx ) )
-      {
-        e->AssureGlobalKW( countIx );
-        e->SetKW( countIx, new DLongGDL( count ) );
-      }
+    if (e->KeywordPresent(countIx)) {
+      e->AssureGlobalKW(countIx);
+      e->SetKW(countIx, new DLongGDL(count));
+    }
 
     return retVal;
 

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -2300,7 +2300,6 @@ namespace lib {
     }
 
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
-    //no use toGDL_NTHREADS=parallelize, fast enough (on par)
     SizeT nEl = p0S->N_Elements();
     for (SizeT i = 0; i < nEl; ++i) {
       (*res)[ i] = (*p0S)[ i].length();
@@ -2330,7 +2329,7 @@ namespace lib {
       return res;
     }
 
-    dimension resDim(p0S->Dim()==1);
+    dimension resDim(p0S->Dim());
     resDim.Purge();
 
     SizeT stride = resDim.Stride(1);

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -70,7 +70,6 @@ extern "C" char **environ;
 #include "objects.hpp"
 //#include "file.hpp"
 
-
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
 #endif
@@ -4042,6 +4041,11 @@ namespace lib {
         if (j == rank)
           e->Throw("Incorrect permutation vector.");
       }
+      //check we transpose something
+      bool identical=true;
+      for (SizeT i = 0; i < rank; ++i) if (perm[i] != i) identical=false;
+      if (identical) return p0->Dup();
+      
       return p0->Transpose(perm);
     }
 

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -2633,7 +2633,7 @@ namespace lib {
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-    if (GDL_NTHREADS=parallelize( (nEl / outerStride)==1)) {
+    if (GDL_NTHREADS=parallelize( (nEl / outerStride) )==1) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
@@ -3400,7 +3400,7 @@ namespace lib {
     SizeT prodStride = srcDim.Stride(prodDimIx);
     SizeT outerStride = srcDim.Stride(prodDimIx + 1);
     SizeT prodLimit = nProd * prodStride;
-    if (GDL_NTHREADS=parallelize( (nEl / outerStride)==1)) {
+    if (GDL_NTHREADS=parallelize( (nEl / outerStride))==1) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1220,8 +1220,7 @@ namespace lib {
     if (re->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
-      if (!parallelize) {
+      if (!parallelize( nE)) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1232,8 +1231,7 @@ namespace lib {
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
-      if (!parallelize) {
+      if (!parallelize( nE)) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1244,8 +1242,7 @@ namespace lib {
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
-      if (!parallelize) {
+      if (!parallelize( nE)) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1256,8 +1253,7 @@ namespace lib {
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));
-      if (!parallelize) {
+      if (!parallelize( nE)) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1813,8 +1809,7 @@ namespace lib {
     if (e1->Scalar()) {
       if (e1->LogTrue(0)) {
         res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl2));
-        if (!parallelize) {
+        if (!parallelize( nEl2)) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
 
         } else {
@@ -1828,8 +1823,7 @@ namespace lib {
     } else if (e2->Scalar()) {
       if (e2->LogTrue(0)) {
         res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl1));
-        if (!parallelize) {
+        if (!parallelize( nEl1)) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1841,8 +1835,7 @@ namespace lib {
       }
     } else if (nEl2 <= nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl2));
-      if (!parallelize) {
+      if (!parallelize( nEl2)) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1852,8 +1845,7 @@ namespace lib {
     } else // ( nEl2 > nEl1)
     {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl1));
-      if (!parallelize) {
+      if (!parallelize( nEl1)) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1882,9 +1874,8 @@ namespace lib {
 
     if (e1->Scalar()) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl2));
       if (e1->LogTrue(0)) {
-        if (!parallelize) {
+        if (!parallelize( nEl2)) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1892,7 +1883,7 @@ namespace lib {
             for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = 1;
         }
       } else {
-        if (!parallelize) {
+        if (!parallelize( nEl2)) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1902,9 +1893,8 @@ namespace lib {
       }
     } else if (e2->Scalar()) {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl1));
       if (e2->LogTrue(0)) {
-        if (!parallelize) {
+        if (!parallelize( nEl1)) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1912,7 +1902,7 @@ namespace lib {
             for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = 1;
         }
       } else {
-        if (!parallelize) {
+        if (!parallelize( nEl1)) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1922,8 +1912,7 @@ namespace lib {
       }
     } else if (nEl2 < nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl2));
-      if (!parallelize) {
+      if (!parallelize( nEl2)) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1932,8 +1921,7 @@ namespace lib {
       }
     } else { // ( nEl2 >= nEl1)
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl1));
-      if (!parallelize) {
+      if (!parallelize( nEl1)) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1951,8 +1939,7 @@ namespace lib {
     ULong nEl1 = e1->N_Elements();
 
     Data_<SpDByte>* res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl1));
-    if (!parallelize) {
+    if (!parallelize( nEl1)) {
       for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2029,10 +2016,9 @@ namespace lib {
 
     SizeT nEl = res->N_Elements();
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (mode == 2) // both
     {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2041,7 +2027,7 @@ namespace lib {
       }
     } else if (mode == 1) // leading
     {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2050,7 +2036,7 @@ namespace lib {
       }
     } else // trailing
     {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2071,8 +2057,7 @@ namespace lib {
     DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2116,8 +2101,7 @@ namespace lib {
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
       }
@@ -2194,8 +2178,7 @@ namespace lib {
       }
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr ) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nSrcStr)));
-    if (!parallelize) {
+    if (!parallelize(nSrcStr)) {
       for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
@@ -2241,11 +2224,10 @@ namespace lib {
     }
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2254,7 +2236,7 @@ namespace lib {
       }
     } else {
       res = p0S;
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2281,11 +2263,10 @@ namespace lib {
     }
 
     SizeT nEl = p0S->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2294,7 +2275,7 @@ namespace lib {
       }
     } else {
       res = p0S;
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2440,8 +2421,7 @@ namespace lib {
   BaseGDL* total_template_generic(T* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
     typename T::Ty sum = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
     } else {
@@ -2464,9 +2444,8 @@ namespace lib {
     SizeT nEl = src->N_Elements();
     DFloat sr = 0;
     DFloat si = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!omitNaN) {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2480,7 +2459,7 @@ namespace lib {
         }
       }
     } else {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2512,9 +2491,8 @@ namespace lib {
     SizeT nEl = src->N_Elements();
     DDouble sr = 0;
     DDouble si = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!omitNaN) {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2528,7 +2506,7 @@ namespace lib {
         }
       }
     } else {
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2560,9 +2538,8 @@ namespace lib {
   DDoubleGDL* total_template_double(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_double "<<std::endl;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     DDouble sum = 0;
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2586,9 +2563,8 @@ namespace lib {
   DFloatGDL* total_template_single(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_single "<<std::endl;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     DDouble sum = 0;
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2616,8 +2592,7 @@ namespace lib {
     //   std::cerr<<" total_template_integer "<<std::endl;
     SizeT nEl = src->N_Elements();
     DLong64 sum = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2659,8 +2634,7 @@ namespace lib {
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * sumStride)));
-    if (!parallelize) {
+    if (!parallelize( (nEl / outerStride))) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
@@ -3312,9 +3286,8 @@ namespace lib {
   BaseGDL* product_template(T* src, bool omitNaN) {
     typename T::Ty prod = 1;
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       if (!omitNaN) for (OMPInt i = 0; i < nEl; ++i) prod *= (*src)[ i];
       else for (OMPInt i = 0; i < nEl; ++i) if (std::isfinite((*src)[ i])) prod *= (*src)[ i];
     } else {
@@ -3334,8 +3307,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       DComplexGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -3368,8 +3340,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexDblGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       DComplexDblGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -3430,8 +3401,7 @@ namespace lib {
     SizeT prodStride = srcDim.Stride(prodDimIx);
     SizeT outerStride = srcDim.Stride(prodDimIx + 1);
     SizeT prodLimit = nProd * prodStride;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * prodStride)));
-    if (!parallelize) {
+    if (!parallelize( (nEl / outerStride))) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
@@ -5421,8 +5391,7 @@ namespace lib {
 
   template <typename Ty> static inline Ty do_mean(const Ty* data, const SizeT sz) {
     Ty mean = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -5435,8 +5404,7 @@ namespace lib {
   template <typename Ty, typename T2> static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         meanr += data[i].real();
         meani += data[i].imag();
@@ -5456,8 +5424,7 @@ namespace lib {
   template <typename Ty> static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
     Ty mean = 0;
     SizeT n = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty v = data[i];
         if (std::isfinite(v)) {
@@ -5484,8 +5451,7 @@ namespace lib {
     T2 meani = 0;
     SizeT nr = 0;
     SizeT ni = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].real();
         if (std::isfinite(v)) {
@@ -5672,8 +5638,7 @@ namespace lib {
 
     Ty var = 0;
     Ty md = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
@@ -5698,7 +5663,7 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5717,7 +5682,7 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (!parallelize) {
+    if (!parallelize(sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5748,8 +5713,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5784,7 +5748,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5824,7 +5788,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (!parallelize) {
+    if (!parallelize(sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5879,8 +5843,7 @@ namespace lib {
     Ty var = 0;
     Ty md = 0;
     SizeT k = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
@@ -5914,7 +5877,7 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5933,7 +5896,7 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5965,8 +5928,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6013,7 +5975,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6053,7 +6015,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (!parallelize) {
+    if (!parallelize( sz)) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6178,7 +6140,6 @@ namespace lib {
       // resize destDim
       destDim.Remove(momentDim); //will be one dimension less
       SizeT nEl = destDim.NDimElementsConst(); //need to compute that here, before adding last dim.
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       auxiliaryDim = destDim;
 
       destDim << 4; //add 4 as last dim
@@ -6208,7 +6169,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6236,7 +6197,7 @@ namespace lib {
             }
           }
         } else {
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6292,7 +6253,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6320,7 +6281,7 @@ namespace lib {
             }
           }
         } else {
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6377,7 +6338,7 @@ namespace lib {
           if (dosdev) sdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (!parallelize) {
+            if (!parallelize( nEl)) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6407,7 +6368,7 @@ namespace lib {
               }
             }
           } else {
-            if (!parallelize) {
+            if (!parallelize( nEl)) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6465,7 +6426,7 @@ namespace lib {
           if (dosdev) sdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (!parallelize) {
+            if (!parallelize( nEl)) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6495,7 +6456,7 @@ namespace lib {
               }
             }
           } else {
-            if (!parallelize) {
+            if (!parallelize( nEl)) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6641,8 +6602,7 @@ namespace lib {
   }
 
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-    bool parallelize = ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
-    if (!parallelize) {
+    if (!parallelize( n)) {
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
@@ -7244,8 +7204,7 @@ namespace lib {
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       if (IntType(p0->Type())) {
         //Is a thread pool function
         for (SizeT i = 0; i < nEl; ++i) {

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1222,45 +1222,49 @@ namespace lib {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
-      } else
+      if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
+      }
       return res;
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
-      } else
+      if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
+      }
       return res;
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
-      } else
+      if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+      }
       return res;
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
-      } else
+      if (!parallelize) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+      }
       return res;
     }
   }
@@ -1993,30 +1997,30 @@ namespace lib {
     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (mode == 2) // both
     {
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       }
     } else if (mode == 1) // leading
     {
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       }
     } else // trailing
     {
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       }
     }
     return res;
@@ -2037,7 +2041,7 @@ namespace lib {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
       }
@@ -2084,7 +2088,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
       }
@@ -2170,7 +2174,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) default( shared)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) default( shared)
         for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
@@ -2206,21 +2210,21 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       }
     }
     return res;
@@ -2246,21 +2250,21 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
-      if (parallelize) {
-        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
-          for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
-      } else {
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       }
     }
     return res;
@@ -2410,11 +2414,11 @@ namespace lib {
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for reduction(+:sum) num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel for reduction(+:sum) num_threads(CpuTPOOL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS)
         {
           typename T::Ty localsum = 0;
 #pragma omp for
@@ -2442,7 +2446,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sr,si)
           for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2457,7 +2461,7 @@ namespace lib {
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS)
         {
           DFloat lsr = 0;
           DFloat lsi = 0;
@@ -2490,7 +2494,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sr,si)
           for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2505,7 +2509,7 @@ namespace lib {
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS)
         {
           DDouble lsr = 0;
           DDouble lsi = 0;
@@ -2540,12 +2544,12 @@ namespace lib {
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
           for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS)
         {
           DDouble localsum = 0;
 #pragma omp for nowait
@@ -2573,12 +2577,12 @@ namespace lib {
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
           for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS)
         {
           DDouble localsum = 0;
 #pragma omp for nowait
@@ -2603,7 +2607,7 @@ namespace lib {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     }
     return new DLong64GDL(sum);
@@ -2687,7 +2691,7 @@ namespace lib {
     } else {
       if (omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -2699,7 +2703,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -3332,7 +3336,7 @@ namespace lib {
       if (!omitNaN) {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) shared(prod)
         {
 #pragma omp for reduction(*:prod)
           for (OMPInt i = 0; i < nEl; ++i) {
@@ -3342,7 +3346,7 @@ namespace lib {
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) shared(prod)
         {
 #pragma omp for reduction(*:prod)
           for (OMPInt i = 0; i < nEl; ++i) {
@@ -3447,7 +3451,7 @@ namespace lib {
     } else {
       if (omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -3460,7 +3464,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -5415,7 +5419,7 @@ namespace lib {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:mean)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:mean)
         for (SizeT i = 0; i < sz; ++i) mean += data[i];
     }
     return mean / sz;
@@ -5431,7 +5435,7 @@ namespace lib {
     } else {
 
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) 
       {
 #pragma omp for reduction(+:meanr)
         for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
@@ -5457,7 +5461,7 @@ namespace lib {
     } else {
 
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS)
       {
 #pragma omp for reduction(+:mean,n)
         for (SizeT i = 0; i < sz; ++i) {
@@ -5496,7 +5500,7 @@ namespace lib {
     } else {
 
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS)
       {
 #pragma omp for reduction(+:meanr,nr)
         for (SizeT i = 0; i < sz; ++i) {
@@ -5683,7 +5687,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:var,md)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
@@ -5707,7 +5711,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skew)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5726,7 +5730,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurt)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5762,7 +5766,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:varr,vari,mdr)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5803,7 +5807,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skewr,skewi)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5846,7 +5850,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurtr,kurti)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5893,7 +5897,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md,k)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:var,md,k)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
@@ -5923,7 +5927,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skew)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5942,7 +5946,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurt)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5985,7 +5989,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr,kr,ki)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:varr,vari,mdr,kr,ki)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6032,7 +6036,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skewr,skewi)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6075,7 +6079,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurtr,kurti)
         for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6224,7 +6228,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6252,7 +6256,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6308,7 +6312,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6336,7 +6340,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6394,7 +6398,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
                 for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6424,7 +6428,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
                 for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6482,7 +6486,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
                 for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6512,7 +6516,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
                 for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6651,7 +6655,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
@@ -7276,7 +7280,7 @@ namespace lib {
       if (IntType(p0->Type())) {
         //Is a thread pool function
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
@@ -7289,7 +7293,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1266,9 +1266,8 @@ namespace lib {
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
-        SizeT i;
-#pragma omp parallel for private(i)
-        for (i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       } else 
         for (SizeT i = 0; i < nE; i++)  (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       return res;
@@ -1277,9 +1276,8 @@ namespace lib {
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
-        SizeT i;
-#pragma omp parallel for private(i)
-        for (i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       return res; 
@@ -1288,9 +1286,8 @@ namespace lib {
       SizeT nE = im->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
-        SizeT i;
-#pragma omp parallel for private(i)
-        for (i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nE; ++i)  (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else 
         for (SizeT i = 0; i < nE; i++)  (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       return res;
@@ -1299,9 +1296,8 @@ namespace lib {
       SizeT nE = re->N_Elements();
       bool parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nE));
       if (parallelize) {
-        SizeT i;
-#pragma omp parallel for private(i)
-        for (i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       return res;
@@ -1888,9 +1884,7 @@ namespace lib {
     if( e1->LogTrue(0)) 
       {
         res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl2))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl2; i++)
         (*res)[i] = e2->LogTrue( i) ? 1 : 0;
         }
@@ -1905,9 +1899,7 @@ namespace lib {
     if( e2->LogTrue(0)) 
       {
         res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl1; i++)
         (*res)[i] = e1->LogTrue( i) ? 1 : 0;
         }
@@ -1920,9 +1912,7 @@ namespace lib {
     else if( nEl2 <= nEl1) 
       {
     res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
-    // #pragma omp parallel if (nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl2))
     {
-      // #pragma omp for
       for( SizeT i=0; i < nEl2; i++)
         (*res)[i] = (e1->LogTrue( i) && e2->LogTrue( i)) ? 1 : 0;
     }
@@ -1930,9 +1920,7 @@ namespace lib {
     else // ( nEl2 > nEl1)
       {
     res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-    // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
     {
-      // #pragma omp for
       for( SizeT i=0; i < nEl1; i++)
         (*res)[i] = (e1->LogTrue( i) && e2->LogTrue( i)) ? 1 : 0;
     }
@@ -1961,9 +1949,7 @@ namespace lib {
     if( e1->LogTrue(0)) 
       {
         res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl2))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl2; i++)
         (*res)[i] = 1;
         }
@@ -1971,9 +1957,7 @@ namespace lib {
     else
       {
         res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl2))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl2; i++)
         (*res)[i] = e2->LogTrue( i) ? 1 : 0;
         }
@@ -1984,9 +1968,7 @@ namespace lib {
     if( e2->LogTrue(0)) 
       {
         res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl1; i++)
         (*res)[i] = 1;
         }
@@ -1994,9 +1976,7 @@ namespace lib {
     else
       {
         res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-        // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
         {
-          // #pragma omp for
           for( SizeT i=0; i < nEl1; i++)
         (*res)[i] = e1->LogTrue( i) ? 1 : 0;
         }
@@ -2005,9 +1985,7 @@ namespace lib {
     else if( nEl2 < nEl1) 
       {
     res= new Data_<SpDByte>( e2->Dim(), BaseGDL::NOZERO);
-    // #pragma omp parallel if (nEl2 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl2))
     {
-      // #pragma omp for
       for( SizeT i=0; i < nEl2; i++)
         (*res)[i] = (e1->LogTrue( i) || e2->LogTrue( i)) ? 1 : 0;
     }
@@ -2015,9 +1993,7 @@ namespace lib {
     else // ( nEl2 >= nEl1)
       {
     res= new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-    // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
     {
-      // #pragma omp for
       for( SizeT i=0; i < nEl1; i++)
         (*res)[i] = (e1->LogTrue( i) || e2->LogTrue( i)) ? 1 : 0;
     }
@@ -2032,9 +2008,7 @@ namespace lib {
     ULong nEl1 = e1->N_Elements();
 
     Data_<SpDByte>* res = new Data_<SpDByte>( e1->Dim(), BaseGDL::NOZERO);
-    // #pragma omp parallel if (nEl1 >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl1))
     {
-      // #pragma omp for
       for( SizeT i=0; i < nEl1; i++)
     (*res)[i] = e1->LogTrue( i) ? 1 : 0;
     }    
@@ -2056,130 +2030,106 @@ namespace lib {
 
     return p0->New( dim, BaseGDL::INIT);
   }
+static const std::string trimmable(" \t");
 
-  BaseGDL* strtrim( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 1);//, "STRTRIM");
-
-    BaseGDL* p0 = e->GetPar( 0);
-    if( p0 == NULL)
-      e->Throw("Variable is undefined: " + e->GetParString(0));
-    DStringGDL* p0S = static_cast<DStringGDL*>(p0->Convert2(GDL_STRING,BaseGDL::COPY));
-    
-    DLong mode = 0;
-    if( nParam == 2)
-      {
-    BaseGDL* p1 = e->GetPar( 1);
-    if( p1 == NULL)
-      e->Throw("Variable is undefined: "+e->GetParString(1));
-    if( !p1->Scalar())
-      e->Throw("Expression must be a scalar in this context: "+
-           e->GetParString(1));
-    DLongGDL* p1L = static_cast<DLongGDL*>
-      (p1->Convert2(GDL_LONG,BaseGDL::COPY));
-
-    mode = (*p1L)[ 0];
-
-    GDLDelete(p1L);
-
-    if( mode < 0 || mode > 2)
-      {
-        ostringstream os;
-        p1->ToStream( os);
-        e->Throw( "Value of <"+ p1->TypeStr() + "  ("+ os.str() +
-              ")> is out of allowed range.");
-      }
-      }
-    
-    SizeT nEl = p0S->N_Elements();
-
-    if( mode == 2) // both
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        unsigned long first= (*p0S)[ i].find_first_not_of(" \t");
-//      if( first == (*p0S)[ i].npos)
-                if (first >= (*p0S)[i].length())
-          {
-            (*p0S)[ i] = "";
-          }
-        else
-          {
-            unsigned long last = (*p0S)[ i].find_last_not_of(" \t");
-            (*p0S)[ i] = (*p0S)[ i].substr(first,last-first+1);
-          }
-          }
-      }
-      }
-    else if( mode == 1) // leading
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        unsigned long first= (*p0S)[ i].find_first_not_of(" \t");
-//      if( first == (*p0S)[ i].npos)
-            if (first >= (*p0S)[i].length())
-          {
-            (*p0S)[ i] = "";
-          }
-        else
-          {
-            (*p0S)[ i] = (*p0S)[ i].substr(first);
-          }
-          }
-      }
-      }
-    else // trailing
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        unsigned long last = (*p0S)[ i].find_last_not_of(" \t");
-//      if( last == (*p0S)[ i].npos)
-            if (last >= (*p0S)[i].length())
-          {
-            (*p0S)[ i] = "";
-          }
-        else
-          {
-            (*p0S)[ i] = (*p0S)[ i].substr(0,last+1);
-          }
-          }
-      }
-      }
-    return p0S;
+ 
+  //leading blanks
+  inline void trim1(std::string &s) {
+    std::size_t found = s.find_first_not_of(trimmable);
+    if (found != std::string::npos)
+      s.erase(0,found);
+    else
+      s.clear();
+  }
+  //trailing blanks
+  inline void trim0(std::string &s) {
+    std::size_t found = s.find_last_not_of(trimmable);
+    if (found != std::string::npos)
+      s.erase(found + 1);
+    else
+      s.clear();
+  }
+ inline void trim2(std::string &s) {
+    trim0(s);
+    trim1(s);
   }
 
-  BaseGDL* strcompress( EnvT* e)
-  {
-    e->NParam( 1);
+  BaseGDL* strtrim(EnvT* e) {
+    SizeT nParam = e->NParam(1); //, "STRTRIM");
 
-    DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
+    BaseGDL* p0 = e->GetPar(0);
+    if (p0 == NULL)   e->Throw("Variable is undefined: " + e->GetParString(0));
 
-    bool removeAll =  e->KeywordSet(0);
+    DLong mode = 0;
+    if (nParam == 2) {
+      e->AssureLongScalarPar(1,mode);
 
-    DStringGDL* res = new DStringGDL( p0S->Dim(), BaseGDL::NOZERO);
+      if (mode < 0 || mode > 2) {
+        ostringstream os;
+        e->GetPar(1)->ToStream(os);
+        e->Throw("Value of <" + e->GetPar(1)->TypeStr() + "  (" + os.str() +
+          ")> is out of allowed range.");
+      }
+    }
+    
+    DStringGDL* res;
+
+    if (p0->Type() == GDL_STRING)
+      res = static_cast<DStringGDL*>(p0->Dup());
+    else {
+      res = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
+    }
+    
+    SizeT nEl = res->N_Elements();
+    
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (mode == 2) // both
+    {
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
+      }
+    } else if (mode == 1) // leading
+    {
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
+      }
+    } else // trailing
+    {
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
+      }
+    }
+    return res;
+  }
+
+  BaseGDL* strcompress(EnvT* e) {
+    e->NParam(1);
+
+    DStringGDL* p0S = e->GetParAs<DStringGDL>(0);
+
+    bool removeAll = e->KeywordSet(0);
+
+    DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-    for( OMPInt i=0; i<nEl; ++i)
-      {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+      for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
       }
-      }
+    }
     return res;
   }
 
@@ -2216,241 +2166,209 @@ namespace lib {
 
     DLongGDL* res = new DLongGDL( p0S->Dim(), BaseGDL::NOZERO);
 
-    SizeT nSrcStr = p0S->N_Elements();
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nSrcStr*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr*10)))
+    SizeT nEl = p0S->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) {
+        (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
+      }      
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+    for( OMPInt i=0; i<nEl; ++i)
       {
-#pragma omp for
-    for( OMPInt i=0; i<nSrcStr; ++i)
-      {
-        (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, 
-                reverseOffset, reverseSearch);
-      }
-      }    
+        (*res)[ i] = StrPos((*p0S)[ i], searchString, pos,  reverseOffset, reverseSearch);
+      } 
+    }
     return res;
   }
 
-  BaseGDL* strmid( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 2);//, "STRMID");
+  BaseGDL* strmid(EnvT* e) {
+    SizeT nParam = e->NParam(2); //, "STRMID");
 
-    bool reverse =  e->KeywordSet(0);
+    bool reverse = e->KeywordSet(0);
 
-    DStringGDL* p0S = e->GetParAs<DStringGDL>( 0);
-    DLongGDL*   p1L = e->GetParAs<DLongGDL>( 1);
+    DStringGDL* p0S = e->GetParAs<DStringGDL>(0);
+    DLongGDL* p1L = e->GetParAs<DLongGDL>(1);
 
     //     BaseGDL*  p2  = e->GetPar( 2);
     DLongGDL* p2L = NULL;
-    if( nParam > 2) p2L = e->GetParAs<DLongGDL>( 2);
+    if (nParam > 2) p2L = e->GetParAs<DLongGDL>(2);
 
     DLong scVal1;
-    bool sc1 = p1L->Scalar( scVal1);
+    bool sc1 = p1L->Scalar(scVal1);
 
     DLong scVal2 = numeric_limits<DLong>::max();
     bool sc2 = true;
-    if( p2L != NULL) 
-      {
-    DLong scalar;
-    sc2 = p2L->Scalar( scalar);
-    scVal2 = scalar;
-      }
+    if (p2L != NULL) {
+      DLong scalar;
+      sc2 = p2L->Scalar(scalar);
+      scVal2 = scalar;
+    }
 
     DLong stride;
-    if( !sc1 && !sc2)
-      {
-    stride = p1L->Dim( 0);
-    if( stride != p2L->Dim( 0))
-      e->Throw( "Starting offset and length arguments "
-            "have incompatible first dimension.");    
-      }
-    else
-      {
-    // at least one scalar, p2L possibly NULL
-    if( p2L == NULL)
-      stride = p1L->Dim( 0);
-    else
-      stride = max( p1L->Dim( 0), p2L->Dim( 0));
-    
-    stride = (stride > 0)? stride : 1;
-      }
+    if (!sc1 && !sc2) {
+      stride = p1L->Dim(0);
+      if (stride != p2L->Dim(0))
+        e->Throw("Starting offset and length arguments "
+        "have incompatible first dimension.");
+    } else {
+      // at least one scalar, p2L possibly NULL
+      if (p2L == NULL)
+        stride = p1L->Dim(0);
+      else
+        stride = max(p1L->Dim(0), p2L->Dim(0));
 
-    dimension resDim( p0S->Dim());
-    if( stride > 1)
+      stride = (stride > 0) ? stride : 1;
+    }
+
+    dimension resDim(p0S->Dim());
+    if (stride > 1)
       resDim >> stride;
 
-    DStringGDL* res = new DStringGDL( resDim, BaseGDL::NOZERO);
+    DStringGDL* res = new DStringGDL(resDim, BaseGDL::NOZERO);
 
     SizeT nEl1 = p1L->N_Elements();
-    SizeT nEl2 = (sc2)? 1 : p2L->N_Elements();
+    SizeT nEl2 = (sc2) ? 1 : p2L->N_Elements();
 
     SizeT nSrcStr = p0S->N_Elements();
-    if( nSrcStr == 1)
-      {
-    // possibly this optimization is not worth the longer code (as the gain can only be a small fraction
-    // of the overall time), but then this is a very common use
-    for( long ii=0; ii<stride; ++ii)
-      {
+    if (nSrcStr == 1) {
+      // possibly this optimization is not worth the longer code (as the gain can only be a small fraction
+      // of the overall time), but then this is a very common use
+      for (long ii = 0; ii < stride; ++ii) {
         SizeT destIx = ii;
-        DLong actFirst = (sc1)? scVal1 : (*p1L)[ destIx % nEl1];
-        DLong actLen   = (sc2)? scVal2 : (*p2L)[ destIx % nEl2];
-        if( actLen <= 0)
-          (*res)[ destIx] = "";//StrMid((*p0S)[ i], actFirst, actLen, reverse);
-        else    
+        DLong actFirst = (sc1) ? scVal1 : (*p1L)[ destIx % nEl1];
+        DLong actLen = (sc2) ? scVal2 : (*p2L)[ destIx % nEl2];
+        if (actLen <= 0)
+          (*res)[ destIx] = ""; //StrMid((*p0S)[ i], actFirst, actLen, reverse);
+        else
           (*res)[ destIx] = StrMid((*p0S)[ 0], actFirst, actLen, reverse);
       }
-    return res;
+      return res;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nSrcStr * 10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr * 10)));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nSrcStr; ++i) {
+        for (long ii = 0; ii < stride; ++ii) {
+          SizeT destIx = i * stride + ii;
+          DLong actFirst = (sc1) ? scVal1 : (*p1L)[ destIx % nEl1];
+          DLong actLen = (sc2) ? scVal2 : (*p2L)[ destIx % nEl2];
+          if (actLen <= 0)
+            (*res)[ destIx] = ""; //StrMid((*p0S)[ i], actFirst, actLen, reverse);
+          else
+            (*res)[ destIx] = StrMid((*p0S)[ i], actFirst, actLen, reverse);
+        }
       }
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nSrcStr*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nSrcStr*10))) default( shared)
-      {
-#pragma omp for
-    for( OMPInt i=0; i<nSrcStr; ++i)
-      {
-        for( long ii=0; ii<stride; ++ii)
-          {
-        SizeT destIx = i * stride + ii;
-        DLong actFirst = (sc1)? scVal1 : (*p1L)[ destIx % nEl1];
-        DLong actLen   = (sc2)? scVal2 : (*p2L)[ destIx % nEl2];
-        if( actLen <= 0)
-          (*res)[ destIx] = "";//StrMid((*p0S)[ i], actFirst, actLen, reverse);
-        else    
-          (*res)[ destIx] = StrMid((*p0S)[ i], actFirst, actLen, reverse);
-          }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) default( shared)
+      for (OMPInt i = 0; i < nSrcStr; ++i) {
+        for (long ii = 0; ii < stride; ++ii) {
+          SizeT destIx = i * stride + ii;
+          DLong actFirst = (sc1) ? scVal1 : (*p1L)[ destIx % nEl1];
+          DLong actLen = (sc2) ? scVal2 : (*p2L)[ destIx % nEl2];
+          if (actLen <= 0)
+            (*res)[ destIx] = ""; //StrMid((*p0S)[ i], actFirst, actLen, reverse);
+          else
+            (*res)[ destIx] = StrMid((*p0S)[ i], actFirst, actLen, reverse);
+        }
       }
-      }    
+    }
     return res;
   }
 
-  BaseGDL* strlowcase( BaseGDL* p0, bool isReference)//( EnvT* e)
+  BaseGDL* strlowcase(BaseGDL* p0, bool isReference)//( EnvT* e)
   {
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     DStringGDL* p0S;
     DStringGDL* res;
-    //  Guard<DStringGDL> guard;
+    Guard<DStringGDL> guard;
 
-    if( p0->Type() == GDL_STRING)
-      {
-    p0S = static_cast<DStringGDL*>( p0);
-    if( !isReference)
-      res = p0S;
-    else
-      res = new DStringGDL( p0S->Dim(), BaseGDL::NOZERO);
-      }
-    else
-      {
-    p0S = static_cast<DStringGDL*>( p0->Convert2( GDL_STRING, BaseGDL::COPY));
-    res = p0S;
-    //      guard.Reset( p0S);
-      }
+    if (p0->Type() == GDL_STRING)
+      p0S = static_cast<DStringGDL*> (p0);
+    else {
+      p0S = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
+      guard.Reset(p0S);
+      isReference=true;
+    }
 
-    //     DStringGDL* res = new DStringGDL( p0S->Dim(), BaseGDL::NOZERO);
-    
     SizeT nEl = p0S->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
 
-    if( res == p0S)
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        StrLowCaseInplace((*p0S)[ i]);
-          }
+    if (isReference) {
+      res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       }
+    } else {
+      res = p0S;
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       }
-    else
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        (*res)[ i] = StrLowCase((*p0S)[ i]);
-          }
-      }
-      }
+    }
     return res;
   }
 
-  BaseGDL* strupcase( BaseGDL* p0, bool isReference)//( EnvT* e)
+  BaseGDL* strupcase(BaseGDL* p0, bool isReference)//( EnvT* e)
   {
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     DStringGDL* p0S;
     DStringGDL* res;
-    //  Guard<DStringGDL> guard;
+    Guard<DStringGDL> guard;
 
-    if( p0->Type() == GDL_STRING)
-      {
-    p0S = static_cast<DStringGDL*>( p0);
-    if( !isReference)
-      res = p0S;
-    else
-      res = new DStringGDL( p0S->Dim(), BaseGDL::NOZERO);
-      }
-    else
-      {
-    p0S = static_cast<DStringGDL*>( p0->Convert2( GDL_STRING, BaseGDL::COPY));
-    res = p0S;
-    //      guard.Reset( p0S);
-      }
-
-    //     DStringGDL* res = new DStringGDL( p0S->Dim(), BaseGDL::NOZERO);
+    if (p0->Type() == GDL_STRING)
+      p0S = static_cast<DStringGDL*> (p0);
+    else {
+      p0S = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
+      guard.Reset(p0S);
+      isReference = true;
+    }
 
     SizeT nEl = p0S->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
 
-    if( res == p0S)
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        StrUpCaseInplace((*p0S)[ i]);
-          }
+    if (isReference) {
+      res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       }
+    } else {
+      res = p0S;
+      if (parallelize) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       }
-    else
-      {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if ((nEl*10) >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl*10)))
-      {
-#pragma omp for
-        for( OMPInt i=0; i<nEl; ++i)
-          {
-        (*res)[ i] = StrUpCase((*p0S)[ i]);
-          }
-      }
-      }
+    }
     return res;
   }
-
-  BaseGDL* strlen( BaseGDL* p0, bool isReference)//( EnvT* e)
+  
+  BaseGDL* strlen(BaseGDL* p0, bool isReference)//( EnvT* e)
   {
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     DStringGDL* p0S;
     Guard<DStringGDL> guard;
-    
-    if( p0->Type() == GDL_STRING)
-      p0S = static_cast<DStringGDL*>( p0);
-    else
-      {
-    p0S = static_cast<DStringGDL*>( p0->Convert2( GDL_STRING, BaseGDL::COPY));
-    guard.Reset( p0S);
-      }
 
-    DLongGDL* res = new DLongGDL( p0S->Dim(), BaseGDL::NOZERO);
-
-    SizeT nEl = p0S->N_Elements();
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-      // #pragma omp for
-      for( SizeT i=0; i<nEl; ++i)
-    {
-      (*res)[ i] = (*p0S)[ i].length();
+    if (p0->Type() == GDL_STRING)
+      p0S = static_cast<DStringGDL*> (p0);
+    else {
+      p0S = static_cast<DStringGDL*> (p0->Convert2(GDL_STRING, BaseGDL::COPY));
+      guard.Reset(p0S);
     }
+
+    DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
+//no use to parallelize, fast enough (on par)
+    SizeT nEl = p0S->N_Elements();
+    for (SizeT i = 0; i < nEl; ++i) {
+      (*res)[ i] = (*p0S)[ i].length();
     }
     return res;
   }
@@ -2583,59 +2501,71 @@ namespace lib {
   // total over all elements, preserve type
 
   template<class T>
-  BaseGDL* total_template_generic(T* src, bool omitNaN)
-  {
+  BaseGDL* total_template_generic(T* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
     typename T::Ty sum = 0;
-    bool parallelize=(CpuTPOOL_NTHREADS> 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
-    if (parallelize) {
-      SizeT i;
-      if (!omitNaN) {
-#pragma omp  parallel for reduction(+:sum) private(i)
-      for (i = 0; i < nEl; ++i) sum += (*src)[ i];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+      else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
+    } else {
+        if (!omitNaN) {
+#pragma omp  parallel for reduction(+:sum) num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
-#pragma omp  parallel
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         {
           typename T::Ty localsum = 0;
-#pragma omp for nowait
+#pragma omp for  
           for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) localsum += (*src)[ i];
 #pragma omp atomic
           sum += localsum;
         }
       }
-    } else {
-      if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
-      else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
     }
     return new T(sum);
   }
- 
+
   template<>
-  BaseGDL* total_template_generic(DComplexGDL* src, bool omitNaN)
-  {
+  BaseGDL* total_template_generic(DComplexGDL* src, bool omitNaN) {
     //    std::cerr << " total_template_generic_DComplexGdl " << std::endl;
     SizeT nEl = src->N_Elements();
     DFloat sr = 0;
     DFloat si = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (!omitNaN) {
-#pragma omp  parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) reduction(+:sr,si)
-      for (SizeT i = 0; i < nEl; ++i) {
-        sr += (*src)[i].real();
-        si += (*src)[i].imag();
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          sr += (*src)[i].real();
+          si += (*src)[i].imag();
+        }
+      } else {
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
+        for (SizeT i = 0; i < nEl; ++i) {
+          sr += (*src)[i].real();
+          si += (*src)[i].imag();
+        }
       }
     } else {
-#pragma omp  parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-        DFloat lsr = 0;
-        DFloat lsi = 0;
-#pragma omp for nowait
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) {
-          if (isfinite((*src)[i].real())) lsr += (*src)[i].real();
-          if (isfinite((*src)[i].imag())) lsi += (*src)[i].imag();
+          if (isfinite((*src)[i].real())) sr += (*src)[i].real();
+          if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
         }
+      } else {
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        {
+          DFloat lsr = 0;
+          DFloat lsi = 0;
+#pragma omp for nowait
+          for (SizeT i = 0; i < nEl; ++i) {
+            if (isfinite((*src)[i].real())) lsr += (*src)[i].real();
+            if (isfinite((*src)[i].imag())) lsi += (*src)[i].imag();
+          }
 #pragma omp atomic
-        sr += lsr;
-        si += lsi;
+          sr += lsr;
+          si += lsi;
+        }
       }
     }
     return new DComplexGDL(std::complex<float>(sr, si));
@@ -2648,25 +2578,40 @@ namespace lib {
     SizeT nEl = src->N_Elements();
     DDouble sr = 0;
     DDouble si = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (!omitNaN) {
-#pragma omp  parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) reduction(+:sr,si)
-      for (SizeT i = 0; i < nEl; ++i) {
-        sr += (*src)[i].real();
-        si += (*src)[i].imag();
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          sr += (*src)[i].real();
+          si += (*src)[i].imag();
+        }
+      } else {
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sr,si)
+        for (SizeT i = 0; i < nEl; ++i) {
+          sr += (*src)[i].real();
+          si += (*src)[i].imag();
+        }
       }
     } else {
-#pragma omp  parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-        DDouble lsr = 0;
-        DDouble lsi = 0;
-#pragma omp for nowait
+      if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) {
-          if (isfinite((*src)[i].real())) lsr += (*src)[i].real();
-          if (isfinite((*src)[i].imag())) lsi += (*src)[i].imag();
+          if (isfinite((*src)[i].real())) sr += (*src)[i].real();
+          if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
         }
+      } else {
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        {
+          DDouble lsr = 0;
+          DDouble lsi = 0;
+#pragma omp for nowait
+          for (SizeT i = 0; i < nEl; ++i) {
+            if (isfinite((*src)[i].real())) lsr += (*src)[i].real();
+            if (isfinite((*src)[i].imag())) lsi += (*src)[i].imag();
+          }
 #pragma omp atomic
-        sr += lsr;
-        si += lsi;
+          sr += lsr;
+          si += lsi;
+        }
       }
     }
     return new DComplexDblGDL(std::complex<double>(sr, si));
@@ -2675,48 +2620,60 @@ namespace lib {
   // total over all elements, done on Double. Avoids costly convert! 
 
   template<class T>
-  DDoubleGDL* total_template_double(T* src, bool omitNaN)
-  {
+  DDoubleGDL* total_template_double(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_double "<<std::endl;
     SizeT nEl = src->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     DDouble sum = 0;
-    if (!omitNaN) {
-#pragma omp  parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) reduction(+:sum)
-      for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+    if (!parallelize) {
+      if (!omitNaN) {
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
+      }
     } else {
-#pragma omp  parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-        DDouble localsum = 0;
+      if (!omitNaN) {
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+      } else {
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+        {
+          DDouble localsum = 0;
 #pragma omp for nowait
-        for (SizeT i = 0; i < nEl; ++i) {
-          if (isfinite((*src)[i])) localsum += (*src)[ i];
-        }
+          for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) localsum += (*src)[ i];
 #pragma omp atomic
-        sum += localsum;
+          sum += localsum;
+        }
       }
     }
     return new DDoubleGDL(sum);
   }
 
   template<class T>
-  DFloatGDL* total_template_single(T* src, bool omitNaN)
-  {
+  DFloatGDL* total_template_single(T* src, bool omitNaN) {
     //   std::cerr<<" total_template_single "<<std::endl;
     SizeT nEl = src->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     DDouble sum = 0;
-    if (!omitNaN) {
-#pragma omp  parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) reduction(+:sum)
-      for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+    if (!parallelize) {
+      if (!omitNaN) {
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+      } else {
+        for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
+      }
     } else {
-#pragma omp  parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-        DDouble localsum = 0;
+      if (!omitNaN) {
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+        for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+      } else {
+#pragma omp  parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+        {
+          DDouble localsum = 0;
 #pragma omp for nowait
-        for (SizeT i = 0; i < nEl; ++i) {
-          if (isfinite((*src)[i])) localsum += (*src)[ i];
-        }
+          for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) localsum += (*src)[ i];
 #pragma omp atomic
-        sum += localsum;
+          sum += localsum;
+        }
       }
     }
     return new DFloatGDL(sum);
@@ -2725,13 +2682,17 @@ namespace lib {
   //special case for /INT  using LONG64
 
   template<class T>
-  DLong64GDL* total_template_integer(T* src)
-  {
+  DLong64GDL* total_template_integer(T* src) {
     //   std::cerr<<" total_template_integer "<<std::endl;
     SizeT nEl = src->N_Elements();
     DLong64 sum = 0;
-#pragma omp  parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) reduction(+:sum)
-    for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+    } else {
+#pragma omp  parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:sum)
+      for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
+    }
     return new DLong64GDL(sum);
   }
 
@@ -2761,7 +2722,6 @@ namespace lib {
     SizeT nEl=val->N_Elements();
     res=static_cast<T2*>(val->DataAddr());
     if (omitNaN) {
-       #pragma omp parallel for if (CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i) NaN2Zero(res[i]);
     }
     //this formulation is slightly faster on my machine
@@ -2789,11 +2749,9 @@ namespace lib {
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-
-    if (omitNaN) {
-#pragma omp parallel if ((nEl/outerStride)*sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*sumStride))
-      {
-#pragma omp for
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl/outerStride)*sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*sumStride)));
+    if (!parallelize) {
+      if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -2803,11 +2761,7 @@ namespace lib {
             ++rIx;
           }
         }
-      }
-    } else {
-#pragma omp parallel if ((nEl/outerStride)*sumStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*sumStride))
-      {
-#pragma omp for
+      } else {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -2818,6 +2772,30 @@ namespace lib {
           }
         }
       }
+    } else {
+    if (omitNaN) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT o = 0; o < nEl; o += outerStride) {
+          SizeT rIx = (o / outerStride) * sumStride;
+          for (SizeT i = 0; i < sumStride; ++i) {
+            SizeT oi = o + i;
+            SizeT oiLimit = sumLimit + oi;
+            for (SizeT s = oi; s < oiLimit; s += sumStride) AddOmitNaN((*res)[ rIx], (*src)[ s]);
+            ++rIx;
+          }
+        }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT o = 0; o < nEl; o += outerStride) {
+          SizeT rIx = (o / outerStride) * sumStride;
+          for (SizeT i = 0; i < sumStride; ++i) {
+            SizeT oi = o + i;
+            SizeT oiLimit = sumLimit + oi;
+            for (SizeT s = oi; s < oiLimit; s += sumStride) (*res)[ rIx] += (*src)[ s];
+            ++rIx;
+          }
+        }
+    }
     }
     return res;
   }
@@ -3412,33 +3390,45 @@ namespace lib {
   template<> inline void Nan2One(DComplex& value)
   { Nan2OneCpx< DComplex>(value); }
   template<> inline void Nan2One(DComplexDbl& value)
-  { Nan2OneCpx< DComplexDbl>(value); }
+  { Nan2OneCpx< DComplexDbl>(value);
+  }
 
   // product over all elements
+
   template<class T>
   BaseGDL* product_template(T* src, bool omitNaN) {
     typename T::Ty prod = 1;
     SizeT nEl = src->N_Elements();
-    if (!omitNaN) {
-
-      TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared(prod)
-        {
-#pragma omp for reduction(*:prod)
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      if (!omitNaN) {
         for (OMPInt i = 0; i < nEl; ++i) {
           prod *= (*src)[ i];
+        }
+      } else {
+        for (OMPInt i = 0; i < nEl; ++i) {
+          MultOmitNaN(prod, (*src)[ i]);
         }
       }
     } else {
 
-      TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared(prod)
-      {
+      if (!omitNaN) {
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
+        {
 #pragma omp for reduction(*:prod)
-        for (OMPInt i = 0; i < nEl; ++i) {
-          MultOmitNaN(prod, (*src)[ i]);
+          for (OMPInt i = 0; i < nEl; ++i) {
+            prod *= (*src)[ i];
+          }
+        }
+      } else {
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) shared(prod)
+        {
+#pragma omp for reduction(*:prod)
+          for (OMPInt i = 0; i < nEl; ++i) {
+            MultOmitNaN(prod, (*src)[ i]);
+          }
+        }
       }
-    }
     }
     return new T(prod);
   }
@@ -3489,11 +3479,12 @@ namespace lib {
   }
 
   // product over one dim
+
   template< typename T>
-  BaseGDL* product_over_dim_template( T* src, 
-                      const dimension& srcDim, 
-                      SizeT prodDimIx,
-                      bool omitNaN) {
+  BaseGDL* product_over_dim_template(T* src,
+    const dimension& srcDim,
+    SizeT prodDimIx,
+    bool omitNaN) {
     SizeT nEl = src->N_Elements();
 
     // get dest dim and number of products
@@ -3506,10 +3497,9 @@ namespace lib {
     SizeT prodStride = srcDim.Stride(prodDimIx);
     SizeT outerStride = srcDim.Stride(prodDimIx + 1);
     SizeT prodLimit = nProd * prodStride;
-    if (omitNaN) {
-#pragma omp parallel if ((nEl/outerStride)*prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*prodStride))
-      {
-#pragma omp for
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && ((nEl / outerStride) * prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * prodStride)));
+    if (!parallelize) {
+      if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -3520,11 +3510,33 @@ namespace lib {
             ++rIx;
           }
         }
+      } else {
+        for (SizeT o = 0; o < nEl; o += outerStride) {
+          SizeT rIx = (o / outerStride) * prodStride;
+          for (SizeT i = 0; i < prodStride; ++i) {
+            (*res)[ rIx] = 1;
+            SizeT oi = o + i;
+            SizeT oiLimit = prodLimit + oi;
+            for (SizeT s = oi; s < oiLimit; s += prodStride) (*res)[ rIx] *= (*src)[ s];
+            ++rIx;
+          }
+        }
       }
     } else {
-#pragma omp parallel if ((nEl/outerStride)*prodStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*prodStride))
-      {
-#pragma omp for
+      if (omitNaN) {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+        for (SizeT o = 0; o < nEl; o += outerStride) {
+          SizeT rIx = (o / outerStride) * prodStride;
+          for (SizeT i = 0; i < prodStride; ++i) {
+            (*res)[ rIx] = 1;
+            SizeT oi = o + i;
+            SizeT oiLimit = prodLimit + oi;
+            for (SizeT s = oi; s < oiLimit; s += prodStride) MultOmitNaN((*res)[ rIx], (*src)[ s]);
+            ++rIx;
+          }
+        }
+      } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -4025,21 +4037,17 @@ namespace lib {
       }
 
       SizeT rIx = 0;
-#pragma omp parallel if ((nEl/outerStride)*searchStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*searchStride))
-      {
-#pragma omp for
-        for (SizeT o = 0; o < nEl; o += outerStride) {
-          SizeT rIx = (o / outerStride) * searchStride;
-          for (SizeT i = 0; i < searchStride; ++i) {
-            searchArr->MinMax(
-              (nParam == 2 ? &((*minElArr)[rIx]) : NULL),
-              (subMax ? &((*maxElArr)[rIx]) : NULL),
-              &resArr,
-              (maxSet ? &maxVal : NULL),
-              omitNaN, o + i, searchLimit + o + i, searchStride, rIx, absSet
-              );
-            rIx++;
-          }
+      for (SizeT o = 0; o < nEl; o += outerStride) {
+        SizeT rIx = (o / outerStride) * searchStride;
+        for (SizeT i = 0; i < searchStride; ++i) {
+          searchArr->MinMax(
+            (nParam == 2 ? &((*minElArr)[rIx]) : NULL),
+            (subMax ? &((*maxElArr)[rIx]) : NULL),
+            &resArr,
+            (maxSet ? &maxVal : NULL),
+            omitNaN, o + i, searchLimit + o + i, searchStride, rIx, absSet
+            );
+          rIx++;
         }
       }
       if (nParam == 2) e->SetPar(1, minElArr);
@@ -4129,22 +4137,17 @@ namespace lib {
         e->AssureGlobalPar(1); // instead of using a guard pointer
         maxElArr = new DLongGDL(destDim);
       }
-
-#pragma omp parallel if ((nEl/outerStride)*searchStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*searchStride))
-      {
-#pragma omp for
-        for (SizeT o = 0; o < nEl; o += outerStride) {
-          SizeT rIx = (o/outerStride)*searchStride;
-          for (SizeT i = 0; i < searchStride; ++i) {
-            searchArr->MinMax(
-              (subMin ? &((*minElArr)[rIx]) : NULL),
-              (nParam == 2 ? &((*maxElArr)[rIx]) : NULL),
-              (minSet ? &minVal : NULL),
-              &resArr,
-              omitNaN, o + i, searchLimit + o + i, searchStride, rIx, absSet
-              );
-            rIx++;
-          }
+      for (SizeT o = 0; o < nEl; o += outerStride) {
+        SizeT rIx = (o/outerStride)*searchStride;
+        for (SizeT i = 0; i < searchStride; ++i) {
+          searchArr->MinMax(
+            (subMin ? &((*minElArr)[rIx]) : NULL),
+            (nParam == 2 ? &((*maxElArr)[rIx]) : NULL),
+            (minSet ? &minVal : NULL),
+            &resArr,
+            omitNaN, o + i, searchLimit + o + i, searchStride, rIx, absSet
+            );
+          rIx++;
         }
       }
       if (nParam == 2) e->SetPar(1, maxElArr);
@@ -4623,8 +4626,8 @@ namespace lib {
               clean_array = true;
             }
             DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
-            //probably overkill to start multithreading in some easy cases. TBD.
-#pragma omp for private(i,hasnan)
+//            //probably overkill to start multithreading in some easy cases. TBD.
+//#pragma omp for private(i,hasnan)
             for (SizeT i = 0; i < nEl; ++i) {
               if (hasnan_d(&(*input)[i * stride], stride)) (*res)[i] = quick_select_d_filter_nan(&(*input)[i * stride], stride, iseven); //special if nan.
               else (*res)[i] = quick_select_d_protect_input(&(*input)[i * stride], stride, iseven);
@@ -4638,8 +4641,8 @@ namespace lib {
               clean_array = true;
             }
             DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
-            //probably overkill to start multithreading in some easy cases. TBD.
-#pragma omp for private(i)
+//            //probably overkill to start multithreading in some easy cases. TBD.
+//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) {
               if (hasnan_f(&(*input)[i * stride], stride)) (*res)[i] = quick_select_f_filter_nan(&(*input)[i * stride], stride, iseven); //special if nan.
               else (*res)[i] = quick_select_f_protect_input(&(*input)[i * stride], stride, iseven);            }
@@ -4654,7 +4657,7 @@ namespace lib {
               clean_array = true;
             }
             DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
-#pragma omp for private(i)
+//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = quick_select_d_protect_input(&(*input)[i * stride], stride, iseven);
             if (clean_array) delete input;
             return res;
@@ -4665,7 +4668,7 @@ namespace lib {
               clean_array = true;
             }
             DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
-#pragma omp for private(i)
+//#pragma omp for private(i)
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = quick_select_f_protect_input(&(*input)[i * stride], stride, iseven);
             if (clean_array) delete input;
             return res;
@@ -5498,100 +5501,109 @@ namespace lib {
     return NULL;
 
   }// end of median
-  
-//template <typename Ty>  static inline Ty do_max(const Ty* data, const SizeT sz) {
-//    Ty maxval = data[0];
-//
-//#if OMP_HAS_MAX
-//#pragma omp parallel
-//    {
-//#pragma omp for reduction(max:maxval)
-//#endif
-//    for (SizeT i = 1; i < sz; ++i) maxval = max(maxval,data[i]);
-//#if OMP_HAS_MAX
-//    }
-//#endif
-//    return maxval;
-//  }
-//template <typename Ty>  static inline Ty do_max_nan(const Ty* data, const SizeT sz) {
-//    Ty maxval = data[0];
-//#if OMP_HAS_MAX
-//#pragma omp parallel
-//    {
-//#pragma omp for reduction(max:maxval)
-//#endif
-//      for (SizeT i = 1; i < sz; ++i) maxval = max(maxval,data[i]);
-//#if OMP_HAS_MAX
-//    }
-//#endif
-//    return maxval;
-//  }  
 
-template <typename Ty>  static inline Ty do_mean(const Ty* data, const SizeT sz) {
+  template <typename Ty> static inline Ty do_mean(const Ty* data, const SizeT sz) {
     Ty mean = 0;
-#pragma omp parallel
-    {
-#pragma omp for reduction(+:mean)
-    for (SizeT i = 0; i < sz; ++i) mean += data[i];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) mean += data[i];
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:mean)
+      for (SizeT i = 0; i < sz; ++i) mean += data[i];
     }
-    return mean/sz;
+    return mean / sz;
   }
 
-template <typename Ty, typename T2>  static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
+  template <typename Ty, typename T2> static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
-#pragma omp parallel
-    {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
+      for (SizeT i = 0; i < sz; ++i) meani += data[i].imag();
+    } else {
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+      {
 #pragma omp for reduction(+:meanr)
-    for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
+        for (SizeT i = 0; i < sz; ++i) meanr += data[i].real();
 #pragma omp for reduction(+:meani)
-    for (SizeT i = 0; i < sz; ++i) meani += data[i].imag();
+        for (SizeT i = 0; i < sz; ++i) meani += data[i].imag();
+      }
     }
-    return std::complex<T2>(meanr/sz,meani/sz);
+    return std::complex<T2>(meanr / sz, meani / sz);
   }
- 
-template <typename Ty>  static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
+
+  template <typename Ty> static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
     Ty mean = 0;
     SizeT n = 0;
-#pragma omp parallel //if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:mean,n)
-     for (SizeT i = 0; i < sz; ++i) {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
         Ty v = data[i];
         if (std::isfinite(v)) {
           n++,
-          mean += v;
+            mean += v;
+        }
+      }
+    } else {
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+      {
+#pragma omp for reduction(+:mean,n)
+        for (SizeT i = 0; i < sz; ++i) {
+          Ty v = data[i];
+          if (std::isfinite(v)) {
+            n++,
+              mean += v;
+          }
         }
       }
     }
-    return mean/n;
+    return mean / n;
   }
 
-template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* data, const SizeT sz) {
+  template <typename Ty, typename T2> static inline Ty do_mean_cpx_nan(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
     SizeT nr = 0;
     SizeT ni = 0;
-#pragma omp parallel //if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:meanr,nr)
-     for (SizeT i = 0; i < sz; ++i) {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].real();
         if (std::isfinite(v)) {
           nr++,
-          meanr += v;
+            meanr += v;
         }
       }
-#pragma omp for reduction(+:meani,ni)
-     for (SizeT i = 0; i < sz; ++i) {
+      for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].imag();
         if (std::isfinite(v)) {
           ni++,
-          meani += v;
+            meani += v;
         }
       }
-    }    
-    return std::complex<T2>(meanr/nr,meani/ni);
+    } else {
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+      {
+#pragma omp for reduction(+:meanr,nr)
+        for (SizeT i = 0; i < sz; ++i) {
+          T2 v = data[i].real();
+          if (std::isfinite(v)) {
+            nr++,
+              meanr += v;
+          }
+        }
+#pragma omp for reduction(+:meani,ni)
+        for (SizeT i = 0; i < sz; ++i) {
+          T2 v = data[i].imag();
+          if (std::isfinite(v)) {
+            ni++,
+              meani += v;
+          }
+        }
+      }
+    }
+    return std::complex<T2>(meanr / nr, meani / ni);
   }
 
   BaseGDL* mean_fun(EnvT* e) {
@@ -5662,17 +5674,9 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
         }
         DComplexDblGDL* res = new DComplexDblGDL(destDim, BaseGDL::NOZERO);
         if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride);
-          }
         } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplexDbl, double>(&(*input)[i * stride], stride);
-          }
         }
         if (clean_array) delete input;
         return res;
@@ -5684,17 +5688,9 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
         }
         DComplexGDL* res = new DComplexGDL(destDim, BaseGDL::NOZERO);
         if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx_nan<DComplex, float>(&(*input)[i * stride], stride);
-          }
         } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
             for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_cpx<DComplex, float>(&(*input)[i * stride], stride);
-          }
         }
         if (clean_array) delete input;
         return res;
@@ -5707,17 +5703,9 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           }
           DDoubleGDL* res = new DDoubleGDL(destDim, BaseGDL::NOZERO);
           if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
               for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
-            }
           } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
               for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
-            }
           }
           if (clean_array) delete input;
           return res;
@@ -5730,17 +5718,9 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           }
           DFloatGDL* res = new DFloatGDL(destDim, BaseGDL::NOZERO);
           if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
               for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean_nan(&(*input)[i * stride], stride);
-            }
           } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
               for (SizeT i = 0; i < nEl; ++i) (*res)[i] = do_mean(&(*input)[i * stride], stride);
-            }
           }
           if (clean_array) delete input;
           return res;
@@ -5768,58 +5748,82 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
       }
     }
   }
-  
+
   template<typename Ty>
-  static inline void do_moment(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness, 
-    Ty &kurtosis, Ty &mdev, Ty &sdev, const int maxmoment){
-    Ty meanl=do_mean(data,sz);
-    mean=meanl;
-    if (maxmoment==1) {
-      variance=skewness=kurtosis=mdev=sdev=std::numeric_limits<float>::quiet_NaN();
+  static inline void do_moment(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness,
+    Ty &kurtosis, Ty &mdev, Ty &sdev, const int maxmoment) {
+    Ty meanl = do_mean(data, sz);
+    mean = meanl;
+    if (maxmoment == 1) {
+      variance = skewness = kurtosis = mdev = sdev = std::numeric_limits<float>::quiet_NaN();
       return;
     }
 
-    Ty var=0;
-    Ty md=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:var,md)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; var += cdata*cdata; md+=fabs(cdata);}
+    Ty var = 0;
+    Ty md = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        var += cdata*cdata;
+        md += fabs(cdata);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        var += cdata*cdata;
+        md += fabs(cdata);
+      }
     }
-    var/=(sz-1);
-    variance=var;
-    sdev=sqrt(var);
-    mdev=md/sz;
-    
-    if (maxmoment==2 || var==0 ) {
-      skewness=kurtosis=std::numeric_limits<float>::quiet_NaN();
+    var /= (sz - 1);
+    variance = var;
+    sdev = sqrt(var);
+    mdev = md / sz;
+
+    if (maxmoment == 2 || var == 0) {
+      skewness = kurtosis = std::numeric_limits<float>::quiet_NaN();
       return;
     }
-    Ty skew=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:skew)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; skew += (cdata*cdata*cdata)/(var*sdev); }
+    Ty skew = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        skew += (cdata * cdata * cdata) / (var * sdev);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        skew += (cdata * cdata * cdata) / (var * sdev);
+      }
     }
-    skewness=skew/sz;
-    if (maxmoment==3) {
-      kurtosis=std::numeric_limits<float>::quiet_NaN();
+    skewness = skew / sz;
+    if (maxmoment == 3) {
+      kurtosis = std::numeric_limits<float>::quiet_NaN();
       return;
     }
-    Ty kurt=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:kurt)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; kurt += (cdata*cdata*cdata*cdata)/(var*var);}
+    Ty kurt = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        kurt += (cdata * cdata * cdata * cdata) / (var * var);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        kurt += (cdata * cdata * cdata * cdata) / (var * var);
+      }
     }
-    kurtosis=(kurt/sz)-3; 
+    kurtosis = (kurt / sz) - 3;
   }
-  
+
   template<typename Ty, typename T2>
-  static inline void do_moment_cpx(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness, 
-    Ty &kurtosis, T2 &mdev, Ty &sdev, const int maxmoment){
-    Ty meanl=do_mean_cpx<Ty, T2>(data,sz);
-    mean=meanl;
+  static inline void do_moment_cpx(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness,
+    Ty &kurtosis, T2 &mdev, Ty &sdev, const int maxmoment) {
+    Ty meanl = do_mean_cpx<Ty, T2>(data, sz);
+    mean = meanl;
     if (maxmoment == 1) {
       variance = skewness = kurtosis = sdev =
         std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
@@ -5827,222 +5831,345 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
       return;
     }
 
-    T2 mdr=0;
-    T2 varr=0;
-    T2 vari=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:varr,vari,mdr)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-        T2 cdatar=cdata.real();
-        T2 cdatai=cdata.imag();
-        varr += (cdatar*cdatar)-(cdatai*cdatai);
-        vari += 2*cdatar*cdatai;
-        mdr += sqrt(cdatar*cdatar+cdatai*cdatai);
+    T2 mdr = 0;
+    T2 varr = 0;
+    T2 vari = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        varr += (cdatar * cdatar)-(cdatai * cdatai);
+        vari += 2 * cdatar*cdatai;
+        mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        varr += (cdatar * cdatar)-(cdatai * cdatai);
+        vari += 2 * cdatar*cdatai;
+        mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
       }
     }
-    varr/=(sz-1);
-    vari/=(sz-1);
-    mdr/=sz;
-    variance=std::complex<T2>(varr,vari);
-    sdev=sqrt(variance);
-    mdev=mdr;
+    varr /= (sz - 1);
+    vari /= (sz - 1);
+    mdr /= sz;
+    variance = std::complex<T2>(varr, vari);
+    sdev = sqrt(variance);
+    mdev = mdr;
 
-    if (maxmoment==2) {
-      skewness=kurtosis=
-        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(),std::numeric_limits<T2>::quiet_NaN());
+    if (maxmoment == 2) {
+      skewness = kurtosis =
+        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
       return;
     }
-    T2 skewr=0;
-    T2 skewi=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:skewr,skewi)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-        T2 cdatar=cdata.real();
-        T2 cdatai=cdata.imag();
-        skewr += (cdatar*cdatar*cdatar-3.0*cdatar*cdatai*cdatai)*
-          exp(-0.75*log(varr*varr+vari*vari))*
-          cos(0.15E1*atan2(vari,varr))+(3.0*cdatar*cdatar*cdatai-cdatai*cdatai*cdatai)*
-          exp(-0.75*log(varr*varr+vari*vari))*sin(1.5*atan2(vari,varr));
+    T2 skewr = 0;
+    T2 skewi = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        skewr += (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) *
+          cos(0.15E1 * atan2(vari, varr))+(3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
 
-        skewi += (3.0*cdatar*cdatar*cdatai-cdatai*cdatai*cdatai)*
-          exp(-0.75*log(varr*varr+vari*vari))*cos(1.5*atan2(vari,varr))-
-          (cdatar*cdatar*cdatar-3.0*cdatar*cdatai*cdatai)*
-          exp(-0.75*log(varr*varr+vari*vari))*sin(1.5*atan2(vari,varr));
+        skewi += (3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * cos(1.5 * atan2(vari, varr))-
+          (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        skewr += (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) *
+          cos(0.15E1 * atan2(vari, varr))+(3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
+
+        skewi += (3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * cos(1.5 * atan2(vari, varr))-
+          (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
       }
     }
-    skewness=std::complex<T2>(skewr/sz,skewi/sz);
-    if (maxmoment==3) {
-      kurtosis=std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(),std::numeric_limits<T2>::quiet_NaN());
+    skewness = std::complex<T2>(skewr / sz, skewi / sz);
+    if (maxmoment == 3) {
+      kurtosis = std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
       return;
     }
-    T2 kurtr=0;
-    T2 kurti=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:kurtr,kurti)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-        T2 cdatar=cdata.real();
-        T2 cdatai=cdata.imag();
-        kurtr += (cdatar*cdatar*cdatar*cdatar-6.0*cdatar*cdatar*cdatai*cdatai+cdatai*
-          cdatai*cdatai*cdatai)*(varr*varr-vari*vari)/(pow(varr*varr-vari*vari,2.0)+
-          4.0*varr*varr*vari*vari)+2.0*(4.0*cdatar*cdatar*cdatar*cdatai-
-          4.0*cdatar*cdatai*cdatai*cdatai)*varr*vari/
-          (pow(varr*varr-vari*vari,2.0)+
-          4.0*varr*varr*vari*vari);
-        kurti += (4.0*cdatar*cdatar*cdatar*cdatai-4.0*cdatar*cdatai*cdatai*cdatai)*
-          (varr*varr-vari*vari)/(pow(varr*varr-vari*vari,2.0)+4.0*varr*varr*vari*vari)-
-          2.0*(cdatar*cdatar*cdatar*cdatar-
-          6.0*cdatar*cdatar*cdatai*cdatai+cdatai*cdatai*cdatai*cdatai)*varr*vari/
-          (pow(varr*varr-vari*vari,2.0)+
-          4.0*varr*varr*vari*vari);
+    T2 kurtr = 0;
+    T2 kurti = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        kurtr += (cdatar * cdatar * cdatar * cdatar - 6.0 * cdatar * cdatar * cdatai * cdatai + cdatai *
+          cdatai * cdatai * cdatai)*(varr * varr - vari * vari) / (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari) + 2.0 * (4.0 * cdatar * cdatar * cdatar * cdatai -
+          4.0 * cdatar * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+        kurti += (4.0 * cdatar * cdatar * cdatar * cdatai - 4.0 * cdatar * cdatai * cdatai * cdatai)*
+          (varr * varr - vari * vari) / (pow(varr * varr - vari*vari, 2.0) + 4.0 * varr * varr * vari * vari) -
+          2.0 * (cdatar * cdatar * cdatar * cdatar -
+          6.0 * cdatar * cdatar * cdatai * cdatai + cdatai * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        kurtr += (cdatar * cdatar * cdatar * cdatar - 6.0 * cdatar * cdatar * cdatai * cdatai + cdatai *
+          cdatai * cdatai * cdatai)*(varr * varr - vari * vari) / (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari) + 2.0 * (4.0 * cdatar * cdatar * cdatar * cdatai -
+          4.0 * cdatar * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+        kurti += (4.0 * cdatar * cdatar * cdatar * cdatai - 4.0 * cdatar * cdatai * cdatai * cdatai)*
+          (varr * varr - vari * vari) / (pow(varr * varr - vari*vari, 2.0) + 4.0 * varr * varr * vari * vari) -
+          2.0 * (cdatar * cdatar * cdatar * cdatar -
+          6.0 * cdatar * cdatar * cdatai * cdatai + cdatai * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari*vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
       }
     }
-    kurtosis=std::complex<T2>((kurtr/sz)-3,(kurti/sz)-3); 
+    kurtosis = std::complex<T2>((kurtr / sz) - 3, (kurti / sz) - 3);
   }
-  
+
   template<typename Ty>
-  static inline void do_moment_nan(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness, 
-    Ty &kurtosis, Ty &mdev, Ty &sdev, const int maxmoment){
-    Ty meanl=do_mean_nan(data,sz);
-    mean=meanl;
-    if (maxmoment==1 || !std::isfinite(mean)) {
-      variance=skewness=kurtosis=mdev=sdev=std::numeric_limits<float>::quiet_NaN();
+  static inline void do_moment_nan(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness,
+    Ty &kurtosis, Ty &mdev, Ty &sdev, const int maxmoment) {
+    Ty meanl = do_mean_nan(data, sz);
+    mean = meanl;
+    if (maxmoment == 1 || !std::isfinite(mean)) {
+      variance = skewness = kurtosis = mdev = sdev = std::numeric_limits<float>::quiet_NaN();
       return;
     }
 
-    Ty var=0;
-    Ty md=0;
-    SizeT k=0;
-#pragma omp parallel //if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:var,md,k)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; if (std::isfinite(cdata)) {var += cdata*cdata; md+=fabs(cdata); k+=1;} }
+    Ty var = 0;
+    Ty md = 0;
+    SizeT k = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) {
+          var += cdata*cdata;
+          md += fabs(cdata);
+          k += 1;
+        }
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:var,md,k)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) {
+          var += cdata*cdata;
+          md += fabs(cdata);
+          k += 1;
+        }
+      }
     }
-    if (k>1) var/=(k-1); else {
-      variance=skewness=kurtosis=mdev=sdev=std::numeric_limits<float>::quiet_NaN();
+    if (k > 1) var /= (k - 1);
+    else {
+      variance = skewness = kurtosis = mdev = sdev = std::numeric_limits<float>::quiet_NaN();
       return;
     }
-    variance=var;
-    sdev=sqrt(var);
-    mdev=md/k;
-    if (maxmoment==2 || var==0 ) {
-      skewness=kurtosis=std::numeric_limits<float>::quiet_NaN();
+    variance = var;
+    sdev = sqrt(var);
+    mdev = md / k;
+    if (maxmoment == 2 || var == 0) {
+      skewness = kurtosis = std::numeric_limits<float>::quiet_NaN();
       return;
     }
-    Ty skew=0;
-#pragma omp parallel //if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:skew)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; if (std::isfinite(cdata)) skew += (cdata*cdata*cdata)/(var*sdev); }
+    Ty skew = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skew)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
+      }
     }
-    skewness=skew/k;
-    if (maxmoment==3) {
-      kurtosis=std::numeric_limits<float>::quiet_NaN();
+    skewness = skew / k;
+    if (maxmoment == 3) {
+      kurtosis = std::numeric_limits<float>::quiet_NaN();
       return;
     }
-    Ty kurt=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:kurt)
-    for (SizeT i = 0; i < sz; ++i) { Ty cdata=data[i]-meanl; if (std::isfinite(cdata)) kurt += (cdata*cdata*cdata*cdata)/(var*var);}
+    Ty kurt = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurt)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
+      }
     }
-    kurtosis=(kurt/k)-3; 
+    kurtosis = (kurt / k) - 3;
   }
-  
+
   template<typename Ty, typename T2>
-  static inline void do_moment_cpx_nan(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness, 
-    Ty &kurtosis, T2 &mdev, Ty &sdev, const int maxmoment){
-    Ty meanl=do_mean_cpx_nan<Ty, T2>(data,sz);
-    mean=meanl;
-    if (maxmoment==1) {
-      variance=skewness=kurtosis=sdev=
-        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(),std::numeric_limits<T2>::quiet_NaN());
-        mdev=std::numeric_limits<T2>::quiet_NaN();
+  static inline void do_moment_cpx_nan(const Ty* data, const SizeT sz, Ty &mean, Ty &variance, Ty &skewness,
+    Ty &kurtosis, T2 &mdev, Ty &sdev, const int maxmoment) {
+    Ty meanl = do_mean_cpx_nan<Ty, T2>(data, sz);
+    mean = meanl;
+    if (maxmoment == 1) {
+      variance = skewness = kurtosis = sdev =
+        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
+      mdev = std::numeric_limits<T2>::quiet_NaN();
       return;
     }
-    SizeT kr=0;
-    SizeT ki=0;
-    T2 mdr=0;
-    T2 varr=0;
-    T2 vari=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:varr,vari,mdr,kr,ki)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-          T2 cdatar=cdata.real();
-          T2 cdatai=cdata.imag();
-        if (std::isfinite(cdatar)) {varr += cdatar*cdatar; kr++;}
-        if (std::isfinite(cdatai)) {vari += cdatai*cdatai; ki++;}
-        if (std::isfinite(cdatar))  mdr += sqrt(cdatar*cdatar+cdatai*cdatai);
+    SizeT kr = 0;
+    SizeT ki = 0;
+    T2 mdr = 0;
+    T2 varr = 0;
+    T2 vari = 0;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) {
+          varr += cdatar*cdatar;
+          kr++;
         }
+        if (std::isfinite(cdatai)) {
+          vari += cdatai*cdatai;
+          ki++;
+        }
+        if (std::isfinite(cdatar)) mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:varr,vari,mdr,kr,ki)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) {
+          varr += cdatar*cdatar;
+          kr++;
+        }
+        if (std::isfinite(cdatai)) {
+          vari += cdatai*cdatai;
+          ki++;
+        }
+        if (std::isfinite(cdatar)) mdr += sqrt(cdatar * cdatar + cdatai * cdatai);
+      }
     }
-    varr/=(kr-1);
-    vari/=(ki-1);
-    mdr/=kr;
-    variance=std::complex<T2>(varr,vari);    
-    sdev=sqrt(variance);
-    mdev=mdr;
+    varr /= (kr - 1);
+    vari /= (ki - 1);
+    mdr /= kr;
+    variance = std::complex<T2>(varr, vari);
+    sdev = sqrt(variance);
+    mdev = mdr;
 
-    if (maxmoment==2) {
-      skewness=kurtosis=
-        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(),std::numeric_limits<T2>::quiet_NaN());
+    if (maxmoment == 2) {
+      skewness = kurtosis =
+        std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
       return;
     }
-    T2 skewr=0;
-    T2 skewi=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:skewr,skewi)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-          T2 cdatar=cdata.real();
-          T2 cdatai=cdata.imag();
-          if (std::isfinite(cdatar)) skewr += (cdatar*cdatar*cdatar-3.0*cdatar*cdatai*cdatai)*
-            exp(-0.75*log(varr*varr+vari*vari))*
-            cos(0.15E1*atan2(vari,varr))+(3.0*cdatar*cdatar*cdatai-cdatai*cdatai*cdatai)*
-            exp(-0.75*log(varr*varr+vari*vari))*sin(1.5*atan2(vari,varr));
+    T2 skewr = 0;
+    T2 skewi = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) skewr += (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) *
+          cos(0.15E1 * atan2(vari, varr))+(3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
 
-          if (std::isfinite(cdatai)) skewi += (3.0*cdatar*cdatar*cdatai-cdatai*cdatai*cdatai)*
-            exp(-0.75*log(varr*varr+vari*vari))*cos(1.5*atan2(vari,varr))-
-            (cdatar*cdatar*cdatar-3.0*cdatar*cdatai*cdatai)*
-            exp(-0.75*log(varr*varr+vari*vari))*sin(1.5*atan2(vari,varr));
-        }
+        if (std::isfinite(cdatai)) skewi += (3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * cos(1.5 * atan2(vari, varr))-
+          (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:skewr,skewi)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) skewr += (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) *
+          cos(0.15E1 * atan2(vari, varr))+(3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
+
+        if (std::isfinite(cdatai)) skewi += (3.0 * cdatar * cdatar * cdatai - cdatai * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * cos(1.5 * atan2(vari, varr))-
+          (cdatar * cdatar * cdatar - 3.0 * cdatar * cdatai * cdatai) *
+          exp(-0.75 * log(varr * varr + vari * vari)) * sin(1.5 * atan2(vari, varr));
+      }
     }
-    skewness=std::complex<T2>(skewr/kr,skewi/ki);
-    if (maxmoment==3) {
-      kurtosis=std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(),std::numeric_limits<T2>::quiet_NaN());
+    skewness = std::complex<T2>(skewr / kr, skewi / ki);
+    if (maxmoment == 3) {
+      kurtosis = std::complex<T2>(std::numeric_limits<T2>::quiet_NaN(), std::numeric_limits<T2>::quiet_NaN());
       return;
     }
-    T2 kurtr=0;
-    T2 kurti=0;
-#pragma omp parallel // if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    {
-#pragma omp for reduction(+:kurtr,kurti)
-      for (SizeT i = 0; i < sz; ++i) { 
-        Ty cdata=data[i]-meanl;
-          T2 cdatar=cdata.real();
-          T2 cdatai=cdata.imag();
-          if (std::isfinite(cdatar)) kurtr += (cdatar*cdatar*cdatar*cdatar-6.0*cdatar*cdatar*cdatai*cdatai+cdatai*
-            cdatai*cdatai*cdatai)*(varr*varr-vari*vari)/(pow(varr*varr-vari*vari,2.0)+
-            4.0*varr*varr*vari*vari)+2.0*(4.0*cdatar*cdatar*cdatar*cdatai-
-            4.0*cdatar*cdatai*cdatai*cdatai)*varr*vari/
-            (pow(varr*varr-vari*vari,2.0)+
-            4.0*varr*varr*vari*vari);
-          if (std::isfinite(cdatai)) kurti += (4.0*cdatar*cdatar*cdatar*cdatai-4.0*cdatar*cdatai*cdatai*cdatai)*
-            (varr*varr-vari*vari)/(pow(varr*varr-vari*vari,2.0)+4.0*varr*varr*vari*vari)-
-            2.0*(cdatar*cdatar*cdatar*cdatar-
-            6.0*cdatar*cdatar*cdatai*cdatai+cdatai*cdatai*cdatai*cdatai)*varr*vari/
-            (pow(varr*varr-vari*vari,2.0)+
-            4.0*varr*varr*vari*vari);
-        }
+    T2 kurtr = 0;
+    T2 kurti = 0;
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) kurtr += (cdatar * cdatar * cdatar * cdatar - 6.0 * cdatar * cdatar * cdatai * cdatai + cdatai *
+          cdatai * cdatai * cdatai)*(varr * varr - vari * vari) / (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari) + 2.0 * (4.0 * cdatar * cdatar * cdatar * cdatai -
+          4.0 * cdatar * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+        if (std::isfinite(cdatai)) kurti += (4.0 * cdatar * cdatar * cdatar * cdatai - 4.0 * cdatar * cdatai * cdatai * cdatai)*
+          (varr * varr - vari * vari) / (pow(varr * varr - vari * vari, 2.0) + 4.0 * varr * varr * vari * vari) -
+          2.0 * (cdatar * cdatar * cdatar * cdatar -
+          6.0 * cdatar * cdatar * cdatai * cdatai + cdatai * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+      }
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) reduction(+:kurtr,kurti)
+      for (SizeT i = 0; i < sz; ++i) {
+        Ty cdata = data[i] - meanl;
+        T2 cdatar = cdata.real();
+        T2 cdatai = cdata.imag();
+        if (std::isfinite(cdatar)) kurtr += (cdatar * cdatar * cdatar * cdatar - 6.0 * cdatar * cdatar * cdatai * cdatai + cdatai *
+          cdatai * cdatai * cdatai)*(varr * varr - vari * vari) / (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari) + 2.0 * (4.0 * cdatar * cdatar * cdatar * cdatai -
+          4.0 * cdatar * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+        if (std::isfinite(cdatai)) kurti += (4.0 * cdatar * cdatar * cdatar * cdatai - 4.0 * cdatar * cdatai * cdatai * cdatai)*
+          (varr * varr - vari * vari) / (pow(varr * varr - vari * vari, 2.0) + 4.0 * varr * varr * vari * vari) -
+          2.0 * (cdatar * cdatar * cdatar * cdatar -
+          6.0 * cdatar * cdatar * cdatai * cdatai + cdatai * cdatai * cdatai * cdatai) * varr * vari /
+          (pow(varr * varr - vari * vari, 2.0) +
+          4.0 * varr * varr * vari * vari);
+      }
     }
-    kurtosis=std::complex<T2>((kurtr/kr)-3,(kurti/kr)-3); 
+    kurtosis = std::complex<T2>((kurtr / kr) - 3, (kurti / kr) - 3);
   }
   
   BaseGDL* moment_fun(EnvT* e) {
@@ -6128,6 +6255,7 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
       // resize destDim
       destDim.Remove(momentDim); //will be one dimension less
       SizeT nEl = destDim.NDimElementsConst(); //need to compute that here, before adding last dim.
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
       auxiliaryDim=destDim;
       
       destDim<<4; //add 4 as last dim
@@ -6157,9 +6285,20 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
         if (dosdev) sdev = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) {
+              DDouble mdevl;
+              DComplexDbl sdevl;
+              do_moment_cpx_nan<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i + nEl], (*res)[i + 2 * nEl], (*res)[i + 3 * nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i] = (*res)[i];
+              if (dovar) (*var)[i] = (*res)[i + nEl];
+              if (doskew) (*skew)[i] = (*res)[i + 2 * nEl];
+              if (dokurt) (*kurt)[i] = (*res)[i + 3 * nEl];
+              if (dosdev) (*sdev)[i] = sdevl;
+              if (domdev) (*mdev)[i] = mdevl;
+            }            
+          } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6173,9 +6312,20 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
             }
           }
         } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) {
+              DDouble mdevl;
+              DComplexDbl sdevl;
+              do_moment_cpx<DComplexDbl, double>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i]=(*res)[i];
+              if (dovar ) (*var )[i]=(*res)[i+nEl];
+              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+              if (dosdev) (*sdev)[i]=sdevl;
+              if (domdev) (*mdev)[i]=mdevl;
+            }                      
+          } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6217,9 +6367,20 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
         if (dosdev) sdev = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) {
+              DFloat mdevl;
+              DComplex sdevl;
+              do_moment_cpx_nan<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i]=(*res)[i];
+              if (dovar ) (*var )[i]=(*res)[i+nEl];
+              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+              if (dosdev) (*sdev)[i]=sdevl;
+              if (domdev) (*mdev)[i]=mdevl;
+            }            
+          } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6233,9 +6394,20 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
             }
           }
         } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          {
-#pragma omp for
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) {
+              DFloat mdevl;
+              DComplex sdevl;
+              do_moment_cpx<DComplex, float>(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+              if (domean) (*mean)[i]=(*res)[i];
+              if (dovar ) (*var )[i]=(*res)[i+nEl];
+              if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+              if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+              if (dosdev) (*sdev)[i]=sdevl;
+              if (domdev) (*mdev)[i]=mdevl;
+            }
+          } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6278,9 +6450,21 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           if (dosdev) sdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
+            if (!parallelize) {
+              for (SizeT i = 0; i < nEl; ++i) {
+                DDouble mdevl;
+                DDouble sdevl;
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
+                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i]=(*res)[i];
+                if (dovar ) (*var )[i]=(*res)[i+nEl];
+                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+                if (dosdev) (*sdev)[i]=sdevl;
+                if (domdev) (*mdev)[i]=mdevl;
+              }              
+            } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6295,9 +6479,21 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
               }
             }
           } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
+            if (!parallelize) {
+              for (SizeT i = 0; i < nEl; ++i) {
+                DDouble mdevl;
+                DDouble sdevl;
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
+                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i]=(*res)[i];
+                if (dovar ) (*var )[i]=(*res)[i+nEl];
+                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+                if (dosdev) (*sdev)[i]=sdevl;
+                if (domdev) (*mdev)[i]=mdevl;
+              }              
+            } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6340,9 +6536,21 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           if (dosdev) sdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
+            if (!parallelize) {
+              for (SizeT i = 0; i < nEl; ++i) {
+                DFloat mdevl;
+                DFloat sdevl;
+                do_moment_nan(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
+                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i]=(*res)[i];
+                if (dovar ) (*var )[i]=(*res)[i+nEl];
+                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+                if (dosdev) (*sdev)[i]=sdevl;
+                if (domdev) (*mdev)[i]=mdevl;
+              }
+            } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6357,9 +6565,21 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
               }
             }
           } else {
-#pragma omp parallel //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            {
-#pragma omp for
+            if (!parallelize) {
+              for (SizeT i = 0; i < nEl; ++i) {
+                DFloat mdevl;
+                DFloat sdevl;
+                do_moment(&(*input)[i * stride], stride, (*res)[i], (*res)[i+nEl], 
+                  (*res)[i+2*nEl], (*res)[i+3*nEl], mdevl, sdevl, maxmoment);
+                if (domean) (*mean)[i]=(*res)[i];
+                if (dovar ) (*var )[i]=(*res)[i+nEl];
+                if (doskew) (*skew)[i]=(*res)[i+2*nEl];
+                if (dokurt) (*kurt)[i]=(*res)[i+3*nEl];
+                if (dosdev) (*sdev)[i]=sdevl;
+                if (domdev) (*mdev)[i]=mdevl;
+              }
+            } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6480,21 +6700,27 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
   }
   template<typename T> void pos_ishft_s(T* out, const SizeT n, const char s) {
 // parallelization is marginally useful as the loop is well paralleized by compiler.
-#pragma omp parallel for if ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
       for (SizeT i=0; i < n; ++i) out[i] <<= s;
   }
 
   template<typename T> void neg_ishft_s(T* out, const SizeT n, const char s) {
 // parallelization is marginally useful as the loop is well paralleized by compiler.
-#pragma omp parallel for if ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
       for (SizeT i = 0; i < n; ++i) out[i] >>= s;
   }
   
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-#pragma omp parallel for if ((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
+    bool parallelize=((CpuTPOOL_NTHREADS > 1) && (n >= CpuTPOOL_MIN_ELTS) && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n));
+    if (!parallelize) {
+      for (SizeT i = 0; i < n; ++i) {
+        if (s[i] >= 0) out[i] <<= s[i];
+        else out[i] >>= s[i];
+      }      
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0 ) out[i] <<= s[i]; else out[i] >>= s[i];
       }
+    }
   }
   
   BaseGDL* ishft_single(BaseGDL* in, SizeT n, char s, bool pos) {
@@ -6742,61 +6968,55 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
     return new DIntGDL( 0);
   }
 
-  BaseGDL* rebin_fun( EnvT* e)
-  {
-    SizeT nParam = e->NParam( 2);
+  BaseGDL* rebin_fun(EnvT* e) {
+    SizeT nParam = e->NParam(2);
 
-    BaseGDL* p0 = e->GetNumericParDefined( 0);
+    BaseGDL* p0 = e->GetNumericParDefined(0);
 
     SizeT rank = p0->Rank();
 
-    if( rank == 0) 
-      e->Throw( "Expression must be an array in this context: "+
-        e->GetParString(0));
-    
+    if (rank == 0)
+      e->Throw("Expression must be an array in this context: " +
+      e->GetParString(0));
+
     SizeT resDimInit[ MAXRANK];
 
     DLongGDL* p1 = e->GetParAs<DLongGDL>(1);
-    if (p1->Rank() > 0 && nParam > 2) 
+    if (p1->Rank() > 0 && nParam > 2)
       e->Throw("The new dimensions must either be specified as an array or as a set of scalars.");
     SizeT np = p1->Rank() == 0 ? nParam : p1->N_Elements() + 1;
 
-    for( SizeT p=1; p<np; ++p)
-      {
-    DLong newDim;
-    if (p1->Rank() == 0) e->AssureLongScalarPar( p, newDim);
-        else newDim = (*p1)[p - 1];
+    for (SizeT p = 1; p < np; ++p) {
+      DLong newDim;
+      if (p1->Rank() == 0) e->AssureLongScalarPar(p, newDim);
+      else newDim = (*p1)[p - 1];
 
-    if( newDim <= 0)
-      e->Throw( "Array dimensions must be greater than 0.");
-    
-    if( rank >= p)
-      {
-        SizeT oldDim = p0->Dim( p-1);
+      if (newDim <= 0)
+        e->Throw("Array dimensions must be greater than 0.");
 
-        if( newDim > oldDim)
-          {
-        if( (newDim % oldDim) != 0)
-          e->Throw( "Result dimensions must be integer factor "
-                "of original dimensions.");
-          }
-        else
-          {
-        if( (oldDim % newDim) != 0)
-          e->Throw( "Result dimensions must be integer factor "
-                "of original dimensions.");
-          }
-      }
-    
-    resDimInit[ p-1] = newDim; 
+      if (rank >= p) {
+        SizeT oldDim = p0->Dim(p - 1);
+
+        if (newDim > oldDim) {
+          if ((newDim % oldDim) != 0)
+            e->Throw("Result dimensions must be integer factor "
+            "of original dimensions.");
+        } else {
+          if ((oldDim % newDim) != 0)
+            e->Throw("Result dimensions must be integer factor "
+            "of original dimensions.");
+        }
       }
 
-    dimension resDim( resDimInit, np-1);
+      resDimInit[ p - 1] = newDim;
+    }
 
-    static int sampleIx = e->KeywordIx( "SAMPLE");
-    bool sample = e->KeywordSet( sampleIx);
-    
-    return p0->Rebin( resDim, sample);
+    dimension resDim(resDimInit, np - 1);
+
+    static int sampleIx = e->KeywordIx("SAMPLE");
+    bool sample = e->KeywordSet(sampleIx);
+
+    return p0->Rebin(resDim, sample);
   }
 
   BaseGDL* obj_class(EnvT* e)
@@ -7084,10 +7304,10 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-
-    if (IntType(p0->Type())) {
+    bool parallelize=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      if (IntType(p0->Type())) {
         //Is a thread pool function
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
@@ -7099,7 +7319,33 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           }
         }
       } else {
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+        for (SizeT i = 0; i < nEl; ++i) {
+          DDouble& d = (*dRes)[ i];
+          if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
+          else if (d <= min) (*dRes)[ i] = 0;
+          else if (d >= max) (*dRes)[ i] = dTop;
+          else {
+            // SA (?): here floor is used (instead of round) to simulate IDL behaviour
+            (*dRes)[ i] = floor(((dTop + .9999)*(d - min)) / (max - min));
+          }
+        }
+      }     
+    } else {
+    if (IntType(p0->Type())) {
+        //Is a thread pool function
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
+        for (SizeT i = 0; i < nEl; ++i) {
+          DDouble& d = (*dRes)[ i];
+          if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
+          else if (d <= min) (*dRes)[ i] = 0;
+          else if (d >= max) (*dRes)[ i] = dTop;
+          else {
+            // SA: floor is used for integer types to simulate manipulation on input data types
+            (*dRes)[ i] = floor(((dTop + 1.)*(d - min) - 1.) / (max - min));
+          }
+        }
+      } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) 
         for (SizeT i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;
@@ -7111,6 +7357,7 @@ template <typename Ty, typename T2>  static inline Ty do_mean_cpx_nan(const Ty* 
           }
         }
       }
+    }
     return dRes->Convert2(GDL_BYTE);
   } 
   

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1219,7 +1219,7 @@ namespace lib {
     if (re->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      if (GDL_NTHREADS=parallelize( nE)==1) {
+      if ((GDL_NTHREADS=parallelize( nE))==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1230,7 +1230,7 @@ namespace lib {
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      if (GDL_NTHREADS=parallelize( nE)==1) {
+      if ((GDL_NTHREADS=parallelize( nE))==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1241,7 +1241,7 @@ namespace lib {
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      if (GDL_NTHREADS=parallelize( nE)==1) {
+      if ((GDL_NTHREADS=parallelize( nE))==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1252,7 +1252,7 @@ namespace lib {
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      if (GDL_NTHREADS=parallelize( nE)==1) {
+      if ((GDL_NTHREADS=parallelize( nE))==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1808,7 +1808,7 @@ namespace lib {
     if (e1->Scalar()) {
       if (e1->LogTrue(0)) {
         res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl2)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl2))==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
 
         } else {
@@ -1822,7 +1822,7 @@ namespace lib {
     } else if (e2->Scalar()) {
       if (e2->LogTrue(0)) {
         res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl1)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl1))==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1834,7 +1834,7 @@ namespace lib {
       }
     } else if (nEl2 <= nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl2)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl2))==1) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1844,7 +1844,7 @@ namespace lib {
     } else // ( nEl2 > nEl1)
     {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl1)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl1))==1) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1874,7 +1874,7 @@ namespace lib {
     if (e1->Scalar()) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
       if (e1->LogTrue(0)) {
-        if (GDL_NTHREADS=parallelize( nEl2)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl2))==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1882,7 +1882,7 @@ namespace lib {
             for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = 1;
         }
       } else {
-        if (GDL_NTHREADS=parallelize( nEl2)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl2))==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1893,7 +1893,7 @@ namespace lib {
     } else if (e2->Scalar()) {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
       if (e2->LogTrue(0)) {
-        if (GDL_NTHREADS=parallelize( nEl1)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl1))==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1901,7 +1901,7 @@ namespace lib {
             for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = 1;
         }
       } else {
-        if (GDL_NTHREADS=parallelize( nEl1)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl1))==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -1911,7 +1911,7 @@ namespace lib {
       }
     } else if (nEl2 < nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl2)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl2))==1) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1920,7 +1920,7 @@ namespace lib {
       }
     } else { // ( nEl2 >= nEl1)
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl1)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl1))==1) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1938,7 +1938,7 @@ namespace lib {
     ULong nEl1 = e1->N_Elements();
 
     Data_<SpDByte>* res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl1)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl1))==1) {
       for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2017,7 +2017,7 @@ namespace lib {
 
     if (mode == 2) // both
     {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2026,7 +2026,7 @@ namespace lib {
       }
     } else if (mode == 1) // leading
     {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2035,7 +2035,7 @@ namespace lib {
       }
     } else // trailing
     {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2056,7 +2056,7 @@ namespace lib {
     DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2100,7 +2100,7 @@ namespace lib {
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
       }
@@ -2177,7 +2177,7 @@ namespace lib {
       }
       return res;
     }
-    if (GDL_NTHREADS=parallelize(nSrcStr)==1) {
+    if ((GDL_NTHREADS=parallelize(nSrcStr))==1) {
       for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
@@ -2226,7 +2226,7 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2235,7 +2235,7 @@ namespace lib {
       }
     } else {
       res = p0S;
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2265,7 +2265,7 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2274,7 +2274,7 @@ namespace lib {
       }
     } else {
       res = p0S;
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2419,7 +2419,7 @@ namespace lib {
   BaseGDL* total_template_generic(T* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
     typename T::Ty sum = 0;
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
     } else {
@@ -2443,7 +2443,7 @@ namespace lib {
     DFloat sr = 0;
     DFloat si = 0;
     if (!omitNaN) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2457,7 +2457,7 @@ namespace lib {
         }
       }
     } else {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2490,7 +2490,7 @@ namespace lib {
     DDouble sr = 0;
     DDouble si = 0;
     if (!omitNaN) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
@@ -2504,7 +2504,7 @@ namespace lib {
         }
       }
     } else {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2537,7 +2537,7 @@ namespace lib {
     //   std::cerr<<" total_template_double "<<std::endl;
     SizeT nEl = src->N_Elements();
     DDouble sum = 0;
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2562,7 +2562,7 @@ namespace lib {
     //   std::cerr<<" total_template_single "<<std::endl;
     SizeT nEl = src->N_Elements();
     DDouble sum = 0;
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2590,7 +2590,7 @@ namespace lib {
     //   std::cerr<<" total_template_integer "<<std::endl;
     SizeT nEl = src->N_Elements();
     DLong64 sum = 0;
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3253,7 +3253,7 @@ namespace lib {
     typename T::Ty prod = 1;
     SizeT nEl = src->N_Elements();
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       if (!omitNaN) for (OMPInt i = 0; i < nEl; ++i) prod *= (*src)[ i];
       else for (OMPInt i = 0; i < nEl; ++i) if (std::isfinite((*src)[ i])) prod *= (*src)[ i];
     } else {
@@ -3273,7 +3273,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       DComplexGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -3306,7 +3306,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexDblGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       DComplexDblGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -5326,7 +5326,7 @@ namespace lib {
 
   template <typename Ty> static inline Ty do_mean(const Ty* data, const SizeT sz) {
     Ty mean = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -5339,7 +5339,7 @@ namespace lib {
   template <typename Ty, typename T2> static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         meanr += data[i].real();
         meani += data[i].imag();
@@ -5359,7 +5359,7 @@ namespace lib {
   template <typename Ty> static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
     Ty mean = 0;
     SizeT n = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty v = data[i];
         if (std::isfinite(v)) {
@@ -5386,7 +5386,7 @@ namespace lib {
     T2 meani = 0;
     SizeT nr = 0;
     SizeT ni = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].real();
         if (std::isfinite(v)) {
@@ -5573,7 +5573,7 @@ namespace lib {
 
     Ty var = 0;
     Ty md = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
@@ -5598,7 +5598,7 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5617,7 +5617,7 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (GDL_NTHREADS=parallelize(sz)==1) {
+    if ((GDL_NTHREADS=parallelize(sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5648,7 +5648,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5683,7 +5683,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5723,7 +5723,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (GDL_NTHREADS=parallelize(sz)==1) {
+    if ((GDL_NTHREADS=parallelize(sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5778,7 +5778,7 @@ namespace lib {
     Ty var = 0;
     Ty md = 0;
     SizeT k = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
@@ -5812,7 +5812,7 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5831,7 +5831,7 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5863,7 +5863,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5910,7 +5910,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5950,7 +5950,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (GDL_NTHREADS=parallelize( sz)==1) {
+    if ((GDL_NTHREADS=parallelize( sz))==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6104,7 +6104,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6132,7 +6132,7 @@ namespace lib {
             }
           }
         } else {
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6188,7 +6188,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6216,7 +6216,7 @@ namespace lib {
             }
           }
         } else {
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6273,7 +6273,7 @@ namespace lib {
           if (dosdev) sdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (GDL_NTHREADS=parallelize( nEl)==1) {
+            if ((GDL_NTHREADS=parallelize( nEl))==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6303,7 +6303,7 @@ namespace lib {
               }
             }
           } else {
-            if (GDL_NTHREADS=parallelize( nEl)==1) {
+            if ((GDL_NTHREADS=parallelize( nEl))==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6361,7 +6361,7 @@ namespace lib {
           if (dosdev) sdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (GDL_NTHREADS=parallelize( nEl)==1) {
+            if ((GDL_NTHREADS=parallelize( nEl))==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6391,7 +6391,7 @@ namespace lib {
               }
             }
           } else {
-            if (GDL_NTHREADS=parallelize( nEl)==1) {
+            if ((GDL_NTHREADS=parallelize( nEl))==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6537,7 +6537,7 @@ namespace lib {
   }
 
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-    if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
@@ -7139,7 +7139,7 @@ namespace lib {
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       if (IntType(p0->Type())) {
         //Is a thread pool function
         for (SizeT i = 0; i < nEl; ++i) {

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1220,44 +1220,44 @@ namespace lib {
     if (re->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      if (!parallelize( nE)) {
+      if (GDL_NTHREADS=parallelize( nE)==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
           for (OMPInt i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[0], (*im)[i]);
       }
       return res;
     } else if (im->Rank() == 0) {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      if (!parallelize( nE)) {
+      if (GDL_NTHREADS=parallelize( nE)==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[0]);
       }
       return res;
     } else if (re->N_Elements() >= im->N_Elements()) {
       TypOutGDL* res = new TypOutGDL(im->Dim(), BaseGDL::NOZERO);
       SizeT nE = im->N_Elements();
-      if (!parallelize( nE)) {
+      if (GDL_NTHREADS=parallelize( nE)==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
           for (OMPInt i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       }
       return res;
     } else {
       TypOutGDL* res = new TypOutGDL(re->Dim(), BaseGDL::NOZERO);
       SizeT nE = re->N_Elements();
-      if (!parallelize( nE)) {
+      if (GDL_NTHREADS=parallelize( nE)==1) {
         for (SizeT i = 0; i < nE; i++) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nE; ++i) (*res)[i] = std::complex<decltype(t)>((*re)[i], (*im)[i]);
       }
       return res;
@@ -1809,12 +1809,12 @@ namespace lib {
     if (e1->Scalar()) {
       if (e1->LogTrue(0)) {
         res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-        if (!parallelize( nEl2)) {
+        if (GDL_NTHREADS=parallelize( nEl2)==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
 
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         }
       } else {
@@ -1823,11 +1823,11 @@ namespace lib {
     } else if (e2->Scalar()) {
       if (e2->LogTrue(0)) {
         res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-        if (!parallelize( nEl1)) {
+        if (GDL_NTHREADS=parallelize( nEl1)==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         }
       } else {
@@ -1835,21 +1835,21 @@ namespace lib {
       }
     } else if (nEl2 <= nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl2)) {
+      if (GDL_NTHREADS=parallelize( nEl2)==1) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       }
     } else // ( nEl2 > nEl1)
     {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl1)) {
+      if (GDL_NTHREADS=parallelize( nEl1)==1) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) && e2->LogTrue(i)) ? 1 : 0;
       }
     }
@@ -1875,57 +1875,57 @@ namespace lib {
     if (e1->Scalar()) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
       if (e1->LogTrue(0)) {
-        if (!parallelize( nEl2)) {
+        if (GDL_NTHREADS=parallelize( nEl2)==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = 1;
         }
       } else {
-        if (!parallelize( nEl2)) {
+        if (GDL_NTHREADS=parallelize( nEl2)==1) {
           for (SizeT i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = e2->LogTrue(i) ? 1 : 0;
         }
       }
     } else if (e2->Scalar()) {
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
       if (e2->LogTrue(0)) {
-        if (!parallelize( nEl1)) {
+        if (GDL_NTHREADS=parallelize( nEl1)==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = 1;
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = 1;
         }
       } else {
-        if (!parallelize( nEl1)) {
+        if (GDL_NTHREADS=parallelize( nEl1)==1) {
           for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
         }
       }
     } else if (nEl2 < nEl1) {
       res = new Data_<SpDByte>(e2->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl2)) {
+      if (GDL_NTHREADS=parallelize( nEl2)==1) {
         for (SizeT i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl2; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       }
     } else { // ( nEl2 >= nEl1)
       res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl1)) {
+      if (GDL_NTHREADS=parallelize( nEl1)==1) {
         for (SizeT i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = (e1->LogTrue(i) || e2->LogTrue(i)) ? 1 : 0;
       }
     }
@@ -1939,11 +1939,11 @@ namespace lib {
     ULong nEl1 = e1->N_Elements();
 
     Data_<SpDByte>* res = new Data_<SpDByte>(e1->Dim(), BaseGDL::NOZERO);
-    if (!parallelize( nEl1)) {
+    if (GDL_NTHREADS=parallelize( nEl1)==1) {
       for (SizeT i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl1; i++) (*res)[i] = e1->LogTrue(i) ? 1 : 0;
     }
     return res;
@@ -2018,29 +2018,29 @@ namespace lib {
 
     if (mode == 2) // both
     {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) trim2((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) trim2((*res)[i]);
       }
     } else if (mode == 1) // leading
     {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) trim1((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) trim1((*res)[i]);
       }
     } else // trailing
     {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) trim0((*res)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) trim0((*res)[i]);
       }
     }
@@ -2057,11 +2057,11 @@ namespace lib {
     DStringGDL* res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrCompress((*p0S)[ i], removeAll);
       }
@@ -2101,13 +2101,13 @@ namespace lib {
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
 
     SizeT nEl = p0S->N_Elements();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[ i] = StrPos((*p0S)[ i], searchString, pos, reverseOffset, reverseSearch);
       }
@@ -2178,7 +2178,7 @@ namespace lib {
       }
       return res;
     }
-    if (!parallelize(nSrcStr)) {
+    if (GDL_NTHREADS=parallelize(nSrcStr)==1) {
       for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
@@ -2192,7 +2192,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) default( shared)
+#pragma omp parallel for num_threads(GDL_NTHREADS) default( shared)
         for (OMPInt i = 0; i < nSrcStr; ++i) {
         for (long ii = 0; ii < stride; ++ii) {
           SizeT destIx = i * stride + ii;
@@ -2227,20 +2227,20 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrLowCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) StrLowCaseInplace((*p0S)[ i]);
       }
     }
@@ -2266,20 +2266,20 @@ namespace lib {
 
     if (isReference) {
       res = new DStringGDL(p0S->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = StrUpCase((*p0S)[ i]);
       }
     } else {
       res = p0S;
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) StrUpCaseInplace((*p0S)[ i]);
       }
     }
@@ -2300,7 +2300,7 @@ namespace lib {
     }
 
     DLongGDL* res = new DLongGDL(p0S->Dim(), BaseGDL::NOZERO);
-    //no use to parallelize, fast enough (on par)
+    //no use toGDL_NTHREADS=parallelize, fast enough (on par)
     SizeT nEl = p0S->N_Elements();
     for (SizeT i = 0; i < nEl; ++i) {
       (*res)[ i] = (*p0S)[ i].length();
@@ -2330,7 +2330,7 @@ namespace lib {
       return res;
     }
 
-    dimension resDim(p0S->Dim());
+    dimension resDim(p0S->Dim()==1);
     resDim.Purge();
 
     SizeT stride = resDim.Stride(1);
@@ -2421,17 +2421,17 @@ namespace lib {
   BaseGDL* total_template_generic(T* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
     typename T::Ty sum = 0;
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       if (!omitNaN) for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       else for (SizeT i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum) 
           for (OMPInt i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
           for (OMPInt i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
       }
     }
@@ -2445,21 +2445,21 @@ namespace lib {
     DFloat sr = 0;
     DFloat si = 0;
     if (!omitNaN) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sr,si)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sr,si)
           for (OMPInt i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
       }
     } else {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2467,7 +2467,7 @@ namespace lib {
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           DFloat lsr = 0;
           DFloat lsi = 0;
@@ -2492,21 +2492,21 @@ namespace lib {
     DDouble sr = 0;
     DDouble si = 0;
     if (!omitNaN) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sr,si)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sr,si)
           for (OMPInt i = 0; i < nEl; ++i) {
           sr += (*src)[i].real();
           si += (*src)[i].imag();
         }
       }
     } else {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) {
           if (isfinite((*src)[i].real())) sr += (*src)[i].real();
           if (isfinite((*src)[i].imag())) si += (*src)[i].imag();
@@ -2514,7 +2514,7 @@ namespace lib {
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           DDouble lsr = 0;
           DDouble lsi = 0;
@@ -2539,7 +2539,7 @@ namespace lib {
     //   std::cerr<<" total_template_double "<<std::endl;
     SizeT nEl = src->N_Elements();
     DDouble sum = 0;
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2548,11 +2548,11 @@ namespace lib {
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
           for (OMPInt i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
           for (OMPInt i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
       }
     }
@@ -2564,7 +2564,7 @@ namespace lib {
     //   std::cerr<<" total_template_single "<<std::endl;
     SizeT nEl = src->N_Elements();
     DDouble sum = 0;
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
@@ -2573,12 +2573,12 @@ namespace lib {
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
           for (OMPInt i = 0; i < nEl; ++i) sum += (*src)[ i];
       } else {
 
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
           for (OMPInt i = 0; i < nEl; ++i) if (isfinite((*src)[i])) sum += (*src)[ i];
       }
     }
@@ -2592,11 +2592,11 @@ namespace lib {
     //   std::cerr<<" total_template_integer "<<std::endl;
     SizeT nEl = src->N_Elements();
     DLong64 sum = 0;
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) sum += (*src)[ i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:sum)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:sum)
         for (OMPInt i = 0; i < nEl; ++i) sum += (*src)[ i];
     }
     return new DLong64GDL(sum);
@@ -2634,7 +2634,7 @@ namespace lib {
     SizeT sumStride = srcDim.Stride(sumDimIx);
     SizeT outerStride = srcDim.Stride(sumDimIx + 1);
     SizeT sumLimit = nSum * sumStride;
-    if (!parallelize( (nEl / outerStride))) {
+    if (GDL_NTHREADS=parallelize( (nEl / outerStride)==1)) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
@@ -2659,7 +2659,7 @@ namespace lib {
     } else {
       if (omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -2671,7 +2671,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * sumStride;
           for (SizeT i = 0; i < sumStride; ++i) {
@@ -3287,17 +3287,17 @@ namespace lib {
     typename T::Ty prod = 1;
     SizeT nEl = src->N_Elements();
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       if (!omitNaN) for (OMPInt i = 0; i < nEl; ++i) prod *= (*src)[ i];
       else for (OMPInt i = 0; i < nEl; ++i) if (std::isfinite((*src)[ i])) prod *= (*src)[ i];
     } else {
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prod)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prod)
           for (OMPInt i = 0; i < nEl; ++i) prod *= (*src)[ i];
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prod)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prod)
           for (OMPInt i = 0; i < nEl; ++i) if (std::isfinite((*src)[ i])) prod *= (*src)[ i];
       }
     }
@@ -3307,7 +3307,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       DComplexGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -3320,14 +3320,14 @@ namespace lib {
         DFloat prodi = 1;
         if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prodr,prodi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prodr,prodi)
           for (OMPInt i = 0; i < nEl; ++i) {
             prodr *= (*src)[i].real();
             prodi *= (*src)[i].imag();
           }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prodr,prodi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prodr,prodi)
           for (OMPInt i = 0; i < nEl; ++i) {
             prodr *= (std::isfinite((*src)[i].real())) ? (*src)[i].real() : 1;
             prodi *= (std::isfinite((*src)[i].imag())) ? (*src)[i].imag() : 1;
@@ -3340,7 +3340,7 @@ namespace lib {
   template<>
   BaseGDL* product_template(DComplexDblGDL* src, bool omitNaN) {
     SizeT nEl = src->N_Elements();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       DComplexDblGDL::Ty prod = 1;
       if (!omitNaN) {
         for (SizeT i = 0; i < nEl; ++i) prod *= (*src)[ i];
@@ -3353,14 +3353,14 @@ namespace lib {
       DDouble prodi = 1;
       if (!omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prodr,prodi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prodr,prodi)
           for (OMPInt i = 0; i < nEl; ++i) {
           prodr *= (*src)[i].real();
           prodi *= (*src)[i].imag();
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(*:prodr,prodi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(*:prodr,prodi)
           for (OMPInt i = 0; i < nEl; ++i) {
           prodr *= (std::isfinite((*src)[i].real())) ? (*src)[i].real() : 1;
           prodi *= (std::isfinite((*src)[i].imag())) ? (*src)[i].imag() : 1;
@@ -3401,7 +3401,7 @@ namespace lib {
     SizeT prodStride = srcDim.Stride(prodDimIx);
     SizeT outerStride = srcDim.Stride(prodDimIx + 1);
     SizeT prodLimit = nProd * prodStride;
-    if (!parallelize( (nEl / outerStride))) {
+    if (GDL_NTHREADS=parallelize( (nEl / outerStride)==1)) {
       if (omitNaN) {
         for (SizeT o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
@@ -3428,7 +3428,7 @@ namespace lib {
     } else {
       if (omitNaN) {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -3441,7 +3441,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt o = 0; o < nEl; o += outerStride) {
           SizeT rIx = (o / outerStride) * prodStride;
           for (SizeT i = 0; i < prodStride; ++i) {
@@ -5391,11 +5391,11 @@ namespace lib {
 
   template <typename Ty> static inline Ty do_mean(const Ty* data, const SizeT sz) {
     Ty mean = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) mean += data[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:mean)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:mean)
         for (OMPInt i = 0; i < sz; ++i) mean += data[i];
     }
     return mean / sz;
@@ -5404,7 +5404,7 @@ namespace lib {
   template <typename Ty, typename T2> static inline Ty do_mean_cpx(const Ty* data, const SizeT sz) {
     T2 meanr = 0;
     T2 meani = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         meanr += data[i].real();
         meani += data[i].imag();
@@ -5412,7 +5412,7 @@ namespace lib {
     } else {
 
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:meanr,meani)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:meanr,meani)
       for (OMPInt i = 0; i < sz; ++i) {
         meanr += data[i].real();
         meani += data[i].imag();
@@ -5424,7 +5424,7 @@ namespace lib {
   template <typename Ty> static inline Ty do_mean_nan(const Ty* data, const SizeT sz) {
     Ty mean = 0;
     SizeT n = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty v = data[i];
         if (std::isfinite(v)) {
@@ -5434,7 +5434,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:mean,n)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:mean,n)
       for (OMPInt i = 0; i < sz; ++i) {
         Ty v = data[i];
         if (std::isfinite(v)) {
@@ -5451,7 +5451,7 @@ namespace lib {
     T2 meani = 0;
     SizeT nr = 0;
     SizeT ni = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         T2 v = data[i].real();
         if (std::isfinite(v)) {
@@ -5466,7 +5466,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:meanr,nr,meani,ni)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:meanr,nr,meani,ni)
         for (OMPInt i = 0; i < sz; ++i) {
         T2 v = data[i].real();
         if (std::isfinite(v)) {
@@ -5638,7 +5638,7 @@ namespace lib {
 
     Ty var = 0;
     Ty md = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
@@ -5646,7 +5646,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:var,md)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:var,md)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         var += cdata*cdata;
@@ -5663,14 +5663,14 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skew)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:skew)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5682,14 +5682,14 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (!parallelize(sz)) {
+    if (GDL_NTHREADS=parallelize(sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurt)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:kurt)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5713,7 +5713,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5724,7 +5724,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:varr,vari,mdr)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:varr,vari,mdr)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5748,7 +5748,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5765,7 +5765,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skewr,skewi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:skewr,skewi)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5788,7 +5788,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (!parallelize(sz)) {
+    if (GDL_NTHREADS=parallelize(sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5808,7 +5808,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurtr,kurti)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:kurtr,kurti)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5843,7 +5843,7 @@ namespace lib {
     Ty var = 0;
     Ty md = 0;
     SizeT k = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
@@ -5854,7 +5854,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:var,md,k)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:var,md,k)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) {
@@ -5877,14 +5877,14 @@ namespace lib {
       return;
     }
     Ty skew = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skew)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:skew)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) skew += (cdata * cdata * cdata) / (var * sdev);
@@ -5896,14 +5896,14 @@ namespace lib {
       return;
     }
     Ty kurt = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurt)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:kurt)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         if (std::isfinite(cdata)) kurt += (cdata * cdata * cdata * cdata) / (var * var);
@@ -5928,7 +5928,7 @@ namespace lib {
     T2 mdr = 0;
     T2 varr = 0;
     T2 vari = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5945,7 +5945,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:varr,vari,mdr,kr,ki)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:varr,vari,mdr,kr,ki)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5975,7 +5975,7 @@ namespace lib {
     }
     T2 skewr = 0;
     T2 skewi = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -5992,7 +5992,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:skewr,skewi)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:skewr,skewi)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6015,7 +6015,7 @@ namespace lib {
     }
     T2 kurtr = 0;
     T2 kurti = 0;
-    if (!parallelize( sz)) {
+    if (GDL_NTHREADS=parallelize( sz)==1) {
       for (SizeT i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6035,7 +6035,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:kurtr,kurti)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:kurtr,kurti)
         for (OMPInt i = 0; i < sz; ++i) {
         Ty cdata = data[i] - meanl;
         T2 cdatar = cdata.real();
@@ -6169,7 +6169,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexDblGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6183,7 +6183,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6197,7 +6197,7 @@ namespace lib {
             }
           }
         } else {
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6211,7 +6211,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < nEl; ++i) {
               DDouble mdevl;
               DComplexDbl sdevl;
@@ -6253,7 +6253,7 @@ namespace lib {
         if (dosdev) sdev = new DComplexGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
         if (omitNaN) {
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6267,7 +6267,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6281,7 +6281,7 @@ namespace lib {
             }
           }
         } else {
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6295,7 +6295,7 @@ namespace lib {
             }
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < nEl; ++i) {
               DFloat mdevl;
               DComplex sdevl;
@@ -6338,7 +6338,7 @@ namespace lib {
           if (dosdev) sdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DDoubleGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (!parallelize( nEl)) {
+            if (GDL_NTHREADS=parallelize( nEl)==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6353,7 +6353,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
                 for (OMPInt i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6368,7 +6368,7 @@ namespace lib {
               }
             }
           } else {
-            if (!parallelize( nEl)) {
+            if (GDL_NTHREADS=parallelize( nEl)==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6383,7 +6383,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
                 for (OMPInt i = 0; i < nEl; ++i) {
                 DDouble mdevl;
                 DDouble sdevl;
@@ -6426,7 +6426,7 @@ namespace lib {
           if (dosdev) sdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (domdev) mdev = new DFloatGDL(auxiliaryDim, BaseGDL::NOZERO);
           if (omitNaN) {
-            if (!parallelize( nEl)) {
+            if (GDL_NTHREADS=parallelize( nEl)==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6441,7 +6441,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
                 for (OMPInt i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6456,7 +6456,7 @@ namespace lib {
               }
             }
           } else {
-            if (!parallelize( nEl)) {
+            if (GDL_NTHREADS=parallelize( nEl)==1) {
               for (SizeT i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6471,7 +6471,7 @@ namespace lib {
               }
             } else {
               TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
                 for (OMPInt i = 0; i < nEl; ++i) {
                 DFloat mdevl;
                 DFloat sdevl;
@@ -6602,14 +6602,14 @@ namespace lib {
   }
 
   template<typename T> void ishft_m(T* out, const SizeT n, const DLong* s) {
-    if (!parallelize( n)) {
+    if (GDL_NTHREADS=parallelize( n)==1) {
       for (SizeT i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < n; ++i) {
         if (s[i] >= 0) out[i] <<= s[i];
         else out[i] >>= s[i];
@@ -7204,7 +7204,7 @@ namespace lib {
     //    cout << "Min/max :" << min << " " << max << endl;
 
     SizeT nEl = dRes->N_Elements();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       if (IntType(p0->Type())) {
         //Is a thread pool function
         for (SizeT i = 0; i < nEl; ++i) {
@@ -7232,7 +7232,7 @@ namespace lib {
       if (IntType(p0->Type())) {
         //Is a thread pool function
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (d <= min) (*dRes)[ i] = 0;
@@ -7244,7 +7244,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) {
           DDouble& d = (*dRes)[ i];
           if (omitNaN && (isnan(d) || isinf(d))) (*dRes)[ i] = 0;

--- a/src/basic_fun_cl.cpp
+++ b/src/basic_fun_cl.cpp
@@ -562,11 +562,12 @@ namespace lib {
 
   BaseGDL* legendre(EnvT* e)
   {
+    SizeT nParam=e->NParam(2); //, "LEGENDRE");
+
     Guard<BaseGDL> x_guard;
     Guard<BaseGDL> l_guard;
     Guard<BaseGDL> m_guard;
 
-    SizeT nParam=e->NParam(2); //, "LEGENDRE");
     Guard<BaseGDL> guard;
     int count;
     

--- a/src/basic_fun_jmg.cpp
+++ b/src/basic_fun_jmg.cpp
@@ -44,7 +44,7 @@ namespace lib {
  
   BaseGDL* isa_fun( EnvT* e) 
   {
-    if (e->NParam() == 0) e->Throw("Requires at least one argument !");
+    e->NParam(1);
 
     DString type;
     BaseGDL *p0;

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -51,8 +51,7 @@ Data_<Sp>* Data_<Sp>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -73,8 +72,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -93,8 +91,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -146,8 +143,7 @@ BaseGDL* Data_<Sp>::UMinus() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -192,8 +188,7 @@ Data_<SpDByte>* Data_<Sp>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -224,8 +219,7 @@ Data_<SpDByte>* Data_<SpDObj>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -246,8 +240,7 @@ Data_<SpDByte>* Data_<SpDFloat>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -268,8 +261,7 @@ Data_<SpDByte>* Data_<SpDDouble>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -290,8 +282,7 @@ Data_<SpDByte>* Data_<SpDString>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -312,8 +303,7 @@ Data_<SpDByte>* Data_<SpDComplex>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -334,8 +324,7 @@ Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FI
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -358,8 +347,7 @@ void Data_<Sp>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -378,8 +366,7 @@ void Data_<Sp>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -400,8 +387,7 @@ void Data_<SpDFloat>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -421,8 +407,7 @@ void Data_<SpDFloat>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -443,8 +428,7 @@ void Data_<SpDDouble>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -464,8 +448,7 @@ void Data_<SpDDouble>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -486,8 +469,7 @@ void Data_<SpDComplex>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -507,8 +489,7 @@ void Data_<SpDComplex>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -528,8 +509,7 @@ void Data_<SpDComplexDbl>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -549,8 +529,7 @@ void Data_<SpDComplexDbl>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -616,8 +595,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -631,8 +609,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -642,8 +619,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -658,8 +634,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -771,8 +746,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -786,8 +760,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -797,8 +770,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -813,8 +785,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -847,8 +818,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -862,8 +832,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -873,8 +842,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -889,8 +857,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -999,8 +966,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1014,8 +980,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1025,8 +990,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1041,8 +1005,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1075,8 +1038,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1090,8 +1052,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1101,8 +1062,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1117,8 +1077,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1176,8 +1135,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1191,8 +1149,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1202,8 +1159,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1218,8 +1174,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1277,8 +1232,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1292,8 +1246,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1303,8 +1256,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1319,8 +1271,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1378,8 +1329,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1393,8 +1343,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1404,8 +1353,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1420,8 +1368,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1626,8 +1573,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
-      if (!parallelize) {
+      if (!parallelize( nOp)) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1653,8 +1599,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
-      if (!parallelize) {
+      if (!parallelize( nOp)) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1682,8 +1627,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
-      if (!parallelize) {
+      if (!parallelize( nOp)) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, ++rowBnCol) // res dim 1
@@ -1709,8 +1653,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
-      if (!parallelize) {
+      if (!parallelize( nOp)) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
           {
@@ -1785,8 +1728,7 @@ Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
   // note: we can't use valarray operation here as right->dd
   // might be larger than this->dd
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1814,8 +1756,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1836,8 +1777,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1860,8 +1800,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1882,8 +1821,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1971,8 +1909,7 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2028,8 +1965,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2080,8 +2016,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2147,8 +2082,7 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2176,8 +2110,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2198,8 +2131,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2221,8 +2153,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2243,8 +2174,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2301,8 +2231,7 @@ Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2332,8 +2261,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2365,8 +2293,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2391,8 +2318,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2423,8 +2349,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2485,8 +2410,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   if (right->StrictScalar(s)) {
     if (s != Sp::zero) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2496,8 +2420,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     }
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2563,8 +2486,7 @@ Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   }
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2635,8 +2557,7 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2689,8 +2610,7 @@ Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   }
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2745,8 +2665,7 @@ Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2800,8 +2719,7 @@ Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
 
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2860,8 +2778,7 @@ Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -2888,8 +2805,7 @@ Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -2914,8 +2830,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2933,8 +2848,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2957,8 +2871,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2976,8 +2889,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3105,8 +3017,7 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -3127,8 +3038,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3147,8 +3057,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3166,8 +3075,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3186,8 +3094,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3293,8 +3200,7 @@ Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3312,8 +3218,7 @@ Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3334,8 +3239,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   assert(nEl);
   {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3366,8 +3270,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3380,8 +3283,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3392,8 +3294,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   }
   if (nEl <= rEl) {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3404,8 +3305,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3427,8 +3327,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3441,8 +3340,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3453,8 +3351,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   }
   if (nEl <= rEl) {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3465,8 +3362,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3487,8 +3383,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3508,8 +3403,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   assert(rEl);
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3529,8 +3423,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   assert(rEl);
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3558,8 +3451,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3575,8 +3467,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3586,8 +3477,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3599,8 +3489,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3620,8 +3509,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3637,8 +3525,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3648,8 +3535,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3661,8 +3547,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3680,8 +3565,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3701,8 +3585,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3730,8 +3613,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3747,8 +3629,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3758,8 +3639,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3771,8 +3651,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3794,8 +3673,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3811,8 +3689,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3822,8 +3699,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3835,8 +3711,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3854,8 +3729,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3879,8 +3753,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) { TRACE_ROUTINE(_
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*right)[ i], (*this)[i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3936,8 +3809,7 @@ Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3956,8 +3828,7 @@ Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3976,8 +3847,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3995,8 +3865,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4015,8 +3884,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4035,8 +3903,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4064,8 +3931,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4081,8 +3947,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4092,8 +3957,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4105,8 +3969,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4126,8 +3989,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4143,8 +4005,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4154,8 +4015,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4167,8 +4027,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4183,8 +4042,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4204,8 +4062,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   assert(rEl);
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4233,8 +4090,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4250,8 +4106,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4261,8 +4116,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4274,8 +4128,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4297,8 +4150,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4314,8 +4166,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4325,8 +4176,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4338,8 +4188,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4354,8 +4203,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4374,8 +4222,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -23,7 +23,6 @@
 #include <omp.h>
 #endif
 
-//#include "datatypes.hpp" // for friend declaration
 #include "nullgdl.hpp"
 #include "dinterpreter.hpp"
 
@@ -41,528 +40,554 @@ using namespace Eigen;
 
 // Not operation
 // for integers
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::NotOp()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
+Data_<Sp>* Data_<Sp>::NotOp() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
 
-  if( nEl == 1)
-    {
-      (*this)[0] = ~(*this)[0];
-      return this;
-    }
+  if (nEl == 1) {
+    (*this)[0] = ~(*this)[0];
+    return this;
+  }
 
-  //  if( !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  {
-#pragma omp for
-    for( OMPInt i=0; i < nEl; ++i)
-      (*this)[i] = ~(*this)[i];
-  }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
+  }
   return this;
 }
+
 // others
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::NotOp()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  //  if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] = ((*this)[0] == 0.0f)? 1.0f : 0.0f;
-      return this;
-    }
 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = ((*this)[i] == 0.0f)? 1.0f : 0.0f;
-    }  return this;
-}
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::NotOp()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  //  if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] = ((*this)[0] == 0.0)? 1.0 : 0.0;
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = ((*this)[i] == 0.0)? 1.0 : 0.0;
-    }  return this;
-}
-template<>
-Data_<SpDString>* Data_<SpDString>::NotOp()
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDFloat>* Data_<SpDFloat>::NotOp() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+  if (nEl == 1) {
+    (*this)[0] = ((*this)[0] == 0.0f) ? 1.0f : 0.0f;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
+  }
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::NotOp()
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDDouble>* Data_<SpDDouble>::NotOp() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+  if (nEl == 1) {
+    (*this)[0] = ((*this)[0] == 0.0) ? 1.0 : 0.0;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
+  }
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::NotOp()
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDString>* Data_<SpDString>::NotOp() {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::NotOp()
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::NotOp() {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::NotOp()
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::NotOp() {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::NotOp() {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::NotOp() {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 // UMinus unary minus
 // for numbers
+
 template<class Sp>
-BaseGDL* Data_<Sp>::UMinus()
-{
-  //  dd = -dd;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  //  if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] = -(*this)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = -(*this)[i];
-    }  return this;
-}
-template<>
-BaseGDL* Data_<SpDString>::UMinus()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  //  if( !nEl) throw GDLException("Variable is undefined.");  
-  Data_<SpDFloat>* newThis=static_cast<Data_<SpDFloat>*>(this->Convert2( GDL_FLOAT));
-  //  this is deleted by convert2!!! 
-  return static_cast<BaseGDL*>( newThis->UMinus());
-}
-template<>
-BaseGDL* Data_<SpDPtr>::UMinus()
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<Sp>::UMinus() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+  if (nEl == 1) {
+    (*this)[0] = -(*this)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
+  }
   return this;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::UMinus()
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+BaseGDL* Data_<SpDString>::UMinus() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+  Data_<SpDFloat>* newThis = static_cast<Data_<SpDFloat>*> (this->Convert2(GDL_FLOAT));
+  //  this is deleted by convert2!!!
+  return static_cast<BaseGDL*> (newThis->UMinus());
+}
+
+template<>
+BaseGDL* Data_<SpDPtr>::UMinus() {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+BaseGDL* Data_<SpDObj>::UMinus() {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 // logical negation
 // integers, also ptr and object
+
 template<class Sp>
-Data_<SpDByte>* Data_<Sp>::LogNeg()
-{
+Data_<SpDByte>* Data_<Sp>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  DByteGDL* res = new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-  
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0] == 0)? 1 : 0;
-      return res;
-    }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i] == 0)? 1 : 0;
-    }  return res;
+  assert(nEl);
+  DByteGDL* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0] == 0) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDObj>::LogNeg()
-{
-  if( this->Scalar())
-  {
-    DSubUD* isTrueOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( dd[0], OOIsTrue));
-    if( isTrueOverload != NULL) 
-    {
-      if( this->LogTrue())
-	return new Data_<SpDByte>( 0);
-      else 
-	return new Data_<SpDByte>( 1);
+Data_<SpDByte>* Data_<SpDObj>::LogNeg() {
+  if (this->Scalar()) {
+    DSubUD* isTrueOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator(dd[0], OOIsTrue));
+    if (isTrueOverload != NULL) {
+      if (this->LogTrue())
+        return new Data_<SpDByte>(0);
+      else
+        return new Data_<SpDByte>(1);
     }
   }
-  
+
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  DByteGDL* res = new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-  
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0] == 0)? 1 : 0;
-      return res;
-    }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i] == 0)? 1 : 0;
-    }  return res;
+  assert(nEl);
+  DByteGDL* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0] == 0) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDFloat>::LogNeg()
-{
+Data_<SpDByte>* Data_<SpDFloat>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  
-  DByteGDL* res = new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0] == 0.0f)? 1 : 0;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i] == 0.0f)? 1 : 0;
-    }  return res;
+  assert(nEl);
+
+  DByteGDL* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0] == 0.0f) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDDouble>::LogNeg()
-{
+Data_<SpDByte>* Data_<SpDDouble>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  
-  DByteGDL* res = new Data_<SpDByte>( dim, BaseGDL::NOZERO);
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0] == 0.0)? 1 : 0;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i] == 0.0)? 1 : 0;
-    }  return res;
+  assert(nEl);
+
+  DByteGDL* res = new Data_<SpDByte>(dim, BaseGDL::NOZERO);
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0] == 0.0) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDString>::LogNeg()
-{
+Data_<SpDByte>* Data_<SpDString>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  DByteGDL* res = new Data_<SpDByte>( dim, BaseGDL::NOZERO);
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0] == "")? 1 : 0;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i] == "")? 1 : 0;
-    }  return res;
+  assert(nEl);
+
+  DByteGDL* res = new Data_<SpDByte>(dim, BaseGDL::NOZERO);
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0] == "") ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDComplex>::LogNeg()
-{
+Data_<SpDByte>* Data_<SpDComplex>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  DByteGDL* res = new Data_<SpDByte>( dim, BaseGDL::NOZERO);
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0].real() == 0.0 && (*this)[0].imag() == 0.0)? 1 : 0;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0)? 1 : 0;
-    }  return res;
+  assert(nEl);
+
+  DByteGDL* res = new Data_<SpDByte>(dim, BaseGDL::NOZERO);
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0].real() == 0.0 && (*this)[0].imag() == 0.0) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
+  }
+  return res;
 }
+
 template<>
-Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg()
-{
+Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() {
   SizeT nEl = dd.size();
-  assert( nEl);
-  //  if( nEl == 0) throw GDLException("Variable is undefined.");  
-  DByteGDL* res = new Data_<SpDByte>( dim, BaseGDL::NOZERO);
-  if( nEl == 1)
-    {
-      (*res)[0] = ((*this)[0].real() == 0.0 && (*this)[0].imag() == 0.0)? 1 : 0;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0)? 1 : 0;
-    }  return res;
+  assert(nEl);
+
+  DByteGDL* res = new Data_<SpDByte>(dim, BaseGDL::NOZERO);
+  if (nEl == 1) {
+    (*res)[0] = ((*this)[0].real() == 0.0 && (*this)[0].imag() == 0.0) ? 1 : 0;
+    return res;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
+  }
+  return res;
 }
 
 // increment decrement operators
 // integers
+
 template<class Sp>
-void Data_<Sp>::Dec()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0]--;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i]--;
-    }}
+void Data_<Sp>::Dec() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0]--;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
+  }
+}
+
 template<class Sp>
-void Data_<Sp>::Inc()
-{
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0]++;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i]++;
-    }}
+void Data_<Sp>::Inc() {
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0]++;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
+  }
+}
 // float
+
 template<>
-void Data_<SpDFloat>::Dec()
-{
-  //   dd -= 1.0f;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] -= 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] -= 1.0;
-    }}
+void Data_<SpDFloat>::Dec() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] -= 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  }
+}
+
 template<>
-void Data_<SpDFloat>::Inc()
-{
-  //   dd += 1.0f;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] += 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += 1.0;
-    }}
+void Data_<SpDFloat>::Inc() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] += 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  }
+}
 // double
+
 template<>
-void Data_<SpDDouble>::Dec()
-{
-  //   dd -= 1.0;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] -= 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] -= 1.0;
-    }}
+void Data_<SpDDouble>::Dec() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] -= 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  }
+}
+
 template<>
-void Data_<SpDDouble>::Inc()
-{
-  //   dd += 1.0;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] += 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += 1.0;
-    }}
+void Data_<SpDDouble>::Inc() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] += 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  }
+}
 // complex
+
 template<>
-void Data_<SpDComplex>::Dec()
-{
-  //   dd -= 1.0f;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] -= 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] -= 1.0;
-    }}
+void Data_<SpDComplex>::Dec() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] -= 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  }
+}
+
 template<>
-void Data_<SpDComplex>::Inc()
-{
-  //   dd += 1.0f;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] += 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += 1.0;
-    }}
+void Data_<SpDComplex>::Inc() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] += 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  }
+}
+
 template<>
-void Data_<SpDComplexDbl>::Dec()
-{
-  //   dd -= 1.0;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] -= 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] -= 1.0;
-    }}
+void Data_<SpDComplexDbl>::Dec() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] -= 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
+  }
+}
+
 template<>
-void Data_<SpDComplexDbl>::Inc()
-{
-  //   dd += 1.0;
-  ULong nEl=N_Elements();
-  assert( nEl != 0);
-  // if( !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] += 1.0;
-      return;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += 1.0;
-    }}
+void Data_<SpDComplexDbl>::Inc() {
+
+  ULong nEl = N_Elements();
+  assert(nEl != 0);
+
+  if (nEl == 1) {
+    (*this)[0] += 1.0;
+    return;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
+  }
+}
 // forbidden types
+
 template<>
-void Data_<SpDString>::Dec()
-{
-  throw GDLException("String expression not allowed in this context.",true,false);
+void Data_<SpDString>::Dec() {
+  throw GDLException("String expression not allowed in this context.", true, false);
 }
+
 template<>
-void Data_<SpDPtr>::Dec()
-{
-  throw GDLException("Pointer expression not allowed in this context.",true,false);
+void Data_<SpDPtr>::Dec() {
+  throw GDLException("Pointer expression not allowed in this context.", true, false);
 }
+
 template<>
-void Data_<SpDObj>::Dec()
-{
-  throw GDLException("Object expression not allowed in this context.",true,false);
+void Data_<SpDObj>::Dec() {
+  throw GDLException("Object expression not allowed in this context.", true, false);
 }
+
 template<>
-void Data_<SpDString>::Inc()
-{
-  throw GDLException("String expression not allowed in this context.",true,false);
+void Data_<SpDString>::Inc() {
+  throw GDLException("String expression not allowed in this context.", true, false);
 }
+
 template<>
-void Data_<SpDPtr>::Inc()
-{
-  throw GDLException("Pointer expression not allowed in this context.",true,false);
+void Data_<SpDPtr>::Inc() {
+  throw GDLException("Pointer expression not allowed in this context.", true, false);
 }
+
 template<>
-void Data_<SpDObj>::Inc()
-{
-  throw GDLException("Object expression not allowed in this context.",true,false);
+void Data_<SpDObj>::Inc() {
+  throw GDLException("Object expression not allowed in this context.", true, false);
 }
 
 
@@ -571,1213 +596,1147 @@ void Data_<SpDObj>::Inc()
 // 1. operators that always return a new result
 // EqOp
 // returns *this eq *r
-template<class Sp>
-BaseGDL* Data_<Sp>::EqOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //   if( nEl == 0)
-  // 	 nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = (s == (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] == s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = (s == (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] == s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] == (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    }
+  }
   return res;
 }
 // must handle overloads
+
 template<>
-BaseGDL* Data_<SpDObj>::EqOp( BaseGDL* r)
-{
-  if( Scalar())
-//   if( StrictScalar())
-  {
-//     DStructGDL* oStructGDL= GDLInterpreter::GetObjHeapNoThrow( (*this)[0]);
-//     if( oStructGDL != NULL) // object not valid -> default behaviour
-//     {
-//       DStructDesc* desc = oStructGDL->Desc();
-//   
-//       DFun* EQOverload = static_cast<DFun*>(desc->GetOperator( OOEQ));
-//
-      DSubUD* EQOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*this)[0], OOEQ));
-      if( EQOverload == NULL)
-      {
+BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
+  if (Scalar()) {
+    DSubUD* EQOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*this)[0], OOEQ));
+    if (EQOverload == NULL) {
       //scalar object 'this' can be equal to NullGDL::GetSingleInstance() only of it is undefined. If not scalar, not equal, if defined, not equal.
-	if( r == NullGDL::GetSingleInstance())
-	{
-            DObj pVal;
-            if( this->Scalar( pVal)) {
-               if (pVal==0) return new Data_<SpDByte>( 1);
-               return new DByteGDL( !interpreter->ObjValid( pVal ));
-              }
-	  Data_<SpDByte>* res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-	  (*res)[0] = (0 == (*this)[0]);
-	  return res;
-	} 
+      if (r == NullGDL::GetSingleInstance()) {
+        DObj pVal;
+        if (this->Scalar(pVal)) {
+          if (pVal == 0) return new Data_<SpDByte>(1);
+          return new DByteGDL(!interpreter->ObjValid(pVal));
+        }
+        Data_<SpDByte>* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+        (*res)[0] = (0 == (*this)[0]);
+        return res;
       }
-      else //( EQOverload != NULL)
+    } else //( EQOverload != NULL)
+    {
+      ProgNodeP callingNode = interpreter->GetRetTree();
+      // hidden SELF is counted as well
+      int nParSub = EQOverload->NPar();
+      assert(nParSub >= 1); // SELF
+      if (nParSub < 3) // (SELF), LEFT, RIGHT
       {
-	ProgNodeP callingNode = interpreter->GetRetTree();
-	// hidden SELF is counted as well
-	int nParSub = EQOverload->NPar();
-	assert( nParSub >= 1); // SELF
-	if( nParSub < 3) // (SELF), LEFT, RIGHT
-	{
-	  throw GDLException( callingNode, EQOverload->ObjectName() +
-			  ": Incorrect number of arguments.",
-			  false, false);
-	}
-	EnvUDT* newEnv;
-	DObjGDL* self;
-	Guard<BaseGDL> selfGuard;
-	// Dup() here is not optimal
-	// avoid at least for internal overload routines (which do/must not change SELF or r)
-	bool internalDSubUD = EQOverload->GetTree()->IsWrappedNode();  
-	if( internalDSubUD)  
-	{
-	  self = this;
-	  newEnv= new EnvUDT( callingNode, EQOverload, &self);
-	  newEnv->SetNextParUnchecked( (BaseGDL**) &self); // LEFT  parameter
-	  newEnv->SetNextParUnchecked( &r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
-	}
-	else
-	{
-	  self = this->Dup();
-	  selfGuard.Init( self);
-	  newEnv= new EnvUDT( callingNode, EQOverload, &self);
-	  newEnv->SetNextParUnchecked( this->Dup()); // LEFT  parameter, as value
-	  newEnv->SetNextParUnchecked( r->Dup()); // RIGHT parameter, as value
-	}
-
-	
-	// better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
-	StackGuard<EnvStackT> guard(interpreter->CallStack());
-
-	interpreter->CallStack().push_back( newEnv); 
-	
-	// make the call
-	BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
-
-	if( !internalDSubUD && self != selfGuard.Get())
-	{
-	  // always put out warning first, in case of a later crash
-	  Warning( "WARNING: " + EQOverload->ObjectName() + 
-		": Assignment to SELF detected (GDL session still ok).");
-	  // assignment to SELF -> self was deleted and points to new variable
-	  // which it owns
-	  selfGuard.Release();
-	  if( static_cast<BaseGDL*>(self) != NullGDL::GetSingleInstance())
-	    selfGuard.Reset(self);
-	}
-
-	return res;
+        throw GDLException(callingNode, EQOverload->ObjectName() +
+          ": Incorrect number of arguments.",
+          false, false);
       }
-//     }
+      EnvUDT* newEnv;
+      DObjGDL* self;
+      Guard<BaseGDL> selfGuard;
+      // Dup() here is not optimal
+      // avoid at least for internal overload routines (which do/must not change SELF or r)
+      bool internalDSubUD = EQOverload->GetTree()->IsWrappedNode();
+      if (internalDSubUD) {
+        self = this;
+        newEnv = new EnvUDT(callingNode, EQOverload, &self);
+        newEnv->SetNextParUnchecked((BaseGDL**) & self); // LEFT  parameter
+        newEnv->SetNextParUnchecked(&r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
+      } else {
+        self = this->Dup();
+        selfGuard.Init(self);
+        newEnv = new EnvUDT(callingNode, EQOverload, &self);
+        newEnv->SetNextParUnchecked(this->Dup()); // LEFT  parameter, as value
+        newEnv->SetNextParUnchecked(r->Dup()); // RIGHT parameter, as value
+      }
+
+
+      // better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
+      StackGuard<EnvStackT> guard(interpreter->CallStack());
+
+      interpreter->CallStack().push_back(newEnv);
+
+      // make the call
+      BaseGDL* res = interpreter->call_fun(static_cast<DSubUD*> (newEnv->GetPro())->GetTree());
+
+      if (!internalDSubUD && self != selfGuard.Get()) {
+        // always put out warning first, in case of a later crash
+        Warning("WARNING: " + EQOverload->ObjectName() +
+          ": Assignment to SELF detected (GDL session still ok).");
+        // assignment to SELF -> self was deleted and points to new variable
+        // which it owns
+        selfGuard.Release();
+        if (static_cast<BaseGDL*> (self) != NullGDL::GetSingleInstance())
+          selfGuard.Reset(self);
+      }
+
+      return res;
+    }
   } // if( StrictScalar())
-  
+
   // handle type conversion first
   // here r can be of any GDL type (due to operator overloading)
-  if( r->Type() != GDL_OBJ)
-  {
-	if( r == NullGDL::GetSingleInstance()) // "this" is not scalar here -> return always false
-	{
-	  Data_<SpDByte>* res= new Data_<SpDByte>(0);
-// 	  (*res)[0] = 0;
-	  return res;
-	} 
-        throw GDLException("Unable to convert variable to type object reference.",true,false);
+  if (r->Type() != GDL_OBJ) {
+    if (r == NullGDL::GetSingleInstance()) // "this" is not scalar here -> return always false
+    {
+      Data_<SpDByte>* res = new Data_<SpDByte>(0);
+      return res;
+    }
+    throw GDLException("Unable to convert variable to type object reference.", true, false);
   }
 
   // same code as for other types from here
-  Data_* right=static_cast<Data_*>(r);
-  
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //   if( nEl == 0)
-  // 	 nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = (s == (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] == s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] == (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] == (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = (s == (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] == s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] == (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
+    }
+  }
   return res;
 }
-// invalid types
-// template<>
-// Data_<SpDByte>* Data_<SpDPtr>::EqOp( BaseGDL* r)
-// {
-//   throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-//   return NULL;
-// }
-// template<>
-// Data_<SpDByte>* Data_<SpDObj>::EqOp( BaseGDL* r)
-// {
-//   throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-//   return NULL;
-// }
 
 // NeOp
 // returns *this ne *r, //C deletes itself and right
-template<class Sp>
-BaseGDL* Data_<Sp>::NeOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
-  
-  Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = (s != (*this)[0]);
-	  return res;
-	}
 
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] != s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  Ty s;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = (s != (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] != s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] != (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    }
+  }
   return res;
 }
 
 // must handle overloads
+
 template<>
-BaseGDL* Data_<SpDObj>::NeOp( BaseGDL* r)
-{  
-  if( Scalar())
-//   if( StrictScalar())
-  {
-//     DStructGDL* oStructGDL= GDLInterpreter::GetObjHeapNoThrow( (*this)[0]);
-//     if( oStructGDL != NULL) // object not valid -> default behaviour
-//     {
-//       DStructDesc* desc = oStructGDL->Desc();
-//   
-//       DFun* NEOverload = static_cast<DFun*>(desc->GetOperator( OONE));
-//       
-      DSubUD* NEOverload = 
-	static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*this)[0], OONE));
-      if( NEOverload == NULL)
-      {
-	if( r == NullGDL::GetSingleInstance())
-	{
-	  Data_<SpDByte>* res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-	  (*res)[0] = (0 != (*this)[0]);
-	  return res;
-	} 
+BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
+  if (Scalar()) {
+    DSubUD* NEOverload =
+      static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*this)[0], OONE));
+    if (NEOverload == NULL) {
+      if (r == NullGDL::GetSingleInstance()) {
+        Data_<SpDByte>* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+        (*res)[0] = (0 != (*this)[0]);
+        return res;
       }
-      else //      if( NEOverload != NULL)
+    } else //      if( NEOverload != NULL)
+    {
+      ProgNodeP callingNode = interpreter->GetRetTree();
+      // hidden SELF is counted as well
+      int nParSub = NEOverload->NPar();
+      assert(nParSub >= 1); // SELF
+      if (nParSub < 3) // (SELF), LEFT, RIGHT
       {
-	ProgNodeP callingNode = interpreter->GetRetTree();
-	// hidden SELF is counted as well
-	int nParSub = NEOverload->NPar();
-	assert( nParSub >= 1); // SELF
-	if( nParSub < 3) // (SELF), LEFT, RIGHT
-	{
-	  throw GDLException( callingNode, NEOverload->ObjectName() +
-			  ": Incorrect number of arguments.",
-			  false, false);
-	}
-	EnvUDT* newEnv;
-	DObjGDL* self;
-	Guard<BaseGDL> selfGuard;
-	// Dup() here is not optimal
-	// avoid at least for internal overload routines (which do/must not change SELF or r)
-	bool internalDSubUD = NEOverload->GetTree()->IsWrappedNode();  
-	if( internalDSubUD)  
-	{
-	  self = this;
-	  newEnv= new EnvUDT( callingNode, NEOverload, &self);
-	  newEnv->SetNextParUnchecked( (BaseGDL**)&self); // LEFT  parameter
-	  newEnv->SetNextParUnchecked( &r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
-	}
-	else
-	{
-	  self = this->Dup();
-	  selfGuard.Init( self);
-	  newEnv= new EnvUDT( callingNode, NEOverload, &self);
-	  newEnv->SetNextParUnchecked( this->Dup()); // LEFT  parameter, as value
-	  newEnv->SetNextParUnchecked( r->Dup()); // RIGHT parameter, as value
-	}
-
-	
-	// better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
-	StackGuard<EnvStackT> guard(interpreter->CallStack());
-
-	interpreter->CallStack().push_back( newEnv); 
-	
-	// make the call
-	BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
-
-	if( !internalDSubUD && self != selfGuard.Get())
-	{
-	  // always put out warning first, in case of a later crash
-	  Warning( "WARNING: " + NEOverload->ObjectName() + 
-		": Assignment to SELF detected (GDL session still ok).");
-	  // assignment to SELF -> self was deleted and points to new variable
-	  // which it owns
-	  selfGuard.Release();
-	  if( static_cast<BaseGDL*>( self) != NullGDL::GetSingleInstance())
-	    selfGuard.Reset(self);
-	}
-
-	return res;
+        throw GDLException(callingNode, NEOverload->ObjectName() +
+          ": Incorrect number of arguments.",
+          false, false);
       }
-//     }
+      EnvUDT* newEnv;
+      DObjGDL* self;
+      Guard<BaseGDL> selfGuard;
+      // Dup() here is not optimal
+      // avoid at least for internal overload routines (which do/must not change SELF or r)
+      bool internalDSubUD = NEOverload->GetTree()->IsWrappedNode();
+      if (internalDSubUD) {
+        self = this;
+        newEnv = new EnvUDT(callingNode, NEOverload, &self);
+        newEnv->SetNextParUnchecked((BaseGDL**) & self); // LEFT  parameter
+        newEnv->SetNextParUnchecked(&r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
+      } else {
+        self = this->Dup();
+        selfGuard.Init(self);
+        newEnv = new EnvUDT(callingNode, NEOverload, &self);
+        newEnv->SetNextParUnchecked(this->Dup()); // LEFT  parameter, as value
+        newEnv->SetNextParUnchecked(r->Dup()); // RIGHT parameter, as value
+      }
+
+
+      // better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
+      StackGuard<EnvStackT> guard(interpreter->CallStack());
+
+      interpreter->CallStack().push_back(newEnv);
+
+      // make the call
+      BaseGDL* res = interpreter->call_fun(static_cast<DSubUD*> (newEnv->GetPro())->GetTree());
+
+      if (!internalDSubUD && self != selfGuard.Get()) {
+        // always put out warning first, in case of a later crash
+        Warning("WARNING: " + NEOverload->ObjectName() +
+          ": Assignment to SELF detected (GDL session still ok).");
+        // assignment to SELF -> self was deleted and points to new variable
+        // which it owns
+        selfGuard.Release();
+        if (static_cast<BaseGDL*> (self) != NullGDL::GetSingleInstance())
+          selfGuard.Reset(self);
+      }
+
+      return res;
+    }
   } // if( StrictScalar())
-  
+
   // handle type conversion first
   // here r can be of any GDL type (due to operator overloading)
-  if( r->Type() != GDL_OBJ)
-  {
-    if( r == NullGDL::GetSingleInstance()) // "this" is not scalar here -> return always true
+  if (r->Type() != GDL_OBJ) {
+    if (r == NullGDL::GetSingleInstance()) // "this" is not scalar here -> return always true
     {
-      Data_<SpDByte>* res= new Data_<SpDByte>(1);
-// 	  (*res)[0] = 0;
+      Data_<SpDByte>* res = new Data_<SpDByte>(1);
       return res;
-    } 
-      
-    throw GDLException("Unable to convert variable to type object reference.",true,false);
+    }
+
+    throw GDLException("Unable to convert variable to type object reference.", true, false);
   }
 
   // same code as for other types from here
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
-  
-  Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = (s != (*this)[0]);
-	  return res;
-	}
 
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] != s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] != (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] != (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  Ty s;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = (s != (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] != s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] != (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
+    }
+  }
   return res;
 }
-
-// invalid types
-// template<>
-// Data_<SpDByte>* Data_<SpDPtr>::NeOp( BaseGDL* r)
-// {
-//   throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-//   return NULL;
-// }
-// template<>
-// Data_<SpDByte>* Data_<SpDObj>::NeOp( BaseGDL* r)
-// {
-//   throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-//   return NULL;
-// }
 
 // LeOp
 // returns *this le *r, //C deletes itself and right
-template<class Sp>
-BaseGDL* Data_<Sp>::LeOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = ((*this)[0] <= s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] <= s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] >= s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] >= s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] >= (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] >= (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] >= (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = ((*this)[0] <= s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] >= s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] >= (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
+    }
+  }
   return res;
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::LeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::LeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::LeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+BaseGDL* Data_<SpDObj>::LeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplex>::LeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplex>::LeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplexDbl>::LeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplexDbl>::LeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // LtOp
 // returns *this lt *r, //C deletes itself and right
-template<class Sp>
-BaseGDL* Data_<Sp>::LtOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = ((*this)[0] < s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] < s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] > s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] > s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] > (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] > (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] > (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = ((*this)[0] < s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] > s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] > (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
+    }
+  }
   return res;
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::LtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::LtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::LtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+BaseGDL* Data_<SpDObj>::LtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplex>::LtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplex>::LtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplexDbl>::LtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplexDbl>::LtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // GeOp
 // returns *this ge *r, //C deletes itself and right
-template<class Sp>
-BaseGDL* Data_<Sp>::GeOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
-  
+
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = ((*this)[0] >= s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] >= s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] <= s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] <= s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] <= (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] <= (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] <= (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = ((*this)[0] >= s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] <= s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] <= (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
+    }
+  }
   return res;
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::GeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::GeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::GeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+BaseGDL* Data_<SpDObj>::GeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplex>::GeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplex>::GeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplexDbl>::GeOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplexDbl>::GeOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // GtOp
 // returns *this gt *r, //C deletes itself and right
-template<class Sp>
-BaseGDL* Data_<Sp>::GtOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 
   Data_<SpDByte>* res;
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( nEl == 1)
-	{
-	  (*res)[0] = ((*this)[0] > s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*this)[i] > s);
-	}    }
-  else if( StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] < s);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] < s);
-	}    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->dim, BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = ((*right)[i] < (*this)[i]);
-	}    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( this->dim, BaseGDL::NOZERO);
-      if( rEl == 1)
-	{
-	  (*res)[0] = ((*right)[0] < (*this)[0]);
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = ((*right)[i] < (*this)[i]);
-	}    }
-  //C delete right;
-  //C delete this;
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (nEl == 1) {
+      (*res)[0] = ((*this)[0] > s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
+    }
+  } else if (StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] < s);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
+    if (rEl == 1) {
+      (*res)[0] = ((*right)[0] < (*this)[0]);
+      return res;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
+    }
+  }
   return res;
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::GtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::GtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::GtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+BaseGDL* Data_<SpDObj>::GtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplex>::GtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplex>::GtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDComplexDbl>::GtOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+BaseGDL* Data_<SpDComplexDbl>::GtOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 //#undef USE_EIGEN
 // MatrixOp
 // returns *this # *r, //C does not delete itself and right
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
-{
-    bool at = atranspose;
-    bool bt = btranspose;
+Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+  bool at = atranspose;
+  bool bt = btranspose;
 
-    Data_*  par1 = static_cast<Data_*>(r);
+  Data_* par1 = static_cast<Data_*> (r);
 
-    long NbCol0, NbRow0, NbCol1, NbRow1;//, NbCol2, NbRow2;
-    SizeT rank0 = this->Rank();
-    if (rank0 > 2)
-		throw GDLException("Array must have 1 or 2 dimensions",true,false);  
-    SizeT rank1 = par1->Rank();
-	if (rank1 > 2)
-		throw GDLException("Array must have 1 or 2 dimensions",true,false);  
+  long NbCol0, NbRow0, NbCol1, NbRow1; //, NbCol2, NbRow2;
+  SizeT rank0 = this->Rank();
+  if (rank0 > 2)
+    throw GDLException("Array must have 1 or 2 dimensions", true, false);
+  SizeT rank1 = par1->Rank();
+  if (rank1 > 2)
+    throw GDLException("Array must have 1 or 2 dimensions", true, false);
 
-	NbCol0 = this->Dim(0);	if( NbCol0 == 0) NbCol0 = 1;
-	NbRow0 = 		(rank0 == 2) ? this->Dim(1): 1;
+  NbCol0 = this->Dim(0);
+  if (NbCol0 == 0) NbCol0 = 1;
+  NbRow0 = (rank0 == 2) ? this->Dim(1) : 1;
 
-	NbCol1 = par1->Dim(0);	if( NbCol1 == 0) NbCol1 = 1;
-	NbRow1 = 		(rank1 == 2) ? par1->Dim(1): 1;
-    // NbCol0, NbRow0, NbCol1, NbRow1 are properly set now
+  NbCol1 = par1->Dim(0);
+  if (NbCol1 == 0) NbCol1 = 1;
+  NbRow1 = (rank1 == 2) ? par1->Dim(1) : 1;
+  // NbCol0, NbRow0, NbCol1, NbRow1 are properly set now
 
-    // vector cases (possible degeneration)
-    if( rank0 <= 1 || rank1 <=1)  
+  // vector cases (possible degeneration)
+  if (rank0 <= 1 || rank1 <= 1) {
+    if (rank0 <= 1 && rank1 <= 1) {
+      // [NbCol0,1]#[NbCol1,1] -> just transpose b (if a is not transposed)
+      if (!at) // && !bt
+        bt = true;
+    } else if (rank0 <= 1) // rank1 == 2
     {
-      if( rank0 <= 1 && rank1 <=1)  
-      {
-	// [NbCol0,1]#[NbCol1,1] -> just transpose b (if a is not transposed)
-	if( !at) // && !bt
-	  bt = true;
-      } 
-      else if( rank0 <= 1) // rank1 == 2
-      {
-	// [NbCol0,1]#[NbCol1,NbRow1]
-	if( !at && ((!bt && NbCol1 != 1) || (bt && NbRow1 != 1)))
-	  at = true;
-      }
-      else // if( rank1 <= 1) // rank0 == 2
-      {
-	// [NbCol0,NbRow0]#[NbCol1,1]
-	if( !bt && ((!at && NbRow0 == 1) || (at && NbCol0 == 1)))
-	  bt = true;
-      } 
-    } 
-    
+      // [NbCol0,1]#[NbCol1,NbRow1]
+      if (!at && ((!bt && NbCol1 != 1) || (bt && NbRow1 != 1)))
+        at = true;
+    } else // if( rank1 <= 1) // rank0 == 2
+    {
+      // [NbCol0,NbRow0]#[NbCol1,1]
+      if (!bt && ((!at && NbRow0 == 1) || (at && NbCol0 == 1)))
+        bt = true;
+    }
+  }
+
 #ifdef USE_EIGEN
 
-    Map<Matrix<Ty,-1,-1>,Aligned> m0(&(*this)[0], NbCol0, NbRow0);
-    Map<Matrix<Ty,-1,-1>,Aligned> m1(&(*par1)[0], NbCol1, NbRow1);
+  Map < Matrix<Ty, -1, -1 >, Aligned > m0(&(*this)[0], NbCol0, NbRow0);
+  Map < Matrix<Ty, -1, -1 >, Aligned > m1(&(*par1)[0], NbCol1, NbRow1);
 
-    if (at && bt)
-      {
-	if(  /*(at &&  bt) &&*/ (NbCol0 != NbRow1))
-	  {
-	    throw GDLException("Operands of matrix multiply have incompatible dimensions.atbt",true,false);  
-// 	    e->Throw("Operands of matrix multiply have incompatible dimensions: " + e->GetParString(0) + ", " + e->GetParString(1) + ".");
-	  }
-	long& NbCol2 = NbRow0 ;
-	long& NbRow2 = NbCol1 ;
-	dimension dim(NbCol2, NbRow2);
-	
-	Data_* res = new Data_(dim, BaseGDL::NOZERO);
-	// no guarding necessary: eigen only throws on memory allocation
+  if (at && bt) {
+    if (/*(at &&  bt) &&*/ (NbCol0 != NbRow1)) {
+      throw GDLException("Operands of matrix multiply have incompatible dimensions.atbt", true, false);
+    }
+    long& NbCol2 = NbRow0;
+    long& NbRow2 = NbCol1;
+    dimension dim(NbCol2, NbRow2);
 
-	Map<Matrix<Ty,-1,-1>,Aligned> m2(&(*res)[0], NbCol2, NbRow2);
-	m2.noalias() = m0.transpose() * m1.transpose();
-	return res;
-      } 
-    else if (bt)
-      {
-	if( /*(!at &&  bt) &&*/ (NbRow0 != NbRow1))
-	  {
-	    throw GDLException("Operands of matrix multiply have incompatible dimensions.bt",true,false);  
-// 	    e->Throw("Operands of matrix multiply have incompatible dimensions: " + e->GetParString(0) + ", " + e->GetParString(1) + ".");
-	  }
-	long& NbCol2 = NbCol0;
-	long& NbRow2 = NbCol1;
-	dimension dim(NbCol2, NbRow2);
+    Data_* res = new Data_(dim, BaseGDL::NOZERO);
+    // no guarding necessary: eigen only throws on memory allocation
 
-	Data_* res = new Data_(dim, BaseGDL::NOZERO);
-	Map<Matrix<Ty,-1,-1>,Aligned> m2(&(*res)[0], NbCol2, NbRow2);
-	m2.noalias() = m0 * m1.transpose();
-	return res;
-      } else if (at)
-      {
-	if( /*(at && !bt) &&*/ (NbCol0 != NbCol1))
-	  {
-	    throw GDLException("Operands of matrix multiply have incompatible dimensions.at",true,false);  
-// 	    e->Throw("Operands of matrix multiply have incompatible dimensions: " + e->GetParString(0) + ", " + e->GetParString(1) + ".");
-	  }
-	long& NbCol2 = NbRow0;
-	long& NbRow2 = NbRow1;
-	dimension dim(NbCol2, NbRow2);
+    Map < Matrix<Ty, -1, -1 >, Aligned > m2(&(*res)[0], NbCol2, NbRow2);
+    m2.noalias() = m0.transpose() * m1.transpose();
+    return res;
+  } else if (bt) {
+    if (/*(!at &&  bt) &&*/ (NbRow0 != NbRow1)) {
+      throw GDLException("Operands of matrix multiply have incompatible dimensions.bt", true, false);
+    }
+    long& NbCol2 = NbCol0;
+    long& NbRow2 = NbCol1;
+    dimension dim(NbCol2, NbRow2);
 
-	Data_* res = new Data_(dim, BaseGDL::NOZERO);
-	Map<Matrix<Ty,-1,-1>,Aligned> m2(&(*res)[0], NbCol2, NbRow2);
-	m2.noalias() = m0.transpose() * m1;
-	return res;
-      } else
-      {
-	if( /*(!at && !bt) &&*/ (NbRow0 != NbCol1))
-	  {
-	    throw GDLException("Operands of matrix multiply have incompatible dimensions._",true,false);  
-// 	    e->Throw("Operands of matrix multiply have incompatible dimensions: " + e->GetParString(0) + ", " + e->GetParString(1) + ".");
-	  }
-	long& NbCol2 = NbCol0;
-	long& NbRow2 = NbRow1;
-	dimension dim(NbCol2, NbRow2);
+    Data_* res = new Data_(dim, BaseGDL::NOZERO);
+    Map < Matrix<Ty, -1, -1 >, Aligned > m2(&(*res)[0], NbCol2, NbRow2);
+    m2.noalias() = m0 * m1.transpose();
+    return res;
+  } else if (at) {
+    if (/*(at && !bt) &&*/ (NbCol0 != NbCol1)) {
+      throw GDLException("Operands of matrix multiply have incompatible dimensions.at", true, false);
+    }
+    long& NbCol2 = NbRow0;
+    long& NbRow2 = NbRow1;
+    dimension dim(NbCol2, NbRow2);
 
-	Data_* res = new Data_(dim, BaseGDL::NOZERO);
-	Map<Matrix<Ty,-1,-1>,Aligned> m2(&(*res)[0], NbCol2, NbRow2);
-	m2.noalias() = m0*m1;
-	return res;
-      }
+    Data_* res = new Data_(dim, BaseGDL::NOZERO);
+    Map < Matrix<Ty, -1, -1 >, Aligned > m2(&(*res)[0], NbCol2, NbRow2);
+    m2.noalias() = m0.transpose() * m1;
+    return res;
+  } else {
+    if (/*(!at && !bt) &&*/ (NbRow0 != NbCol1)) {
+      throw GDLException("Operands of matrix multiply have incompatible dimensions._", true, false);
+    }
+    long& NbCol2 = NbCol0;
+    long& NbRow2 = NbRow1;
+    dimension dim(NbCol2, NbRow2);
+
+    Data_* res = new Data_(dim, BaseGDL::NOZERO);
+    Map < Matrix<Ty, -1, -1 >, Aligned > m2(&(*res)[0], NbCol2, NbRow2);
+    m2.noalias() = m0*m1;
+    return res;
+  }
 
 #else
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
   Data_* res;
-      // right op 1st
-	SizeT nRow, nRowEl;
-      if(bt) {
-		  nRow = NbCol1; nRowEl = NbRow1; }
-		else {
-		  nRow = NbRow1; nRowEl = NbCol1; }
-		  
-	SizeT nCol, nColEl;
-      if(at) {
-		  nCol = NbRow0; nColEl = NbCol0; }
-		else {
-		  nCol = NbCol0; nColEl = NbRow0; }
-	
-      if( nColEl != nRowEl)
-	throw GDLException("Operands of matrix multiply have"
-			   " incompatible dimensions.",true,false);  
+  // right op 1st
+  SizeT nRow, nRowEl;
+  if (bt) {
+    nRow = NbCol1;
+    nRowEl = NbRow1;
+  } else {
+    nRow = NbRow1;
+    nRowEl = NbCol1;
+  }
 
-      if( nRow > 1)
-		res=New(dimension(nCol,nRow),  BaseGDL::NOZERO);
-	  else
-		res=New(dimension(nCol),  BaseGDL::NOZERO);
-/*
-   if( rank0 <= 1 && rank1 <= 1)
-    {
-#ifdef _OPENMP 
-      SizeT nOp = nRow * nCol;
-#endif
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared)
-	{
-#pragma omp for 
-	  for( OMPInt colA=0; colA < nCol; colA++)   // res dim 0
-	    for( OMPInt rowB=0; rowB < nRow; rowB++) // res dim 1
-	      (*res)[ rowB * nCol + colA] += (*this)[colA] * (*right)[rowB];
-	}
-	return res;
-    }
-*/ 
-	SizeT rIxEnd = nRow * nColEl;
-	//#ifdef _OPENMP 
-	SizeT nOp = rIxEnd * nCol;
+  SizeT nCol, nColEl;
+  if (at) {
+    nCol = NbRow0;
+    nColEl = NbCol0;
+  } else {
+    nCol = NbCol0;
+    nColEl = NbRow0;
+  }
+
+  if (nColEl != nRowEl)
+    throw GDLException("Operands of matrix multiply have"
+    " incompatible dimensions.", true, false);
+
+  if (nRow > 1)
+    res = New(dimension(nCol, nRow), BaseGDL::NOZERO);
+  else
+    res = New(dimension(nCol), BaseGDL::NOZERO);
+  SizeT rIxEnd = nRow * nColEl;
+  SizeT nOp = rIxEnd * nCol;
 
 #ifdef USE_STRASSEN_MATRIXMULTIPLICATION
-      if( !bt && !at && strassen)
-	//if( nOp > 1000000)
-	{
-	  SizeT maxDim;
-	  if( nCol >= nColEl && nCol >= nRow)
-	    maxDim = nCol;
-	  else if( nColEl >= nRow)
-	    maxDim = nColEl;
-	  else
-	    maxDim = nRow;
+  if (!bt && !at && strassen) {
+    SizeT maxDim;
+    if (nCol >= nColEl && nCol >= nRow)
+      maxDim = nCol;
+    else if (nColEl >= nRow)
+      maxDim = nColEl;
+    else
+      maxDim = nRow;
 
-	  SizeT sOp = maxDim * maxDim * maxDim;
-	  //if( (sOp / nOp) < 8)
-	  {
-	    SizeT mSz = 2;
-	    while (mSz < maxDim) mSz <<= 1;
+    SizeT sOp = maxDim * maxDim * maxDim;
 
-	    SM1<Ty>( mSz, nCol, nColEl, nRow,
-		     static_cast<Ty*>(right->DataAddr()),
-		     static_cast<Ty*>(this->DataAddr()),
-		     static_cast<Ty*>(res->DataAddr()));
+    {
+      SizeT mSz = 2;
+      while (mSz < maxDim) mSz <<= 1;
 
-	    // 		delete[] buf;
+      SM1<Ty>(mSz, nCol, nColEl, nRow,
+        static_cast<Ty*> (right->DataAddr()),
+        static_cast<Ty*> (this->DataAddr()),
+        static_cast<Ty*> (res->DataAddr()));
 
-	    return res;
-	  }
-	}
+      return res;
+    }
+  }
 #endif
 
-      if( !at) // normal
-	{
-	  if( !bt) // normal
-	    {
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared)
-		{
-#pragma omp for
-		  for( OMPInt colA=0; colA < nCol; ++colA) // res dim 0
-		    for( OMPInt rIx=0, rowBnCol=0; rIx < rIxEnd;
-			 rIx += nColEl, rowBnCol += nCol) // res dim 1
-		      {
-			Ty& resEl = (*res)[ rowBnCol + colA];
-			resEl = 0;//(*this)[ colA] * (*right)[ rIx]; // initialization
-			for( OMPInt i=0; i < nColEl; ++i)
-			  resEl += (*this)[ i*nCol+colA] * (*right)[ rIx+i];
-		      }
-		}
-	    }
-	  else // transpose r
-	    {
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared)
-		{
-#pragma omp for
-		  for( OMPInt colA=0; colA < nCol; ++colA) // res dim 0
-		    for( OMPInt rIx=0, rowBnCol=0; rIx < nRow; ++rIx, rowBnCol += nCol) // res dim 1
-		      {
-			Ty& resEl = (*res)[ rowBnCol + colA];
-			resEl = 0;//(*this)[ colA] * (*right)[ rIx]; // initialization
-			for( OMPInt i=0; i < nColEl; ++i)
-			  resEl += (*this)[ i*nCol+colA] * (*right)[ rIx + i * nRow];
-		      }
-		}
-	    }
-	}
-      else // atranspose
-	{
-	  if( !bt) // normal
-	    {
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared)
-		{
-#pragma omp for
-		  for( OMPInt colA=0; colA < nCol; ++colA) // res dim 0
-		    for( OMPInt rIx=0, rowBnCol=0; rIx < rIxEnd;
-			 rIx += nColEl, ++rowBnCol) // res dim 1
-		      {
-			Ty& resEl = (*res)[ rowBnCol * nCol + colA];
-// 			Ty& resEl = (*res)[ rowBnCol + colA * nRow];
-			resEl = 0;//(*this)[ colA] * (*right)[ rIx]; // initialization
-			for( OMPInt i=0; i < nColEl; ++i)
-			  resEl += (*this)[ i+colA*nColEl] * (*right)[ rIx+i];
-// 			  resEl += (*this)[ i*nCol+colA] * (*right)[ rIx+i];
-		      }
-		}
-	    }
-	  else // transpose r
-	    {
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared)
-		{
-#pragma omp for
-		  for( OMPInt colA=0; colA < nCol; ++colA) // res dim 0
-		    for( OMPInt rIx=0; rIx < nRow; ++rIx) // res dim 1
-		      {
-			Ty& resEl = (*res)[ rIx *nCol + colA];
-// 			Ty& resEl = (*res)[ rIx + colA * nRow];
-			resEl = 0;//(*this)[ colA] * (*right)[ rIx]; // initialization
-			for( OMPInt i=0; i < nColEl; ++i)
-			  resEl += (*this)[ i+colA*nColEl] * (*right)[ rIx + i * nRow];
-// 			  resEl += (*this)[ i*nCol+colA] * (*right)[ rIx + i * nRow];
-		      }
-		}
-	    }
-	}
+  if (!at) // normal
+  {
+    if (!bt) // normal
+    {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      if (!parallelize) {
+        for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
+            rIx += nColEl, rowBnCol += nCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i * nCol + colA] * (*right)[ rIx + i];
+          }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
+            rIx += nColEl, rowBnCol += nCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i * nCol + colA] * (*right)[ rIx + i];
+          }
+      }
+    } else // transpose r
+    {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      if (!parallelize) {
+        for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
+            rIx += nColEl, rowBnCol += nCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i * nCol + colA] * (*right)[ rIx + i];
+          }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < nRow; ++rIx, rowBnCol += nCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i * nCol + colA] * (*right)[ rIx + i * nRow];
+          }
+      }
+    }
+  } else // atranspose
+  {
+    if (!bt) // normal
+    {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      if (!parallelize) {
+        for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
+            rIx += nColEl, ++rowBnCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol * nCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i + colA * nColEl] * (*right)[ rIx + i];
+          }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
+            rIx += nColEl, ++rowBnCol) // res dim 1
+          {
+            Ty& resEl = (*res)[ rowBnCol * nCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i + colA * nColEl] * (*right)[ rIx + i];
+          }
+      }
+    } else // transpose r
+    {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      if (!parallelize) {
+        for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
+          {
+            Ty& resEl = (*res)[ rIx * nCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i + colA * nColEl] * (*right)[ rIx + i * nRow];
+          }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
+          for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
+          {
+            Ty& resEl = (*res)[ rIx * nCol + colA];
+            resEl = 0; //(*this)[ colA] * (*right)[ rIx]; // initialization
+            for (OMPInt i = 0; i < nColEl; ++i)
+              resEl += (*this)[ i + colA * nColEl] * (*right)[ rIx + i * nRow];
+          }
+      }
+    }
+  }
 
   return res;
 
-#endif // #elseif USE_EIGEN 
+#endif // #elseif USE_EIGEN
 }
 
 
@@ -1785,22 +1744,22 @@ Data_<Sp>* Data_<Sp>::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
 
 
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::MatrixOp( BaseGDL* r, bool atranspose, bool btranspose)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -1810,374 +1769,364 @@ Data_<SpDObj>* Data_<SpDObj>::MatrixOp( BaseGDL* r, bool atranspose, bool btrans
 // Ands right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOp( BaseGDL* r)
+Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
 // GDL_DEFINE_INTEGER_FUNCTION( Data_<Sp>*) AndOp( BaseGDL* r)
 {
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      (*this)[0] = (*this)[0] & (*right)[0]; // & Ty(1);
-      return this;
-    }
-  // note: we can't use valarray operation here as right->dd 
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] = (*this)[0] & (*right)[0]; // & Ty(1);
+    return this;
+  }
+  // note: we can't use valarray operation here as right->dd
   // might be larger than this->dd
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
+  }
   return this;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInv( BaseGDL* right)
-{
-  return AndOp( right);
+Data_<Sp>* Data_<Sp>::AndOpInv(BaseGDL* right) {
+  return AndOp(right);
 }
 // for floats
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*right)[0] == zero) (*this)[0]=zero;
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] == zero) (*this)[i]=zero;
-      //     if( (*this)[i] == zero || (*right)[i] == zero) (*this)[i]=zero;
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] == zero) (*this)[0] = zero;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
+  }
   return this;
 }
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*this)[0] != zero) (*this)[0] = (*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] != zero) (*this)[i] = (*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] != zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
-// // for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*right)[0] == zero) (*this)[0]=zero;
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] == zero) (*this)[i]=zero;
-      //     if( (*this)[i] == zero || (*right)[i] == zero) (*this)[i]=zero;
-    }  //C delete right;
+// for doubles
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] == zero) (*this)[0] = zero;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
+  }
   return this;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*this)[0] != zero) (*this)[0] = (*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] != zero) (*this)[i] = (*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] != zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
+
 // invalid types
 // GDL_DEFINE_COMPLEX_FUNCTION( Data_<Sp>*) AndOp( BaseGDL* r)
 // {
-//   throw GDLException("Cannot apply operation to datatype "+Sp::str+".",true,false);  
+//   throw GDLException("Cannot apply operation to datatype "+Sp::str+".",true,false);
 //   return this;
 // }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::AndOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 // GDL_DEFINE_OTHER_FUNCTION( Data_<Sp>*) AndOp( BaseGDL* r)
 // {
-//   throw GDLException("Cannot apply operation to datatype "+Sp::str+".",true,false);  
+//   throw GDLException("Cannot apply operation to datatype "+Sp::str+".",true,false);
 //   return this;
 // }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDString>* Data_<SpDString>::AndOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInv( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return this;
 // }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::AndOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInv( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return this;
 // }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::AndOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 // template<>
 // Data_<SpDObj>* Data_<SpDObj>::AndOpInv( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);
 //  return this;
 // }
-template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Ty s = (*right)[0];
-  // right->Scalar(s);
 
-  // s &= Ty(1);
-  //  dd &= s;
-  if( nEl == 1)
-    {
-      (*this)[0] &= s;
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared(s)
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] &= s;
-    }
+  if (nEl == 1) {
+    (*this)[0] &= s;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) shared(s)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
+  }
   return this;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvS( BaseGDL* right)
-{
-  return AndOpS( right);
+Data_<Sp>* Data_<Sp>::AndOpInvS(BaseGDL* right) {
+  return AndOpS(right);
 }
 // for floats
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if( s == zero)
-    //   dd = zero;
-    {
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT i=0; i < nEl; ++i)
-	  (*this)[i] = zero;
-      }}
-  return this;
-}
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  ULong nEl=N_Elements();
-
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  Ty s = (*right)[0];
-  // right->Scalar(s);
-  if( s == zero)
-    //    dd = zero;
-    {
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT i=0; i < nEl; ++i)
-	  (*this)[i] = zero;
-      }}
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*this)[i] = s;
-	}}
-  return this;
-}
-// for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  ULong nEl=N_Elements();
-
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  Ty s = (*right)[0];
-  // right->Scalar(s); 
-  if( s == zero)
-    //    dd = zero;
+  if (s == zero) {
     // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
       // #pragma omp for
-      for( SizeT i=0; i < nEl; ++i)
-	(*this)[i] = zero;
+      for (SizeT i = 0; i < nEl; ++i) (*this)[i] = zero;
     }
+  }
   return this;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  if( s == zero)
-    //    dd = zero;
+  if (s == zero) {
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT i=0; i < nEl; ++i)
-	  (*this)[i] = zero;
-      }}
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*this)[i] = s;
-	}}
+      // #pragma omp for
+      for (SizeT i = 0; i < nEl; ++i)
+        (*this)[i] = zero;
+    }
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    }
+  }
   return this;
 }
+
+// for doubles
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+
+  assert(nEl);
+  Ty s = (*right)[0];
+  if (s == zero)
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  {
+    // #pragma omp for
+    for (SizeT i = 0; i < nEl; ++i)
+      (*this)[i] = zero;
+  }
+  return this;
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Ty s = (*right)[0];
+  if (s == zero) {
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    {
+      // #pragma omp for
+      for (SizeT i = 0; i < nEl; ++i)
+        (*this)[i] = zero;
+    }
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    }
+  }
+  return this;
+}
+
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::AndOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvS( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return this;
 // }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::AndOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::AndOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
@@ -2186,352 +2135,334 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpS( BaseGDL* r)
 // Ors right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
-    }
-  //C delete right;
+template<class Sp>
+Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
+  }
   return this;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInv( BaseGDL* right)
-{
-  return OrOp( right);
+Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) {
+  return OrOp(right);
 }
 // for floats
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] == zero) (*this)[0]=(*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] == zero) (*this)[i]=(*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] == zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*right)[0] != zero) (*this)[0] = (*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] != zero) (*this)[i] = (*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] != zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
 // for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] == zero) (*this)[0]= (*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] == zero) (*this)[i]= (*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] == zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*right)[0] != zero) (*this)[0] = (*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] != zero) (*this)[i] = (*right)[i];
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] != zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
+  }
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::OrOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::OrOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::OrOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::OrOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 // OrOp
 // Ors right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //s &= Ty(1);
-  //  dd |= s;
-  if( nEl == 1)
-    {
-      (*this)[0] = (*this)[0] | s;
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = (*this)[i] | s;
-    }  //C delete right;
+  if (nEl == 1) {
+    (*this)[0] = (*this)[0] | s;
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
+  }
   return this;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvS( BaseGDL* right)
-{
-  return OrOpS( right);
+Data_<Sp>* Data_<Sp>::OrOpInvS(BaseGDL* right) {
+  return OrOpS(right);
 }
 // for floats
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  if( s != zero)
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] == zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] == zero) (*this)[i] = s;
-	}}  //C delete right;
+  if (s != zero) {
+    if (nEl == 1) {
+      if ((*this)[0] == zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
+    }
+  }
   return this;
 }
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  if( s != zero)
-    //    dd = s;
+  if (s != zero) {
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT i=0; i < nEl; ++i)
-	  (*this)[i] = s;
-	return this;
-      }}
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*this)[i] = s;
-	}}  //C delete right;
+      // #pragma omp for
+      for (SizeT i = 0; i < nEl; ++i)
+        (*this)[i] = s;
+      return this;
+    }
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    }
+  }
   return this;
 }
 // for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  if( s != zero)
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] == zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] == zero) (*this)[i] = s;
-	}}  //C delete right;
+  if (s != zero) {
+    if (nEl == 1) {
+      if ((*this)[0] == zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
+    }
+  }
   return this;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  if( s != zero)
-    //    dd = s;
+  if (s != zero) {
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT i=0; i < nEl; ++i)
-	  (*this)[i] = s;
-      }}
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*this)[0] = s;
-	  return this;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*this)[i] = s;
-	}}  //C delete right;
+      // #pragma omp for
+      for (SizeT i = 0; i < nEl; ++i)
+        (*this)[i] = s;
+    }
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*this)[0] = s;
+      return this;
+    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
+    }
+  }
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::OrOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::OrOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::OrOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
@@ -2539,2127 +2470,1955 @@ Data_<SpDObj>* Data_<SpDObj>::OrOpS( BaseGDL* r)
 // Xors right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOp( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if( nEl == 1)
-    {
-      (*this)[0] ^= (*right)[0];
-      return this;
-    }
+template<class Sp>
+Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] ^= (*right)[0];
+    return this;
+  }
   Ty s = (*right)[0];
-  if( right->StrictScalar(s))
-    {
-      if( s != Sp::zero)
-	//	dd ^= s;
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i < nEl; ++i)
-		(*this)[i] ^= s;
-	    }}
+  if (right->StrictScalar(s)) {
+    if (s != Sp::zero) {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
+      }
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] ^= (*right)[i];
-	}    }
-  //C delete right;
+  } else {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
+    }
+  }
   return this;
 }
 // invalid types
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype FLOAT.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype DOUBLE.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDString>* Data_<SpDString>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOp( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      (*this)[0] ^= /*(*this)[0] ^*/  (*right)[0];
-      return this;
-    }
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::XorOp(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] ^= /*(*this)[0] ^*/ (*right)[0];
+    return this;
+  }
   Ty s = (*right)[0];
-  //  dd ^= s;
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] ^= s;
-      //     (*this)[i] = (*this)[i] ^ s;
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
+  }
   return this;
 }
 // different for floats
 // for floats
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype FLOAT.",true,false);  
+Data_<SpDFloat>* Data_<SpDFloat>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
   return this;
 }
 // for doubles
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype DOUBLE.",true,false);  
+Data_<SpDDouble>* Data_<SpDDouble>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOpS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::XorOpS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 // LtMark
 // LtMarks right to itself, //C deletes right
 // right must always have more or same number of elements
-template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMark( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] > (*right)[0]) (*this)[0]=(*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] > (*right)[i]) (*this)[i]=(*right)[i];
-    }  //C delete right;
-  return this;
-}
-// invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::LtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-  
-  ULong nEl=N_Elements();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*this)[0] > (*right)[0]) (*this)[0]=(*right)[0];
-      return this;
-    }
-  Ty s = (*right)[0];
-  // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] > s) (*this)[i]=s;
-    }  //C delete right;
+Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] > (*right)[0]) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
+  }
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::LtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::LtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::LtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::LtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::LtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] > (*right)[0]) (*this)[0] = (*right)[0];
+    return this;
+  }
+  Ty s = (*right)[0];
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
+  }
+  return this;
+}
+// invalid types
+
+template<>
+Data_<SpDString>* Data_<SpDString>::LtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::LtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::LtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::LtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 // GtMark
 // GtMarks right to itself, //C deletes right
 // right must always have more or same number of elements
-template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMark( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] < (*right)[0]) (*this)[0]=(*right)[0];
-      return this;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] < (*right)[i]) (*this)[i]=(*right)[i];
-    }  //C delete right;
+template<class Sp>
+Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] < (*right)[0]) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
+  }
   return this;
 }
 // invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::GtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMark( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*this)[0] < (*right)[0]) (*this)[0]=(*right)[0];
-      return this;
-    }
+template<>
+Data_<SpDString>* Data_<SpDString>::GtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::GtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::GtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::GtMark(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] < (*right)[0]) (*this)[0] = (*right)[0];
+    return this;
+  }
 
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] < s) (*this)[i]=s;
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
+  }
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::GtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::GtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::GtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::GtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMarkS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::GtMarkS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 
 // Mod
 // modulo division: left=left % right
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Mod( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
+  ULong nEl = N_Elements();
+  assert(nEl);
 
-  SizeT i=0;
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] %= (*right)[i];
-      //C delete right;
-      return this;
+  SizeT i = 0;
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] %= (*right)[i];
+    return this;
+  } else {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
+        else (*this)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
+        else (*this)[ix] = this->zero;
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-	  //       bool zeroEncountered = false;
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*right)[i] == this->zero)
-		{
-		zeroEncountered = true;
-		(*this)[i] = this->zero;
-		}
-		}
-		else*/
-	    if( (*right)[ix] != this->zero) 
-	      (*this)[ix] %= (*right)[ix];
-	    else
-	      (*this)[ix] = this->zero;
-	}    //C delete right;
-      return this;
-    }
+    return this;
+  }
 }
 // inverse modulo division: left=right % left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  SizeT i=0;
+  ULong nEl = N_Elements();
+  assert(nEl);
+  SizeT i = 0;
 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] = (*right)[i] % (*this)[i];
-      //C delete right;
-      return this;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] = (*right)[i] % (*this)[i];
+    return this;
+  } else {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
+        else (*this)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
+        else (*this)[ix] = this->zero;
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-	  //       bool zeroEncountered = false;
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*this)[ix] == this->zero)
-		{
-		zeroEncountered = true;
-		(*this)[ ix] = this->zero;
-		}
-		}
-		else*/
-	    if( (*this)[ix] != this->zero) 
-	      (*this)[ix] = (*right)[ix] % (*this)[ix]; 
-	    else
-	      (*this)[ix] = this->zero;
-	}      //C delete right;
-      return this;
-    }    
+    return this;
+  }
 }
 // float modulo division: left=left % right
-inline DFloat Modulo( const DFloat& l, const DFloat& r)
-{
-//   float t=abs(l/r);
-//   if( l < 0.0) return t=(floor(t)-t)*abs(r);
-//   return (t-floor(t))*abs(r);
-  return fmod(l,r);
-}
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::Mod( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = Modulo((*this)[i],(*right)[i]);
-    }  //C delete right;
+inline DFloat Modulo(const DFloat& l, const DFloat& r) {
+  return fmod(l, r);
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
+  }
   return this;
 }
 // float  inverse modulo division: left=right % left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = Modulo((*right)[i],(*this)[i]);
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // in basic_op.cpp
 // double modulo division: left=left % right
-inline DDouble DModulo( const DDouble& l, const DDouble& r)
- {
-//    DDouble t=abs(l/r);
-//    if( l < 0.0) return t=(floor(t)-t)*abs(r);
-//    return (t-floor(t))*abs(r);
-   return fmod(l,r);
- }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::Mod( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = DModulo((*this)[i],(*right)[i]);
-    }  //C delete right;
+inline DDouble DModulo(const DDouble& l, const DDouble& r) {
+  return fmod(l, r);
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
+  }
   return this;
 }
 // double inverse modulo division: left=right % left
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = DModulo((*right)[i],(*this)[i]);
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::Mod( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDString>* Data_<SpDString>::ModInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::Mod( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Mod( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::Mod( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::Mod( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<class Sp>
-Data_<Sp>* Data_<Sp>::ModS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+template<>
+Data_<SpDString>* Data_<SpDString>::Mod(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::ModInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::Mod(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Mod(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::ModInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::Mod(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::ModInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::Mod(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::ModInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Ty s = (*right)[0];
-  SizeT i=0;
+  SizeT i = 0;
 
   // remember: this is a template (must work for several types)
-  // due to error handling the actual devision by 0
-  // has to be done 
+  // due to error handling the actual division by 0
+  // has to be done
   // but if not 0, we save the expensive error handling
-  if( s != this->zero)
+  if (s != this->zero) {
+    for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] %= s;
+    return this;
+  }
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] %= s;
+    return this;
+  } else {
+    assert(s == this->zero);
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
-      // right->Scalar(s); 
-      //     dd %= s;
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] %= s;
-      //C delete right;
-      return this;
+      // #pragma omp for
+      for (SizeT ix = i; ix < nEl; ++ix) (*this)[ix] = 0;
     }
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      // right->Scalar(s); 
-      //     dd %= s;
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] %= s;
-      //C delete right;
-      return this;
-    }
-  else
-    {
-      //       bool zeroEncountered = false; // until zero operation is already done.
-      
-      // right->Scalar(s); 
-      assert( s == this->zero);
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-	// #pragma omp for
-	for( SizeT ix=i; ix < nEl; ++ix)
-	  (*this)[ix] = 0;
-      }      //C delete right;
-      return this;
-    }
+    return this;
+  }
 }
 // inverse modulo division: left=right % left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-
+  ULong nEl = N_Elements();
+  assert(nEl);
   // remember: this is a template (must work for several types)
-  // due to error handling the actual devision by 0
-  // has to be done 
+  // due to error handling the actual division by 0
+  // has to be done
   // but if not 0, we save the expensive error handling
-  if( nEl == 1 && (*this)[0] != this->zero) 
-  {
-    (*this)[0] = (*right)[0] % (*this)[0]; 
+  if (nEl == 1 && (*this)[0] != this->zero) {
+    (*this)[0] = (*right)[0] % (*this)[0];
     return this;
   }
 
   Ty s = (*right)[0];
-  SizeT i=0;
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      // right->Scalar(s); 
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	{
-	  (*this)[i] = s % (*this)[i];
-	}
-      //C delete right;
-      return this;
+  SizeT i = 0;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) {
+      (*this)[i] = s % (*this)[i];
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  //       bool zeroEncountered = false;
-	  // right->Scalar(s); 
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*this)[ix] == this->zero)
-		{
-		zeroEncountered = true;
-		(*this)[ix] = this->zero;
-		}
-		}
-		else*/
-	    if( (*this)[ix] != this->zero) 
-	      (*this)[ix] = s % (*this)[ix]; 
-	    else 
-	      (*this)[ix] = this->zero;
-	}      //C delete right;
-      return this;
-    }    
-}
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+    return this;
+  } else {
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
+        else (*this)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
+        else (*this)[ix] = this->zero;
+    }
+    return this;
+  }
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = Modulo((*this)[i],s);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
+  }
   return this;
 }
 // float  inverse modulo division: left=right % left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = Modulo(s,(*this)[i]);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
+  }
   return this;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = DModulo((*this)[i],s);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
+  }
   return this;
 }
 // double inverse modulo division: left=right % left
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = DModulo(s,(*this)[i]);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
+  }
   return this;
 }
 // invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::ModS( BaseGDL* r)
 
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+template<>
+Data_<SpDString>* Data_<SpDString>::ModS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::ModInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::ModInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 // Pow
 // C++ defines pow only for floats and doubles
 //template <typename T, typename TT> T pow( const T r, const TT l)
-template <typename T> T pow( const T r, const T l)
-{
+
+template <typename T> T pow(const T r, const T l) {
   typedef T TT;
 
-  if( l == 0) return 1;
-  if( l < 0)  return 0;
+  if (l == 0) return 1;
+  if (l < 0) return 0;
 
-  const int nBits = sizeof(TT) * 8;
+  const int nBits = sizeof (TT) * 8;
 
   T arr = r;
   T res = 1;
   TT mask = 1;
-  for( SizeT i=0; i<nBits; ++i)
-    {
-      if( l & mask) res *= arr;
-      mask <<= 1;
-      if( l < mask) return res;
-      arr *= arr;
-    }
+  for (SizeT i = 0; i < nBits; ++i) {
+    if (l & mask) res *= arr;
+    mask <<= 1;
+    if (l < mask) return res;
+    arr *= arr;
+  }
 
   return res;
 }
 
 // power of value: left=left ^ right
 // integral types
-template<class Sp>
-Data_<Sp>* Data_<Sp>::Pow( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*this)[i], (*right)[i]); // valarray
-    }  //C delete right;
+template<class Sp>
+Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
+  }
   return this;
 }
 // inverse power of value: left=right ^ left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  //      dd = pow( right->Resize(nEl), dd); // valarray
-      
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*right)[i], (*this)[i]);
-    }  //C delete right;
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // floats power of value: left=left ^ right
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::Pow( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  /*  if( rEl == nEl)
-      {
-      for( SizeT i=0; i < nEl; ++i)
-      dd[ i] = pow( dd[ i], right->dd[ i]); // valarray
-      }
-      else*/
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
   {
-    TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-	for( OMPInt i=0; i < nEl; ++i)
-	  (*this)[i] = pow( (*this)[i], (*right)[i]);
-      }    }
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+    }
+  }
   return this;
 }
 
 // PowInt and PowIntNew can only be called for GDL_FLOAT and GDL_DOUBLE
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInt( BaseGDL* r)
-{
-  assert( 0);
+Data_<Sp>* Data_<Sp>::PowInt(BaseGDL* r) {
+  assert(0);
   return this;
 }
 // floats power of value with GDL_LONG: left=left ^ right
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInt( BaseGDL* r)
-{
-  DLongGDL* right=static_cast<DLongGDL*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  if( r->StrictScalar())
-    {
-      DLong r0 = (*right)[0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] = pow( (*this)[i], r0);
-	}      return this;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
+  DLongGDL* right = static_cast<DLongGDL*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  if (r->StrictScalar()) {
+    DLong r0 = (*right)[0];
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     }
-  if( StrictScalar())
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      Ty s0 = (*this)[ 0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[ i] = pow( s0, (*right)[ i]);
-	}      return res;
+    return this;
+  }
+  if (StrictScalar()) {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    Ty s0 = (*this)[ 0];
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
-  if( nEl <= rEl)
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] = pow( (*this)[i], (*right)[i]);
-	}      return this;
+    return res;
+  }
+  if (nEl <= rEl) {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     }
-  else
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return this;
+  } else {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInt( BaseGDL* r)
-{
-  DLongGDL* right=static_cast<DLongGDL*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
+  DLongGDL* right = static_cast<DLongGDL*> (r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  if( r->StrictScalar())
-    {
-      DLong r0 = (*right)[0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] = pow( (*this)[i], r0);
-	}      return this;
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  if (r->StrictScalar()) {
+    DLong r0 = (*right)[0];
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     }
-  if( StrictScalar())
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      Ty s0 = (*this)[ 0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[ i] = pow( s0, (*right)[ i]);
-	}      return res;
+    return this;
+  }
+  if (StrictScalar()) {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    Ty s0 = (*this)[ 0];
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
-  if( nEl <= rEl)
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] = pow( (*this)[i], (*right)[i]);
-	}      return this;
+    return res;
+  }
+  if (nEl <= rEl) {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     }
-  else
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return this;
+  } else {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
 
 // floats inverse power of value: left=right ^ left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  /*  if( rEl == nEl)
-      dd = pow( right->dd, dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*right)[i], (*this)[i]);
-    }  //C delete right;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // doubles power of value: left=left ^ right
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::Pow( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  //      dd = pow( dd, right->Resize(nEl)); // valarray
-  /*  if( rEl == nEl)
-      dd = pow( dd, right->dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*this)[i], (*right)[i]);
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  }
   return this;
 }
 // doubles inverse power of value: left=right ^ left
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  // dd = pow( right->Resize(nEl), dd); // valarray
-  /*  if( rEl == nEl)
-      dd = pow( right->dd, dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*right)[i], (*this)[i]);
-    }  //C delete right;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // complex power of value: left=left ^ right
 // complex is special here
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::Pow( BaseGDL* r)
-{
+Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
-  assert( r->N_Elements() > 0);
+  assert(nEl > 0);
+  assert(r->N_Elements() > 0);
 
-  if( r->Type() == GDL_FLOAT)
-    {
-      Data_<SpDFloat>* right=static_cast<Data_<SpDFloat>* >(r);
+  if (r->Type() == GDL_FLOAT) {
+    Data_<SpDFloat>* right = static_cast<Data_<SpDFloat>*> (r);
 
-      DFloat s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DFloat s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      DLong s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DLong s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  //   ULong rEl=right->N_Elements();
-  //   ULong nEl=N_Elements();
-  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  //      dd = pow( dd, right->dd); // valarray
 #if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  for( SizeT i=0; i<nEl; ++i)
-    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
+  for (SizeT i = 0; i < nEl; ++i)
+    (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  //      dd = pow( dd, right->Resize(nEl)); // valarray
-  /*  if( r->N_Elements() == nEl)
-      dd = pow( dd, right->dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*this)[i], (*right)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  }
 #endif
-  //C delete right;
   return this;
 }
 // complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  for( SizeT i=0; i<nEl; ++i)
-    (*this)[ i] = pow( (*right)[ i], (*this)[i]);
-#else
-  //      right->dd.resize(nEl);
-  //      dd = pow( right->Resize(nEl), dd); // valarray
-  /*  if( rEl == nEl)
-      dd = pow( right->dd, dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*right)[i], (*this)[i]);
-#endif
-    }  //C delete right;
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  }
   return this;
 }
 // double complex power of value: left=left ^ right
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow( BaseGDL* r)
-{
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
+  assert(nEl > 0);
 
-  if( r->Type() == GDL_DOUBLE)
-    {
-      Data_<SpDDouble>* right=static_cast<Data_<SpDDouble>* >(r);
+  if (r->Type() == GDL_DOUBLE) {
+    Data_<SpDDouble>* right = static_cast<Data_<SpDDouble>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DDouble s;
+    DDouble s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DLong s;
+    DLong s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  //   ULong rEl=right->N_Elements();
-  //   ULong nEl=N_Elements();
-  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  //      right->dd.resize(nEl);
-  //      dd = pow( dd, right->dd); // valarray
 #if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  for( SizeT i=0; i<nEl; ++i)
-    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
+  for (SizeT i = 0; i < nEl; ++i)
+    (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  //      dd = pow( dd, right->Resize(nEl)); // valarray
-  /*  if( r->N_Elements() == nEl)
-      dd = pow( dd, right->dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*this)[i], (*right)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
+  }
 #endif
-  //C delete right;
   return this;
 }
 // double complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
 #if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  for( SizeT i=0; i<nEl; ++i)
-    (*this)[ i] = pow( (*right)[ i], (*this)[i]);
+  for (SizeT i = 0; i < nEl; ++i)
+    (*this)[ i] = pow((*right)[ i], (*this)[i]);
 #else
-  //      right->dd.resize(nEl);
-  //      dd = pow( right->Resize(nEl), dd); // valarray
-  /*  if( rEl == nEl)
-      dd = pow( right->dd, dd); // valarray
-      else*/
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*right)[i], (*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
+  }
 #endif
-  //C delete right;
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::Pow( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::Pow(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::Pow( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::Pow(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::Pow( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::Pow(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( (*this)[i], s); 
-    }
-  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
+  }
   return this;
 }
 // inverse power of value: left=right ^ left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //      dd = pow( s, d); // valarray
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = pow( s, (*this)[i]);
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
+  }
   return this;
 }
 // floats power of value: left=left ^ right
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)	
-	dd[ i] = pow( dd[ i], s); // valarray
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
+  }
   return this;
 }
 // floats inverse power of value: left=right ^ left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)	
-	dd[ i] = pow( s, dd[ i]); // valarray
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
+  }
   return this;
 }
 // doubles power of value: left=left ^ right
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)	
-	dd[ i] = pow( dd[ i], s); // valarray
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
+  }
   return this;
 }
 // doubles inverse power of value: left=right ^ left
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)	
-	dd[ i] = pow( s, dd[ i]); // valarray
-    }  //C delete right;
+
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
+  }
   return this;
 }
 // complex power of value: left=left ^ right
 // complex is special here
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowS( BaseGDL* r)
-{
+Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
-  assert( r->N_Elements() > 0);
+  assert(nEl > 0);
+  assert(r->N_Elements() > 0);
 
-  if( r->Type() == GDL_FLOAT)
-    {
-      Data_<SpDFloat>* right=static_cast<Data_<SpDFloat>* >(r);
+  if (r->Type() == GDL_FLOAT) {
+    Data_<SpDFloat>* right = static_cast<Data_<SpDFloat>*> (r);
 
-      DFloat s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DFloat s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      DLong s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DLong s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  //   ULong rEl=right->N_Elements();
-  //   ULong nEl=N_Elements();
-  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*this)[ i] = pow( (*this)[ i], s);
-    }
-  //#else
-  //  dd = pow( dd, s); // valarray
-  //#endif
-  //C delete right;
-
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+  }
   return this;
 }
 // complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*this)[ i] = pow( s, (*this)[ i]);
-    }
-  //#else
-  //  dd = pow( s, dd); // valarray
-  //#endif
-  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
+  }
   return this;
 }
 // double complex power of value: left=left ^ right
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS( BaseGDL* r)
-{
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
+  assert(nEl > 0);
 
-  if( r->Type() == GDL_DOUBLE)
-    {
-      Data_<SpDDouble>* right=static_cast<Data_<SpDDouble>* >(r);
+  if (r->Type() == GDL_DOUBLE) {
+    Data_<SpDDouble>* right = static_cast<Data_<SpDDouble>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DDouble s;
+    DDouble s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (prognodeexpr.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (prognodeexpr.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DLong s;
+    DLong s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*this)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return this;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
 
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*this)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return this;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+      }
+      return this;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return this;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
-  //   ULong rEl=right->N_Elements();
-  //   ULong nEl=N_Elements();
-  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*this)[ i] = pow( (*this)[ i], s);
-    }
-  //#else
-  //  dd = pow( dd, s); // valarray
-  //#endif
-  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
+  }
   return this;
 }
-// double complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+// double complex inverse power of value: left=right ^ left
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*this)[ i] = pow( s, (*this)[ i]);
-    }
-  //#else
-  //  dd = pow( s, dd); // valarray
-  //#endif
-  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
+  }
   return this;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -51,11 +51,11 @@ Data_<Sp>* Data_<Sp>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
   }
   return this;
@@ -72,11 +72,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
   }
   return this;
@@ -91,11 +91,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
   }
   return this;
@@ -143,11 +143,11 @@ BaseGDL* Data_<Sp>::UMinus() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
   }
   return this;
@@ -188,11 +188,11 @@ Data_<SpDByte>* Data_<Sp>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   }
   return res;
@@ -219,11 +219,11 @@ Data_<SpDByte>* Data_<SpDObj>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   }
   return res;
@@ -240,11 +240,11 @@ Data_<SpDByte>* Data_<SpDFloat>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
   }
   return res;
@@ -261,11 +261,11 @@ Data_<SpDByte>* Data_<SpDDouble>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
   }
   return res;
@@ -282,11 +282,11 @@ Data_<SpDByte>* Data_<SpDString>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
   }
   return res;
@@ -303,11 +303,11 @@ Data_<SpDByte>* Data_<SpDComplex>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   }
   return res;
@@ -324,11 +324,11 @@ Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FI
     return res;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   }
   return res;
@@ -347,11 +347,11 @@ void Data_<Sp>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
   }
 }
@@ -366,11 +366,11 @@ void Data_<Sp>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
   }
 }
@@ -387,11 +387,11 @@ void Data_<SpDFloat>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   }
 }
@@ -407,11 +407,11 @@ void Data_<SpDFloat>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   }
 }
@@ -428,11 +428,11 @@ void Data_<SpDDouble>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   }
 }
@@ -448,11 +448,11 @@ void Data_<SpDDouble>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   }
 }
@@ -469,11 +469,11 @@ void Data_<SpDComplex>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   }
 }
@@ -489,11 +489,11 @@ void Data_<SpDComplex>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   }
 }
@@ -509,11 +509,11 @@ void Data_<SpDComplexDbl>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   }
 }
@@ -529,11 +529,11 @@ void Data_<SpDComplexDbl>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   }
 }
@@ -595,11 +595,11 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     }
   } else if (StrictScalar(s)) {
@@ -609,21 +609,21 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -634,11 +634,11 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     }
   }
@@ -746,11 +746,11 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     }
   } else if (StrictScalar(s)) {
@@ -760,21 +760,21 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -785,11 +785,11 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     }
   }
@@ -818,11 +818,11 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     }
   } else if (StrictScalar(s)) {
@@ -832,21 +832,21 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -857,11 +857,11 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     }
   }
@@ -966,11 +966,11 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     }
   } else if (StrictScalar(s)) {
@@ -980,21 +980,21 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -1005,11 +1005,11 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     }
   }
@@ -1038,11 +1038,11 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
     }
   } else if (StrictScalar(s)) {
@@ -1052,21 +1052,21 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -1077,11 +1077,11 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     }
   }
@@ -1135,11 +1135,11 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
     }
   } else if (StrictScalar(s)) {
@@ -1149,21 +1149,21 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -1174,11 +1174,11 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     }
   }
@@ -1232,11 +1232,11 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
     }
   } else if (StrictScalar(s)) {
@@ -1246,21 +1246,21 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -1271,11 +1271,11 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     }
   }
@@ -1329,11 +1329,11 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
     }
   } else if (StrictScalar(s)) {
@@ -1343,21 +1343,21 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     }
   } else // ( rEl >= nEl)
@@ -1368,11 +1368,11 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     }
   }
@@ -1573,7 +1573,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      if (!parallelize( nOp)) {
+      if (GDL_NTHREADS=parallelize( nOp)==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1585,7 +1585,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
           }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1599,7 +1599,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      if (!parallelize( nOp)) {
+      if (GDL_NTHREADS=parallelize( nOp)==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1611,7 +1611,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
           }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < nRow; ++rIx, rowBnCol += nCol) // res dim 1
           {
@@ -1627,7 +1627,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      if (!parallelize( nOp)) {
+      if (GDL_NTHREADS=parallelize( nOp)==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, ++rowBnCol) // res dim 1
@@ -1639,7 +1639,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
           }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, ++rowBnCol) // res dim 1
@@ -1653,7 +1653,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      if (!parallelize( nOp)) {
+      if (GDL_NTHREADS=parallelize( nOp)==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
           {
@@ -1664,7 +1664,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
           }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
           {
@@ -1728,11 +1728,11 @@ Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
   // note: we can't use valarray operation here as right->dd
   // might be larger than this->dd
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   }
   return this;
@@ -1756,11 +1756,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   }
   return this;
@@ -1777,11 +1777,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -1800,11 +1800,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   }
   return this;
@@ -1821,11 +1821,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -1909,11 +1909,11 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) shared(s)
+#pragma omp parallel for num_threads(GDL_NTHREADS) shared(s)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
   }
   return this;
@@ -1935,9 +1935,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   Ty s = (*right)[0];
   // right->Scalar(s);
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i) (*this)[i] = zero;
     }
   }
@@ -1953,9 +1951,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
         (*this)[i] = zero;
     }
@@ -1965,11 +1961,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     }
   }
@@ -1987,9 +1983,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero)
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   {
-    // #pragma omp for
     for (SizeT i = 0; i < nEl; ++i)
       (*this)[i] = zero;
   }
@@ -2004,9 +1998,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
         (*this)[i] = zero;
     }
@@ -2016,11 +2008,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     }
   }
@@ -2082,11 +2074,11 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   }
   return this;
@@ -2110,11 +2102,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2131,11 +2123,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2153,11 +2145,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2174,11 +2166,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2231,11 +2223,11 @@ Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
   }
   return this;
@@ -2261,11 +2253,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     }
   }
@@ -2280,9 +2272,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   assert(nEl);
   Ty s = (*right)[0];
   if (s != zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
         (*this)[i] = s;
       return this;
@@ -2293,11 +2283,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     }
   }
@@ -2318,11 +2308,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     }
   }
@@ -2337,9 +2327,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   assert(nEl);
   Ty s = (*right)[0];
   if (s != zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
         (*this)[i] = s;
     }
@@ -2349,11 +2337,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       return this;
     }
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     }
   }
@@ -2410,21 +2398,21 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   if (right->StrictScalar(s)) {
     if (s != Sp::zero) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
       }
     }
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
     }
   }
@@ -2486,11 +2474,11 @@ Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   }
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
   }
   return this;
@@ -2557,11 +2545,11 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2610,11 +2598,11 @@ Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   }
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
   }
   return this;
@@ -2665,11 +2653,11 @@ Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
   }
   return this;
@@ -2719,11 +2707,11 @@ Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
 
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
   }
   return this;
@@ -2778,12 +2766,12 @@ Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
         else (*this)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
         else (*this)[ix] = this->zero;
     }
@@ -2805,12 +2793,12 @@ Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
         else (*this)[ix] = this->zero;
     }
@@ -2830,11 +2818,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
   }
   return this;
@@ -2848,11 +2836,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
   }
   return this;
@@ -2871,11 +2859,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
   }
   return this;
@@ -2889,11 +2877,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
   }
   return this;
@@ -2983,9 +2971,7 @@ Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     return this;
   } else {
     assert(s == this->zero);
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
-      // #pragma omp for
       for (SizeT ix = i; ix < nEl; ++ix) (*this)[ix] = 0;
     }
     return this;
@@ -3017,12 +3003,12 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
         else (*this)[ix] = this->zero;
     }
@@ -3038,11 +3024,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
   }
   return this;
@@ -3057,11 +3043,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
   }
   return this;
@@ -3075,11 +3061,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
   }
   return this;
@@ -3094,11 +3080,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
   }
   return this;
@@ -3200,11 +3186,11 @@ Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
   }
   return this;
@@ -3218,11 +3204,11 @@ Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   }
   return this;
@@ -3239,11 +3225,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   assert(nEl);
   {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     }
   }
@@ -3270,11 +3256,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     }
     return this;
@@ -3283,33 +3269,33 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
     return res;
   }
   if (nEl <= rEl) {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     }
     return this;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -3327,11 +3313,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     }
     return this;
@@ -3340,33 +3326,33 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
     return res;
   }
   if (nEl <= rEl) {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     }
     return this;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -3383,11 +3369,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   }
   return this;
@@ -3403,11 +3389,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   assert(rEl);
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   }
   return this;
@@ -3423,11 +3409,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   assert(rEl);
   assert(nEl);
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   }
   return this;
@@ -3451,11 +3437,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -3467,21 +3453,21 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -3489,11 +3475,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3509,11 +3495,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -3525,21 +3511,21 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -3547,11 +3533,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3565,11 +3551,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   }
 #endif
@@ -3585,11 +3571,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   }
   return this;
@@ -3613,11 +3599,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -3629,21 +3615,21 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -3651,11 +3637,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3673,11 +3659,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -3689,21 +3675,21 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -3711,11 +3697,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3729,11 +3715,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   }
 #endif
@@ -3753,11 +3739,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) { TRACE_ROUTINE(_
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*right)[ i], (*this)[i]);
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   }
 #endif
@@ -3809,11 +3795,11 @@ Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
   }
   return this;
@@ -3828,11 +3814,11 @@ Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
   }
   return this;
@@ -3847,11 +3833,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   }
   return this;
@@ -3865,11 +3851,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   }
   return this;
@@ -3884,11 +3870,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   }
   return this;
@@ -3903,11 +3889,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   }
   return this;
@@ -3931,11 +3917,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -3947,21 +3933,21 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -3969,11 +3955,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3989,11 +3975,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -4005,21 +3991,21 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -4027,11 +4013,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -4042,11 +4028,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   }
   return this;
@@ -4062,11 +4048,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   assert(rEl);
   assert(nEl);
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   }
   return this;
@@ -4090,11 +4076,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -4106,21 +4092,21 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -4128,11 +4114,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -4150,11 +4136,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       }
       return this;
@@ -4166,21 +4152,21 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return this;
@@ -4188,11 +4174,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -4203,11 +4189,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   }
   return this;
@@ -4222,11 +4208,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   }
   return this;

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -51,7 +51,7 @@ Data_<Sp>* Data_<Sp>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -72,7 +72,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -91,7 +91,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -143,7 +143,7 @@ BaseGDL* Data_<Sp>::UMinus() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -188,7 +188,7 @@ Data_<SpDByte>* Data_<Sp>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -219,7 +219,7 @@ Data_<SpDByte>* Data_<SpDObj>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -240,7 +240,7 @@ Data_<SpDByte>* Data_<SpDFloat>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -261,7 +261,7 @@ Data_<SpDByte>* Data_<SpDDouble>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -282,7 +282,7 @@ Data_<SpDByte>* Data_<SpDString>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -303,7 +303,7 @@ Data_<SpDByte>* Data_<SpDComplex>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -324,7 +324,7 @@ Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FI
     return res;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -347,7 +347,7 @@ void Data_<Sp>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -366,7 +366,7 @@ void Data_<Sp>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -387,7 +387,7 @@ void Data_<SpDFloat>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -407,7 +407,7 @@ void Data_<SpDFloat>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -428,7 +428,7 @@ void Data_<SpDDouble>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -448,7 +448,7 @@ void Data_<SpDDouble>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -469,7 +469,7 @@ void Data_<SpDComplex>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -489,7 +489,7 @@ void Data_<SpDComplex>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -509,7 +509,7 @@ void Data_<SpDComplexDbl>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -529,7 +529,7 @@ void Data_<SpDComplexDbl>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     return;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -595,7 +595,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -609,7 +609,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -619,7 +619,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -634,7 +634,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -746,7 +746,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -760,7 +760,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -770,7 +770,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -785,7 +785,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -818,7 +818,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -832,7 +832,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -842,7 +842,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -857,7 +857,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -966,7 +966,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -980,7 +980,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -990,7 +990,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1005,7 +1005,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1038,7 +1038,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1052,7 +1052,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1062,7 +1062,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1077,7 +1077,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1135,7 +1135,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1149,7 +1149,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1159,7 +1159,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1174,7 +1174,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1232,7 +1232,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1246,7 +1246,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1256,7 +1256,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1271,7 +1271,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1329,7 +1329,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1343,7 +1343,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1353,7 +1353,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1368,7 +1368,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LIN
       return res;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1573,7 +1573,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      if (GDL_NTHREADS=parallelize( nOp)==1) {
+      if ((GDL_NTHREADS=parallelize( nOp))==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1599,7 +1599,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      if (GDL_NTHREADS=parallelize( nOp)==1) {
+      if ((GDL_NTHREADS=parallelize( nOp))==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, rowBnCol += nCol) // res dim 1
@@ -1627,7 +1627,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     if (!bt) // normal
     {
 
-      if (GDL_NTHREADS=parallelize( nOp)==1) {
+      if ((GDL_NTHREADS=parallelize( nOp))==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
             rIx += nColEl, ++rowBnCol) // res dim 1
@@ -1653,7 +1653,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { T
     } else // transpose r
     {
 
-      if (GDL_NTHREADS=parallelize( nOp)==1) {
+      if ((GDL_NTHREADS=parallelize( nOp))==1) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
           {
@@ -1728,7 +1728,7 @@ Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
   // note: we can't use valarray operation here as right->dd
   // might be larger than this->dd
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1756,7 +1756,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1777,7 +1777,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1800,7 +1800,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1821,7 +1821,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1909,7 +1909,7 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1961,7 +1961,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2008,7 +2008,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2074,7 +2074,7 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2102,7 +2102,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2123,7 +2123,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2145,7 +2145,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2166,7 +2166,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2223,7 +2223,7 @@ Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2253,7 +2253,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2283,7 +2283,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2308,7 +2308,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2337,7 +2337,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       return this;
     }
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2398,7 +2398,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   if (right->StrictScalar(s)) {
     if (s != Sp::zero) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2408,7 +2408,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
     }
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2474,7 +2474,7 @@ Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   }
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2545,7 +2545,7 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2598,7 +2598,7 @@ Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   }
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2653,7 +2653,7 @@ Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   }
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2707,7 +2707,7 @@ Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
 
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2766,7 +2766,7 @@ Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -2793,7 +2793,7 @@ Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -2818,7 +2818,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2836,7 +2836,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2859,7 +2859,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2877,7 +2877,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3003,7 +3003,7 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     return this;
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
         else (*this)[ix] = this->zero;
     } else {
@@ -3024,7 +3024,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3043,7 +3043,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3061,7 +3061,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3080,7 +3080,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3186,7 +3186,7 @@ Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3204,7 +3204,7 @@ Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   ULong nEl = N_Elements();
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3225,7 +3225,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
   assert(nEl);
   {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3256,7 +3256,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3269,7 +3269,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3280,7 +3280,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   }
   if (nEl <= rEl) {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3291,7 +3291,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3313,7 +3313,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3326,7 +3326,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3337,7 +3337,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   }
   if (nEl <= rEl) {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3348,7 +3348,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3369,7 +3369,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3389,7 +3389,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__
   assert(rEl);
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3409,7 +3409,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   assert(rEl);
   assert(nEl);
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3437,7 +3437,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3453,7 +3453,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3463,7 +3463,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3475,7 +3475,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3495,7 +3495,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3511,7 +3511,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3521,7 +3521,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3533,7 +3533,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3551,7 +3551,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3571,7 +3571,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3599,7 +3599,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3615,7 +3615,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3625,7 +3625,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3637,7 +3637,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3659,7 +3659,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3675,7 +3675,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3685,7 +3685,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3697,7 +3697,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3715,7 +3715,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FU
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3739,7 +3739,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) { TRACE_ROUTINE(_
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*right)[ i], (*this)[i]);
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3795,7 +3795,7 @@ Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3814,7 +3814,7 @@ Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3833,7 +3833,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3851,7 +3851,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3870,7 +3870,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3889,7 +3889,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   assert(nEl);
   Ty s = (*right)[0];
 
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3917,7 +3917,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3933,7 +3933,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3943,7 +3943,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3955,7 +3955,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3975,7 +3975,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3991,7 +3991,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4001,7 +4001,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4013,7 +4013,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4028,7 +4028,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4048,7 +4048,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   assert(rEl);
   assert(nEl);
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4076,7 +4076,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4092,7 +4092,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4102,7 +4102,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4114,7 +4114,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4136,7 +4136,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -4152,7 +4152,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -4162,7 +4162,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
           return res;
         }
 
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4174,7 +4174,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -4189,7 +4189,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__F
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4208,7 +4208,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -40,9 +40,9 @@ using namespace Eigen;
 
 // Not operation
 // for integers
-
+// ex: b=(not a)
 template<class Sp>
-Data_<Sp>* Data_<Sp>::NotOp() {
+Data_<Sp>* Data_<Sp>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
 
@@ -51,7 +51,7 @@ Data_<Sp>* Data_<Sp>::NotOp() {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ~(*this)[i];
   } else {
@@ -65,7 +65,7 @@ Data_<Sp>* Data_<Sp>::NotOp() {
 // others
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::NotOp() {
+Data_<SpDFloat>* Data_<SpDFloat>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
   if (nEl == 1) {
@@ -73,7 +73,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::NotOp() {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0f) ? 1.0f : 0.0f;
   } else {
@@ -85,7 +85,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::NotOp() {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::NotOp() {
+Data_<SpDDouble>* Data_<SpDDouble>::NotOp() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
   if (nEl == 1) {
@@ -93,7 +93,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::NotOp() {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = ((*this)[i] == 0.0) ? 1.0 : 0.0;
   } else {
@@ -105,31 +105,31 @@ Data_<SpDDouble>* Data_<SpDDouble>::NotOp() {
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::NotOp() {
+Data_<SpDString>* Data_<SpDString>::NotOp() { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::NotOp() {
+Data_<SpDComplex>* Data_<SpDComplex>::NotOp() { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::NotOp() {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::NotOp() { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::NotOp() {
+Data_<SpDPtr>* Data_<SpDPtr>::NotOp() { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::NotOp() {
+Data_<SpDObj>* Data_<SpDObj>::NotOp() { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
@@ -138,7 +138,7 @@ Data_<SpDObj>* Data_<SpDObj>::NotOp() {
 // for numbers
 
 template<class Sp>
-BaseGDL* Data_<Sp>::UMinus() {
+BaseGDL* Data_<Sp>::UMinus() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
   if (nEl == 1) {
@@ -146,7 +146,7 @@ BaseGDL* Data_<Sp>::UMinus() {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = -(*this)[i];
   } else {
@@ -158,7 +158,7 @@ BaseGDL* Data_<Sp>::UMinus() {
 }
 
 template<>
-BaseGDL* Data_<SpDString>::UMinus() {
+BaseGDL* Data_<SpDString>::UMinus() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
   Data_<SpDFloat>* newThis = static_cast<Data_<SpDFloat>*> (this->Convert2(GDL_FLOAT));
@@ -167,13 +167,13 @@ BaseGDL* Data_<SpDString>::UMinus() {
 }
 
 template<>
-BaseGDL* Data_<SpDPtr>::UMinus() {
+BaseGDL* Data_<SpDPtr>::UMinus() { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::UMinus() {
+BaseGDL* Data_<SpDObj>::UMinus() { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -182,7 +182,7 @@ BaseGDL* Data_<SpDObj>::UMinus() {
 // integers, also ptr and object
 
 template<class Sp>
-Data_<SpDByte>* Data_<Sp>::LogNeg() {
+Data_<SpDByte>* Data_<Sp>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
   DByteGDL* res = new Data_<SpDByte>(this->dim, BaseGDL::NOZERO);
@@ -192,7 +192,7 @@ Data_<SpDByte>* Data_<Sp>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
@@ -204,7 +204,7 @@ Data_<SpDByte>* Data_<Sp>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDObj>::LogNeg() {
+Data_<SpDByte>* Data_<SpDObj>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if (this->Scalar()) {
     DSubUD* isTrueOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator(dd[0], OOIsTrue));
     if (isTrueOverload != NULL) {
@@ -224,7 +224,7 @@ Data_<SpDByte>* Data_<SpDObj>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0) ? 1 : 0;
   } else {
@@ -236,7 +236,7 @@ Data_<SpDByte>* Data_<SpDObj>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDFloat>::LogNeg() {
+Data_<SpDByte>* Data_<SpDFloat>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
 
@@ -246,7 +246,7 @@ Data_<SpDByte>* Data_<SpDFloat>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0f) ? 1 : 0;
   } else {
@@ -258,7 +258,7 @@ Data_<SpDByte>* Data_<SpDFloat>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDDouble>::LogNeg() {
+Data_<SpDByte>* Data_<SpDDouble>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
 
@@ -268,7 +268,7 @@ Data_<SpDByte>* Data_<SpDDouble>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == 0.0) ? 1 : 0;
   } else {
@@ -280,7 +280,7 @@ Data_<SpDByte>* Data_<SpDDouble>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDString>::LogNeg() {
+Data_<SpDByte>* Data_<SpDString>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
 
@@ -290,7 +290,7 @@ Data_<SpDByte>* Data_<SpDString>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == "") ? 1 : 0;
   } else {
@@ -302,7 +302,7 @@ Data_<SpDByte>* Data_<SpDString>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDComplex>::LogNeg() {
+Data_<SpDByte>* Data_<SpDComplex>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
 
@@ -312,7 +312,7 @@ Data_<SpDByte>* Data_<SpDComplex>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
@@ -324,7 +324,7 @@ Data_<SpDByte>* Data_<SpDComplex>::LogNeg() {
 }
 
 template<>
-Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() {
+Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   assert(nEl);
 
@@ -334,7 +334,7 @@ Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() {
     return res;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i].real() == 0.0 && (*this)[i].imag() == 0.0) ? 1 : 0;
   } else {
@@ -349,7 +349,7 @@ Data_<SpDByte>* Data_<SpDComplexDbl>::LogNeg() {
 // integers
 
 template<class Sp>
-void Data_<Sp>::Dec() {
+void Data_<Sp>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
 
@@ -358,7 +358,7 @@ void Data_<Sp>::Dec() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]--;
   } else {
@@ -369,7 +369,7 @@ void Data_<Sp>::Dec() {
 }
 
 template<class Sp>
-void Data_<Sp>::Inc() {
+void Data_<Sp>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   ULong nEl = N_Elements();
   assert(nEl != 0);
 
@@ -378,7 +378,7 @@ void Data_<Sp>::Inc() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i]++;
   } else {
@@ -390,7 +390,7 @@ void Data_<Sp>::Inc() {
 // float
 
 template<>
-void Data_<SpDFloat>::Dec() {
+void Data_<SpDFloat>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -400,7 +400,7 @@ void Data_<SpDFloat>::Dec() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
@@ -411,7 +411,7 @@ void Data_<SpDFloat>::Dec() {
 }
 
 template<>
-void Data_<SpDFloat>::Inc() {
+void Data_<SpDFloat>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -421,7 +421,7 @@ void Data_<SpDFloat>::Inc() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
@@ -433,7 +433,7 @@ void Data_<SpDFloat>::Inc() {
 // double
 
 template<>
-void Data_<SpDDouble>::Dec() {
+void Data_<SpDDouble>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -443,7 +443,7 @@ void Data_<SpDDouble>::Dec() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
@@ -454,7 +454,7 @@ void Data_<SpDDouble>::Dec() {
 }
 
 template<>
-void Data_<SpDDouble>::Inc() {
+void Data_<SpDDouble>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -464,7 +464,7 @@ void Data_<SpDDouble>::Inc() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
@@ -476,7 +476,7 @@ void Data_<SpDDouble>::Inc() {
 // complex
 
 template<>
-void Data_<SpDComplex>::Dec() {
+void Data_<SpDComplex>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -486,7 +486,7 @@ void Data_<SpDComplex>::Dec() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
@@ -497,7 +497,7 @@ void Data_<SpDComplex>::Dec() {
 }
 
 template<>
-void Data_<SpDComplex>::Inc() {
+void Data_<SpDComplex>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -507,7 +507,7 @@ void Data_<SpDComplex>::Inc() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
@@ -518,7 +518,7 @@ void Data_<SpDComplex>::Inc() {
 }
 
 template<>
-void Data_<SpDComplexDbl>::Dec() {
+void Data_<SpDComplexDbl>::Dec() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -528,7 +528,7 @@ void Data_<SpDComplexDbl>::Dec() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= 1.0;
   } else {
@@ -539,7 +539,7 @@ void Data_<SpDComplexDbl>::Dec() {
 }
 
 template<>
-void Data_<SpDComplexDbl>::Inc() {
+void Data_<SpDComplexDbl>::Inc() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 
   ULong nEl = N_Elements();
   assert(nEl != 0);
@@ -549,7 +549,7 @@ void Data_<SpDComplexDbl>::Inc() {
     return;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] += 1.0;
   } else {
@@ -561,32 +561,32 @@ void Data_<SpDComplexDbl>::Inc() {
 // forbidden types
 
 template<>
-void Data_<SpDString>::Dec() {
+void Data_<SpDString>::Dec() { 
   throw GDLException("String expression not allowed in this context.", true, false);
 }
 
 template<>
-void Data_<SpDPtr>::Dec() {
+void Data_<SpDPtr>::Dec() { 
   throw GDLException("Pointer expression not allowed in this context.", true, false);
 }
 
 template<>
-void Data_<SpDObj>::Dec() {
+void Data_<SpDObj>::Dec() { 
   throw GDLException("Object expression not allowed in this context.", true, false);
 }
 
 template<>
-void Data_<SpDString>::Inc() {
+void Data_<SpDString>::Inc() { 
   throw GDLException("String expression not allowed in this context.", true, false);
 }
 
 template<>
-void Data_<SpDPtr>::Inc() {
+void Data_<SpDPtr>::Inc() { 
   throw GDLException("Pointer expression not allowed in this context.", true, false);
 }
 
 template<>
-void Data_<SpDObj>::Inc() {
+void Data_<SpDObj>::Inc() { 
   throw GDLException("Object expression not allowed in this context.", true, false);
 }
 
@@ -596,9 +596,9 @@ void Data_<SpDObj>::Inc() {
 // 1. operators that always return a new result
 // EqOp
 // returns *this eq *r
-
+// ex: b=(a eq 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -616,7 +616,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
@@ -631,7 +631,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
@@ -642,7 +642,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
@@ -658,7 +658,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
@@ -672,7 +672,7 @@ BaseGDL* Data_<Sp>::EqOp(BaseGDL* r) {
 // must handle overloads
 
 template<>
-BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if (Scalar()) {
     DSubUD* EQOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*this)[0], OOEQ));
     if (EQOverload == NULL) {
@@ -771,7 +771,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] == s);
     } else {
@@ -786,7 +786,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == s);
     } else {
@@ -797,7 +797,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
@@ -813,7 +813,7 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*this)[i]);
     } else {
@@ -827,9 +827,9 @@ BaseGDL* Data_<SpDObj>::EqOp(BaseGDL* r) {
 
 // NeOp
 // returns *this ne *r, //C deletes itself and right
-
+// ex b=(a ne 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -847,7 +847,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
@@ -862,7 +862,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
@@ -873,7 +873,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
@@ -889,7 +889,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
@@ -904,7 +904,7 @@ BaseGDL* Data_<Sp>::NeOp(BaseGDL* r) {
 // must handle overloads
 
 template<>
-BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if (Scalar()) {
     DSubUD* NEOverload =
       static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*this)[0], OONE));
@@ -999,7 +999,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] != s);
     } else {
@@ -1014,7 +1014,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
@@ -1025,7 +1025,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
@@ -1041,7 +1041,7 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*this)[i]);
     } else {
@@ -1055,9 +1055,9 @@ BaseGDL* Data_<SpDObj>::NeOp(BaseGDL* r) {
 
 // LeOp
 // returns *this le *r, //C deletes itself and right
-
+//ex:b=(a le 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1075,7 +1075,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] <= s);
     } else {
@@ -1090,7 +1090,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= s);
     } else {
@@ -1101,7 +1101,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
@@ -1117,7 +1117,7 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] >= (*this)[i]);
     } else {
@@ -1131,34 +1131,34 @@ BaseGDL* Data_<Sp>::LeOp(BaseGDL* r) {
 // invalid types
 
 template<>
-BaseGDL* Data_<SpDPtr>::LeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDPtr>::LeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::LeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::LeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplex>::LeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplex>::LeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplexDbl>::LeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplexDbl>::LeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // LtOp
 // returns *this lt *r, //C deletes itself and right
-
+// ex: b=(a lt 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1176,7 +1176,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] < s);
     } else {
@@ -1191,7 +1191,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > s);
     } else {
@@ -1202,7 +1202,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
@@ -1218,7 +1218,7 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] > (*this)[i]);
     } else {
@@ -1232,34 +1232,34 @@ BaseGDL* Data_<Sp>::LtOp(BaseGDL* r) {
 // invalid types
 
 template<>
-BaseGDL* Data_<SpDPtr>::LtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDPtr>::LtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::LtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::LtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplex>::LtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplex>::LtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplexDbl>::LtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplexDbl>::LtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // GeOp
 // returns *this ge *r, //C deletes itself and right
-
+// ex: b=(a ge 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1277,7 +1277,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] >= s);
     } else {
@@ -1292,7 +1292,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= s);
     } else {
@@ -1303,7 +1303,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
@@ -1319,7 +1319,7 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] <= (*this)[i]);
     } else {
@@ -1333,34 +1333,34 @@ BaseGDL* Data_<Sp>::GeOp(BaseGDL* r) {
 // invalid types
 
 template<>
-BaseGDL* Data_<SpDPtr>::GeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDPtr>::GeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::GeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::GeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplex>::GeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplex>::GeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplexDbl>::GeOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplexDbl>::GeOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 // GtOp
 // returns *this gt *r, //C deletes itself and right
-
+// ex: b=(a gt 0)
 template<class Sp>
-BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
+BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1378,7 +1378,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*this)[i] > s);
     } else {
@@ -1393,7 +1393,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < s);
     } else {
@@ -1404,7 +1404,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->dim, BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
@@ -1420,7 +1420,7 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
       return res;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] < (*this)[i]);
     } else {
@@ -1434,25 +1434,25 @@ BaseGDL* Data_<Sp>::GtOp(BaseGDL* r) {
 // invalid types
 
 template<>
-BaseGDL* Data_<SpDPtr>::GtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDPtr>::GtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::GtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::GtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplex>::GtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplex>::GtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 
 template<>
-BaseGDL* Data_<SpDComplexDbl>::GtOp(BaseGDL* r) {
+BaseGDL* Data_<SpDComplexDbl>::GtOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
@@ -1462,7 +1462,7 @@ BaseGDL* Data_<SpDComplexDbl>::GtOp(BaseGDL* r) {
 // returns *this # *r, //C does not delete itself and right
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   bool at = atranspose;
   bool bt = btranspose;
 
@@ -1626,7 +1626,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
     if (!bt) // normal
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
       if (!parallelize) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
@@ -1653,7 +1653,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
     } else // transpose r
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
       if (!parallelize) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
@@ -1682,7 +1682,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
     if (!bt) // normal
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
       if (!parallelize) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0, rowBnCol = 0; rIx < rIxEnd;
@@ -1709,7 +1709,7 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
     } else // transpose r
     {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) default(shared);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nOp)) default(shared);
       if (!parallelize) {
         for (OMPInt colA = 0; colA < nCol; ++colA) // res dim 0
           for (OMPInt rIx = 0; rIx < nRow; ++rIx) // res dim 1
@@ -1746,19 +1746,19 @@ Data_<Sp>* Data_<Sp>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+Data_<SpDString>* Data_<SpDString>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+Data_<SpDPtr>* Data_<SpDPtr>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) {
+Data_<SpDObj>* Data_<SpDObj>::MatrixOp(BaseGDL* r, bool atranspose, bool btranspose) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
@@ -1773,7 +1773,7 @@ Data_<SpDObj>* Data_<SpDObj>::MatrixOp(BaseGDL* r, bool atranspose, bool btransp
 template<class Sp>
 Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
 // GDL_DEFINE_INTEGER_FUNCTION( Data_<Sp>*) AndOp( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1785,7 +1785,7 @@ Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
   // note: we can't use valarray operation here as right->dd
   // might be larger than this->dd
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
@@ -1798,13 +1798,13 @@ Data_<Sp>* Data_<Sp>::AndOp(BaseGDL* r)
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInv(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::AndOpInv(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AndOp(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1814,7 +1814,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
@@ -1826,7 +1826,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOp(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1836,7 +1836,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
@@ -1850,7 +1850,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1860,7 +1860,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*this)[i] = zero;
   } else {
@@ -1872,7 +1872,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOp(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1882,7 +1882,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = (*right)[i];
   } else {
@@ -1901,13 +1901,13 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) {
 // }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOp(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::AndOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
@@ -1919,46 +1919,46 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp(BaseGDL* r) {
 // }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOp(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::AndOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInv( BaseGDL* r)
-// {
+// { 
 //  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return this;
 // }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOp(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::AndOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInv( BaseGDL* r)
-// {
+// { 
 //  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return this;
 // }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOp(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::AndOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 // template<>
 // Data_<SpDObj>* Data_<SpDObj>::AndOpInv( BaseGDL* r)
-// {
+// { 
 //  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);
 //  return this;
 // }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1971,7 +1971,7 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] &= s;
   } else {
@@ -1984,13 +1984,13 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvS(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::AndOpInvS(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AndOpS(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1998,7 +1998,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) {
   Ty s = (*right)[0];
   // right->Scalar(s);
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i) (*this)[i] = zero;
@@ -2008,7 +2008,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2016,7 +2016,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
@@ -2028,7 +2028,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
@@ -2043,7 +2043,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2051,7 +2051,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) {
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero)
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   {
     // #pragma omp for
     for (SizeT i = 0; i < nEl; ++i)
@@ -2061,14 +2061,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
   if (s == zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
@@ -2080,7 +2080,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
@@ -2095,37 +2095,37 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOpS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::AndOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvS( BaseGDL* r)
-// {
+// { 
 //  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return this;
 // }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOpS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::AndOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOpS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::AndOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2137,7 +2137,7 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpS(BaseGDL* r) {
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2147,7 +2147,7 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
@@ -2160,13 +2160,13 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return OrOp(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2176,7 +2176,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
@@ -2188,7 +2188,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2198,7 +2198,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
@@ -2211,7 +2211,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2221,7 +2221,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
   } else {
@@ -2233,7 +2233,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2243,7 +2243,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
   } else {
@@ -2256,31 +2256,31 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOp(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOp(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOp(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOp(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOp(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2290,7 +2290,7 @@ Data_<SpDObj>* Data_<SpDObj>::OrOp(BaseGDL* r) {
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2301,7 +2301,7 @@ Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*this)[i] | s;
   } else {
@@ -2314,13 +2314,13 @@ Data_<Sp>* Data_<Sp>::OrOpS(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvS(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::OrOpInvS(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return OrOpS(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2332,7 +2332,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
@@ -2345,14 +2345,14 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
   if (s != zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
@@ -2365,7 +2365,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
@@ -2379,7 +2379,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2391,7 +2391,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = s;
     } else {
@@ -2404,14 +2404,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
   if (s != zero) {
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT i = 0; i < nEl; ++i)
@@ -2423,7 +2423,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) {
       return this;
     }
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*this)[i] = s;
     } else {
@@ -2437,31 +2437,31 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOpS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::OrOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOpS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::OrOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOpS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::OrOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2472,7 +2472,7 @@ Data_<SpDObj>* Data_<SpDObj>::OrOpS(BaseGDL* r) {
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2485,7 +2485,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) {
   if (right->StrictScalar(s)) {
     if (s != Sp::zero) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
       } else {
@@ -2496,7 +2496,7 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) {
     }
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= (*right)[i];
     } else {
@@ -2510,49 +2510,49 @@ Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOp(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOp(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::XorOp(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOp(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOp(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOp(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOp(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::XorOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2563,7 +2563,7 @@ Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) {
   }
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] ^= s;
   } else {
@@ -2577,45 +2577,45 @@ Data_<Sp>* Data_<Sp>::XorOpS(BaseGDL* r) {
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOpS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
   return this;
 }
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOpS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
   return this;
 }
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::XorOpS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOpS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOpS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOpS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::XorOpS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2625,7 +2625,7 @@ Data_<SpDObj>* Data_<SpDObj>::XorOpS(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2635,7 +2635,7 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*this)[i] = (*right)[i];
   } else {
@@ -2648,37 +2648,37 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::LtMark(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::LtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMark(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::LtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMark(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMark(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::LtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMark(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::LtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2689,7 +2689,7 @@ Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) {
   }
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*this)[i] = s;
   } else {
@@ -2702,31 +2702,31 @@ Data_<Sp>* Data_<Sp>::LtMarkS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::LtMarkS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::LtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMarkS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::LtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMarkS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::LtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMarkS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::LtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2735,7 +2735,7 @@ Data_<SpDObj>* Data_<SpDObj>::LtMarkS(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2745,7 +2745,7 @@ Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) {
     return this;
   }
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*this)[i] = (*right)[i];
   } else {
@@ -2758,37 +2758,37 @@ Data_<Sp>* Data_<Sp>::GtMark(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::GtMark(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::GtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMark(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::GtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMark(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMark(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::GtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMark(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::GtMark(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2800,7 +2800,7 @@ Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) {
 
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*this)[i] = s;
   } else {
@@ -2813,31 +2813,31 @@ Data_<Sp>* Data_<Sp>::GtMarkS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::GtMarkS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::GtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMarkS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::GtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMarkS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::GtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMarkS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::GtMarkS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -2847,7 +2847,7 @@ Data_<SpDObj>* Data_<SpDObj>::GtMarkS(BaseGDL* r) {
 // modulo division: left=left % right
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2860,7 +2860,7 @@ Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) {
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] %= (*right)[ix];
         else (*this)[ix] = this->zero;
@@ -2876,7 +2876,7 @@ Data_<Sp>* Data_<Sp>::Mod(BaseGDL* r) {
 // inverse modulo division: left=right % left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2888,7 +2888,7 @@ Data_<Sp>* Data_<Sp>::ModInv(BaseGDL* r) {
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = (*right)[ix] % (*this)[ix];
         else (*this)[ix] = this->zero;
@@ -2908,13 +2908,13 @@ inline DFloat Modulo(const DFloat& l, const DFloat& r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
@@ -2927,13 +2927,13 @@ Data_<SpDFloat>* Data_<SpDFloat>::Mod(BaseGDL* r) {
 // float  inverse modulo division: left=right % left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
@@ -2951,13 +2951,13 @@ inline DDouble DModulo(const DDouble& l, const DDouble& r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
@@ -2970,13 +2970,13 @@ Data_<SpDDouble>* Data_<SpDDouble>::Mod(BaseGDL* r) {
 // double inverse modulo division: left=right % left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
@@ -2989,67 +2989,67 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInv(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::Mod(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::Mod(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::ModInv(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::ModInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::Mod(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::Mod(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Mod(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Mod(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInv(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::ModInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInv(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::Mod(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::Mod(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInv(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::ModInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::Mod(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::Mod(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInv(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::ModInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -3062,7 +3062,7 @@ Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) {
   // due to error handling the actual division by 0
   // has to be done
   // but if not 0, we save the expensive error handling
-  if (s != this->zero) {
+  if (s != this->zero) { 
     for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] %= s;
     return this;
   }
@@ -3071,7 +3071,7 @@ Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) {
     return this;
   } else {
     assert(s == this->zero);
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS)// && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     {
       // #pragma omp for
       for (SizeT ix = i; ix < nEl; ++ix) (*this)[ix] = 0;
@@ -3082,7 +3082,7 @@ Data_<Sp>* Data_<Sp>::ModS(BaseGDL* r) {
 // inverse modulo division: left=right % left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -3091,7 +3091,7 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) {
   // due to error handling the actual division by 0
   // has to be done
   // but if not 0, we save the expensive error handling
-  if (nEl == 1 && (*this)[0] != this->zero) {
+  if (nEl == 1 && (*this)[0] != this->zero) { 
     (*this)[0] = (*right)[0] % (*this)[0];
     return this;
   }
@@ -3105,7 +3105,7 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) {
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s % (*this)[ix];
         else (*this)[ix] = this->zero;
@@ -3120,14 +3120,14 @@ Data_<Sp>* Data_<Sp>::ModInvS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo((*this)[i], s);
   } else {
@@ -3140,14 +3140,14 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModS(BaseGDL* r) {
 // float  inverse modulo division: left=right % left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = Modulo(s, (*this)[i]);
   } else {
@@ -3159,14 +3159,14 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvS(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo((*this)[i], s);
   } else {
@@ -3179,14 +3179,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModS(BaseGDL* r) {
 // double inverse modulo division: left=right % left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = DModulo(s, (*this)[i]);
   } else {
@@ -3199,61 +3199,61 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::ModS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::ModS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::ModInvS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::ModInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::ModS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInvS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::ModInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::ModS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInvS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::ModInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::ModS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInvS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::ModInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
@@ -3262,7 +3262,7 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvS(BaseGDL* r) {
 // C++ defines pow only for floats and doubles
 //template <typename T, typename TT> T pow( const T r, const TT l)
 
-template <typename T> T pow(const T r, const T l) {
+template <typename T> T pow(const T r, const T l) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   typedef T TT;
 
   if (l == 0) return 1;
@@ -3287,13 +3287,13 @@ template <typename T> T pow(const T r, const T l) {
 // integral types
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
@@ -3306,13 +3306,13 @@ Data_<Sp>* Data_<Sp>::Pow(BaseGDL* r) {
 // inverse power of value: left=right ^ left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3325,7 +3325,7 @@ Data_<Sp>* Data_<Sp>::PowInv(BaseGDL* r) {
 // floats power of value: left=left ^ right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3334,7 +3334,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) {
   assert(nEl);
   {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3349,14 +3349,14 @@ Data_<SpDFloat>* Data_<SpDFloat>::Pow(BaseGDL* r) {
 // PowInt and PowIntNew can only be called for GDL_FLOAT and GDL_DOUBLE
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInt(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert(0);
   return this;
 }
 // floats power of value with GDL_LONG: left=left ^ right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DLongGDL* right = static_cast<DLongGDL*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3366,7 +3366,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
@@ -3380,7 +3380,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
@@ -3392,7 +3392,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
   }
   if (nEl <= rEl) {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3404,7 +3404,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3417,7 +3417,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInt(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DLongGDL* right = static_cast<DLongGDL*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3427,7 +3427,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
   if (r->StrictScalar()) {
     DLong r0 = (*right)[0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], r0);
     } else {
@@ -3441,7 +3441,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
@@ -3453,7 +3453,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
   }
   if (nEl <= rEl) {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3465,7 +3465,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3480,14 +3480,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInt(BaseGDL* r) {
 // floats inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3500,7 +3500,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInv(BaseGDL* r) {
 // doubles power of value: left=left ^ right
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3508,7 +3508,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) {
   assert(rEl);
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
@@ -3521,7 +3521,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::Pow(BaseGDL* r) {
 // doubles inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3529,7 +3529,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) {
   assert(rEl);
   assert(nEl);
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3543,7 +3543,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInv(BaseGDL* r) {
 // complex is special here
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -3558,7 +3558,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -3575,7 +3575,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3586,7 +3586,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3599,7 +3599,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3620,7 +3620,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -3637,7 +3637,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3648,7 +3648,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3661,7 +3661,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3680,7 +3680,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
@@ -3694,14 +3694,14 @@ Data_<SpDComplex>* Data_<SpDComplex>::Pow(BaseGDL* r) {
 // complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3714,7 +3714,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInv(BaseGDL* r) {
 // double complex power of value: left=left ^ right
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -3730,7 +3730,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -3747,7 +3747,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3758,7 +3758,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3771,7 +3771,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3794,7 +3794,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -3811,7 +3811,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3822,7 +3822,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3835,7 +3835,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3854,7 +3854,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*this)[ i], (*right)[ i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], (*right)[i]);
   } else {
@@ -3868,7 +3868,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Pow(BaseGDL* r) {
 // double complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3879,7 +3879,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) {
   for (SizeT i = 0; i < nEl; ++i)
     (*this)[ i] = pow((*right)[ i], (*this)[i]);
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3893,50 +3893,50 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInv(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::Pow(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::Pow(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInv(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::PowInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::Pow(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::Pow(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInv(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::PowInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::Pow(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::Pow(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInv(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::PowInv(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow((*this)[i], s);
   } else {
@@ -3949,14 +3949,14 @@ Data_<Sp>* Data_<Sp>::PowS(BaseGDL* r) {
 // inverse power of value: left=right ^ left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = pow(s, (*this)[i]);
   } else {
@@ -3969,14 +3969,14 @@ Data_<Sp>* Data_<Sp>::PowInvS(BaseGDL* r) {
 // floats power of value: left=left ^ right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
@@ -3989,13 +3989,13 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowS(BaseGDL* r) {
 // floats inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
@@ -4008,14 +4008,14 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvS(BaseGDL* r) {
 // doubles power of value: left=left ^ right
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(dd[ i], s); // valarray
   } else {
@@ -4028,14 +4028,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowS(BaseGDL* r) {
 // doubles inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
 
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) dd[ i] = pow(s, dd[ i]); // valarray
   } else {
@@ -4049,7 +4049,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvS(BaseGDL* r) {
 // complex is special here
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -4064,7 +4064,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -4081,7 +4081,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -4092,7 +4092,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4105,7 +4105,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4126,7 +4126,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -4143,7 +4143,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -4154,7 +4154,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4167,7 +4167,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4183,7 +4183,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
@@ -4196,7 +4196,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowS(BaseGDL* r) {
 // complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -4204,7 +4204,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) {
   assert(rEl);
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
@@ -4217,7 +4217,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvS(BaseGDL* r) {
 // double complex power of value: left=left ^ right
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -4233,7 +4233,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -4250,7 +4250,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -4261,7 +4261,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4274,7 +4274,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4297,7 +4297,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
       } else {
@@ -4314,7 +4314,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
 
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -4325,7 +4325,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
           return res;
         }
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4338,7 +4338,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
 
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -4354,7 +4354,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
   Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow((*this)[ i], s);
   } else {
@@ -4368,13 +4368,13 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowS(BaseGDL* r) {
 // double complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[ i] = pow(s, (*this)[ i]);
   } else {
@@ -4387,37 +4387,37 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvS(BaseGDL* r) {
 // invalid types
 
 template<>
-Data_<SpDString>* Data_<SpDString>::PowS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::PowS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInvS(BaseGDL* r) {
+Data_<SpDString>* Data_<SpDString>::PowInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::PowS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInvS(BaseGDL* r) {
+Data_<SpDPtr>* Data_<SpDPtr>::PowInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::PowS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInvS(BaseGDL* r) {
+Data_<SpDObj>* Data_<SpDObj>::PowInvS(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -55,8 +55,7 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 	return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -85,8 +84,7 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
       (*this)[0] = (*right)[0] + (*this)[0];
       return this;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -312,8 +310,7 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 	mThis += s;
 	return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -337,8 +334,7 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -366,8 +362,7 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -60,7 +60,7 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for
+#pragma omp parallel for  num_threads(CpuTPOOL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     }
   return this;
@@ -90,7 +90,7 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } 
   return this;
@@ -317,7 +317,7 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     }
   return this;
@@ -342,7 +342,7 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     }
   return this;
@@ -371,7 +371,7 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     }
   return this;

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -40,9 +40,7 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
   
   Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
   ULong nEl=N_Elements();
-  // assert( rEl);
   assert( nEl);
   if( nEl == 1)
     {
@@ -57,13 +55,14 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 	return this;
 #else
 
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += (*right)[i];
-    }  //C delete right;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
+    } else {
+      TRACEOMP( __FILE__, __LINE__)
+#pragma omp parallel for
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
+    }
   return this;
 #endif
   
@@ -79,23 +78,21 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
 {
   Data_* right=static_cast<Data_*>(r);
 
-  // ULong rEl=right->N_Elements();
   ULong nEl=N_Elements();
-  // assert( rEl);
   assert( nEl);
   if( nEl == 1)
     {
       (*this)[0] = (*right)[0] + (*this)[0];
       return this;
     }
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = (*right)[i] + (*this)[i];
-    }  //C delete right;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
+    } else {
+      TRACEOMP( __FILE__, __LINE__)
+#pragma omp parallel for
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
+    } 
   return this;
 }
 // invalid types
@@ -132,7 +129,6 @@ BaseGDL* Data_<SpDObj>::Add( BaseGDL* r)
   }
   else
   {
-    // Scalar()
     self = static_cast<Data_*>( this);
     plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOPlus));
     if( plusOverload == NULL)
@@ -230,7 +226,6 @@ BaseGDL* Data_<SpDObj>::AddInv( BaseGDL* r)
   }
   else
   {
-    // Scalar()
     self = static_cast<Data_*>( this);
     plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOPlus));
     if( plusOverload == NULL)
@@ -305,28 +300,26 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 
   ULong nEl=N_Elements();
   assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
   if( nEl == 1)
     {
       (*this)[0] += (*right)[0];
       return this;
     }
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  //  dd += s;
 #ifdef USE_EIGEN
 
         Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
 	mThis += s;
 	return this;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += s;
-    }  //C delete right;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
+    } else {
+      TRACEOMP( __FILE__, __LINE__)
+#pragma omp parallel for
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
+    }
   return this;
 #endif
   
@@ -338,22 +331,20 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
 
   ULong nEl=N_Elements();
   assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
   if( nEl == 1)
     {
       (*this)[0] += (*right)[0];
       return this;
     }
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  //  dd += s;
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] += s;
-    }  //C delete right;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
+    } else {
+      TRACEOMP( __FILE__, __LINE__)
+#pragma omp parallel for
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
+    }
   return this;
 }
 
@@ -369,21 +360,20 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
 
   ULong nEl=N_Elements();
   assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
   if( nEl == 1)
     {
       (*this)[0] = (*right)[0] + (*this)[0] ;
       return this;
     }
   Ty s = (*right)[0];
-  // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = s + (*this)[i];
-    }  //C delete right;
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
+    } else {
+      TRACEOMP( __FILE__, __LINE__)
+#pragma omp parallel for
+      for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
+    }
   return this;
   
 }

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -55,11 +55,11 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 	return this;
 #else
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for  num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for  num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     }
   return this;
@@ -84,11 +84,11 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
       (*this)[0] = (*right)[0] + (*this)[0];
       return this;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } 
   return this;
@@ -310,11 +310,11 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 	mThis += s;
 	return this;
 #else
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     }
   return this;
@@ -334,11 +334,11 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     }
   return this;
@@ -362,11 +362,11 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     }
   return this;

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -35,7 +35,7 @@
 // right must always have more or same number of elements
 template<class Sp>
 BaseGDL* Data_<Sp>::Add( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   
   
   Data_* right=static_cast<Data_*>(r);
@@ -55,7 +55,7 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 	return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     } else {
@@ -69,13 +69,13 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 }
 template<class Sp>
 BaseGDL* Data_<Sp>::AddInv( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( this->Type() != GDL_OBJ); // should never be called via this
   return Add( r); // this needs to be modified
 }
 template<>
 BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
 
   ULong nEl=N_Elements();
@@ -85,7 +85,7 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
       (*this)[0] = (*right)[0] + (*this)[0];
       return this;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } else {
@@ -98,13 +98,13 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
 // invalid types
 template<>
 BaseGDL* Data_<SpDPtr>::Add( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
   return this;
 }
 template<>
 BaseGDL* Data_<SpDObj>::Add( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // overload here
   Data_* self;
   DSubUD* plusOverload;
@@ -208,7 +208,7 @@ BaseGDL* Data_<SpDObj>::Add( BaseGDL* r)
 // difference from above: Order of parameters in call
 template<>
 BaseGDL* Data_<SpDObj>::AddInv( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( r->Type() == GDL_OBJ && r->Scalar())
   {
     return r->Add( this); // for right order of parameters
@@ -295,7 +295,7 @@ BaseGDL* Data_<SpDObj>::AddInv( BaseGDL* r)
 
 template<class Sp>
 BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
 
   ULong nEl=N_Elements();
@@ -312,7 +312,7 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 	mThis += s;
 	return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
@@ -326,7 +326,7 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 }
 template<>
 BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
 
   ULong nEl=N_Elements();
@@ -337,7 +337,7 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
@@ -350,12 +350,12 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
 
 template<class Sp>
 BaseGDL* Data_<Sp>::AddInvS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddS( r);
 }
 template<>
 BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
 
   ULong nEl=N_Elements();
@@ -366,7 +366,7 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     } else {
@@ -381,18 +381,18 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
 // invalid types
 template<>
 BaseGDL* Data_<SpDPtr>::AddS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
   return this;
 }
 template<>
 BaseGDL* Data_<SpDObj>::AddS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return Add( r);
 }
 template<>
 BaseGDL* Data_<SpDObj>::AddInvS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddInv( r);
 }
 

--- a/src/basic_op_add.cpp
+++ b/src/basic_op_add.cpp
@@ -55,7 +55,7 @@ BaseGDL* Data_<Sp>::Add( BaseGDL* r)
 	return this;
 #else
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+	if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -84,7 +84,7 @@ BaseGDL* Data_<SpDString>::AddInv( BaseGDL* r)
       (*this)[0] = (*right)[0] + (*this)[0];
       return this;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = (*right)[i] + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -310,7 +310,7 @@ BaseGDL* Data_<Sp>::AddS( BaseGDL* r)
 	mThis += s;
 	return this;
 #else
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+	if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -334,7 +334,7 @@ BaseGDL* Data_<SpDString>::AddS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] += s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -362,7 +362,7 @@ BaseGDL* Data_<SpDString>::AddInvS( BaseGDL* r)
       return this;
     }
   Ty s = (*right)[0];
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] = s + (*this)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -49,8 +49,7 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -75,8 +74,7 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix)
         if ((*this)[ix] != this->zero)
           (*this)[ix] = (*right)[ix] / (*this)[ix];

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -49,7 +49,7 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -74,7 +74,7 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix)
         if ((*this)[ix] != this->zero)
           (*this)[ix] = (*right)[ix] / (*this)[ix];

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -49,11 +49,11 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
     return this;
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     }
     return this;
@@ -74,7 +74,7 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     return this;
   } else {
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix)
         if ((*this)[ix] != this->zero)
           (*this)[ix] = (*right)[ix] / (*this)[ix];
@@ -82,7 +82,7 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
           (*this)[ix] = (*right)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix)
         if ((*this)[ix] != this->zero)
           (*this)[ix] = (*right)[ix] / (*this)[ix];
@@ -181,10 +181,6 @@ Data_<Sp>* Data_<Sp>::DivInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] = s / (*this)[i];
     return this;
   } else {
-    //      TRACEOMP( __FILE__, __LINE__)
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
-    // 	{
-    // #pragma omp for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s / (*this)[ix];
       else (*this)[ix] = s;
     return this;

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -35,7 +35,7 @@
 // division: left=left/right
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
   ULong nEl = N_Elements();
   assert(nEl);
@@ -49,7 +49,7 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) {
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     } else {
@@ -63,7 +63,7 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) {
 // inverse division: left=right/left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
   ULong nEl = N_Elements();
   assert(nEl);
@@ -75,7 +75,7 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) {
     return this;
   } else {
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix)
         if ((*this)[ix] != this->zero)
@@ -133,7 +133,7 @@ Data_<SpDObj>* Data_<SpDObj>::DivInv(BaseGDL* r) {
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -162,7 +162,7 @@ Data_<Sp>* Data_<Sp>::DivS(BaseGDL* r) {
 // inverse division: left=right/left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -184,7 +184,7 @@ Data_<Sp>* Data_<Sp>::DivInvS(BaseGDL* r) {
     return this;
   } else {
     //      TRACEOMP( __FILE__, __LINE__)
-    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
     // 	{
     // #pragma omp for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s / (*this)[ix];

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -33,253 +33,200 @@
 
 // Div
 // division: left=left/right
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Div( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-
+Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
   SizeT i = 0;
 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      // TODO: Check if we can use OpenMP here (is longjmp allowed?)
-      //             if yes: need to run the full loop after the longjmp
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] /= (*right)[i];
-      //C delete right;
-      return this;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    // TODO: Check if we can use OpenMP here (is longjmp allowed?)
+    //             if yes: need to run the full loop after the longjmp
+    for (/*SizeT i=0*/; i < nEl; ++i)
+      (*this)[i] /= (*right)[i];
+    return this;
+  } else {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-	  //       bool zeroEncountered = false; // until zero operation is already done.
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*right)[ix] == this->zero)
-		zeroEncountered = true;
-		}
-		else*/
-	    if( (*right)[ix] != this->zero) (*this)[ix] /= (*right)[ix];
-	}      //C delete right;
-      return this;
-    }
-}
-// inverse division: left=right/left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  //  assert( rEl);
-  assert( nEl);
-
-  SizeT i = 0;
-
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] = (*right)[i] / (*this)[i];
-      //C delete right;
-      return this;
-    }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-	  //       bool zeroEncountered = false; // until zero operation is already done.
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*this)[ix] == this->zero)
-		{
-		zeroEncountered = true;
-		(*this)[ ix] = (*right)[i];
-		}
-		}
-		else*/
-	    if( (*this)[ix] != this->zero) 
-	      (*this)[ix] = (*right)[ix] / (*this)[ix]; 
-	    else
-	      (*this)[ix] = (*right)[ix];
-	}      //C delete right;
-      return this;
-    }
-}
-// invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::Div( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDString>* Data_<SpDString>::DivInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::Div( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::Div( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::DivInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return this;
-}
-template<class Sp>
-Data_<Sp>* Data_<Sp>::DivS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  ULong nEl=N_Elements();
-  assert( nEl);
-  Ty s = (*right)[0];
-
-  // remember: this is a template (must work for several types)
-  // due to error handling the actual devision by 0
-  // has to be done 
-  // but if not 0, we save the expensive error handling
-  if( s != this->zero)
-    {
-      for(SizeT i=0; i < nEl; ++i)
-      {
-	(*this)[i] /= s;
-      }
-      return this;
-    }
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for(SizeT i=0; i < nEl; ++i)
-      {
-	(*this)[i] /= s;
-      }
-      return this;
-    }
-  return this;
-}
-
-// inverse division: left=right/left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  ULong nEl=N_Elements();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-
-  // remember: this is a template (must work for several types)
-  // due to error handling the actual devision by 0
-  // has to be done 
-  // but if not 0, we save the expensive error handling
-  if( nEl == 1 && (*this)[0] != this->zero) 
-  {
-    (*this)[0] = (*right)[0] / (*this)[0]; 
     return this;
   }
-  
-  Ty s = (*right)[0];
-  SizeT i=0;
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      // right->Scalar(s); 
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*this)[i] = s / (*this)[i];
-      //C delete right;
-      return this;
+}
+// inverse division: left=right/left
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  SizeT i = 0;
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i)    (*this)[i] = (*right)[i] / (*this)[i];
+    return this;
+  } else {
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix)
+        if ((*this)[ix] != this->zero)
+          (*this)[ix] = (*right)[ix] / (*this)[ix];
+        else
+          (*this)[ix] = (*right)[ix];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix)
+        if ((*this)[ix] != this->zero)
+          (*this)[ix] = (*right)[ix] / (*this)[ix];
+        else
+          (*this)[ix] = (*right)[ix];
     }
-  else
-    {
-//      TRACEOMP( __FILE__, __LINE__)
-// #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-// 	{
-// 	  //       bool zeroEncountered = false;
-// #pragma omp for
-	  // right->Scalar(s); 
-	  for( SizeT ix=i; ix < nEl; ++ix)
-	    /*	if( !zeroEncountered)
-		{
-		if( (*this)[ix] == this->zero)
-		{
-		zeroEncountered = true;
-		(*this)[ix] = s;
-		}
-		}
-		else*/
-	    if( (*this)[ix] != this->zero) 
-	      (*this)[ix] = s / (*this)[ix]; 
-	    else 
-	      (*this)[ix] = s;
-// 	}      //C delete right;
-      return this;
-    }
+    return this;
+  }
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::Div(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::DivInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::Div(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::DivInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::Div(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::DivInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::DivS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Ty s = (*right)[0];
+
+  // remember: this is a template (must work for several types)
+  // due to error handling the actual devision by 0
+  // has to be done
+  // but if not 0, we save the expensive error handling
+  if (s != this->zero) {
+    for (SizeT i = 0; i < nEl; ++i) {
+      (*this)[i] /= s;
+    }
+    return this;
+  }
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (SizeT i = 0; i < nEl; ++i) {
+      (*this)[i] /= s;
+    }
+    return this;
+  }
+  return this;
+}
+
+// inverse division: left=right/left
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::DivInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  // remember: this is a template (must work for several types)
+  // due to error handling the actual devision by 0
+  // has to be done
+  // but if not 0, we save the expensive error handling
+  if (nEl == 1 && (*this)[0] != this->zero) {
+    (*this)[0] = (*right)[0] / (*this)[0];
+    return this;
+  }
+
+  Ty s = (*right)[0];
+  SizeT i = 0;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) (*this)[i] = s / (*this)[i];
+    return this;
+  } else {
+    //      TRACEOMP( __FILE__, __LINE__)
+    // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+    // 	{
+    // #pragma omp for num_threads(CpuTPOOL_NTHREADS)
+    for (SizeT ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*this)[ix] = s / (*this)[ix];
+      else (*this)[ix] = s;
+    return this;
+  }
+}
+// invalid types
+
+template<>
+Data_<SpDString>* Data_<SpDString>::DivS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::DivInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::DivS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::DivInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::DivS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return this;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::DivInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 

--- a/src/basic_op_mult.cpp
+++ b/src/basic_op_mult.cpp
@@ -49,11 +49,11 @@ Data_<Sp>* Data_<Sp>::Mult( BaseGDL* r)
   mThis *= mRight;
   return this;
 #else
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= (*right)[i];
     }
   return this;
@@ -99,11 +99,11 @@ Data_<Sp>* Data_<Sp>::MultS( BaseGDL* r)
   mThis *= s;
   return this;
 #else
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= s;
     } else {
       TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= s;
     }
   return this;

--- a/src/basic_op_mult.cpp
+++ b/src/basic_op_mult.cpp
@@ -49,7 +49,7 @@ Data_<Sp>* Data_<Sp>::Mult( BaseGDL* r)
   mThis *= mRight;
   return this;
 #else
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -99,7 +99,7 @@ Data_<Sp>* Data_<Sp>::MultS( BaseGDL* r)
   mThis *= s;
   return this;
 #else
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= s;
     } else {
       TRACEOMP( __FILE__, __LINE__)

--- a/src/basic_op_mult.cpp
+++ b/src/basic_op_mult.cpp
@@ -33,7 +33,7 @@
 // right must always have more or same number of elements
 template<class Sp>
 Data_<Sp>* Data_<Sp>::Mult( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
   ULong nEl=N_Elements();
   assert( nEl);
@@ -49,7 +49,7 @@ Data_<Sp>* Data_<Sp>::Mult( BaseGDL* r)
   mThis *= mRight;
   return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= (*right)[i];
     } else {
@@ -83,7 +83,7 @@ Data_<SpDObj>* Data_<SpDObj>::Mult( BaseGDL* r)
 
 template<class Sp>
 Data_<Sp>* Data_<Sp>::MultS( BaseGDL* r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right=static_cast<Data_*>(r);
 
   ULong nEl=N_Elements();
@@ -100,7 +100,7 @@ Data_<Sp>* Data_<Sp>::MultS( BaseGDL* r)
   mThis *= s;
   return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= s;
     } else {

--- a/src/basic_op_mult.cpp
+++ b/src/basic_op_mult.cpp
@@ -49,8 +49,7 @@ Data_<Sp>* Data_<Sp>::Mult( BaseGDL* r)
   mThis *= mRight;
   return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= (*right)[i];
     } else {
       TRACEOMP( __FILE__, __LINE__)
@@ -100,8 +99,7 @@ Data_<Sp>* Data_<Sp>::MultS( BaseGDL* r)
   mThis *= s;
   return this;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for( OMPInt i=0; i < nEl; ++i) (*this)[i] *= s;
     } else {
       TRACEOMP( __FILE__, __LINE__)

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -62,8 +62,7 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] & (*right)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -95,8 +94,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
@@ -123,8 +121,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     else (*res)[0] = zero;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
@@ -151,8 +148,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
@@ -178,8 +174,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
     else (*res)[0] = zero;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
@@ -256,8 +251,7 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = (*this)[0] & s;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -300,8 +294,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -340,8 +333,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -412,8 +404,7 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -446,8 +437,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -475,8 +465,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -504,8 +493,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -532,8 +520,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -594,8 +581,7 @@ Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] | s;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -627,8 +613,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       else (*res)[0] = (*this)[0];
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
@@ -662,8 +647,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -692,8 +676,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       else (*res)[0] = (*this)[0];
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
@@ -726,8 +709,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FU
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -797,8 +779,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
       return this->Dup();
 
     Data_* res = NewResult();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -808,8 +789,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   } else {
     Data_* res = NewResult();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -879,8 +859,7 @@ Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this->Dup();
 
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -963,8 +942,7 @@ BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   mRes = mThis + mRight;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -992,8 +970,7 @@ BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__
     (*res)[0] = (*right)[0] + (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1043,8 +1020,7 @@ BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis + s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1073,8 +1049,7 @@ BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
     return res;
   }
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1133,8 +1108,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - s;
     return res;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1153,8 +1127,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - mRight;
     return res;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1188,8 +1161,7 @@ BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mRight - mThis;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1258,8 +1230,7 @@ BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis - s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1295,8 +1266,7 @@ BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = s - mThis;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1362,8 +1332,7 @@ Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -1422,8 +1391,7 @@ Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
   }
   Ty s = (*right)[0];
   // right->Scalar(s);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
@@ -1485,8 +1453,7 @@ Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -1546,8 +1513,7 @@ Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
 
   Ty s = (*right)[0];
   // right->Scalar(s);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
@@ -1617,8 +1583,7 @@ Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mThis * mRight;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1671,8 +1636,7 @@ Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = mThis * s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1727,8 +1691,7 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] / (*right)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
         else (*res)[ix] = (*this)[ix];
     } else {
@@ -1760,8 +1723,7 @@ Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] / (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
         else (*res)[ix] = (*right)[ix];
     } else {
@@ -1862,8 +1824,7 @@ Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
       (*res)[i] = s / (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
         else (*res)[ix] = s;
     } else {
@@ -1952,8 +1913,7 @@ Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] % (*right)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -1982,8 +1942,7 @@ Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] % (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -2010,8 +1969,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = Modulo((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2035,8 +1993,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = Modulo((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2060,8 +2017,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = DModulo((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2085,8 +2041,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = DModulo((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2211,8 +2166,7 @@ Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     }
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -2239,8 +2193,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2265,8 +2218,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2290,8 +2242,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2316,8 +2267,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2430,8 +2380,7 @@ Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2453,8 +2402,7 @@ Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2482,11 +2430,10 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2498,8 +2445,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2510,8 +2456,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2521,8 +2466,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2544,8 +2488,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2557,8 +2500,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2569,8 +2511,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2580,8 +2521,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2605,8 +2545,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2628,8 +2567,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2651,8 +2589,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2674,8 +2611,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2704,8 +2640,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2720,8 +2655,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2733,8 +2667,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2745,8 +2678,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2768,8 +2700,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2784,8 +2715,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2797,8 +2727,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2809,8 +2738,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2833,8 +2761,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
     //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2845,8 +2772,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   } else {
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2866,8 +2792,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
   assert(nEl);
 
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2895,8 +2820,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2911,8 +2835,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2924,8 +2847,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2936,8 +2858,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2958,8 +2879,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2974,8 +2894,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2987,8 +2906,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2999,8 +2917,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3018,8 +2935,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
   if (right->StrictScalar(s)) {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3030,8 +2946,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
   } else {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3052,8 +2967,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) { TRACE_ROUTIN
   assert(rEl);
   assert(nEl);
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3114,8 +3028,7 @@ Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = pow((*this)[0], s);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3139,8 +3052,7 @@ Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3167,8 +3079,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3183,8 +3094,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3195,8 +3105,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3207,8 +3116,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3229,8 +3137,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3245,8 +3152,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3257,8 +3163,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3269,8 +3174,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3287,8 +3191,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
 
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3312,8 +3215,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3341,8 +3243,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3357,8 +3258,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3369,8 +3269,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3381,8 +3280,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3404,8 +3302,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3420,8 +3317,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-          if (!parallelize) {
+          if (!parallelize( rEl)) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3432,8 +3328,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3444,8 +3339,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-        if (!parallelize) {
+        if (!parallelize( rEl)) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3460,8 +3354,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
   Data_* right = static_cast<Data_*> (r);
   const Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3480,8 +3373,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) { TRACE_ROUTI
   assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) {
+  if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -50,7 +50,7 @@ using namespace std;
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -62,7 +62,7 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) {
     (*res)[0] = (*this)[0] & (*right)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
@@ -75,13 +75,13 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AndOpNew(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -95,7 +95,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
@@ -108,8 +108,9 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) {
   return res;
 }
 
+//b=(a and a)
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -122,7 +123,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) {
     else (*res)[0] = zero;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
@@ -137,7 +138,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -150,7 +151,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
@@ -164,7 +165,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -177,7 +178,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) {
     else (*res)[0] = zero;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
@@ -210,7 +211,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpNew(BaseGDL* r) {
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvNew( BaseGDL* r)
-// {
+// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 //  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return res;
 // }
@@ -222,7 +223,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::AndOpNew(BaseGDL* r) {
 }
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInvNew( BaseGDL* r)
-// {
+// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 //  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return res;
 // }
@@ -234,7 +235,7 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpNew(BaseGDL* r) {
 }
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInvNew( BaseGDL* r)
-// {
+// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 //  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return res;
 // }
@@ -242,7 +243,7 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -255,7 +256,7 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) {
     (*res)[0] = (*this)[0] & s;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
   } else {
@@ -268,13 +269,13 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvSNew(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::AndOpInvSNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AndOpSNew(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
   if ((*right)[0] == zero) {
     return New(this->dim, BaseGDL::ZERO);
@@ -282,8 +283,9 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) {
   return this->Dup();
 }
 
+//b=(a and 1)
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -298,7 +300,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) {
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
@@ -314,7 +316,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
   if ((*right)[0] == zero) {
     return New(this->dim, BaseGDL::ZERO);
@@ -323,7 +325,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -338,7 +340,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) {
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
@@ -372,7 +374,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpSNew(BaseGDL* r) {
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvSNew( BaseGDL* r)
-// {
+// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 //  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return res;
 // }
@@ -397,7 +399,7 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpSNew(BaseGDL* r) {
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -410,7 +412,7 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) {
     (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
@@ -424,13 +426,13 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return OrOpNew(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -444,7 +446,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -457,8 +459,9 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) {
   return res;
 }
 
+// b=(a or a)
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -472,7 +475,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -487,7 +490,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -501,7 +504,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -515,7 +518,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -529,7 +532,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -577,7 +580,7 @@ Data_<SpDObj>* Data_<SpDObj>::OrOpNew(BaseGDL* r) {
 // for integers
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -591,7 +594,7 @@ Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) {
     (*res)[0] = (*this)[0] | s;
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
   } else {
@@ -604,13 +607,13 @@ Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) {
 // different for floats
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvSNew(BaseGDL* right) {
+Data_<Sp>* Data_<Sp>::OrOpInvSNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return OrOpSNew(right);
 }
 // for floats
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -624,7 +627,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) {
       else (*res)[0] = (*this)[0];
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
@@ -640,9 +643,9 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) {
     return this->Dup();
   }
 }
-
+// b=(a or 0)
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -659,7 +662,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
@@ -675,7 +678,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {
 // for doubles
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -689,7 +692,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) {
       else (*res)[0] = (*this)[0];
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
@@ -706,7 +709,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -723,7 +726,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) {
       else (*res)[0] = zero;
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
@@ -774,9 +777,9 @@ Data_<SpDObj>* Data_<SpDObj>::OrOpSNew(BaseGDL* r) {
 // Xors right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
-
+// ex: b=(a xor c)
 template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -794,7 +797,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) {
       return this->Dup();
 
     Data_* res = NewResult();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     } else {
@@ -805,7 +808,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) {
     return res;
   } else {
     Data_* res = NewResult();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
     } else {
@@ -861,7 +864,7 @@ Data_<SpDObj>* Data_<SpDObj>::XorOpNew(BaseGDL* r) {
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -876,7 +879,7 @@ Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) {
     return this->Dup();
 
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
   } else {
@@ -938,7 +941,7 @@ Data_<SpDObj>* Data_<SpDObj>::XorOpSNew(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -960,7 +963,7 @@ BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) {
   mRes = mThis + mRight;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
   } else {
@@ -973,12 +976,12 @@ BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) {
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::AddInvNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddNew(r);
 }
 
 template<>
-BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) {
+BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -989,7 +992,7 @@ BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) {
     (*res)[0] = (*right)[0] + (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
   } else {
@@ -1009,19 +1012,19 @@ BaseGDL* Data_<SpDPtr>::AddNew(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::AddNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::AddNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return Add(r);
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::AddInvNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddInv(r);
 }
 
 // scalar versions
 
 template<class Sp>
-BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1040,7 +1043,7 @@ BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) {
   mRes = mThis + s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
   } else {
@@ -1054,12 +1057,12 @@ BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) {
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::AddInvSNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddSNew(r);
 }
 
 template<>
-BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) {
+BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1070,7 +1073,7 @@ BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) {
     return res;
   }
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
   } else {
@@ -1090,12 +1093,12 @@ BaseGDL* Data_<SpDPtr>::AddSNew(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::AddSNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::AddSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return Add(r);
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::AddInvSNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AddInv(r);
 }
 
@@ -1105,7 +1108,7 @@ BaseGDL* Data_<SpDObj>::AddInvSNew(BaseGDL* r) {
 // substraction: res=left-right
 
 template<class Sp>
-BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1130,7 +1133,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) {
     mRes = mThis - s;
     return res;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     } else {
@@ -1150,7 +1153,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) {
     mRes = mThis - mRight;
     return res;
 #else
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     } else {
@@ -1165,7 +1168,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) {
 // inverse substraction: left=right-left
 
 template<class Sp>
-BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -1185,7 +1188,7 @@ BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) {
   mRes = mRight - mThis;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
   } else {
@@ -1223,19 +1226,19 @@ BaseGDL* Data_<SpDPtr>::SubInvNew(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::SubNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return Sub(r);
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::SubInvNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::SubInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return SubInv(r);
 }
 
 // scalar versions
 
 template<class Sp>
-BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1255,7 +1258,7 @@ BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) {
   mRes = mThis - s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
   } else {
@@ -1270,7 +1273,7 @@ BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) {
 // inverse substraction: left=right-left
 
 template<class Sp>
-BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) {
+BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1292,7 +1295,7 @@ BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) {
   mRes = s - mThis;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
   } else {
@@ -1331,12 +1334,12 @@ BaseGDL* Data_<SpDPtr>::SubInvSNew(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::SubSNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::SubSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return Sub(r);
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::SubInvSNew(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::SubInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return SubInv(r);
 }
 
@@ -1345,7 +1348,7 @@ BaseGDL* Data_<SpDObj>::SubInvSNew(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
@@ -1359,7 +1362,7 @@ Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -1406,7 +1409,7 @@ Data_<SpDObj>* Data_<SpDObj>::LtMarkNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1419,7 +1422,7 @@ Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) {
   }
   Ty s = (*right)[0];
   // right->Scalar(s);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
@@ -1468,7 +1471,7 @@ Data_<SpDObj>* Data_<SpDObj>::LtMarkSNew(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
@@ -1482,7 +1485,7 @@ Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) {
     else (*res)[0] = (*this)[0];
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
@@ -1529,7 +1532,7 @@ Data_<SpDObj>* Data_<SpDObj>::GtMarkNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1543,7 +1546,7 @@ Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) {
 
   Ty s = (*right)[0];
   // right->Scalar(s);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
@@ -1592,7 +1595,7 @@ Data_<SpDObj>* Data_<SpDObj>::GtMarkSNew(BaseGDL* r) {
 // right must always have more or same number of elements
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   Data_* res = NewResult();
@@ -1614,7 +1617,7 @@ Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) {
   mRes = mThis * mRight;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
   } else {
@@ -1649,7 +1652,7 @@ Data_<SpDObj>* Data_<SpDObj>::MultNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1668,7 +1671,7 @@ Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) {
   mRes = mThis * s;
   return res;
 #else
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
   } else {
@@ -1706,7 +1709,7 @@ Data_<SpDObj>* Data_<SpDObj>::MultSNew(BaseGDL* r) {
 // division: left=left/right
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
@@ -1724,7 +1727,7 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) {
       (*res)[i] = (*this)[i] / (*right)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
         else (*res)[ix] = (*this)[ix];
@@ -1740,7 +1743,7 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) {
 // inverse division: left=right/left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
@@ -1757,7 +1760,7 @@ Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) {
       (*res)[i] = (*right)[i] / (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
         else (*res)[ix] = (*right)[ix];
@@ -1811,7 +1814,7 @@ Data_<SpDObj>* Data_<SpDObj>::DivInvNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1839,7 +1842,7 @@ Data_<Sp>* Data_<Sp>::DivSNew(BaseGDL* r) {
 // inverse division: left=right/left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1859,7 +1862,7 @@ Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) {
       (*res)[i] = s / (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
         else (*res)[ix] = s;
@@ -1932,9 +1935,9 @@ inline DDouble DModulo(const DDouble& l, const DDouble& r) {
   //    return (t-floor(t))*abs(r);
   return fmod(l, r);
 }
-
+// ex: b=(a mod c)
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
@@ -1949,7 +1952,7 @@ Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) {
       (*res)[i] = (*this)[i] % (*right)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
         else (*res)[ix] = this->zero;
@@ -1965,7 +1968,7 @@ Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) {
 // inverse modulo division: left=right % left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -1979,7 +1982,7 @@ Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) {
       (*res)[i] = (*right)[i] % (*this)[i];
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
         else (*res)[ix] = this->zero;
@@ -1996,7 +1999,7 @@ Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) {
 // float modulo division: left=left % right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2007,7 +2010,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) {
     (*res)[0] = Modulo((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
@@ -2020,7 +2023,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) {
 // float  inverse modulo division: left=right % left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -2032,7 +2035,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) {
     (*res)[0] = Modulo((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
@@ -2045,7 +2048,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) {
 // double modulo division: left=left % right
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -2057,7 +2060,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) {
     (*res)[0] = DModulo((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
@@ -2070,7 +2073,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) {
 // double inverse modulo division: left=right % left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
@@ -2082,7 +2085,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) {
     (*res)[0] = DModulo((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
@@ -2157,7 +2160,7 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2185,9 +2188,9 @@ Data_<Sp>* Data_<Sp>::ModSNew(BaseGDL* r) {
   }
 }
 // inverse modulo division: left=right % left
-
+// ex: b=(3 mod a)
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2208,7 +2211,7 @@ Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) {
     }
     return res;
   } else {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
         else (*res)[ix] = this->zero;
@@ -2223,7 +2226,7 @@ Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2236,7 +2239,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) {
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
   } else {
@@ -2249,7 +2252,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) {
 // float  inverse modulo division: left=right % left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2262,7 +2265,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) {
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
   } else {
@@ -2274,7 +2277,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2287,7 +2290,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) {
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
   } else {
@@ -2300,7 +2303,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) {
 // double inverse modulo division: left=right % left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2313,7 +2316,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) {
   }
 
   Ty s = (*right)[0];
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
   } else {
@@ -2391,7 +2394,7 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvSNew(BaseGDL* r) {
 // C++ defines pow only for floats and doubles
 // in basic_op.cpp:
 // template <typename T> T pow( const T r, const T l)
-// {
+// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 //   typedef T TT;
 //
 //   if( l == 0) return 1;
@@ -2417,7 +2420,7 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvSNew(BaseGDL* r) {
 // integral types
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2427,7 +2430,7 @@ Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) {
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
@@ -2440,7 +2443,7 @@ Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) {
 // inverse power of value: left=right ^ left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2450,7 +2453,7 @@ Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) {
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -2472,14 +2475,14 @@ Data_<Sp>* Data_<Sp>::PowIntNew(BaseGDL* r) {
 // floats power of value with GDL_LONG: left=left ^ right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DLongGDL* right = static_cast<DLongGDL*> (r);
 
   ULong rEl = right->N_Elements();
   ULong nEl = N_Elements();
   assert(rEl);
   assert(nEl);
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
@@ -2495,7 +2498,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
@@ -2507,7 +2510,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -2518,7 +2521,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -2531,7 +2534,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DLongGDL* right = static_cast<DLongGDL*> (r);
 
   ULong rEl = right->N_Elements();
@@ -2541,7 +2544,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
@@ -2554,7 +2557,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
@@ -2566,7 +2569,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -2577,7 +2580,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -2592,7 +2595,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
 // floats power of value: left=left ^ right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2602,7 +2605,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) {
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
@@ -2615,7 +2618,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) {
 // floats inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2625,7 +2628,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) {
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -2638,7 +2641,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) {
 // doubles power of value: left=left ^ right
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2648,7 +2651,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) {
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
@@ -2661,7 +2664,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) {
 // doubles inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -2671,7 +2674,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) {
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -2685,7 +2688,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) {
 // complex is special here
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -2701,7 +2704,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
@@ -2717,7 +2720,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -2730,7 +2733,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2742,7 +2745,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2765,7 +2768,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
@@ -2781,7 +2784,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -2794,7 +2797,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2806,7 +2809,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2830,7 +2833,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
     //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
@@ -2842,7 +2845,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
   } else {
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -2856,14 +2859,14 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
 // complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
 
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -2876,7 +2879,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) {
 // double complex power of value: left=left ^ right
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -2892,7 +2895,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
@@ -2908,7 +2911,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -2921,7 +2924,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2933,7 +2936,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2955,7 +2958,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
@@ -2971,7 +2974,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -2984,7 +2987,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -2996,7 +2999,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3015,7 +3018,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
   if (right->StrictScalar(s)) {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
@@ -3027,7 +3030,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
   } else {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
@@ -3041,7 +3044,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
 // double complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -3049,7 +3052,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) {
   assert(rEl);
   assert(nEl);
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
@@ -3100,7 +3103,7 @@ Data_<SpDObj>* Data_<SpDObj>::PowInvNew(BaseGDL* r) {
 // scalar versions
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -3111,7 +3114,7 @@ Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) {
     (*res)[0] = pow((*this)[0], s);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
   } else {
@@ -3125,7 +3128,7 @@ Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) {
 // inverse power of value: left=right ^ left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -3136,7 +3139,7 @@ Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) {
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
   } else {
@@ -3150,7 +3153,7 @@ Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) {
 // complex is special here
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   assert(nEl > 0);
   assert(r->N_Elements() > 0);
@@ -3164,7 +3167,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
@@ -3180,7 +3183,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3192,7 +3195,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3204,7 +3207,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3226,7 +3229,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
@@ -3242,7 +3245,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3254,7 +3257,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3266,7 +3269,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3284,7 +3287,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
 
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
@@ -3298,7 +3301,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
 // complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
   ULong nEl = N_Elements();
   assert(nEl);
@@ -3309,7 +3312,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) {
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
@@ -3322,7 +3325,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) {
 // double complex power of value: left=left ^ right
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
 
   assert(nEl > 0);
@@ -3338,7 +3341,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
@@ -3354,7 +3357,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3366,7 +3369,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3378,7 +3381,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3401,7 +3404,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
@@ -3417,7 +3420,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
           if (!parallelize) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
@@ -3429,7 +3432,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
         }
 
         Data_* res = NewResult();
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3441,7 +3444,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
         if (!parallelize) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
@@ -3457,7 +3460,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
   Data_* right = static_cast<Data_*> (r);
   const Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
@@ -3470,14 +3473,14 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
 // double complex inverse power of value: left=right ^ left
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
   assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -62,7 +62,7 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] & (*right)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -94,7 +94,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
@@ -121,7 +121,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     else (*res)[0] = zero;
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
@@ -148,7 +148,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
@@ -174,7 +174,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
     else (*res)[0] = zero;
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
@@ -251,7 +251,7 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = (*this)[0] & s;
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -294,7 +294,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
       else (*res)[0] = zero;
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -333,7 +333,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
       else (*res)[0] = zero;
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -404,7 +404,7 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -437,7 +437,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -465,7 +465,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -493,7 +493,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -520,7 +520,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -581,7 +581,7 @@ Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] | s;
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -613,7 +613,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       else (*res)[0] = (*this)[0];
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
@@ -647,7 +647,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       else (*res)[0] = zero;
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -676,7 +676,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       else (*res)[0] = (*this)[0];
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
@@ -709,7 +709,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FU
       else (*res)[0] = zero;
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
@@ -779,7 +779,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
       return this->Dup();
 
     Data_* res = NewResult();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -789,7 +789,7 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     return res;
   } else {
     Data_* res = NewResult();
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -859,7 +859,7 @@ Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this->Dup();
 
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -942,7 +942,7 @@ BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   mRes = mThis + mRight;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -970,7 +970,7 @@ BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__
     (*res)[0] = (*right)[0] + (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1020,7 +1020,7 @@ BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis + s;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1049,7 +1049,7 @@ BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
     return res;
   }
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1108,7 +1108,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - s;
     return res;
 #else
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1127,7 +1127,7 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - mRight;
     return res;
 #else
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1161,7 +1161,7 @@ BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mRight - mThis;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1230,7 +1230,7 @@ BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis - s;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1266,7 +1266,7 @@ BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = s - mThis;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1332,7 +1332,7 @@ Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -1391,7 +1391,7 @@ Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
   }
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
@@ -1453,7 +1453,7 @@ Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
@@ -1513,7 +1513,7 @@ Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
 
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
@@ -1583,7 +1583,7 @@ Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mThis * mRight;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1636,7 +1636,7 @@ Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = mThis * s;
   return res;
 #else
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1691,7 +1691,7 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] / (*right)[i];
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
         else (*res)[ix] = (*this)[ix];
     } else {
@@ -1723,7 +1723,7 @@ Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] / (*this)[i];
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
         else (*res)[ix] = (*right)[ix];
     } else {
@@ -1824,7 +1824,7 @@ Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
       (*res)[i] = s / (*this)[i];
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
         else (*res)[ix] = s;
     } else {
@@ -1913,7 +1913,7 @@ Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] % (*right)[i];
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -1942,7 +1942,7 @@ Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] % (*this)[i];
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -1969,7 +1969,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = Modulo((*this)[0], (*right)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1993,7 +1993,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = Modulo((*right)[0], (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2017,7 +2017,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = DModulo((*this)[0], (*right)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2041,7 +2041,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = DModulo((*right)[0], (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2166,7 +2166,7 @@ Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     }
     return res;
   } else {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
@@ -2193,7 +2193,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   }
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2218,7 +2218,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   }
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2242,7 +2242,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   }
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2267,7 +2267,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
   }
 
   Ty s = (*right)[0];
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2380,7 +2380,7 @@ Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2402,7 +2402,7 @@ Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2433,7 +2433,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2445,7 +2445,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2456,7 +2456,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2466,7 +2466,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2488,7 +2488,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2500,7 +2500,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2511,7 +2511,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2521,7 +2521,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( rEl)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2545,7 +2545,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2567,7 +2567,7 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2589,7 +2589,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2611,7 +2611,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2640,7 +2640,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2655,7 +2655,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2667,7 +2667,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2678,7 +2678,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2700,7 +2700,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2715,7 +2715,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2727,7 +2727,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2738,7 +2738,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2761,7 +2761,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
     //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2772,7 +2772,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   } else {
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2792,7 +2792,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
   assert(nEl);
 
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -2820,7 +2820,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2835,7 +2835,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2847,7 +2847,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2858,7 +2858,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2879,7 +2879,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -2894,7 +2894,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2906,7 +2906,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2917,7 +2917,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -2935,7 +2935,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
   if (right->StrictScalar(s)) {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2946,7 +2946,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
   } else {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2967,7 +2967,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) { TRACE_ROUTIN
   assert(rEl);
   assert(nEl);
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3028,7 +3028,7 @@ Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = pow((*this)[0], s);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3052,7 +3052,7 @@ Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3079,7 +3079,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3094,7 +3094,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3105,7 +3105,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         }
 
         Data_* res = NewResult();
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3116,7 +3116,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3137,7 +3137,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3152,7 +3152,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3163,7 +3163,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         }
 
         Data_* res = NewResult();
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3174,7 +3174,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3191,7 +3191,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
 
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3215,7 +3215,7 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3243,7 +3243,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3258,7 +3258,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3269,7 +3269,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         }
 
         Data_* res = NewResult();
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3280,7 +3280,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3302,7 +3302,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -3317,7 +3317,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (GDL_NTHREADS=parallelize( rEl)==1) {
+          if ((GDL_NTHREADS=parallelize( rEl))==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -3328,7 +3328,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         }
 
         Data_* res = NewResult();
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3339,7 +3339,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (GDL_NTHREADS=parallelize( rEl)==1) {
+        if ((GDL_NTHREADS=parallelize( rEl))==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -3354,7 +3354,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
   Data_* right = static_cast<Data_*> (r);
   const Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -3373,7 +3373,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) { TRACE_ROUTI
   assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -48,334 +48,344 @@ using namespace std;
 // Ands right and itself into a new DataT_
 // right must always have more or same number of elements
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   assert(right->N_Elements());
-  
-  Data_* res = NewResult();  
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] & (*right)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
-    }
+
+  Data_* res = NewResult();
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] & (*right)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
+  }
   return res;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvNew( BaseGDL* right)
-{
-  return AndOpNew( right);
+Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) {
+  return AndOpNew(right);
 }
 // for floats
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); 
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
 
   // assert( rEl);
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if ( (*right)[0] == zero ) (*res)[0] = zero; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for ( OMPInt i=0; i < nEl; ++i )
-	if ( (*right)[i] == zero ) (*res)[i] = zero; else (*res)[i] = (*this)[i];
-    }
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] == zero) (*res)[0] = zero;
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
+      else (*res)[i] = (*this)[i];
+  }
   return res;
 }
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  assert( right->N_Elements());
-  
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      if( (*this)[0] != zero) (*res)[0] = (*right)[0]; else (*res)[0] = zero;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] != zero) (*res)[i] = (*right)[i]; else (*res)[i] = zero; 
-    }
+  if (nEl == 1) {
+    if ((*this)[0] != zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = zero;
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  }
   return res;
 }
 // for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  assert( right->N_Elements());
-  
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      if ( (*right)[0] == zero ) (*res)[0] = zero; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if ( (*right)[i] == zero ) (*res)[i] = zero; else (*res)[i] = (*this)[i];
-    }
+  if (nEl == 1) {
+    if ((*right)[0] == zero) (*res)[0] = zero;
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
+      else (*res)[i] = (*this)[i];
+  }
   return res;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  assert( right->N_Elements());
-  
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      if( (*this)[0] != zero) (*res)[0] = (*right)[0]; else (*res)[0] = zero;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] != zero) (*res)[i] = (*right)[i]; else (*res)[i] = zero;
-    }
+  if (nEl == 1) {
+    if ((*this)[0] != zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = zero;
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  }
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::AndOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvNew( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return res;
 // }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::AndOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInvNew( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return res;
 // }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::AndOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::AndOpInvNew( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
 //  return res;
 // }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Ty s = (*right)[0];
-  
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] & s;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared(s)
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] & s;
-    }
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] & s;
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) shared(s)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
+  }
   return res;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvSNew( BaseGDL* right)
-{
-  return AndOpSNew( right);
+Data_<Sp>* Data_<Sp>::AndOpInvSNew(BaseGDL* right) {
+  return AndOpSNew(right);
 }
 // for floats
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-  if( (*right)[0] == zero)
-    {
-	return New( this->dim, BaseGDL::ZERO);
-    }
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
   return this->Dup();
 }
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  if( s == zero)
-    {
-      return New( this->dim, BaseGDL::ZERO);
+  if (s == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  } else {
+    Data_* res = NewResult();
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*res)[0] = s;
+      else (*res)[0] = zero;
+      return res;
     }
-  else
-    {
-      Data_* res = NewResult();
-      if( nEl == 1)
-	{			
-	  if( (*this)[0] != zero) (*res)[0] = s; else (*res)[0] = zero;	
-	  return res;	
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*res)[i] = s; else (*res)[i] = zero;
-	}
-	return res;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
     }
+    return res;
+  }
 }
 // for doubles
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-  if( (*right)[0] == zero)
-    {
-	return New( this->dim, BaseGDL::ZERO);
-    }
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
   return this->Dup();
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  if( s == zero)
-    {
-      return New( this->dim, BaseGDL::ZERO);
+  if (s == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  } else {
+    Data_* res = NewResult();
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*res)[0] = s;
+      else (*res)[0] = zero;
+      return res;
     }
-  else
-    {
-      Data_* res = NewResult();
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*res)[0] = s; else (*res)[0] = zero;
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*res)[i] = s; else (*res)[i] = zero;
-	}
-	return res;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
     }
+    return res;
+  }
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
 // template<>
 // Data_<SpDString>* Data_<SpDString>::AndOpInvSNew( BaseGDL* r)
 // {
-//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
 //  return res;
 // }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -385,358 +395,376 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpSNew( BaseGDL* r)
 // Ors right to itself returns new result
 // right must always have more or same number of elements
 // for integers
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
-  //if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
-    }
+  assert(nEl);
+  //if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
+  }
   //C delete right;
   return res;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvNew( BaseGDL* right)
-{
-  return OrOpNew( right);
+Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) {
+  return OrOpNew(right);
 }
 // for floats
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
+  assert(nEl);
   //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if( nEl == 1)
-    {
-      if( (*this)[0] == zero) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] == zero) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  if (nEl == 1) {
+    if ((*this)[0] == zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); Data_* res = NewResult();
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*right)[0] != zero) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] != zero) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    if ((*right)[0] != zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
 // for doubles
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
+  assert(nEl);
   //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if( nEl == 1)
-    {
-      if( (*this)[0] == zero) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] == zero) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  if (nEl == 1) {
+    if ((*this)[0] == zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); Data_* res = NewResult();
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*right)[0] != zero) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*right)[i] != zero) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    if ((*right)[0] != zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::OrOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::OrOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::OrOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // OrOpS
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
+template<class Sp>
+Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
+  assert(nEl);
   Ty s = (*right)[0];
-  // right->Scalar(s); 
+  // right->Scalar(s);
   //s &= Ty(1);
   //  dd |= s;
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] | s;
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] | s;
-    }  //C delete right;
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] | s;
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
+  } //C delete right;
   return res;
 }
 // different for floats
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvSNew( BaseGDL* right)
-{
-  return OrOpSNew( right);
+Data_<Sp>* Data_<Sp>::OrOpInvSNew(BaseGDL* right) {
+  return OrOpSNew(right);
 }
 // for floats
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
-  Ty s = (*right)[0];
-  if( s != zero)
-    {
-      Data_* res = NewResult();
-      if( nEl == 1)
-	{
-	  if( (*this)[0] == zero) (*res)[0] = s; else (*res)[0] = (*this)[0];
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] == zero) (*res)[i] = s; else (*res)[i] = (*this)[i];
-	}
-	return res;
-      }
-  else // s == zero
-	{
-	return this->Dup();
-	}
-}
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  Data_* res = NewResult();
-  assert( nEl);
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Ty s = (*right)[0];
-  if( s != zero)
-    {
-	for( SizeT i=0; i < nEl; ++i)
-		(*res)[i] = s;
-	return res;
+  if (s != zero) {
+    Data_* res = NewResult();
+    if (nEl == 1) {
+      if ((*this)[0] == zero) (*res)[0] = s;
+      else (*res)[0] = (*this)[0];
+      return res;
     }
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*res)[0] = s; else (*res)[0] = zero;
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*res)[i] = s; else (*res)[i] = zero;
-	}
-	return res;
-    } 
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
+        else (*res)[i] = (*this)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
+        else (*res)[i] = (*this)[i];
+    }
+    return res;
+  } else // s == zero
+  {
+    return this->Dup();
+  }
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
+  Ty s = (*right)[0];
+  if (s != zero) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = s;
+    return res;
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*res)[0] = s;
+      else (*res)[0] = zero;
+      return res;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    }
+    return res;
+  }
 }
 // for doubles
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); Data_* res = NewResult();
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if( s != zero)
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] == zero) (*res)[0] = s; else (*res)[0] = (*this)[0];
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] == zero) (*res)[i] = s; else (*res)[i] = (*this)[i];
-	}
-	return res;
+  if (s != zero) {
+    if (nEl == 1) {
+      if ((*this)[0] == zero) (*res)[0] = s;
+      else (*res)[0] = (*this)[0];
+      return res;
     }
-    // s == zero
-    return this->Dup();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
+        else (*res)[i] = (*this)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
+        else (*res)[i] = (*this)[i];
+    }
+    return res;
+  }
+  // s == zero
+  return this->Dup();
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
+  assert(nEl);
   Ty s = (*right)[0];
-  if( s != zero)
-    {
-	for( SizeT i=0; i < nEl; ++i)
-		(*res)[i] = s;
-	return res;
+  if (s != zero) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = s;
+    return res;
+  } else {
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*res)[0] = s;
+      else (*res)[0] = zero;
+      return res;
     }
-  else
-    {
-      if( nEl == 1)
-	{
-	  if( (*this)[0] != zero) (*res)[0] = s; else (*res)[0] = zero;
-	  return res;
-	}
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    if( (*this)[i] != zero) (*res)[i] = s; else (*res)[i] = zero;
-	}
-	return res;
-    } 
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    }
+    return res;
+  }
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::OrOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::OrOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::OrOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::OrOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::OrOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -746,922 +774,929 @@ Data_<SpDObj>* Data_<SpDObj>::OrOpSNew( BaseGDL* r)
 // Xors right to itself, //C deletes right
 // right must always have more or same number of elements
 // for integers
-template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
-  if( nEl == 1)
-    {
-     Data_* res = NewResult();
-      (*res)[0] = (*this)[0] ^ (*right)[0];
-      return res;
-    }
-    
+template<class Sp>
+Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  if (nEl == 1) {
+    Data_* res = NewResult();
+    (*res)[0] = (*this)[0] ^ (*right)[0];
+    return res;
+  }
+
   Ty s;
-  if( right->StrictScalar(s))
-    {
-	if( s == Sp::zero)
-		return this->Dup();
-	  
-	Data_* res = NewResult();
-	TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-		for( OMPInt i=0; i < nEl; ++i)
-			(*res)[i] = (*this)[i] ^ s;
-	}
-	return res;
+  if (right->StrictScalar(s)) {
+    if (s == Sp::zero)
+      return this->Dup();
+
+    Data_* res = NewResult();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     }
-  else
-	{
- 	Data_* res = NewResult();
-	TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
- 		(*res)[i] = (*this)[i] ^ (*right)[i];
-	}
-	return res;
-	}
+    return res;
+  } else {
+    Data_* res = NewResult();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
+    }
+    return res;
+  }
 }
 // invalid types
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype FLOAT.",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype DOUBLE.",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDString>* Data_<SpDString>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
-  return NULL;
-}
-template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOpNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
-  return NULL;
-}
-template<class Sp>
-Data_<Sp>* Data_<Sp>::XorOpSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      Data_* res = NewResult();
-      (*res)[0] = (*this)[0] ^  (*right)[0];
-      return res;
-    }
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::XorOpNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return NULL;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    Data_* res = NewResult();
+    (*res)[0] = (*this)[0] ^ (*right)[0];
+    return res;
+  }
   Ty s = (*right)[0];
-   if( s == this->zero)
-     return this->Dup();
-     
+  if (s == this->zero)
+    return this->Dup();
+
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] ^ s;
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+  }
   return res;
 }
 // different for floats
 // for floats
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype FLOAT.",true,false);  
+Data_<SpDFloat>* Data_<SpDFloat>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype FLOAT.", true, false);
   return NULL;
 }
 // for doubles
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype DOUBLE.",true,false);  
+Data_<SpDDouble>* Data_<SpDDouble>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype DOUBLE.", true, false);
   return NULL;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::XorOpSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::XorOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // Add ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Adds right to itself returns new result
 // right must always have more or same number of elements
+
 template<class Sp>
-BaseGDL* Data_<Sp>::AddNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( nEl);
-  assert( right->N_Elements());
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
 
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] + (*right)[0];
-      return res;
-    }
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] + (*right)[0];
+    return res;
+  }
 
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis + mRight;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = mThis + mRight;
+  return res;
 #else
-    
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] + (*right)[i];
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
+  } //C delete right;
   return res;
 #endif
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::AddInvNew( BaseGDL* r)
-{
-  return AddNew( r);
+BaseGDL* Data_<Sp>::AddInvNew(BaseGDL* r) {
+  return AddNew(r);
 }
 
 template<>
-BaseGDL* Data_<SpDString>::AddInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*right)[0] + (*this)[0] ;
-      return res;
-    }
-
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*right)[i] + (*this)[i];
-    }  //C delete right;
+  if (nEl == 1) {
+    (*res)[0] = (*right)[0] + (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
+  } //C delete right;
   return res;
 }
 
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::AddNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::AddNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::AddNew( BaseGDL* r)
-{
-    return Add( r);
+BaseGDL* Data_<SpDObj>::AddNew(BaseGDL* r) {
+  return Add(r);
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::AddInvNew( BaseGDL* r)
-{
-    return AddInv( r);
+BaseGDL* Data_<SpDObj>::AddInvNew(BaseGDL* r) {
+  return AddInv(r);
 }
 
 // scalar versions
-template<class Sp>
-BaseGDL* Data_<Sp>::AddSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+template<class Sp>
+BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] + (*right)[0];
-      return res;
-    }
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] + (*right)[0];
+    return res;
+  }
   Ty s = (*right)[0];
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis + s;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = mThis + s;
+  return res;
 #else
-    
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] + s;
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
+  } //C delete right;
   return res;
 #endif
-  
-}
-template<class Sp>
-BaseGDL* Data_<Sp>::AddInvSNew( BaseGDL* r)
-{
-  return AddSNew( r);
-}
-template<>
-BaseGDL* Data_<SpDString>::AddInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); Data_* res = NewResult();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      (*res)[0] = (*right)[0] + (*this)[0];
-      return res;
-    }
+}
+
+template<class Sp>
+BaseGDL* Data_<Sp>::AddInvSNew(BaseGDL* r) {
+  return AddSNew(r);
+}
+
+template<>
+BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = (*right)[0] + (*this)[0];
+    return res;
+  }
   Ty s = (*right)[0];
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = s + (*this)[i];
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
+  } //C delete right;
   return res;
 }
 
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDPtr>::AddSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::AddSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::AddSNew( BaseGDL* r)
-{
-  return Add( r);
+BaseGDL* Data_<SpDObj>::AddSNew(BaseGDL* r) {
+  return Add(r);
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::AddInvSNew( BaseGDL* r)
-{ 
-  return AddInv( r);
+BaseGDL* Data_<SpDObj>::AddInvSNew(BaseGDL* r) {
+  return AddInv(r);
 }
 
 
 
 // Sub ----------------------------------------------------------------------
 // substraction: res=left-right
-template<class Sp>
-BaseGDL* Data_<Sp>::SubNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  
+template<class Sp>
+BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+
   Data_* res = NewResult();
 
-  if( nEl == 1)// && rEl == 1)
-    {
-      (*res)[0] = (*this)[0] - (*right)[0];
-      return res;
-    }
+  if (nEl == 1)// && rEl == 1)
+  {
+    (*res)[0] = (*this)[0] - (*right)[0];
+    return res;
+  }
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
+  if (right->StrictScalar(s)) {
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis - s;
-	return res;
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+    mRes = mThis - s;
+    return res;
 #else
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = (*this)[i] - s;
-	}
-  return res;
-#endif
-      
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     }
-  else 
-    {
+    return res;
+#endif
+
+  } else {
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis - mRight;
-	return res;
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+    mRes = mThis - mRight;
+    return res;
 #else
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = (*this)[i] - (*right)[i];
-	}
-  return res;
-#endif
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     }
+    return res;
+#endif
+  }
 }
 // inverse substraction: left=right-left
-template<class Sp>
-BaseGDL* Data_<Sp>::SubInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
+template<class Sp>
+BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*right)[0] - (*this)[0];
-      return res;
-    }
+  if (nEl == 1) {
+    (*res)[0] = (*right)[0] - (*this)[0];
+    return res;
+  }
 #ifdef USE_EIGEN
 
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
   mRes = mRight - mThis;
   return res;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*right)[i] - (*this)[i];
-    }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
+  }
   return res;
-#endif  
+#endif
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDString>::SubNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::SubNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDString>::SubInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::SubInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::SubNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::SubNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::SubInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::SubInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::SubNew( BaseGDL* r)
-{
-  return Sub( r);
+BaseGDL* Data_<SpDObj>::SubNew(BaseGDL* r) {
+  return Sub(r);
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::SubInvNew( BaseGDL* r)
-{
-  return SubInv( r);
+BaseGDL* Data_<SpDObj>::SubInvNew(BaseGDL* r) {
+  return SubInv(r);
 }
 
 // scalar versions
-template<class Sp>
-BaseGDL* Data_<Sp>::SubSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+template<class Sp>
+BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] - (*right)[0];
-      return res;
-    }
-  
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] - (*right)[0];
+    return res;
+  }
+
   Ty s = (*right)[0];
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis - s;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = mThis - s;
+  return res;
 #else
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] - s;
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
+  }
   return res;
 #endif
-  
+
 }
 // inverse substraction: left=right-left
-template<class Sp>
-BaseGDL* Data_<Sp>::SubInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      (*res)[0] = (*right)[0] - (*this)[0];
-      return res;
-    }
-  
+  if (nEl == 1) {
+    (*res)[0] = (*right)[0] - (*this)[0];
+    return res;
+  }
+
   Ty s = (*right)[0];
-  // right->Scalar(s); 
+  // right->Scalar(s);
   //  dd = s - dd;
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = s - mThis;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = s - mThis;
+  return res;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = s - (*this)[i];
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
+  }
   return res;
 #endif
-  
+
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDString>::SubSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::SubSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDString>::SubInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::SubInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::SubSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::SubSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::SubInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::SubInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::SubSNew( BaseGDL* r)
-{
-  return Sub( r);
+BaseGDL* Data_<SpDObj>::SubSNew(BaseGDL* r) {
+  return Sub(r);
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::SubInvSNew( BaseGDL* r)
-{
-  return SubInv( r);
+BaseGDL* Data_<SpDObj>::SubInvSNew(BaseGDL* r) {
+  return SubInv(r);
 }
 
 // LtMark <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 // LtMarks right to itself, //C deletes right
 // right must always have more or same number of elements
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); Data_* res = NewResult();
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
   //  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] > (*right)[0]) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] > (*right)[i]) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    if ((*this)[0] > (*right)[0]) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::LtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::LtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::LtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::LtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::LtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::LtMarkSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-  
-  ULong nEl=N_Elements();
-  assert( nEl);
+Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-    {
-      if( (*this)[0] > (*right)[0]) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
+  if (nEl == 1) {
+    if ((*this)[0] > (*right)[0]) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
   Ty s = (*right)[0];
   // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] > s) (*res)[i] = s; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::LtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::LtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::LtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::LtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::LtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::LtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::LtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::LtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // GtMark >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 // GtMarks right to itself returns new result
 // right must always have more or same number of elements
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); Data_* res = NewResult();
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
   // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      if( (*this)[0] < (*right)[0]) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] < (*right)[i]) (*res)[i] = (*right)[i]; else (*res)[i] = (*this)[i];
-    }  //C delete right;
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    if ((*this)[0] < (*right)[0]) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
+      else (*res)[i] = (*this)[i];
+  } //C delete right;
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::GtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::GtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::GtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::GtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMarkNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::GtMarkNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::GtMarkSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); Data_* res = NewResult();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      if( (*this)[0] < (*right)[0]) (*res)[0] = (*right)[0]; else (*res)[0] = (*this)[0];
-      return res;
-    }
+template<class Sp>
+Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] < (*right)[0]) (*res)[0] = (*right)[0];
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
 
   Ty s = (*right)[0];
   // right->Scalar(s);
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	if( (*this)[i] < s) (*res)[i] = s; else (*res)[i] = (*this)[i];
-    }  ;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
+      else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
+      else (*res)[i] = (*this)[i];
+  };
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::GtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::GtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::GtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::GtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::GtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::GtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::GtMarkSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::GtMarkSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // Mult *********************************************************************
 // Mults right to itself, //C deletes right
 // right must always have more or same number of elements
-template<class Sp>
-Data_<Sp>* Data_<Sp>::MultNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  Data_* res=NewResult();
-  
+template<class Sp>
+Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  Data_* res = NewResult();
+
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   // assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*res)[0] = (*this)[0] * (*right)[0];
-      return res;
-    }
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] * (*right)[0];
+    return res;
+  }
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis * mRight;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = mThis * mRight;
+  return res;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] * (*right)[i];
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
+  } //C delete right;
   return res;
 #endif
-  
+
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::MultNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::MultNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::MultNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::MultNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::MultNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::MultNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::MultSNew( BaseGDL* r )
-{
-  Data_* right=static_cast<Data_*> ( r );
 
-  ULong nEl=N_Elements();
-  assert ( nEl );
-  
+template<class Sp>
+Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if ( nEl == 1 )
-    {
-      ( *res )[0] = ( *this )[0] * ( *right )[0];
-      return res;
-    }
-  Ty s = ( *right ) [0];
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0] * (*right)[0];
+    return res;
+  }
+  Ty s = (*right) [0];
 #ifdef USE_EIGEN
 
-	Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRes(&(*res)[0], nEl);
-	mRes = mThis * s;
-	return res;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRes(&(*res)[0], nEl);
+  mRes = mThis * s;
+  return res;
 #else
-  TRACEOMP ( __FILE__, __LINE__ )
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for ( OMPInt i=0; i < nEl; ++i )
-	(*res ) [i] = (*this )[i] * s;
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
+  }
   return res;
 #endif
-  
+
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::MultSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::MultSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::MultSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::MultSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::MultSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::MultSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -1669,221 +1704,209 @@ Data_<SpDObj>* Data_<SpDObj>::MultSNew( BaseGDL* r)
 
 // Div //////////////////////////////////////////////////////////////////////
 // division: left=left/right
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
 
   SizeT i = 0;
 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      // TODO: Check if we can use OpenMP here (is longjmp allowed?)
-      //             if yes: need to run the full loop after the longjmp
-      for( ; i < nEl; ++i)
-	(*res)[i] = (*this)[i] / (*right)[i];
-      return res;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    // TODO: Check if we can use OpenMP here (is longjmp allowed?)
+    //             if yes: need to run the full loop after the longjmp
+    for (; i < nEl; ++i)
+      (*res)[i] = (*this)[i] / (*right)[i];
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
+        else (*res)[ix] = (*this)[ix];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
+        else (*res)[ix] = (*this)[ix];
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*right)[ix] != this->zero)
-	    	(*res)[ix] = (*this)[ix] / (*right)[ix];
-	    else	
-	    	(*res)[ix] = (*this)[ix];
-	}
-      return res;
-    }
+    return res;
+  }
 }
 // inverse division: left=right/left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); Data_* res = NewResult();
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
   //  assert( rEl);
-  assert( nEl);
+  assert(nEl);
 
   SizeT i = 0;
 
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	(*res)[i] = (*right)[i] / (*this)[i];
-      return res;
-    }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*this)[ix] != this->zero)
-	      (*res)[ix] = (*right)[ix] / (*this)[ix];
-	    else
-	      (*res)[ix] = (*right)[ix];
-	}      //C delete right;
-      return res;
-    }
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i)
+      (*res)[i] = (*right)[i] / (*this)[i];
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
+        else (*res)[ix] = (*right)[ix];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
+        else (*res)[ix] = (*right)[ix];
+    } //C delete right;
+    return res;
+  }
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::DivNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::DivInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::DivNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::DivInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::DivNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::DivInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::DivSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::DivSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
-  SizeT i=0;
+  SizeT i = 0;
   Data_* res = NewResult();
-  if( s != this->zero)
-    {
-      for( SizeT i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] / s;
-      return res;
-    }
- 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-	{
-	 for( SizeT i=0; i < nEl; ++i)
-		(*res)[i] = (*this)[i] / s;
-	}
-  else
-	{
-	for( SizeT i=0; i < nEl; ++i)
-		(*res)[i] = (*this)[i];
-// 	}
-	}
+  if (s != this->zero) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = (*this)[i] / s;
+    return res;
+  }
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = (*this)[i] / s;
+  } else {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = (*this)[i];
+    // 	}
+  }
   return res;
 }
 
 // inverse division: left=right/left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::DivInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements(); Data_* res = NewResult();
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
 
-  if( nEl == 1 && (*this)[0] != this->zero)
-  {
+  if (nEl == 1 && (*this)[0] != this->zero) {
     (*res)[0] = (*right)[0] / (*this)[0];
-    return res;    
+    return res;
   }
-  
+
   Ty s = (*right)[0];
-  SizeT i=0;
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( ; i < nEl; ++i)
-	(*res)[i] = s / (*this)[i];
-      return res;
+  SizeT i = 0;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (; i < nEl; ++i)
+      (*res)[i] = s / (*this)[i];
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
+        else (*res)[ix] = s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
+        else (*res)[ix] = s;
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*this)[ix] != this->zero)
-	      (*res)[ix] = s / (*this)[ix];
-	    else 
-	      (*res)[ix] = s;
-	}
-      return res;
-    }
+    return res;
+  }
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::DivSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::DivInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::DivInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::DivSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::DivInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::DivInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::DivSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::DivInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::DivInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -1893,495 +1916,472 @@ Data_<SpDObj>* Data_<SpDObj>::DivInvSNew( BaseGDL* r)
 // modulo division: left=left % right
 
 // float modulo division: left=left % right
-inline DFloat Modulo( const DFloat& l, const DFloat& r)
-{
-//   float t=abs(l/r);
-//   if( l < 0.0) return t=(floor(t)-t)*abs(r);
-//   return (t-floor(t))*abs(r);
-  return fmod(l,r);
+
+inline DFloat Modulo(const DFloat& l, const DFloat& r) {
+  //   float t=abs(l/r);
+  //   if( l < 0.0) return t=(floor(t)-t)*abs(r);
+  //   return (t-floor(t))*abs(r);
+  return fmod(l, r);
 }
 // in basic_op.cpp
 // double modulo division: left=left % right
-inline DDouble DModulo( const DDouble& l, const DDouble& r)
- {
-//    DDouble t=abs(l/r);
-//    if( l < 0.0) return t=(floor(t)-t)*abs(r);
-//    return (t-floor(t))*abs(r);
-   return fmod(l,r);
- }
+
+inline DDouble DModulo(const DDouble& l, const DDouble& r) {
+  //    DDouble t=abs(l/r);
+  //    if( l < 0.0) return t=(floor(t)-t)*abs(r);
+  //    return (t-floor(t))*abs(r);
+  return fmod(l, r);
+}
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   //  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
   //  assert( rEl);
-  assert( nEl);
+  assert(nEl);
 
-  SizeT i=0;
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( ; i < nEl; ++i)
-	(*res)[i] = (*this)[i] % (*right)[i];
-      return res;
+  SizeT i = 0;
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (; i < nEl; ++i)
+      (*res)[i] = (*this)[i] % (*right)[i];
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
+        else (*res)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
+        else (*res)[ix] = this->zero;
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*right)[ix] != this->zero)
-	      (*res)[ix] = (*this)[ix] % (*right)[ix];
-	    else
-	      (*res)[ix] = this->zero;
-	}
-      return res;
-    }
+    return res;
+  }
 }
 // inverse modulo division: left=right % left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
-  
-  SizeT i=0;
+  assert(nEl);
 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( ; i < nEl; ++i)
-	(*res)[i] = (*right)[i] % (*this)[i];
-      return res;
+  SizeT i = 0;
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (; i < nEl; ++i)
+      (*res)[i] = (*right)[i] % (*this)[i];
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
+        else (*res)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
+        else (*res)[ix] = this->zero;
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*this)[ix] != this->zero)
-	      (*res)[ix] = (*right)[ix] % (*this)[ix];
-	    else
-	      (*res)[ix] = this->zero;
-	}
-      return res;
-    }    
+    return res;
+  }
 }
 // in basic_op.cpp
 // float modulo division: left=left % right
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  
-  assert( nEl);
-  if( nEl == 1)
-  {
-	(*res)[0] = Modulo((*this)[0],(*right)[0]);
-	return res;
+
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = Modulo((*this)[0], (*right)[0]);
+    return res;
   }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-   {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = Modulo((*this)[i],(*right)[i]);
-  }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
+  }
   return res;
 }
 // float  inverse modulo division: left=right % left
+
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  
-  assert( nEl);
-  if( nEl == 1)
-  {
-	(*res)[0] = Modulo((*right)[0],(*this)[0]);
-	return res;
+
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = Modulo((*right)[0], (*this)[0]);
+    return res;
   }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = Modulo((*right)[i],(*this)[i]);
-    }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
+  }
   return res;
 }
 // double modulo division: left=left % right
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( nEl);
-  
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = DModulo((*this)[0],(*right)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = DModulo((*this)[0], (*right)[0]);
+    return res;
   }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = DModulo((*this)[i],(*right)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
+  }
   return res;
 }
 // double inverse modulo division: left=right % left
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
   // ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  
-  assert( nEl);
-  if( nEl == 1)
-  {
-	(*res)[0] = DModulo((*right)[0],(*this)[0]);
-	return res;
+
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = DModulo((*right)[0], (*this)[0]);
+    return res;
   }
-  
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = DModulo((*right)[i],(*this)[i]);
-    }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
+  }
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::ModNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::ModNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::ModInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::ModInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::ModSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::ModSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Ty s = (*right)[0];
-   
-  Data_* res = NewResult();
-  if( s != this->zero)
-    {
-      for( SizeT i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] % s;
-      return res;
-    }
 
-    
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( SizeT i=0; i < nEl; ++i)
-	(*res)[i] = (*this)[i] % s;
-      return res;
-    }
-  else
-    {
-      assert( s == this->zero);
-      for( SizeT i=0; i < nEl; ++i)
-	(*res)[i] = this->zero;
-      return res;
-    }
+  Data_* res = NewResult();
+  if (s != this->zero) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = (*this)[i] % s;
+    return res;
+  }
+
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = (*this)[i] % s;
+    return res;
+  } else {
+    assert(s == this->zero);
+    for (SizeT i = 0; i < nEl; ++i)
+      (*res)[i] = this->zero;
+    return res;
+  }
 }
 // inverse modulo division: left=right % left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::ModInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
-  
+template<class Sp>
+Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1 && (*this)[0] != this->zero)
-  {
+  if (nEl == 1 && (*this)[0] != this->zero) {
     (*res)[0] = (*right)[0] % (*this)[0];
     return res;
   }
-  
-  Ty s = (*right)[0];
-  SizeT i=0;
 
-  if( sigsetjmp( sigFPEJmpBuf, 1) == 0)
-    {
-      for( /*SizeT i=0*/; i < nEl; ++i)
-	{
-	  (*res)[i] = s % (*this)[i];
-	}
-      return res;
+  Ty s = (*right)[0];
+  SizeT i = 0;
+
+  if (sigsetjmp(sigFPEJmpBuf, 1) == 0) {
+    for (/*SizeT i=0*/; i < nEl; ++i) {
+      (*res)[i] = s % (*this)[i];
     }
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt ix=i; ix < nEl; ++ix)
-	    if( (*this)[ix] != this->zero)
-	      (*res)[ix] = s % (*this)[ix];
-	    else 
-	      (*res)[ix] = this->zero;
-	}
-      return res;
-    }    
-}
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-
-  ULong nEl=N_Elements(); 
-  assert( nEl);
-  
-  Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = Modulo((*this)[0],(*right)[0]);
-	return res;
+    return res;
+  } else {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
+        else (*res)[ix] = this->zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
+        else (*res)[ix] = this->zero;
+    }
+    return res;
   }
-    
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  Data_* res = NewResult();
+  if (nEl == 1) {
+    (*res)[0] = Modulo((*this)[0], (*right)[0]);
+    return res;
+  }
+
   Ty s = (*right)[0];
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = Modulo((*this)[i],s);
-    }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
+  }
   return res;
 }
 // float  inverse modulo division: left=right % left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = Modulo((*right)[0],(*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = Modulo((*right)[0], (*this)[0]);
+    return res;
   }
-  
+
   Ty s = (*right)[0];
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = Modulo(s,(*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
+  }
   return res;
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
-  
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = DModulo((*this)[0],(*right)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = DModulo((*this)[0], (*right)[0]);
+    return res;
   }
-    
+
   Ty s = (*right)[0];
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = DModulo((*this)[i],s);
-    }  
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
+  }
   return res;
 }
 // double inverse modulo division: left=right % left
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
 
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = DModulo((*right)[0],(*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = DModulo((*right)[0], (*this)[0]);
+    return res;
   }
-  
+
   Ty s = (*right)[0];
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = DModulo(s,(*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
+  }
   return res;
 }
 // invalid types
-template<>
-Data_<SpDString>* Data_<SpDString>::ModSNew( BaseGDL* r)
 
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+template<>
+Data_<SpDString>* Data_<SpDString>::ModSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::ModInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::ModInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::ModInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplex>* Data_<SpDComplex>::ModInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype "+str+".",true,false);  
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::ModInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::ModInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::ModInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::ModInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::ModInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
@@ -2393,12 +2393,12 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvSNew( BaseGDL* r)
 // template <typename T> T pow( const T r, const T l)
 // {
 //   typedef T TT;
-// 
+//
 //   if( l == 0) return 1;
 //   if( l < 0)  return 0;
-// 
+//
 //   const int nBits = sizeof(TT) * 8;
-// 
+//
 //   T arr = r;
 //   T res = 1;
 //   TT mask = 1;
@@ -2409,1144 +2409,1119 @@ Data_<SpDObj>* Data_<SpDObj>::ModInvSNew( BaseGDL* r)
 //       if( l < mask) return res;
 //       arr *= arr;
 //     }
-// 
+//
 //   return res;
 // }
 
 // power of value: left=left ^ right
 // integral types
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*this)[0], (*right)[0]);
-	return res;
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = pow((*this)[0], (*right)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*this)[i], (*right)[i]); // valarray
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
+  } //C delete right;
   return res;
 }
 // inverse power of value: left=right ^ left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*right)[0], (*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow((*right)[0], (*this)[0]);
+    return res;
   }
-      
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*right)[i], (*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  }
   return res;
 }
 
 // PowInt and PowIntNew can only be called for GDL_FLOAT and GDL_DOUBLE
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::PowIntNew( BaseGDL* r)
-{
-  assert( 0);
-  throw GDLException("Internal error: Data_::PowIntNew called.",true,false);
+Data_<Sp>* Data_<Sp>::PowIntNew(BaseGDL* r) {
+  assert(0);
+  throw GDLException("Internal error: Data_::PowIntNew called.", true, false);
   return NULL;
 }
 // floats power of value with GDL_LONG: left=left ^ right
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew( BaseGDL* r)
-{
-  DLongGDL* right=static_cast<DLongGDL*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  if( r->StrictScalar())
-    {
-      Data_* res = new Data_( Dim(), BaseGDL::NOZERO);
-      DLong r0 = (*right)[0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], r0);
-	}      return res;
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) {
+  DLongGDL* right = static_cast<DLongGDL*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (r->StrictScalar()) {
+    Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
+    DLong r0 = (*right)[0];
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     }
-  if( StrictScalar())
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      Ty s0 = (*this)[ 0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[ i] = pow( s0, (*right)[ i]);
-	}      return res;
+    return res;
+  }
+  if (StrictScalar()) {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    Ty s0 = (*this)[ 0];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
-  if( nEl <= rEl)
-    {
-      Data_* res = new Data_( Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return res;
+  }
+  if (nEl <= rEl) {
+    Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
-  else
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return res;
+  } else {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew( BaseGDL* r)
-{
-  DLongGDL* right=static_cast<DLongGDL*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  if( r->StrictScalar())
-    {
-      Data_* res = new Data_( Dim(), BaseGDL::NOZERO);
-      DLong r0 = (*right)[0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], r0);
-	}      return res;
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) {
+  DLongGDL* right = static_cast<DLongGDL*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  if (r->StrictScalar()) {
+    Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
+    DLong r0 = (*right)[0];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     }
-  if( StrictScalar())
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      Ty s0 = (*this)[ 0];  
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[ i] = pow( s0, (*right)[ i]);
-	}      return res;
+    return res;
+  }
+  if (StrictScalar()) {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    Ty s0 = (*this)[ 0];
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
-  if( nEl <= rEl)
-    {
-      Data_* res = new Data_( Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return res;
+  }
+  if (nEl <= rEl) {
+    Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
-  else
-    {
-      Data_* res = new Data_( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < rEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}      return res;
+    return res;
+  } else {
+    Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
 
 // floats power of value: left=left ^ right
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*this)[0], (*right)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow((*this)[0], (*right)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	for( OMPInt i=0; i < nEl; ++i)
-	  (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+  }
   return res;
 }
 // floats inverse power of value: left=right ^ left
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*right)[0], (*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow((*right)[0], (*this)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*right)[i], (*this)[i]);
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } //C delete right;
   return res;
 }
 // doubles power of value: left=left ^ right
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements(); 
-  assert( nEl);
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*this)[0], (*right)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow((*this)[0], (*right)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	for( OMPInt i=0; i < nEl; ++i)
-	  (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+  }
   return res;
 }
 // doubles inverse power of value: left=right ^ left
+
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
-  if( nEl == 1)
-  {
-	(*res)[0] = pow( (*right)[0], (*this)[0]);
-	return res;
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = pow((*right)[0], (*this)[0]);
+    return res;
   }
-
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*right)[i], (*this)[i]);
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } //C delete right;
   return res;
 }
 // complex power of value: left=left ^ right
 // complex is special here
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowNew( BaseGDL* r)
-{
-SizeT nEl = N_Elements();
+Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) {
+  SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
-  assert( r->N_Elements() > 0);
+  assert(nEl > 0);
+  assert(r->N_Elements() > 0);
 
-  if( r->Type() == GDL_FLOAT)
-    {
-      Data_<SpDFloat>* right=static_cast<Data_<SpDFloat>* >(r);
+  if (r->Type() == GDL_FLOAT) {
+    Data_<SpDFloat>* right = static_cast<Data_<SpDFloat>*> (r);
 
-      DFloat s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  DComplexGDL* res = new DComplexGDL( this->Dim(), 
-					      BaseGDL::NOZERO);
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DFloat s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      DComplexGDL* res = new DComplexGDL(this->Dim(),
+        BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } //C delete right;
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } //C delete right;
+          return res;
+        }
 
-	      DComplexGDL* res = new DComplexGDL( this->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+        DComplexGDL* res = new DComplexGDL(this->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        //C delete this;
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      DLong s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  DComplexGDL* res = new DComplexGDL( this->Dim(), 
-					      BaseGDL::NOZERO);
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[ i] = pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DLong s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      DComplexGDL* res = new DComplexGDL(this->Dim(),
+        BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } //C delete right;
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } //C delete right;
+          return res;
+        }
 
-	      DComplexGDL* res = new DComplexGDL( this->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+        DComplexGDL* res = new DComplexGDL(this->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        //C delete this;
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
   //   ULong rEl=right->N_Elements();
   //   ULong nEl=N_Elements(); Data_* res = NewResult();
-  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  //   if( !rEl || !nEl) throw GDLException("Variable is undefined.");
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      DComplexGDL* res = new DComplexGDL( this->Dim(), 
-					  BaseGDL::NOZERO);
-      //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i<nEl; ++i)
-	    (*res)[ i] = pow( (*this)[ i], s);
-	}
-	return res;
+  if (right->StrictScalar(s)) {
+    DComplexGDL* res = new DComplexGDL(this->Dim(),
+      BaseGDL::NOZERO);
+    //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     }
-  else 
-    {
-      DComplexGDL* res = new DComplexGDL( this->Dim(), 
-					  BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}
-	return res;
+    return res;
+  } else {
+    DComplexGDL* res = new DComplexGDL(this->Dim(),
+      BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
 // complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-    
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*right)[i], (*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  }
   return res;
 }
 // double complex power of value: left=left ^ right
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew( BaseGDL* r)
-{
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
-  assert( r->N_Elements() > 0);
+  assert(nEl > 0);
+  assert(r->N_Elements() > 0);
 
-  if( r->Type() == GDL_DOUBLE)
-    {
-      Data_<SpDDouble>* right=static_cast<Data_<SpDDouble>* >(r);
+  if (r->Type() == GDL_DOUBLE) {
+    Data_<SpDDouble>* right = static_cast<Data_<SpDDouble>*> (r);
 
-      DDouble s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-						    BaseGDL::NOZERO);
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[ i] = pow( (*this)[ i], s);
-	    }
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }
-		  return res;
-		}
+    DDouble s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+        BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      }
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
 
-	      DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}
-	      return res;
-	    }
-	}
+        DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      DLong s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-						    BaseGDL::NOZERO);
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[ i] = pow( (*this)[ i], s);
-	    }
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }
-		  return res;
-		}
+    DLong s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+        BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+      }
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
 
-	      DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}
-	      return res;
-	    }
-	}
+        DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
   Ty s;
-  if( right->StrictScalar(s)) 
-    {
-      DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-						BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i<nEl; ++i)
-	    (*res)[ i] = pow( (*this)[ i], s);
-	}
-	return res;
+  if (right->StrictScalar(s)) {
+    DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+      BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     }
-  else 
-    {
-      DComplexDblGDL* res = new DComplexDblGDL( this->Dim(), 
-						BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*res)[i] = pow( (*this)[i], (*right)[i]);
-	}
-	return res;
+    return res;
+  } else {
+    DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
+      BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
+    return res;
+  }
 }
 // double complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements(); 
-  assert( rEl);
-  assert( nEl);
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*right)[i], (*this)[i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
+  }
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInvNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowInvNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 
 // scalar versions
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
   Data_* res = NewResult();
-  assert( nEl);
+  assert(nEl);
   Ty s = (*right)[0];
-  if( nEl == 1)
-  {
-  	(*res)[0] = pow( (*this)[0], s);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow((*this)[0], s);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( (*this)[i], s);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
+  }
   //C delete right;
   return res;
 }
 // inverse power of value: left=right ^ left
-template<class Sp>
-Data_<Sp>* Data_<Sp>::PowInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<class Sp>
+Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-  	(*res)[0] = pow( s, (*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow(s, (*this)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*res)[i] = pow( s, (*this)[i]);
-    }  //C delete right;
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
+  } //C delete right;
   return res;
 }
 // complex power of value: left=left ^ right
 // complex is special here
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowSNew( BaseGDL* r)
-{
+Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) {
   SizeT nEl = N_Elements();
-  assert( nEl > 0);
-  assert( r->N_Elements() > 0);
+  assert(nEl > 0);
+  assert(r->N_Elements() > 0);
 
-  if( r->Type() == GDL_FLOAT)
-    {
-      Data_<SpDFloat>* right=static_cast<Data_<SpDFloat>* >(r);
+  if (r->Type() == GDL_FLOAT) {
+    Data_<SpDFloat>* right = static_cast<Data_<SpDFloat>*> (r);
 
-      DFloat s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  Data_* res = NewResult();
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[i] =  pow( (*this)[ i], s);
-	    }
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }
-		  return res;
-		}
+    DFloat s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      Data_* res = NewResult();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      }
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
 
-	      Data_* res = NewResult();
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[i] =  pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      //C delete this;
-	      return res;
-	    }
-	}
+        Data_* res = NewResult();
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        //C delete this;
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      DLong s;
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      // (must also be consistent with ComplexDbl)
-      if( right->StrictScalar(s)) 
-	{
-	  Data_* res = NewResult();
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[i] =  pow( (*this)[ i], s);
-	    }	  //C delete right;
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplex s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						      BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  //C delete right;
-		  return res;
-		}
+    DLong s;
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    // (must also be consistent with ComplexDbl)
+    if (right->StrictScalar(s)) {
+      Data_* res = NewResult();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      } //C delete right;
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplex s;
+        if (StrictScalar(s)) {
+          DComplexGDL* res = new DComplexGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } //C delete right;
+          return res;
+        }
 
-	      Data_* res = NewResult();
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[i] =  pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexGDL* res = new DComplexGDL( right->Dim(), 
-						  BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}
-	      return res;
-	    }
-	}
+        Data_* res = NewResult();
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexGDL* res = new DComplexGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
   // r->Type() == GDL_COMPLEX
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
 
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*res)[i] =  pow( (*this)[ i], s);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+  }
 
   return res;
 }
 // complex inverse power of value: left=right ^ left
+
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
-  ULong nEl=N_Elements();
-  assert( nEl);
-  assert( right->N_Elements());
+Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if( nEl == 1)
-  {
-  	(*res)[0] = pow( s, (*this)[0]);
-	return res;
+  if (nEl == 1) {
+    (*res)[0] = pow(s, (*this)[0]);
+    return res;
   }
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*res)[i] =  pow( s, (*this)[ i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
+  }
   return res;
 }
 // double complex power of value: left=left ^ right
+
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew( BaseGDL* r)
-{
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) {
   SizeT nEl = N_Elements();
 
-  assert( nEl > 0);
+  assert(nEl > 0);
 
-  if( r->Type() == GDL_DOUBLE)
-    {
-      Data_<SpDDouble>* right=static_cast<Data_<SpDDouble>* >(r);
+  if (r->Type() == GDL_DOUBLE) {
+    Data_<SpDDouble>* right = static_cast<Data_<SpDDouble>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DDouble s;
+    DDouble s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  Data_* res = NewResult();
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[i] =  pow( (*this)[ i], s);
-	    }	  
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
+      Data_* res = NewResult();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      }
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
 
-	      Data_* res = NewResult();
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[i] =  pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	     
-	      return res;
-	    }
-	}
+        Data_* res = NewResult();
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
-  if( r->Type() == GDL_LONG)
-    {
-      Data_<SpDLong>* right=static_cast<Data_<SpDLong>* >(r);
+  }
+  if (r->Type() == GDL_LONG) {
+    Data_<SpDLong>* right = static_cast<Data_<SpDLong>*> (r);
 
-      assert( right->N_Elements() > 0);
+    assert(right->N_Elements() > 0);
 
-      DLong s;
+    DLong s;
 
-      // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
-      // (concerning when a new variable is created vs. using this)
-      if( right->StrictScalar(s)) 
-	{
-	  Data_* res = NewResult();
-	  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	    {
-#pragma omp for
-	      for( OMPInt i=0; i<nEl; ++i)
-		(*res)[i] =  pow( (*this)[ i], s);
-	    }	  
-	  return res;
-	}
-      else 
-	{
-	  SizeT rEl = right->N_Elements();
-	  if( nEl < rEl)
-	    {
-	      DComplexDbl s;
-	      if( StrictScalar(s)) 
-		{
-		  DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							    BaseGDL::NOZERO);
-		  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		    {
-#pragma omp for
-		      for( OMPInt i=0; i<rEl; ++i)
-			(*res)[ i] = pow( s, (*right)[ i]);
-		    }		  
-		  return res;
-		}
+    // note: changes here have to be reflected in POWNCNode::Eval() (dnode.cpp)
+    // (concerning when a new variable is created vs. using this)
+    if (right->StrictScalar(s)) {
+      Data_* res = NewResult();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+      }
+      return res;
+    } else {
+      SizeT rEl = right->N_Elements();
+      if (nEl < rEl) {
+        DComplexDbl s;
+        if (StrictScalar(s)) {
+          DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+            BaseGDL::NOZERO);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+          if (!parallelize) {
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
+          }
+          return res;
+        }
 
-	      Data_* res = NewResult();
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<nEl; ++i)
-		    (*res)[i] =  pow( (*this)[ i], (*right)[ i]);
-		}	      //C delete right;
-	      return res;
-	    }
-	  else
-	    {
-	      DComplexDblGDL* res = new DComplexDblGDL( right->Dim(), 
-							BaseGDL::NOZERO);
-	      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl)) 
-		{
-#pragma omp for
-		  for( OMPInt i=0; i<rEl; ++i)
-		    (*res)[ i] = pow( (*this)[ i], (*right)[ i]);
-		}	      
-	      return res;
-	    }
-	}
+        Data_* res = NewResult();
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
+        } //C delete right;
+        return res;
+      } else {
+        DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
+          BaseGDL::NOZERO);
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl));
+        if (!parallelize) {
+          for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
+        }
+        return res;
+      }
     }
+  }
 
-  Data_* right=static_cast<Data_*>(r);
+  Data_* right = static_cast<Data_*> (r);
   const Ty s = (*right)[0];
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*res)[i] =  pow( (*this)[ i], s);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
+  }
   return res;
 }
 // double complex inverse power of value: left=right ^ left
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i<nEl; ++i)
-	(*res)[i] =  pow( s, (*this)[ i]);
-    }
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
+  }
   return res;
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::PowInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::PowInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::PowInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::PowInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::PowInvSNew( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::PowInvSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
 }
 

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -62,11 +62,11 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] & (*right)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & (*right)[i]; // & Ty(1);
   }
   return res;
@@ -94,12 +94,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   }
@@ -121,12 +121,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     else (*res)[0] = zero;
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   }
@@ -148,12 +148,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
       else (*res)[i] = (*this)[i];
   }
@@ -174,12 +174,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
     else (*res)[0] = zero;
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = zero;
   }
@@ -251,11 +251,11 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = (*this)[0] & s;
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) shared(s)
+#pragma omp parallel for num_threads(GDL_NTHREADS) shared(s)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] & s;
   }
   return res;
@@ -294,12 +294,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
       else (*res)[0] = zero;
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     }
@@ -333,12 +333,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
       else (*res)[0] = zero;
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     }
@@ -404,11 +404,11 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = (*this)[0] | (*right)[0]; // | Ty(1);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | (*right)[i]; // | Ty(1);
   }
   //C delete right;
@@ -437,12 +437,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -465,12 +465,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -493,12 +493,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -520,12 +520,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -581,11 +581,11 @@ Data_<Sp>* Data_<Sp>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     (*res)[0] = (*this)[0] | s;
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] | s;
   } //C delete right;
   return res;
@@ -613,12 +613,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
       else (*res)[0] = (*this)[0];
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     }
@@ -647,12 +647,12 @@ Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
       else (*res)[0] = zero;
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     }
@@ -676,12 +676,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
       else (*res)[0] = (*this)[0];
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = s;
         else (*res)[i] = (*this)[i];
     }
@@ -709,12 +709,12 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FU
       else (*res)[0] = zero;
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
         else (*res)[i] = zero;
     }
@@ -779,21 +779,21 @@ Data_<Sp>* Data_<Sp>::XorOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
       return this->Dup();
 
     Data_* res = NewResult();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
     }
     return res;
   } else {
     Data_* res = NewResult();
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] ^ (*right)[i];
     }
     return res;
@@ -859,11 +859,11 @@ Data_<Sp>* Data_<Sp>::XorOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     return this->Dup();
 
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
   }
   return res;
@@ -942,11 +942,11 @@ BaseGDL* Data_<Sp>::AddNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   mRes = mThis + mRight;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + (*right)[i];
   } //C delete right;
   return res;
@@ -970,11 +970,11 @@ BaseGDL* Data_<SpDString>::AddInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__
     (*res)[0] = (*right)[0] + (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] + (*this)[i];
   } //C delete right;
   return res;
@@ -1020,11 +1020,11 @@ BaseGDL* Data_<Sp>::AddSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis + s;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] + s;
   } //C delete right;
   return res;
@@ -1049,11 +1049,11 @@ BaseGDL* Data_<SpDString>::AddInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,_
     return res;
   }
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s + (*this)[i];
   } //C delete right;
   return res;
@@ -1108,11 +1108,11 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - s;
     return res;
 #else
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
     }
     return res;
@@ -1127,11 +1127,11 @@ BaseGDL* Data_<Sp>::SubNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     mRes = mThis - mRight;
     return res;
 #else
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - (*right)[i];
     }
     return res;
@@ -1161,11 +1161,11 @@ BaseGDL* Data_<Sp>::SubInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mRight - mThis;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*right)[i] - (*this)[i];
   }
   return res;
@@ -1230,11 +1230,11 @@ BaseGDL* Data_<Sp>::SubSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__
   mRes = mThis - s;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] - s;
   }
   return res;
@@ -1266,11 +1266,11 @@ BaseGDL* Data_<Sp>::SubInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = s - mThis;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = s - (*this)[i];
   }
   return res;
@@ -1332,12 +1332,12 @@ Data_<Sp>* Data_<Sp>::LtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -1391,12 +1391,12 @@ Data_<Sp>* Data_<Sp>::LtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
   }
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] > s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -1453,12 +1453,12 @@ Data_<Sp>* Data_<Sp>::GtMarkNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     else (*res)[0] = (*this)[0];
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < (*right)[i]) (*res)[i] = (*right)[i];
       else (*res)[i] = (*this)[i];
   } //C delete right;
@@ -1513,12 +1513,12 @@ Data_<Sp>* Data_<Sp>::GtMarkSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
 
   Ty s = (*right)[0];
   // right->Scalar(s);
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] < s) (*res)[i] = s;
       else (*res)[i] = (*this)[i];
   };
@@ -1583,11 +1583,11 @@ Data_<Sp>* Data_<Sp>::MultNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   mRes = mThis * mRight;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i] * (*right)[i];
   } //C delete right;
   return res;
@@ -1636,11 +1636,11 @@ Data_<Sp>* Data_<Sp>::MultSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   mRes = mThis * s;
   return res;
 #else
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res) [i] = (*this)[i] * s;
   }
   return res;
@@ -1691,12 +1691,12 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] / (*right)[i];
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
         else (*res)[ix] = (*this)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] / (*right)[ix];
         else (*res)[ix] = (*this)[ix];
     }
@@ -1723,12 +1723,12 @@ Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] / (*this)[i];
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
         else (*res)[ix] = (*right)[ix];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] / (*this)[ix];
         else (*res)[ix] = (*right)[ix];
     } //C delete right;
@@ -1824,12 +1824,12 @@ Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
       (*res)[i] = s / (*this)[i];
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
         else (*res)[ix] = s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s / (*this)[ix];
         else (*res)[ix] = s;
     }
@@ -1913,12 +1913,12 @@ Data_<Sp>* Data_<Sp>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
       (*res)[i] = (*this)[i] % (*right)[i];
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
         else (*res)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*right)[ix] != this->zero) (*res)[ix] = (*this)[ix] % (*right)[ix];
         else (*res)[ix] = this->zero;
     }
@@ -1942,12 +1942,12 @@ Data_<Sp>* Data_<Sp>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
       (*res)[i] = (*right)[i] % (*this)[i];
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = (*right)[ix] % (*this)[ix];
         else (*res)[ix] = this->zero;
     }
@@ -1969,11 +1969,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = Modulo((*this)[0], (*right)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], (*right)[i]);
   }
   return res;
@@ -1993,11 +1993,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = Modulo((*right)[0], (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*right)[i], (*this)[i]);
   }
   return res;
@@ -2017,11 +2017,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = DModulo((*this)[0], (*right)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], (*right)[i]);
   }
   return res;
@@ -2041,11 +2041,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = DModulo((*right)[0], (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*right)[i], (*this)[i]);
   }
   return res;
@@ -2166,12 +2166,12 @@ Data_<Sp>* Data_<Sp>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     }
     return res;
   } else {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
         else (*res)[ix] = this->zero;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt ix = i; ix < nEl; ++ix) if ((*this)[ix] != this->zero) (*res)[ix] = s % (*this)[ix];
         else (*res)[ix] = this->zero;
     }
@@ -2193,11 +2193,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION
   }
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo((*this)[i], s);
   }
   return res;
@@ -2218,11 +2218,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
   }
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = Modulo(s, (*this)[i]);
   }
   return res;
@@ -2242,11 +2242,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   }
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo((*this)[i], s);
   }
   return res;
@@ -2267,11 +2267,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::ModInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
   }
 
   Ty s = (*right)[0];
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = DModulo(s, (*this)[i]);
   }
   return res;
@@ -2380,11 +2380,11 @@ Data_<Sp>* Data_<Sp>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]); // valarray
   } //C delete right;
   return res;
@@ -2402,11 +2402,11 @@ Data_<Sp>* Data_<Sp>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   }
   return res;
@@ -2433,11 +2433,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     }
     return res;
@@ -2445,32 +2445,32 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
     return res;
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -2488,11 +2488,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (r->StrictScalar()) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
     DLong r0 = (*right)[0];
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], r0);
     }
     return res;
@@ -2500,32 +2500,32 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowIntNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
   if (StrictScalar()) {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
     Ty s0 = (*this)[ 0];
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s0, (*right)[ i]);
     }
     return res;
   }
   if (nEl <= rEl) {
     Data_* res = new Data_(Dim(), BaseGDL::NOZERO);
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
   } else {
     Data_* res = new Data_(right->Dim(), BaseGDL::NOZERO);
-    if (!parallelize( rEl)) {
+    if (GDL_NTHREADS=parallelize( rEl)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -2545,11 +2545,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   }
   return res;
@@ -2567,11 +2567,11 @@ Data_<SpDFloat>* Data_<SpDFloat>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } //C delete right;
   return res;
@@ -2589,11 +2589,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTIO
     (*res)[0] = pow((*this)[0], (*right)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
   }
   return res;
@@ -2611,11 +2611,11 @@ Data_<SpDDouble>* Data_<SpDDouble>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     (*res)[0] = pow((*right)[0], (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } //C delete right;
   return res;
@@ -2640,11 +2640,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } //C delete right;
       return res;
@@ -2655,11 +2655,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } //C delete right;
           return res;
@@ -2667,22 +2667,22 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         //C delete this;
@@ -2700,11 +2700,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     if (right->StrictScalar(s)) {
       DComplexGDL* res = new DComplexGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } //C delete right;
       return res;
@@ -2715,11 +2715,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } //C delete right;
           return res;
@@ -2727,22 +2727,22 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 
         DComplexGDL* res = new DComplexGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         //C delete this;
@@ -2761,22 +2761,22 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
     //#if (__GNUC__ == 3) && (__GNUC_MINOR__ <= 2)
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     }
     return res;
   } else {
     DComplexGDL* res = new DComplexGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -2792,11 +2792,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvNew(BaseGDL* r) { TRACE_ROUTINE(__FU
   assert(nEl);
 
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   }
   return res;
@@ -2820,11 +2820,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       }
       return res;
@@ -2835,11 +2835,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
@@ -2847,22 +2847,22 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -2879,11 +2879,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
     if (right->StrictScalar(s)) {
       DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
         BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
       }
       return res;
@@ -2894,11 +2894,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
@@ -2906,22 +2906,22 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
 
         DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -2935,22 +2935,22 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowNew(BaseGDL* r) { TRACE_ROUTINE(_
   if (right->StrictScalar(s)) {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[ i] = pow((*this)[ i], s);
     }
     return res;
   } else {
     DComplexDblGDL* res = new DComplexDblGDL(this->Dim(),
       BaseGDL::NOZERO);
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], (*right)[i]);
     }
     return res;
@@ -2967,11 +2967,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvNew(BaseGDL* r) { TRACE_ROUTIN
   assert(rEl);
   assert(nEl);
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*right)[i], (*this)[i]);
   }
   return res;
@@ -3028,11 +3028,11 @@ Data_<Sp>* Data_<Sp>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     (*res)[0] = pow((*this)[0], s);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[i], s);
   }
   //C delete right;
@@ -3052,11 +3052,11 @@ Data_<Sp>* Data_<Sp>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[i]);
   } //C delete right;
   return res;
@@ -3079,11 +3079,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       }
       return res;
@@ -3094,33 +3094,33 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
         Data_* res = NewResult();
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         //C delete this;
@@ -3137,11 +3137,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
     // (must also be consistent with ComplexDbl)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } //C delete right;
       return res;
@@ -3152,33 +3152,33 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
         if (StrictScalar(s)) {
           DComplexGDL* res = new DComplexGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } //C delete right;
           return res;
         }
 
         Data_* res = NewResult();
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexGDL* res = new DComplexGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3191,11 +3191,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNC
 
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   }
 
@@ -3215,11 +3215,11 @@ Data_<SpDComplex>* Data_<SpDComplex>::PowInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
     (*res)[0] = pow(s, (*this)[0]);
     return res;
   }
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   }
   return res;
@@ -3243,11 +3243,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       }
       return res;
@@ -3258,33 +3258,33 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
         Data_* res = NewResult();
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3302,11 +3302,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
     // (concerning when a new variable is created vs. using this)
     if (right->StrictScalar(s)) {
       Data_* res = NewResult();
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
       }
       return res;
@@ -3317,33 +3317,33 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
         if (StrictScalar(s)) {
           DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
             BaseGDL::NOZERO);
-          if (!parallelize( rEl)) {
+          if (GDL_NTHREADS=parallelize( rEl)==1) {
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow(s, (*right)[ i]);
           }
           return res;
         }
 
         Data_* res = NewResult();
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], (*right)[ i]);
         } //C delete right;
         return res;
       } else {
         DComplexDblGDL* res = new DComplexDblGDL(right->Dim(),
           BaseGDL::NOZERO);
-        if (!parallelize( rEl)) {
+        if (GDL_NTHREADS=parallelize( rEl)==1) {
           for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (OMPInt i = 0; i < rEl; ++i) (*res)[ i] = pow((*this)[ i], (*right)[ i]);
         }
         return res;
@@ -3354,11 +3354,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowSNew(BaseGDL* r) { TRACE_ROUTINE(
   Data_* right = static_cast<Data_*> (r);
   const Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow((*this)[ i], s);
   }
   return res;
@@ -3373,11 +3373,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::PowInvSNew(BaseGDL* r) { TRACE_ROUTI
   assert(nEl);
   Ty s = (*right)[0];
   Data_* res = NewResult();
-  if (!parallelize( nEl)) {
+  if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = pow(s, (*this)[ i]);
   }
   return res;

--- a/src/basic_op_sub.cpp
+++ b/src/basic_op_sub.cpp
@@ -58,11 +58,11 @@ BaseGDL* Data_<Sp>::Sub(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     dd -= right->dd;
   else {
 
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
       } else {
 	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
     }
   }
@@ -92,11 +92,11 @@ BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
   }
   return this;
@@ -316,11 +316,11 @@ Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
   }
   return this;
@@ -349,11 +349,11 @@ Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   return this;
 #else
 
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
   }
   return this;

--- a/src/basic_op_sub.cpp
+++ b/src/basic_op_sub.cpp
@@ -35,7 +35,7 @@
 // substraction: left=left-right
 
 template<class Sp>
-BaseGDL* Data_<Sp>::Sub(BaseGDL* r) {
+BaseGDL* Data_<Sp>::Sub(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -58,7 +58,7 @@ BaseGDL* Data_<Sp>::Sub(BaseGDL* r) {
     dd -= right->dd;
   else {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
       } else {
@@ -74,7 +74,7 @@ BaseGDL* Data_<Sp>::Sub(BaseGDL* r) {
 // inverse substraction: left=right-left
 
 template<class Sp>
-BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) {
+BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong rEl = right->N_Elements();
@@ -93,7 +93,7 @@ BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) {
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
     } else {
@@ -132,7 +132,7 @@ BaseGDL* Data_<SpDPtr>::SubInv(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::Sub(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::Sub(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // overload here
   Data_* self;
   DSubUD* plusOverload;
@@ -220,7 +220,7 @@ BaseGDL* Data_<SpDObj>::Sub(BaseGDL* r) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::SubInv(BaseGDL* r) {
+BaseGDL* Data_<SpDObj>::SubInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if (r->Type() == GDL_OBJ && r->Scalar()) {
     return r->Sub(this); // for right order of parameters
   }
@@ -298,7 +298,7 @@ BaseGDL* Data_<SpDObj>::SubInv(BaseGDL* r) {
 }
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -318,7 +318,7 @@ Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) {
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
     } else {
@@ -333,7 +333,7 @@ Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) {
 // inverse substraction: left=right-left
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) {
+Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
 
   ULong nEl = N_Elements();
@@ -352,7 +352,7 @@ Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) {
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (!parallelize) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
     } else {

--- a/src/basic_op_sub.cpp
+++ b/src/basic_op_sub.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -33,400 +33,372 @@
 
 // Sub
 // substraction: left=left-right
-template<class Sp>
-BaseGDL* Data_<Sp>::Sub( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  if( nEl == 1)
-    {
-      (*this)[0] -= (*right)[0];
-      return this;
-    }
+template<class Sp>
+BaseGDL* Data_<Sp>::Sub(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] -= (*right)[0];
+    return this;
+  }
 #ifdef USE_EIGEN
 
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
   mThis -= mRight;
   return this;
 #else
 
-  if( nEl == rEl)
+  if (nEl == rEl)
     dd -= right->dd;
-  else
-    {
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-	{
-#pragma omp for
-	  for( OMPInt i=0; i < nEl; ++i)
-	    (*this)[i] -= (*right)[i];
-	}}  //C delete right;
+  else {
+
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+      if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
+      } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
+    }
+  }
   return this;
 #endif
-  
+
 }
 // inverse substraction: left=right-left
-template<class Sp>
-BaseGDL* Data_<Sp>::SubInv( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
 
-  ULong rEl=right->N_Elements();
-  ULong nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
-  /*  if( nEl == rEl)
-      dd = right->dd - dd;
-      else*/
-  if( nEl == 1)
-    {
-      (*this)[0] = (*right)[0] - (*this)[0];
-      return this;
-    }
+template<class Sp>
+BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = N_Elements();
+  assert(rEl);
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] = (*right)[0] - (*this)[0];
+    return this;
+  }
 #ifdef USE_EIGEN
 
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-  Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mRight(&(*right)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mRight(&(*right)[0], nEl);
   mThis = mRight - mThis;
   return this;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = (*right)[i] - (*this)[i];
-    }  //C delete right;
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
+  }
   return this;
 #endif
-  
+
 }
 // invalid types
+
 template<>
-BaseGDL* Data_<SpDString>::Sub( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::Sub(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-BaseGDL* Data_<SpDString>::SubInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+BaseGDL* Data_<SpDString>::SubInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::Sub( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::Sub(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-BaseGDL* Data_<SpDPtr>::SubInv( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+BaseGDL* Data_<SpDPtr>::SubInv(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::Sub( BaseGDL* r)
-{
+BaseGDL* Data_<SpDObj>::Sub(BaseGDL* r) {
   // overload here
   Data_* self;
   DSubUD* plusOverload;
-  
+
   ProgNodeP callingNode = interpreter->GetRetTree();
 
-  if( !Scalar())
-  {
-    if( r->Type() == GDL_OBJ && r->Scalar())
-    {
-      self = static_cast<Data_*>( r);
-      plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOMinus));
-      if( plusOverload == NULL)
-      {
-	throw GDLException( callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
+  if (!Scalar()) {
+    if (r->Type() == GDL_OBJ && r->Scalar()) {
+      self = static_cast<Data_*> (r);
+      plusOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*self)[0], OOMinus));
+      if (plusOverload == NULL) {
+        throw GDLException(callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
       }
+    } else {
+      throw GDLException(callingNode, "Cannot apply operation to non-scalar datatype OBJECT.", true, false);
     }
-    else
-      {
-	throw GDLException( callingNode, "Cannot apply operation to non-scalar datatype OBJECT.", true, false);
-      }
-  }
-  else
-  {
+  } else {
     // Scalar()
-    self = static_cast<Data_*>( this);
-    plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOMinus));
-    if( plusOverload == NULL)
-    {
-      if( r->Type() == GDL_OBJ && r->Scalar())
-      {
-	self = static_cast<Data_*>( r);
-	plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOMinus));
-	if( plusOverload == NULL)
-	{
-	  throw GDLException(callingNode,"Cannot apply not overloaded operator to datatype OBJECT.",true, false);  
-	} 
-      }
-      else
-      {
-	throw GDLException( callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
+    self = static_cast<Data_*> (this);
+    plusOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*self)[0], OOMinus));
+    if (plusOverload == NULL) {
+      if (r->Type() == GDL_OBJ && r->Scalar()) {
+        self = static_cast<Data_*> (r);
+        plusOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*self)[0], OOMinus));
+        if (plusOverload == NULL) {
+          throw GDLException(callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
+        }
+      } else {
+        throw GDLException(callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
       }
     }
   }
 
-  assert( self->Scalar());
-  assert( plusOverload != NULL);
+  assert(self->Scalar());
+  assert(plusOverload != NULL);
 
   // hidden SELF is counted as well
   int nParSub = plusOverload->NPar();
-  assert( nParSub >= 1); // SELF
-  if( nParSub < 3) // (SELF), LEFT, RIGHT
+  assert(nParSub >= 1); // SELF
+  if (nParSub < 3) // (SELF), LEFT, RIGHT
   {
-    throw GDLException( callingNode, plusOverload->ObjectName() +
-		    ": Incorrect number of arguments.",
-		    false, false);
+    throw GDLException(callingNode, plusOverload->ObjectName() +
+      ": Incorrect number of arguments.",
+      false, false);
   }
   EnvUDT* newEnv;
   Guard<BaseGDL> selfGuard;
   BaseGDL* thisP;
   // Dup() here is not optimal
   // avoid at least for internal overload routines (which do/must not change SELF or r)
-  bool internalDSubUD = plusOverload->GetTree()->IsWrappedNode();  
-  if( internalDSubUD)  
-  {
+  bool internalDSubUD = plusOverload->GetTree()->IsWrappedNode();
+  if (internalDSubUD) {
     thisP = this;
-    newEnv= new EnvUDT( callingNode, plusOverload, &self);
-    newEnv->SetNextParUnchecked( &thisP); // LEFT  parameter, as reference to prevent cleanup in newEnv
-    newEnv->SetNextParUnchecked( &r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
-  }
-  else
-  {
+    newEnv = new EnvUDT(callingNode, plusOverload, &self);
+    newEnv->SetNextParUnchecked(&thisP); // LEFT  parameter, as reference to prevent cleanup in newEnv
+    newEnv->SetNextParUnchecked(&r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
+  } else {
     self = self->Dup();
-    selfGuard.Init( self);
-    newEnv= new EnvUDT( callingNode, plusOverload, &self);
-    newEnv->SetNextParUnchecked( this->Dup()); // LEFT  parameter, as value
-    newEnv->SetNextParUnchecked( r->Dup()); // RIGHT parameter, as value
+    selfGuard.Init(self);
+    newEnv = new EnvUDT(callingNode, plusOverload, &self);
+    newEnv->SetNextParUnchecked(this->Dup()); // LEFT  parameter, as value
+    newEnv->SetNextParUnchecked(r->Dup()); // RIGHT parameter, as value
   }
 
-  
+
   // better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
   StackGuard<EnvStackT> guard(interpreter->CallStack());
 
-  interpreter->CallStack().push_back( newEnv); 
-  
-  // make the call
-  BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
+  interpreter->CallStack().push_back(newEnv);
 
-  if( !internalDSubUD && self != selfGuard.Get())
-  {
+  // make the call
+  BaseGDL* res = interpreter->call_fun(static_cast<DSubUD*> (newEnv->GetPro())->GetTree());
+
+  if (!internalDSubUD && self != selfGuard.Get()) {
     // always put out warning first, in case of a later crash
-    Warning( "WARNING: " + plusOverload->ObjectName() + 
-	  ": Assignment to SELF detected (GDL session still ok).");
+    Warning("WARNING: " + plusOverload->ObjectName() +
+      ": Assignment to SELF detected (GDL session still ok).");
     // assignment to SELF -> self was deleted and points to new variable
     // which it owns
     selfGuard.Release();
-    if( static_cast<BaseGDL*>(self) != NullGDL::GetSingleInstance())
+    if (static_cast<BaseGDL*> (self) != NullGDL::GetSingleInstance())
       selfGuard.Reset(self);
   }
   return res;
 }
+
 template<>
-BaseGDL* Data_<SpDObj>::SubInv( BaseGDL* r)
-{
-  if( r->Type() == GDL_OBJ && r->Scalar())
-  {
-    return r->Sub( this); // for right order of parameters
+BaseGDL* Data_<SpDObj>::SubInv(BaseGDL* r) {
+  if (r->Type() == GDL_OBJ && r->Scalar()) {
+    return r->Sub(this); // for right order of parameters
   }
-    
+
   // overload here
   Data_* self;
   DSubUD* plusOverload;
-  
+
   ProgNodeP callingNode = interpreter->GetRetTree();
 
-  if( !Scalar())
-  {
-    throw GDLException( callingNode, "Cannot apply operation to non-scalar datatype OBJECT.", true, false);
-  }
-  else
-  {
+  if (!Scalar()) {
+    throw GDLException(callingNode, "Cannot apply operation to non-scalar datatype OBJECT.", true, false);
+  } else {
     // Scalar()
-    self = static_cast<Data_*>( this);
-    plusOverload = static_cast<DSubUD*>(GDLInterpreter::GetObjHeapOperator( (*self)[0], OOMinus));
-    if( plusOverload == NULL)
-    {
-	throw GDLException( callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
+    self = static_cast<Data_*> (this);
+    plusOverload = static_cast<DSubUD*> (GDLInterpreter::GetObjHeapOperator((*self)[0], OOMinus));
+    if (plusOverload == NULL) {
+      throw GDLException(callingNode, "Cannot apply not overloaded operator to datatype OBJECT.", true, false);
     }
   }
 
-  assert( self->Scalar());
-  assert( plusOverload != NULL);
+  assert(self->Scalar());
+  assert(plusOverload != NULL);
 
   // hidden SELF is counted as well
   int nParSub = plusOverload->NPar();
-  assert( nParSub >= 1); // SELF
-  if( nParSub < 3) // (SELF), LEFT, RIGHT
+  assert(nParSub >= 1); // SELF
+  if (nParSub < 3) // (SELF), LEFT, RIGHT
   {
-    throw GDLException( callingNode, plusOverload->ObjectName() +
-		    ": Incorrect number of arguments.",
-		    false, false);
+    throw GDLException(callingNode, plusOverload->ObjectName() +
+      ": Incorrect number of arguments.",
+      false, false);
   }
   EnvUDT* newEnv;
   Guard<BaseGDL> selfGuard;
   BaseGDL* thisP;
   // Dup() here is not optimal
   // avoid at least for internal overload routines (which do/must not change SELF or r)
-  bool internalDSubUD = plusOverload->GetTree()->IsWrappedNode();  
-  if( internalDSubUD)  
-  {
+  bool internalDSubUD = plusOverload->GetTree()->IsWrappedNode();
+  if (internalDSubUD) {
     thisP = this;
-    newEnv= new EnvUDT( callingNode, plusOverload, &self);
+    newEnv = new EnvUDT(callingNode, plusOverload, &self);
     // order different to Add
-    newEnv->SetNextParUnchecked( &r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
-    newEnv->SetNextParUnchecked( &thisP); // LEFT  parameter, as reference to prevent cleanup in newEnv
-  }
-  else
-  {
+    newEnv->SetNextParUnchecked(&r); // RVALUE  parameter, as reference to prevent cleanup in newEnv
+    newEnv->SetNextParUnchecked(&thisP); // LEFT  parameter, as reference to prevent cleanup in newEnv
+  } else {
     self = self->Dup();
-    selfGuard.Init( self);
-    newEnv= new EnvUDT( callingNode, plusOverload, &self);
+    selfGuard.Init(self);
+    newEnv = new EnvUDT(callingNode, plusOverload, &self);
     // order different to Add
-    newEnv->SetNextParUnchecked( r->Dup()); // RIGHT parameter, as value
-    newEnv->SetNextParUnchecked( this->Dup()); // LEFT  parameter, as value
+    newEnv->SetNextParUnchecked(r->Dup()); // RIGHT parameter, as value
+    newEnv->SetNextParUnchecked(this->Dup()); // LEFT  parameter, as value
   }
 
-  
+
   // better than auto_ptr: auto_ptr wouldn't remove newEnv from the stack
   StackGuard<EnvStackT> guard(interpreter->CallStack());
 
-  interpreter->CallStack().push_back( newEnv); 
-  
-  // make the call
-  BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
+  interpreter->CallStack().push_back(newEnv);
 
-  if( !internalDSubUD && self != selfGuard.Get())
-  {
+  // make the call
+  BaseGDL* res = interpreter->call_fun(static_cast<DSubUD*> (newEnv->GetPro())->GetTree());
+
+  if (!internalDSubUD && self != selfGuard.Get()) {
     // always put out warning first, in case of a later crash
-    Warning( "WARNING: " + plusOverload->ObjectName() + 
-	  ": Assignment to SELF detected (GDL session still ok).");
+    Warning("WARNING: " + plusOverload->ObjectName() +
+      ": Assignment to SELF detected (GDL session still ok).");
     // assignment to SELF -> self was deleted and points to new variable
     // which it owns
     selfGuard.Release();
-    if( static_cast<BaseGDL*>(self) != NullGDL::GetSingleInstance())
+    if (static_cast<BaseGDL*> (self) != NullGDL::GetSingleInstance())
       selfGuard.Reset(self);
   }
   return res;
 }
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::SubS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
-  if( nEl == 1)
-    {
-      (*this)[0] -= (*right)[0];
-      return this;
-    }
-  
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    (*this)[0] -= (*right)[0];
+    return this;
+  }
+
   Ty s = (*right)[0];
-  // right->Scalar(s); 
+  // right->Scalar(s);
   //  dd -= s;
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-	mThis -= s;
-	return this;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  mThis -= s;
+  return this;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] -= s;
-    }  //C delete right;
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
+  }
   return this;
 #endif
-  
+
 }
 // inverse substraction: left=right-left
+
 template<class Sp>
-Data_<Sp>* Data_<Sp>::SubInvS( BaseGDL* r)
-{
-  Data_* right=static_cast<Data_*>(r);
+Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
 
-  ULong nEl=N_Elements();
-  assert( nEl);
+  ULong nEl = N_Elements();
+  assert(nEl);
 
-  if( nEl == 1)
-    {
-      (*this)[0] = (*right)[0] - (*this)[0];
-      return this;
-    }
-  
+  if (nEl == 1) {
+    (*this)[0] = (*right)[0] - (*this)[0];
+    return this;
+  }
+
   Ty s = (*right)[0];
-  // right->Scalar(s); 
-  //  dd = s - dd;
 #ifdef USE_EIGEN
 
-        Eigen::Map<Eigen::Array<Ty,Eigen::Dynamic,1> ,Eigen::Aligned> mThis(&(*this)[0], nEl);
-	mThis = s - mThis;
-	return this;
+  Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, 1>, Eigen::Aligned> mThis(&(*this)[0], nEl);
+  mThis = s - mThis;
+  return this;
 #else
-  TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-	(*this)[i] = s - (*this)[i];
-    }  //C delete right;
+
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    if (!parallelize) {
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
+  }
   return this;
 #endif
-  
+
 }
 // invalid types
+
 template<>
-Data_<SpDString>* Data_<SpDString>::SubS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::SubS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDString>* Data_<SpDString>::SubInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype STRING.",true,false);  
+Data_<SpDString>* Data_<SpDString>::SubInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::SubS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::SubS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::SubInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype PTR.",true,false);  
+Data_<SpDPtr>* Data_<SpDPtr>::SubInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::SubS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::SubS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
 template<>
-Data_<SpDObj>* Data_<SpDObj>::SubInvS( BaseGDL* r)
-{
-  throw GDLException("Cannot apply operation to datatype OBJECT.",true,false);  
+Data_<SpDObj>* Data_<SpDObj>::SubInvS(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 

--- a/src/basic_op_sub.cpp
+++ b/src/basic_op_sub.cpp
@@ -58,7 +58,7 @@ BaseGDL* Data_<Sp>::Sub(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     dd -= right->dd;
   else {
 
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
       } else {
 	TRACEOMP(__FILE__, __LINE__)
@@ -92,7 +92,7 @@ BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -316,7 +316,7 @@ Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -349,7 +349,7 @@ Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   return this;
 #else
 
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_op_sub.cpp
+++ b/src/basic_op_sub.cpp
@@ -58,8 +58,7 @@ BaseGDL* Data_<Sp>::Sub(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     dd -= right->dd;
   else {
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
       for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= (*right)[i];
       } else {
 	TRACEOMP(__FILE__, __LINE__)
@@ -93,8 +92,7 @@ BaseGDL* Data_<Sp>::SubInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = (*right)[i] - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -318,8 +316,7 @@ Data_<Sp>* Data_<Sp>::SubS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] -= s;
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -352,8 +349,7 @@ Data_<Sp>* Data_<Sp>::SubInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   return this;
 #else
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
     for (OMPInt i = 0; i < nEl; ++i) (*this)[i] = s - (*this)[i];
     } else {
       TRACEOMP(__FILE__, __LINE__)

--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -1159,11 +1159,7 @@ namespace lib {
 
     SizeT nEl = dest->N_Elements();
 //too much overhead for parallelizing a complicated function, IDL does not attempt it neither.    
-//#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-//    {
-//#pragma omp for
-      for (OMPInt i = 0; i < nEl; ++i) StrPut((*dest)[i], source, pos);
-//    }
+      for (SizeT i = 0; i < nEl; ++i) StrPut((*dest)[i], source, pos);
   }
 
   void retall(EnvT* e) {

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -33,15 +33,15 @@ using namespace std;
 //#define TRACE_CONVERT2 cout << "Convert2 " << this->TypeStr() << " -> " << destTy << "\tn " << dd.size() << "\tmode " << mode << endl;
 #define TRACE_CONVERT2
 
-#define DO_CONVERT_START(tnew)  {bool parallelize=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));\
+#define DO_CONVERT_START(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!parallelize) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(!parallelize(nEl,  TP_ARRAY_INITIALISATION)) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
-#define DO_CONVERT_START_CPX(tnew)  {bool parallelize=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));\
+#define DO_CONVERT_START_CPX(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!parallelize) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(!parallelize(nEl,  TP_ARRAY_INITIALISATION)) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_END 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 #define DO_CONVERT_END_CPX 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -757,346 +757,296 @@ else
 	Warning( msg);
 }
 
-template<> BaseGDL* Data_<SpDString>::Convert2( DType destTy, BaseGDL::Convert2Mode mode)
-{
-TRACE_CONVERT2
-  if( destTy == t) return (((mode & BaseGDL::COPY) != 0)?Dup():this);
+// The OpenMP below is always faster than IDL, as what is in the loop is quite complicated.
+template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mode mode) {
+  TRACE_CONVERT2
+  if (destTy == t) return (((mode & BaseGDL::COPY) != 0) ? Dup() : this);
 
-  SizeT nEl=dd.size();
-  
+  SizeT nEl = dd.size();
+
   bool errorFlag = false;
 
-  switch( destTy)
-    {
-    case GDL_BYTE: // GDL_STRING to GDL_BYTE: add first dim
-      {
-	SizeT maxLen = 1; // empty string is converted to 0b
-      	for( SizeT i=0; i < nEl; ++i)
-	  if( (*this)[i].length() > maxLen) maxLen = (*this)[i].length();
+  switch (destTy) {
+  case GDL_BYTE: // GDL_STRING to GDL_BYTE: add first dim
+  {
+    SizeT maxLen = 1; // empty string is converted to 0b
+    for (SizeT i = 0; i < nEl; ++i)
+      if ((*this)[i].length() > maxLen) maxLen = (*this)[i].length();
 
-	dimension bytDim( dim);
-	bytDim >> maxLen;
+    dimension bytDim(dim);
+    bytDim >> maxLen;
 
-      	Data_<SpDByte>* dest=new Data_<SpDByte>( bytDim); // zero fields
-  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-	  {
-	    SizeT basePtr = i*maxLen;
+    Data_<SpDByte>* dest = new Data_<SpDByte>(bytDim); // zero fields
 
-	    SizeT strLen = (*this)[ i].length();
-	    for( SizeT b=0; b<strLen; b++)
-	      (*dest)[basePtr + b] = (*this)[ i][ b];
- 	  }
-}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-	return dest;
-      }
-    case GDL_INT:
-      {
-      	Data_<SpDInt>* dest=new Data_<SpDInt>( dim, BaseGDL::NOZERO);
-   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel shared( errorFlag, mode)
- {
- #pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtol(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-		StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to INT.");
-      	      }
-	  }
- }
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to INT.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-	return dest;
-      }
-    case GDL_UINT: 
-      {
-      	Data_<SpDUInt>* dest=new Data_<SpDUInt>( dim, BaseGDL::NOZERO);
-  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtoul(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to UINT.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to UINT.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_LONG: 
-      {
-      	Data_<SpDLong>* dest=new Data_<SpDLong>( dim, BaseGDL::NOZERO);
-  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtol(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to LONG.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to LONG.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_ULONG: 
-      {
-      	Data_<SpDULong>* dest=new Data_<SpDULong>( dim, BaseGDL::NOZERO);
-  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtoul(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to ULONG.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to ULONG.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_LONG64: 
-      {
-      	Data_<SpDLong64>* dest=new Data_<SpDLong64>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtoll(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to LONG64.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to LONG64.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_ULONG64: 
-      {
-      	Data_<SpDULong64>* dest=new Data_<SpDULong64>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=strtoull(cStart,&cEnd,10);
-      	    if( cEnd == cStart && (*this)[i] != "")
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to ULONG64.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to ULONG64.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_FLOAT: 
-      {
-      	Data_<SpDFloat>* dest=new Data_<SpDFloat>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i] = string2real<float>(cStart, &cEnd);
-      	    if((cEnd == cStart && (*this)[i] != "")) //  || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to FLOAT.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to FLOAT.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_DOUBLE: 
-      {
-      	Data_<SpDDouble>* dest=new Data_<SpDDouble>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-	    char* cEnd;
-	    (*dest)[i] = string2real<double>( cStart, &cEnd);
-	    if( (cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
-	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to DOUBLE.");
-	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to DOUBLE.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-      //    case GDL_STRING: 
-    case GDL_COMPLEX: 
-      {
-      	Data_<SpDComplex>* dest=new Data_<SpDComplex>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=string2real<float>(cStart,&cEnd);
-      	    if((cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to COMPLEX.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to COMPLEX.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_COMPLEXDBL: 
-      {
-      	Data_<SpDComplexDbl>* dest=
-	  new Data_<SpDComplexDbl>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel shared( errorFlag, mode)
-{
-#pragma omp for
-      	for( OMPInt i=0; i < nEl; ++i)
-      	  {
-      	    const char* cStart=(*this)[i].c_str();
-      	    char* cEnd;
-      	    (*dest)[i]=string2real<double>(cStart,&cEnd);
-      	    if((cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
-      	      {
-StringConversionError( errorFlag, mode, "Type conversion error: "
-				       "Unable to convert given STRING: '"+
-				       (*this)[i]+"' to DCOMPLEX.");
-      	      }
-      	  }
-}
-	if( errorFlag)
-	{
-		delete dest;
-		if( (mode & BaseGDL::CONVERT) != 0) delete this;
-		throw GDLIOException( "Type conversion error: Unable to convert given STRING to DCOMPLEX.");
-	}
-	if( (mode & BaseGDL::CONVERT) != 0) delete this;
-      	return dest;
-      }
-    case GDL_PTR:
-    case GDL_OBJ:
-    case GDL_STRUCT:
-    case GDL_UNDEF: 
-    default:
-if(BaseGDL::interpreter!=NULL&&BaseGDL::interpreter->CallStack().size()>0) BaseGDL::interpreter->CallStack().back()->Throw("Cannot convert to this type.");
-throw GDLException("Cannot convert to this type.");
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      SizeT basePtr = i*maxLen;
+
+      SizeT strLen = (*this)[ i].length();
+      for (SizeT b = 0; b < strLen; b++)
+        (*dest)[basePtr + b] = (*this)[ i][ b];
     }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_INT:
+  {
+    Data_<SpDInt>* dest = new Data_<SpDInt>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode)  num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtol(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to INT.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to INT.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_UINT:
+  {
+    Data_<SpDUInt>* dest = new Data_<SpDUInt>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtoul(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to UINT.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to UINT.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_LONG:
+  {
+    Data_<SpDLong>* dest = new Data_<SpDLong>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtol(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to LONG.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to LONG.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_ULONG:
+  {
+    Data_<SpDULong>* dest = new Data_<SpDULong>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtoul(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to ULONG.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to ULONG.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_LONG64:
+  {
+    Data_<SpDLong64>* dest = new Data_<SpDLong64>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtoll(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to LONG64.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to LONG64.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_ULONG64:
+  {
+    Data_<SpDULong64>* dest = new Data_<SpDULong64>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = strtoull(cStart, &cEnd, 10);
+      if (cEnd == cStart && (*this)[i] != "") {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to ULONG64.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to ULONG64.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_FLOAT:
+  {
+    Data_<SpDFloat>* dest = new Data_<SpDFloat>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = string2real<float>(cStart, &cEnd);
+      if ((cEnd == cStart && (*this)[i] != "")) //  || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
+      {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to FLOAT.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to FLOAT.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_DOUBLE:
+  {
+    Data_<SpDDouble>* dest = new Data_<SpDDouble>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = string2real<double>(cStart, &cEnd);
+      if ((cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
+      {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to DOUBLE.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to DOUBLE.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+    //    case GDL_STRING: 
+  case GDL_COMPLEX:
+  {
+    Data_<SpDComplex>* dest = new Data_<SpDComplex>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = string2real<float>(cStart, &cEnd);
+      if ((cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
+      {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to COMPLEX.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to COMPLEX.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_COMPLEXDBL:
+  {
+    Data_<SpDComplexDbl>* dest =
+      new Data_<SpDComplexDbl>(dim, BaseGDL::NOZERO);
+
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+      for (OMPInt i = 0; i < nEl; ++i) {
+      const char* cStart = (*this)[i].c_str();
+      char* cEnd;
+      (*dest)[i] = string2real<double>(cStart, &cEnd);
+      if ((cEnd == cStart && (*this)[i] != "")) // || (cEnd - cStart) != strlen(cStart)) // reports error for "16 "
+      {
+        StringConversionError(errorFlag, mode, "Type conversion error: "
+          "Unable to convert given STRING: '" +
+          (*this)[i] + "' to DCOMPLEX.");
+      }
+    }
+    if (errorFlag) {
+      delete dest;
+      if ((mode & BaseGDL::CONVERT) != 0) delete this;
+      throw GDLIOException("Type conversion error: Unable to convert given STRING to DCOMPLEX.");
+    }
+    if ((mode & BaseGDL::CONVERT) != 0) delete this;
+    return dest;
+  }
+  case GDL_PTR:
+  case GDL_OBJ:
+  case GDL_STRUCT:
+  case GDL_UNDEF:
+  default:
+    if (BaseGDL::interpreter != NULL && BaseGDL::interpreter->CallStack().size() > 0) BaseGDL::interpreter->CallStack().back()->Throw("Cannot convert to this type.");
+    throw GDLException("Cannot convert to this type.");
+  }
 
   // get rid of warning
-  return NULL; 
+  return NULL;
 }  
 
 

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -36,12 +36,12 @@ using namespace std;
 #define DO_CONVERT_START(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!parallelize(nEl,  TP_ARRAY_INITIALISATION)) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION)==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_START_CPX(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!parallelize(nEl,  TP_ARRAY_INITIALISATION)) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION)==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_END 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 #define DO_CONVERT_END_CPX 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
@@ -149,59 +149,59 @@ template<> BaseGDL* Data_<SpDByte>::Convert2(DType destTy, BaseGDL::Convert2Mode
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     if (mode == BaseGDL::COPY_BYTE_AS_INT) {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i)
         (*dest)[i] = i2s(static_cast<int> ((*this)[i]), 4);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -256,59 +256,59 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_INT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING:
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
     return dest;
@@ -336,59 +336,59 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2( DType destTy, BaseGDL::Convert2Mod
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_UINT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
     return dest;
@@ -419,59 +419,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -503,59 +503,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -586,60 +586,60 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:      return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
 
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=float2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -671,59 +671,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT: 
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:     return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=double2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -779,7 +779,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDByte>* dest = new Data_<SpDByte>(bytDim); // zero fields
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       SizeT basePtr = i*maxLen;
 
@@ -795,7 +795,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDInt>* dest = new Data_<SpDInt>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode)  num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode)  num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -819,7 +819,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDUInt>* dest = new Data_<SpDUInt>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -843,7 +843,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDLong>* dest = new Data_<SpDLong>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -867,7 +867,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDULong>* dest = new Data_<SpDULong>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -891,7 +891,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDLong64>* dest = new Data_<SpDLong64>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -915,7 +915,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDULong64>* dest = new Data_<SpDULong64>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -939,7 +939,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDFloat>* dest = new Data_<SpDFloat>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -964,7 +964,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDDouble>* dest = new Data_<SpDDouble>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -990,7 +990,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
     Data_<SpDComplex>* dest = new Data_<SpDComplex>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -1016,7 +1016,7 @@ template<> BaseGDL* Data_<SpDString>::Convert2(DType destTy, BaseGDL::Convert2Mo
       new Data_<SpDComplexDbl>(dim, BaseGDL::NOZERO);
 
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for shared( errorFlag, mode) num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for shared( errorFlag, mode) num_threads(GDL_NTHREADS) if (GDL_NTHREADS > 1)
       for (OMPInt i = 0; i < nEl; ++i) {
       const char* cStart = (*this)[i].c_str();
       char* cEnd;
@@ -1063,59 +1063,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_COMPLEX:    return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       
 //FUTURE WORK: the version below is incredibely fast
       // using 'code=[1,2,3,4,5,6,7,9,12,13,14,15] & tic & for i=6,6 do begin a=cindgen(10LL^8) & b=fix(a,type=code[i]) & help,b & print,b[-1] & end & toc'
@@ -1154,59 +1154,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_COMPLEX: 
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:   return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]="("+i2s(real((*this)[i]))+","+i2s(imag((*this)[i]))+")";
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -1239,59 +1239,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -1323,59 +1323,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -36,12 +36,12 @@ using namespace std;
 #define DO_CONVERT_START(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION)==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if((GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION))==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_START_CPX(tnew)  {\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION)==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if((GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION))==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_END 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 #define DO_CONVERT_END_CPX 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -33,15 +33,15 @@ using namespace std;
 //#define TRACE_CONVERT2 cout << "Convert2 " << this->TypeStr() << " -> " << destTy << "\tn " << dd.size() << "\tmode " << mode << endl;
 #define TRACE_CONVERT2
 
-#define DO_CONVERT_START(tnew)  {bool dopar=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));\
+#define DO_CONVERT_START(tnew)  {bool parallelize=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!dopar) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(!parallelize) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
-#define DO_CONVERT_START_CPX(tnew)  {bool dopar=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));\
+#define DO_CONVERT_START_CPX(tnew)  {bool parallelize=(CpuTPOOL_NTHREADS >1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));\
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=(*this)[0].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
-        if(!dopar) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
+        if(!parallelize) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
 #define DO_CONVERT_END 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i]; if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 #define DO_CONVERT_END_CPX 	for( SizeT i=0; i < nEl; ++i) (*dest)[i]=(*this)[i].real(); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
@@ -149,59 +149,59 @@ template<> BaseGDL* Data_<SpDByte>::Convert2(DType destTy, BaseGDL::Convert2Mode
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     if (mode == BaseGDL::COPY_BYTE_AS_INT) {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i)
         (*dest)[i] = i2s(static_cast<int> ((*this)[i]), 4);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -256,59 +256,59 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_INT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING:
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
     return dest;
@@ -336,59 +336,59 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2( DType destTy, BaseGDL::Convert2Mod
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_UINT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
     return dest;
@@ -419,59 +419,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -503,59 +503,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -586,60 +586,60 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:      return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
 
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=float2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -671,59 +671,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT: 
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:     return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=double2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -1113,59 +1113,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_COMPLEX:    return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       
 //FUTURE WORK: the version below is incredibely fast
       // using 'code=[1,2,3,4,5,6,7,9,12,13,14,15] & tic & for i=6,6 do begin a=cindgen(10LL^8) & b=fix(a,type=code[i]) & help,b & print,b[-1] & end & toc'
@@ -1204,59 +1204,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END_CPX
     case GDL_COMPLEX: 
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:   return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]="("+i2s(real((*this)[i]))+","+i2s(imag((*this)[i]))+")";
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -1289,59 +1289,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;
@@ -1373,59 +1373,59 @@ TRACE_CONVERT2
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_ULONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
       return dest;

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -148,48 +148,59 @@ template<> BaseGDL* Data_<SpDByte>::Convert2(DType destTy, BaseGDL::Convert2Mode
   case GDL_BYTE: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     if (mode == BaseGDL::COPY_BYTE_AS_INT) {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i)
         (*dest)[i] = i2s(static_cast<int> ((*this)[i]), 4);
@@ -244,48 +255,59 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
   switch (destTy) {
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_INT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_UINT:
     DO_CONVERT_START(SpDUInt)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_STRING:
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -313,48 +335,59 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2( DType destTy, BaseGDL::Convert2Mod
   switch (destTy) {
   case GDL_BYTE:
     DO_CONVERT_START(SpDByte)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_INT:
     DO_CONVERT_START(SpDInt)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_UINT: return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
   case GDL_LONG:
     DO_CONVERT_START(SpDLong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG:
     DO_CONVERT_START(SpDULong)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_LONG64:
     DO_CONVERT_START(SpDLong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_ULONG64:
     DO_CONVERT_START(SpDULong64)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_FLOAT:
     DO_CONVERT_START(SpDFloat)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_DOUBLE:
     DO_CONVERT_START(SpDDouble)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEX:
     DO_CONVERT_START(SpDComplex)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_COMPLEXDBL:
     DO_CONVERT_START(SpDComplexDbl)
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
     for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
     if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -385,48 +418,59 @@ TRACE_CONVERT2
     switch (destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -458,48 +502,59 @@ TRACE_CONVERT2
   switch( destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
   case GDL_ULONG:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -530,49 +585,60 @@ TRACE_CONVERT2
   switch( destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_FLOAT:      return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
 
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=float2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -604,48 +670,59 @@ TRACE_CONVERT2
   switch( destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
   case GDL_ULONG: 
       DO_CONVERT_START(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
   case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_FLOAT: 
       DO_CONVERT_START(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_DOUBLE:     return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]=double2string((*this)[i]);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -701,7 +778,7 @@ TRACE_CONVERT2
 	bytDim >> maxLen;
 
       	Data_<SpDByte>* dest=new Data_<SpDByte>( bytDim); // zero fields
-TRACEOMP( __FILE__, __LINE__)
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel
 {
 #pragma omp for
@@ -720,8 +797,8 @@ TRACEOMP( __FILE__, __LINE__)
     case GDL_INT:
       {
       	Data_<SpDInt>* dest=new Data_<SpDInt>( dim, BaseGDL::NOZERO);
- TRACEOMP( __FILE__, __LINE__)
- #pragma omp parallel shared( errorFlag, mode)
+   TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel shared( errorFlag, mode)
  {
  #pragma omp for
       	for( OMPInt i=0; i < nEl; ++i)
@@ -749,7 +826,7 @@ TRACEOMP( __FILE__, __LINE__)
     case GDL_UINT: 
       {
       	Data_<SpDUInt>* dest=new Data_<SpDUInt>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel shared( errorFlag, mode)
 {
 #pragma omp for
@@ -778,7 +855,7 @@ StringConversionError( errorFlag, mode, "Type conversion error: "
     case GDL_LONG: 
       {
       	Data_<SpDLong>* dest=new Data_<SpDLong>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel shared( errorFlag, mode)
 {
 #pragma omp for
@@ -807,7 +884,7 @@ StringConversionError( errorFlag, mode, "Type conversion error: "
     case GDL_ULONG: 
       {
       	Data_<SpDULong>* dest=new Data_<SpDULong>( dim, BaseGDL::NOZERO);
-TRACEOMP( __FILE__, __LINE__)
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel shared( errorFlag, mode)
 {
 #pragma omp for
@@ -1035,48 +1112,59 @@ TRACE_CONVERT2
   switch( destTy) {
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_COMPLEX:    return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       
 //FUTURE WORK: the version below is incredibely fast
@@ -1115,48 +1203,59 @@ TRACE_CONVERT2
   switch( destTy) {
     case GDL_BYTE:
       DO_CONVERT_START_CPX(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_INT:
       DO_CONVERT_START_CPX(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_UINT:
       DO_CONVERT_START_CPX(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_LONG:
       DO_CONVERT_START_CPX(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
   case GDL_ULONG: 
       DO_CONVERT_START_CPX(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
   case GDL_LONG64:
       DO_CONVERT_START_CPX(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_ULONG64:
       DO_CONVERT_START_CPX(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_FLOAT: 
       DO_CONVERT_START_CPX(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_DOUBLE: 
       DO_CONVERT_START_CPX(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END_CPX
     case GDL_COMPLEX: 
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:   return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i]="("+i2s(real((*this)[i]))+","+i2s(imag((*this)[i]))+")";
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -1189,48 +1288,59 @@ TRACE_CONVERT2
     switch (destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_ULONG64:
       DO_CONVERT_START(SpDULong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;
@@ -1262,48 +1372,59 @@ TRACE_CONVERT2
     switch (destTy) {
     case GDL_BYTE:
       DO_CONVERT_START(SpDByte)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_INT:
       DO_CONVERT_START(SpDInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_UINT:
       DO_CONVERT_START(SpDUInt)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG:
       DO_CONVERT_START(SpDLong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG:
       DO_CONVERT_START(SpDULong)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_LONG64:
       DO_CONVERT_START(SpDLong64)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_ULONG64:       return (((mode & BaseGDL::COPY) != 0) ? Dup():this);
     case GDL_FLOAT:
       DO_CONVERT_START(SpDFloat)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_DOUBLE:
       DO_CONVERT_START(SpDDouble)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEX:
       DO_CONVERT_START(SpDComplex)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_COMPLEXDBL:
       DO_CONVERT_START(SpDComplexDbl)
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
       Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for
       for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
       if ((mode & BaseGDL::CONVERT) != 0) delete this;

--- a/src/convol.cpp
+++ b/src/convol.cpp
@@ -219,24 +219,26 @@ namespace lib {
         mrep[maxpos]=0;
     }
     /***************************************Preparing_matrices*************************************************/
-     
-    //Computations for REAL and COMPLEX are better made in double precision if we do not want to lose precision
-    //Apparently IDL has severe problems regarding this loss of precision.
-    // try for example the following, which should give exactly ZERO:
-    // C=32*32*0.34564 & a=findgen(100,100)*0.0+1 & b=convol(a,fltarr(32,32)+0.34564) & print,(b-c)[20:80,50],format='(4(F20.12))' 
-    //So, we convert p0 to Double precision if necessary and convert back result.
-    //Do it here since all other parameters are converted to  p0's type.
-    Guard<BaseGDL> p0Guard;
-    bool deprecise=false;
-    if (p0->Type() == GDL_FLOAT) {
-        p0 = p0->Convert2(GDL_DOUBLE, BaseGDL::COPY);
-        p0Guard.Reset(p0);
-        deprecise=true;
-    } else if (p0->Type() == GDL_COMPLEX) {
-        p0 = p0->Convert2(GDL_COMPLEXDBL, BaseGDL::COPY);
-        p0Guard.Reset(p0);
-        deprecise=true;
-    }
+
+    // gain of precision removed: was contradictory twith the necessity to stick to IDL's results.
+    
+//    //Computations for REAL and COMPLEX are better made in double precision if we do not want to lose precision
+//    //Apparently IDL has severe problems regarding this loss of precision.
+//    // try for example the following, which should give exactly ZERO:
+//    // C=32*32*0.34564 & a=findgen(100,100)*0.0+1 & b=convol(a,fltarr(32,32)+0.34564) & print,(b-c)[20:80,50],format='(4(F20.12))' 
+//    //So, we convert p0 to Double precision if necessary and convert back result.
+//    //Do it here since all other parameters are converted to  p0's type.
+//    Guard<BaseGDL> p0Guard;
+//    bool deprecise=false;
+//    if (p0->Type() == GDL_FLOAT) {
+//        p0 = p0->Convert2(GDL_DOUBLE, BaseGDL::COPY);
+//        p0Guard.Reset(p0);
+//        deprecise=true;
+//    } else if (p0->Type() == GDL_COMPLEX) {
+//        p0 = p0->Convert2(GDL_COMPLEXDBL, BaseGDL::COPY);
+//        p0Guard.Reset(p0);
+//        deprecise=true;
+//    }
  
     // convert kernel to array type
     Guard<BaseGDL> p1Guard;
@@ -367,7 +369,7 @@ namespace lib {
       DComplexDbl tmp=std::complex<DDouble>(std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN());
       memcpy((*missing).DataAddr(), &tmp, sizeof(tmp));
     }
-    BaseGDL* result;
+    BaseGDL* result;   
     //handle transpositions
     if (doTranspose) {
       BaseGDL* input;
@@ -381,13 +383,13 @@ namespace lib {
       result=input->Convol(transpP1, scale, bias, center, normalize, edgeMode, doNan, missing, doMissing, invalid, doInvalid)->Transpose(mrep);
     } else result=p0->Convol( p1, scale, bias, center, normalize, edgeMode, doNan, missing, doMissing, invalid, doInvalid);
     
-    if (deprecise) {
-      Guard<BaseGDL> resultGuard;
-      resultGuard.reset(result);
-      if (p0->Type() == GDL_DOUBLE) return result->Convert2(GDL_FLOAT, BaseGDL::COPY);
-      else if (p0->Type() == GDL_COMPLEXDBL) return result->Convert2(GDL_COMPLEX, BaseGDL::COPY);
-      else return result; //should not happen!
-    } else 
+//    if (deprecise) {
+//      Guard<BaseGDL> resultGuard;
+//      resultGuard.reset(result);
+//      if (p0->Type() == GDL_DOUBLE) return result->Convert2(GDL_FLOAT, BaseGDL::COPY);
+//      else if (p0->Type() == GDL_COMPLEXDBL) return result->Convert2(GDL_COMPLEX, BaseGDL::COPY);
+//      else return result; //should not happen!
+//    } else 
       
       return result; 
     

--- a/src/convol_inc.cpp
+++ b/src/convol_inc.cpp
@@ -223,23 +223,36 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doNan = false;
     doInvalid=false;
+    if (!parallelize( nA)) {
+      for (SizeT i = 0; i < nA; ++i) {
+        if (!gdlValid(ddP[i])) {
+          doNan = true;
+        }
+        if (ddP[i] == invalidValue) {
+          doInvalid = true;
+        }
+      }      
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
-    {
-#pragma omp for
-    for( OMPInt i=0; i<nA; ++i)  {
-        if (!gdlValid(ddP[i])) {doNan=true;}
-        if (ddP[i] == invalidValue) {doInvalid=true;}
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nA; ++i) {
+        if (!gdlValid(ddP[i])) {
+          doNan = true;
+        }
+        if (ddP[i] == invalidValue) {
+          doInvalid = true;
+        }
       }
     }
   }
   else if(doNan)
   {
     doNan = false;
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
-    {
-#pragma omp for
+    if (!parallelize( nA)) {
+    for(SizeT i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
+    } else {
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( OMPInt i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
     }
   }
@@ -247,10 +260,10 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doInvalid)
   {
     doInvalid=false;
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
-    {
-#pragma omp for
+    if (!parallelize( nA)) {
+    for(SizeT i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}
+    } else {
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( OMPInt i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}
     }
   }

--- a/src/convol_inc.cpp
+++ b/src/convol_inc.cpp
@@ -223,7 +223,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doNan = false;
     doInvalid=false;
-    if (GDL_NTHREADS=parallelize( nA)==1) {
+    if ((GDL_NTHREADS=parallelize( nA))==1) {
       for (SizeT i = 0; i < nA; ++i) {
         if (!gdlValid(ddP[i])) {
           doNan = true;
@@ -248,7 +248,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doNan)
   {
     doNan = false;
-    if (GDL_NTHREADS=parallelize( nA)==1) {
+    if ((GDL_NTHREADS=parallelize( nA))==1) {
     for(SizeT i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -260,7 +260,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doInvalid)
   {
     doInvalid=false;
-    if (GDL_NTHREADS=parallelize( nA)==1) {
+    if ((GDL_NTHREADS=parallelize( nA))==1) {
     for(SizeT i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}
     } else {
 #pragma omp parallel for num_threads(GDL_NTHREADS)

--- a/src/convol_inc.cpp
+++ b/src/convol_inc.cpp
@@ -223,7 +223,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doNan = false;
     doInvalid=false;
-    if (!parallelize( nA)) {
+    if (GDL_NTHREADS=parallelize( nA)==1) {
       for (SizeT i = 0; i < nA; ++i) {
         if (!gdlValid(ddP[i])) {
           doNan = true;
@@ -234,7 +234,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
       }      
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nA; ++i) {
         if (!gdlValid(ddP[i])) {
           doNan = true;
@@ -248,11 +248,11 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doNan)
   {
     doNan = false;
-    if (!parallelize( nA)) {
+    if (GDL_NTHREADS=parallelize( nA)==1) {
     for(SizeT i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( OMPInt i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
     }
   }
@@ -260,10 +260,10 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doInvalid)
   {
     doInvalid=false;
-    if (!parallelize( nA)) {
+    if (GDL_NTHREADS=parallelize( nA)==1) {
     for(SizeT i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}
     } else {
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( OMPInt i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}
     }
   }
@@ -288,14 +288,13 @@ static bool* regArrRef[33];
 // historical version, slow but true and tested (well, a few bugs were cured along with this version). 
   long chunksize=nA;
   long nchunk=1;
-  if (nA > 1000) { //no use start parallel threading for small numbers.
-    chunksize=nA/((CpuTPOOL_NTHREADS>32)?32:CpuTPOOL_NTHREADS);
-    long n_dim0=chunksize/dim0; chunksize=dim0*n_dim0; //ensures chunksize integer number of dim0.
-    if (chunksize>0) {
-      nchunk=nA/chunksize;
-      if (chunksize*nchunk < nA) ++nchunk;
-    } else {nchunk=1; chunksize=nA;}
-  }
+  GDL_NTHREADS=parallelize( nA, TP_MEMORY_ACCESS);
+  chunksize=nA/((GDL_NTHREADS>32)?32:GDL_NTHREADS);
+  long n_dim0=chunksize/dim0; chunksize=dim0*n_dim0; //ensures chunksize integer number of dim0.
+  if (chunksize>0) {
+    nchunk=nA/chunksize;
+    if (chunksize*nchunk < nA) ++nchunk;
+  } else {nchunk=1; chunksize=nA;}
 // build a nchunk times copy of the master offset table (accelerator). Each thread will use its own copy, properly initialized.
 // GD: could the offset accelerator be made easier? This would certainly simplify the code.
   long  aInitIxT[ MAXRANK+1]; //T for template

--- a/src/convol_inc.cpp
+++ b/src/convol_inc.cpp
@@ -223,6 +223,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doNan = false;
     doInvalid=false;
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
     {
 #pragma omp for
@@ -235,6 +236,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doNan)
   {
     doNan = false;
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
     {
 #pragma omp for
@@ -245,6 +247,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   else if(doInvalid)
   {
     doInvalid=false;
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
     {
 #pragma omp for

--- a/src/convol_inc.cpp
+++ b/src/convol_inc.cpp
@@ -224,7 +224,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
     doNan = false;
     doInvalid=false;
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
+#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
     {
 #pragma omp for
     for( OMPInt i=0; i<nA; ++i)  {
@@ -237,7 +237,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doNan = false;
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
+#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
     {
 #pragma omp for
     for( OMPInt i=0; i<nA; ++i)  if (!gdlValid(ddP[i])) {doNan=true;}
@@ -248,7 +248,7 @@ BaseGDL* Data_<Sp>::Convol( BaseGDL* kIn, BaseGDL* scaleIn, BaseGDL* biasIn,
   {
     doInvalid=false;
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nA))
+#pragma omp parallel if (nA >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nA))
     {
 #pragma omp for
     for( OMPInt i=0; i<nA; ++i)  if (ddP[i] == invalidValue) {doInvalid=true;}

--- a/src/convol_inc0.cpp
+++ b/src/convol_inc0.cpp
@@ -19,8 +19,8 @@ edgemode = 0 (skip)
 // to be included from convol.cpp
 // NOTE: All the unreadble #ifdef below are there to avoid IF constructs which results in much faster code when optimization is on.
 #ifdef INCLUDE_CONVOL_INC_CPP
-
 // for all result elements
+TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) firstprivate(scale,bias) shared(ker,kIxArr,res,aInitIxRef,regArrRef,nchunk,chunksize,aBeg,aEnd,nDim,aBeg0,aStride,ddP,invalidValue,kDim0,kDim0_nDim,nKel,missingValue,aEnd0,dim0,nA,absker,biasker) //default(none)
   {
 #pragma omp for

--- a/src/convol_inc1.cpp
+++ b/src/convol_inc1.cpp
@@ -19,7 +19,7 @@
 // NOTE: All the unreadble #ifdef below are there to avoid IF constructs which results in much faster code when optimization is on.
 
 #ifdef INCLUDE_CONVOL_INC_CPP
-
+TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) firstprivate(scale,bias) shared(ker,kIxArr,res,aInitIxRef,regArrRef,nchunk,chunksize,aBeg,aEnd,nDim,aBeg0,aStride,ddP,invalidValue,kDim0,kDim0_nDim,nKel,missingValue,aEnd0,dim0,nA,absker,biasker,dim0_1) //default(none)
   {
 #pragma omp for

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -1610,7 +1610,7 @@ BaseGDL* Data_<Sp>::Rotate( DLong dir) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     if (dir == 7) return Dup();
 
     if (dir == 1 || dir == 4) {
-      return new Data_(dimension(1, N_Elements()==1), dd);
+      return new Data_(dimension(1, N_Elements()), dd);
     }
     if (dir == 5) // || dir == 2
     {

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -329,8 +329,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -341,8 +340,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       if (off==0 && inc==1) { 
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
@@ -371,8 +369,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -381,8 +378,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -414,8 +410,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -424,8 +419,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -465,8 +459,7 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
 
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -484,8 +477,7 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
   
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) { //most frequent
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -504,8 +496,7 @@ template<class Sp>
 Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), false) { 
   this->dim.Purge(); //useful?
   SizeT sz = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-  if (!parallelize) { //most frequent
+  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -562,8 +553,7 @@ BaseGDL* Data_<SpDFloat>::Log() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -582,8 +572,7 @@ BaseGDL* Data_<SpDDouble>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -601,8 +590,7 @@ BaseGDL* Data_<SpDComplex>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -620,8 +608,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -650,8 +637,7 @@ BaseGDL* Data_<SpDFloat>::LogThis() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -669,8 +655,7 @@ BaseGDL* Data_<SpDDouble>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -688,8 +673,7 @@ BaseGDL* Data_<SpDComplex>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -706,8 +690,7 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -734,8 +717,7 @@ BaseGDL* Data_<SpDFloat>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -754,8 +736,7 @@ BaseGDL* Data_<SpDDouble>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -774,8 +755,7 @@ BaseGDL* Data_<SpDComplex>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -794,8 +774,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -821,8 +800,7 @@ BaseGDL* Data_<SpDFloat>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -840,8 +818,7 @@ BaseGDL* Data_<SpDDouble>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -858,8 +835,7 @@ BaseGDL* Data_<SpDComplex>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -876,8 +852,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -1350,12 +1325,12 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   SizeT nElem = dd.size();
   long chunksize = nElem;
   long nchunk = 1;
-  bool parallelize = false;
+  bool do_parallel = false;
   if (CpuTPOOL_NTHREADS > 1 && nElem > CpuTPOOL_MIN_ELTS) { //no use start parallel threading for small numbers.
     chunksize = nElem / ((CpuTPOOL_NTHREADS > 32) ? 32 : CpuTPOOL_NTHREADS);
     nchunk = nElem / chunksize;
     if (chunksize * nchunk < nElem) ++nchunk;
-    parallelize = true;
+    do_parallel = true;
   }
 
   //compute start parameter for each multiWalk chunks:
@@ -1380,7 +1355,7 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
     for (long j = 0; j < rank; ++j) srcDimPool[iloop][j] = templateDim[j];
   }
 
-  if (!parallelize) {
+  if (!do_parallel) {
     for (long iloop = 0; iloop < nchunk; ++iloop) {
       // populate src multi dim
       SizeT srcDim[MAXRANK];
@@ -1431,7 +1406,7 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
 }
 
 // used by reverse
-
+// NOT A TP function
 template<class Sp>
 void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // SA: based on total_over_dim_template()
@@ -1441,8 +1416,7 @@ void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE_
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride));
-  if (!parallelize) {  //most frequent
+  if (!parallelize((nEl/outerStride)*revStride, TP_MEMORY_ACCESS)) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1458,7 +1432,7 @@ void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE_
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
+#pragma omp parallel
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1487,8 +1461,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
-  if (!parallelize) {  //most frequent
+  if (!parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1504,7 +1477,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
+#pragma omp parallel
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1534,8 +1507,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
-  if (!parallelize) {  //most frequent
+  if (!parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1550,7 +1522,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
+#pragma omp parallel
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1580,8 +1552,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
-  if (!parallelize) {  //most frequent
+  if (!parallelize((nEl / outerStride) * revStride), TP_MEMORY_ACCESS) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1596,7 +1567,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
+#pragma omp parallel
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1711,8 +1682,7 @@ typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
   TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
   Ty s = dd[ 0];
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1739,8 +1709,7 @@ Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const { TRACE_ROUTINE(__FUN
   DDouble sr = dd[ 0].real();
   DDouble si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
@@ -1761,8 +1730,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const { TRACE_ROUTINE(__FUNCTION_
   DFloat sr = dd[ 0].real();
   DFloat si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-  if (!parallelize) { //most frequent
+  if (!parallelize( nEl)) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
@@ -2050,8 +2018,7 @@ Data_<Sp>* Data_<Sp>::New( const dimension& dim_, BaseGDL::InitType noZero) cons
     {
       Data_* res =  new Data_(dim_, BaseGDL::NOZERO);
       SizeT nEl = res->dd.size();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) { //most frequent
+      if (!parallelize( nEl, TP_ARRAY_INITIALISATION)) { //most frequent
       for( SizeT i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
       } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -2446,7 +2413,7 @@ RangeT Data_<SpDObj>::LoopIndex() const
 // True
 template<class Sp>
 bool Data_<Sp>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2455,7 +2422,7 @@ bool Data_<Sp>::True()
 
 template<>
 bool Data_<SpDFloat>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2464,7 +2431,7 @@ bool Data_<SpDFloat>::True()
 
 template<>
 bool Data_<SpDDouble>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2473,7 +2440,7 @@ bool Data_<SpDDouble>::True()
 
 template<>
 bool Data_<SpDString>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2482,7 +2449,7 @@ bool Data_<SpDString>::True()
 
 template<>
 bool Data_<SpDComplex>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2490,7 +2457,7 @@ bool Data_<SpDComplex>::True()
 }
 template<>
 bool Data_<SpDComplexDbl>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2499,7 +2466,7 @@ bool Data_<SpDComplexDbl>::True()
 
 template<>
 bool Data_<SpDPtr>::True()
-{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+{
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3736,8 +3703,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
   SizeT gap = this->dim.Stride (atDim + 1); // dest array
   
 //GD: speed up by using indexing that permit parallel and collapse.
-  bool parallelize=(CpuTPOOL_NTHREADS >1 && len*nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= len*nCp));
-  if (!parallelize) { //most frequent
+  if (!parallelize( len*nCp, TP_MEMORY_ACCESS)) { //most frequent
     for (OMPInt c = 0; c < nCp; ++c) {
       for (SizeT destIx = 0; destIx < len; destIx++) (*this)[destIx + destStart + c * gap] = (*srcArr)[ destIx + c * len];
     }
@@ -4613,8 +4579,13 @@ Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  for( int c=0; c<nCp; ++c)
-    (*res)[c]=(*this)[ (*ix)[ c]];
+  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+    for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ (*ix)[ c]];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+    for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ (*ix)[ c]];
+  }
   return res;
 }
 template<class Sp>
@@ -4622,8 +4593,13 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  for( int c=0; c<nCp; ++c)
-    (*res)[c]=(*this)[ s+c];
+  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+   for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+   for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
+  }
   return res;
 }
 template<class Sp>
@@ -4631,8 +4607,13 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  for( int c=0; c<nCp; ++c)
-    (*res)[c]=(*this)[ s+c];
+  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+  for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
+  }else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+  for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
+  }
   return res;
 }
 template<class Sp>
@@ -4640,8 +4621,7 @@ Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT stride)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = (dd.size() - s + stride - 1)/stride;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  for( SizeT c=0; c<nCp; ++c, s += stride)
-    (*res)[c]=(*this)[ s];
+  for( SizeT c=0; c<nCp; ++c, s += stride) (*res)[c]=(*this)[ s];
   return res;
 }
 template<class Sp>
@@ -4649,8 +4629,7 @@ Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT e, SizeT stride)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = (e - s + stride)/stride;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  for( SizeT c=0; c<nCp; ++c, s += stride)
-    (*res)[c]=(*this)[ s];
+  for( SizeT c=0; c<nCp; ++c, s += stride)  (*res)[c]=(*this)[ s];
   return res;
 }
 

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -336,7 +336,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -347,7 +347,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       if (off==0 && inc==1) { 
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
@@ -376,7 +376,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -385,7 +385,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -417,7 +417,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -426,7 +426,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -466,7 +466,7 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
 
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -484,7 +484,7 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
   
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -503,7 +503,7 @@ template<class Sp>
 Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), false) { 
   this->dim.Purge(); //useful?
   SizeT sz = dd.size();
-  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) { //most frequent
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -560,7 +560,7 @@ BaseGDL* Data_<SpDFloat>::Log() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -579,7 +579,7 @@ BaseGDL* Data_<SpDDouble>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -597,7 +597,7 @@ BaseGDL* Data_<SpDComplex>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -615,7 +615,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -644,7 +644,7 @@ BaseGDL* Data_<SpDFloat>::LogThis() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -662,7 +662,7 @@ BaseGDL* Data_<SpDDouble>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -680,7 +680,7 @@ BaseGDL* Data_<SpDComplex>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -697,7 +697,7 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -724,7 +724,7 @@ BaseGDL* Data_<SpDFloat>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -743,7 +743,7 @@ BaseGDL* Data_<SpDDouble>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -762,7 +762,7 @@ BaseGDL* Data_<SpDComplex>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -781,7 +781,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -807,7 +807,7 @@ BaseGDL* Data_<SpDFloat>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -825,7 +825,7 @@ BaseGDL* Data_<SpDDouble>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -842,7 +842,7 @@ BaseGDL* Data_<SpDComplex>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -859,7 +859,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -1477,7 +1477,7 @@ void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE_
   if (this->dim[dim]%2) halfDim++;
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT span=outerStride - revStride;
-  if (GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS)==1) {  //most frequent
+  if ((GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS))==1) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = o; i < o+revStride; ++i) {
         for (SizeT s = i, opp=span+i; s < halfDim+i  ; s += revStride, opp-=revStride) {
@@ -1515,7 +1515,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   if (this->dim[dim]%2) halfDim++;
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT span=outerStride - revStride;
-  if (GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS)==1) {  //most frequent
+  if ((GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS))==1) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = o; i < o+revStride; ++i) {
         for (SizeT s = i, opp=span+i; s < halfDim+i  ; s += revStride, opp-=revStride) {
@@ -1722,7 +1722,7 @@ typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
   TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
   Ty s = dd[ 0];
   SizeT nEl = dd.size();
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -1749,7 +1749,7 @@ Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const { TRACE_ROUTINE(__FUN
   DDouble sr = dd[ 0].real();
   DDouble si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
@@ -1770,7 +1770,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const { TRACE_ROUTINE(__FUNCTION_
   DFloat sr = dd[ 0].real();
   DFloat si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( nEl))==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
@@ -2058,7 +2058,7 @@ Data_<Sp>* Data_<Sp>::New( const dimension& dim_, BaseGDL::InitType noZero) cons
     {
       Data_* res =  new Data_(dim_, BaseGDL::NOZERO);
       SizeT nEl = res->dd.size();
-      if (GDL_NTHREADS=parallelize( nEl, TP_ARRAY_INITIALISATION)==1) { //most frequent
+      if ((GDL_NTHREADS=parallelize( nEl, TP_ARRAY_INITIALISATION))==1) { //most frequent
       for( SizeT i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
       } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -3743,7 +3743,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
   SizeT gap = this->dim.Stride (atDim + 1); // dest array
   
 //GD: speed up by using indexing that permit parallel and collapse.
-  if (GDL_NTHREADS=parallelize( len*nCp, TP_MEMORY_ACCESS)==1) { //most frequent
+  if ((GDL_NTHREADS=parallelize( len*nCp, TP_MEMORY_ACCESS))==1) { //most frequent
     for (OMPInt c = 0; c < nCp; ++c) {
       for (SizeT destIx = 0; destIx < len; destIx++) (*this)[destIx + destStart + c * gap] = (*srcArr)[ destIx + c * len];
     }
@@ -4619,7 +4619,7 @@ Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
+  if ((GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS))==1) {
     for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ (*ix)[ c]];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4633,7 +4633,7 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
+  if ((GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS))==1) {
    for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -4647,7 +4647,7 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
+  if ((GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS))==1) {
   for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   }else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -4220,10 +4220,12 @@ BaseGDL* Data_<Sp>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key=float(this->dim[d] / dim)+0.01*d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4239,10 +4241,12 @@ BaseGDL* Data_<Sp>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key=float(dim / this->dim[d])+0.01*d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4286,10 +4290,12 @@ BaseGDL* Data_<SpDByte>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4305,10 +4311,12 @@ BaseGDL* Data_<SpDByte>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4347,10 +4355,12 @@ BaseGDL* Data_<SpDInt>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4366,10 +4376,12 @@ BaseGDL* Data_<SpDInt>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4408,10 +4420,12 @@ BaseGDL* Data_<SpDUInt>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4427,10 +4441,12 @@ BaseGDL* Data_<SpDUInt>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4469,10 +4485,12 @@ BaseGDL* Data_<SpDLong>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4488,10 +4506,12 @@ BaseGDL* Data_<SpDLong>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4530,10 +4550,12 @@ BaseGDL* Data_<SpDULong>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4549,10 +4571,12 @@ BaseGDL* Data_<SpDULong>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4590,10 +4614,12 @@ BaseGDL* Data_<SpDLong64>::Rebin(const dimension& newDim, bool sample) {
   // so the key is a real, composed by the compression factor+dim/100. Sufficient to have 2 keys different and still order OK.
   std::map<float, SizeT>compress;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction  
-    if (dim < this->dim[d]) {
-      float key = float(this->dim[d] / dim) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protetion  
+    if (newdim < olddim) {
+      float key=float(olddim / newdim)+0.01*d;
       compress.insert(std::pair<float, SizeT>(key, d));
     }
   }
@@ -4609,10 +4635,12 @@ BaseGDL* Data_<SpDLong64>::Rebin(const dimension& newDim, bool sample) {
   // 2nd expand : make the biggest expansion last
   std::map<float, SizeT>expand;
   for (SizeT d = 0; d < nDim; ++d) {
-    SizeT dim = newDim[d];
-    if (dim == 0) dim = 1; //protction, kept for symmetry with above, but unuseful
-    if (dim > this->dim[d]) {
-      float key = float(dim / this->dim[d]) + 0.01 * d;
+    SizeT newdim = newDim[d];
+    SizeT olddim = this->dim[d];
+    if (newdim == 0) newdim = 1; //protetion  
+    if (olddim == 0) olddim = 1; //protection
+    if (newdim > olddim) {
+      float key=float(newdim / olddim)+0.01*d;
       expand.insert(std::pair<float, SizeT>(key, d));
     }
   }

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -329,18 +329,18 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
   
   else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       if (off==0 && inc==1) { 
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
@@ -349,11 +349,11 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     } else {
       if (off==0 && inc==1) { 
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=off+i*inc;
       }
     }
@@ -369,16 +369,16 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -389,13 +389,13 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     } else {
       if (off == 0 && inc == 1) {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
     }
@@ -410,16 +410,16 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
@@ -430,13 +430,13 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     } else {
       if (off == 0 && inc == 1) {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
     }
@@ -459,11 +459,11 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
 
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
@@ -477,11 +477,11 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
   
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
@@ -496,11 +496,11 @@ template<class Sp>
 Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), false) { 
   this->dim.Purge(); //useful?
   SizeT sz = dd.size();
-  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) { //most frequent
+  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) { //most frequent
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   }
 }
@@ -553,11 +553,11 @@ BaseGDL* Data_<SpDFloat>::Log() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -572,11 +572,11 @@ BaseGDL* Data_<SpDDouble>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -590,11 +590,11 @@ BaseGDL* Data_<SpDComplex>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -608,11 +608,11 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -637,11 +637,11 @@ BaseGDL* Data_<SpDFloat>::LogThis() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -655,11 +655,11 @@ BaseGDL* Data_<SpDDouble>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -673,11 +673,11 @@ BaseGDL* Data_<SpDComplex>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -690,11 +690,11 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -717,11 +717,11 @@ BaseGDL* Data_<SpDFloat>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -736,11 +736,11 @@ BaseGDL* Data_<SpDDouble>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -755,11 +755,11 @@ BaseGDL* Data_<SpDComplex>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -774,11 +774,11 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -800,11 +800,11 @@ BaseGDL* Data_<SpDFloat>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -818,11 +818,11 @@ BaseGDL* Data_<SpDDouble>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -835,11 +835,11 @@ BaseGDL* Data_<SpDComplex>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -852,11 +852,11 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -1326,8 +1326,9 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   long chunksize = nElem;
   long nchunk = 1;
   bool do_parallel = false;
-  if (CpuTPOOL_NTHREADS > 1 && nElem > CpuTPOOL_MIN_ELTS) { //no use start parallel threading for small numbers.
-    chunksize = nElem / ((CpuTPOOL_NTHREADS > 32) ? 32 : CpuTPOOL_NTHREADS);
+  GDL_NTHREADS=parallelize( nElem, TP_MEMORY_ACCESS);
+  if (GDL_NTHREADS > 1) { //no use start parallel threading for small numbers.
+    chunksize = nElem /  GDL_NTHREADS;
     nchunk = nElem / chunksize;
     if (chunksize * nchunk < nElem) ++nchunk;
     do_parallel = true;
@@ -1416,7 +1417,7 @@ void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE_
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  if (!parallelize((nEl/outerStride)*revStride, TP_MEMORY_ACCESS)) {  //most frequent
+  if (GDL_NTHREADS=parallelize((nEl/outerStride)*revStride, TP_MEMORY_ACCESS)==1) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1461,7 +1462,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  if (!parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)) {  //most frequent
+  if (GDL_NTHREADS=parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)==1) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1507,7 +1508,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  if (!parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)) {  //most frequent
+  if (GDL_NTHREADS=parallelize((nEl / outerStride) * revStride, TP_MEMORY_ACCESS)==1) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1552,7 +1553,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FIL
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  if (!parallelize((nEl / outerStride) * revStride), TP_MEMORY_ACCESS) {  //most frequent
+  if (GDL_NTHREADS=parallelize((nEl / outerStride) * revStride), TP_MEMORY_ACCESS) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1609,7 +1610,7 @@ BaseGDL* Data_<Sp>::Rotate( DLong dir) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
     if (dir == 7) return Dup();
 
     if (dir == 1 || dir == 4) {
-      return new Data_(dimension(1, N_Elements()), dd);
+      return new Data_(dimension(1, N_Elements()==1), dd);
     }
     if (dir == 5) // || dir == 2
     {
@@ -1682,11 +1683,11 @@ typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
   TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
   Ty s = dd[ 0];
   SizeT nEl = dd.size();
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:s)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:s)
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   }
   return s;
@@ -1709,14 +1710,14 @@ Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const { TRACE_ROUTINE(__FUN
   DDouble sr = dd[ 0].real();
   DDouble si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:si,sr)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:si,sr)
       for (SizeT i = 1; i < nEl; ++i) {
         sr += dd[i].real();
         si += dd[i].imag();
@@ -1730,14 +1731,14 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const { TRACE_ROUTINE(__FUNCTION_
   DFloat sr = dd[ 0].real();
   DFloat si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  if (!parallelize( nEl)) { //most frequent
+  if (GDL_NTHREADS=parallelize( nEl)==1) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
       si += dd[i].imag();
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) reduction(+:si,sr)
+#pragma omp parallel for num_threads(GDL_NTHREADS) reduction(+:si,sr)
       for (SizeT i = 1; i < nEl; ++i) {
         sr += dd[i].real();
         si += dd[i].imag();
@@ -2018,11 +2019,11 @@ Data_<Sp>* Data_<Sp>::New( const dimension& dim_, BaseGDL::InitType noZero) cons
     {
       Data_* res =  new Data_(dim_, BaseGDL::NOZERO);
       SizeT nEl = res->dd.size();
-      if (!parallelize( nEl, TP_ARRAY_INITIALISATION)) { //most frequent
+      if (GDL_NTHREADS=parallelize( nEl, TP_ARRAY_INITIALISATION)==1) { //most frequent
       for( SizeT i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
       } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for( SizeT i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
       }
       return res;
@@ -3703,13 +3704,13 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
   SizeT gap = this->dim.Stride (atDim + 1); // dest array
   
 //GD: speed up by using indexing that permit parallel and collapse.
-  if (!parallelize( len*nCp, TP_MEMORY_ACCESS)) { //most frequent
+  if (GDL_NTHREADS=parallelize( len*nCp, TP_MEMORY_ACCESS)==1) { //most frequent
     for (OMPInt c = 0; c < nCp; ++c) {
       for (SizeT destIx = 0; destIx < len; destIx++) (*this)[destIx + destStart + c * gap] = (*srcArr)[ destIx + c * len];
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) collapse(2)
+#pragma omp parallel for num_threads(GDL_NTHREADS) collapse(2)
     for (OMPInt c = 0; c < nCp; ++c)
       {
         //            // copy one segment
@@ -4579,11 +4580,11 @@ Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
     for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ (*ix)[ c]];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
     for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ (*ix)[ c]];
   }
   return res;
@@ -4593,11 +4594,11 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
    for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
    for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   }
   return res;
@@ -4607,11 +4608,11 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  if (!parallelize( nCp, TP_MEMORY_ACCESS)) {
+  if (GDL_NTHREADS=parallelize( nCp, TP_MEMORY_ACCESS)==1) {
   for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   }else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
   for( int c=0; c<nCp; ++c)  (*res)[c]=(*this)[ s+c];
   }
   return res;

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -32,6 +32,13 @@
 #define INCLUDE_DATATYPESREF_CPP 1
 #include "datatypesref.cpp"
 
+#ifdef USE_EIGEN  
+#if EIGEN_VERSION_AT_LEAST(3,3,7) //my version atthis time, works.
+#include<unsupported/Eigen/CXX11/Tensor>
+#define EIGEN_HAS_TENSOR
+#endif
+#endif
+
 #if defined(USE_PYTHON) || defined(PYTHON_MODULE)
 
 #  define INCLUDE_TOPYTHON_CPP 1
@@ -1254,8 +1261,6 @@ BaseGDL* Data_<Sp>::CShift( DLong s[ MAXRANK]) const { TRACE_ROUTINE(__FUNCTION_
   return sh;
 }
 
-
-
 // assumes *perm is already checked according to uniqness and length
 // dim[i]_out = dim[perm[i]]_in
 // helper function for Transpose()
@@ -1271,7 +1276,7 @@ template<class Sp>
 BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT rank = this->Rank();
 
-  if (rank == 1) // special case: vector
+ if (rank == 1) // special case: vector
   {
     if (perm != NULL) // must be [0]
     {
@@ -1321,7 +1326,63 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   // src stride
   SizeT srcStride[ MAXRANK + 1];
   this->dim.Stride(srcStride, rank);
+  
+#ifdef USE_EIGEN
+  if (rank == 2) // special case: eigen x 2
+  {
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mThis(&(*this)[0],  this->dim[0],  this->dim[1]);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mRes(&(*res)[0],  res->dim[0],  res->dim[1]);
+    mRes=mThis.transpose();
+    return res;
+  }
+#endif
+#ifdef EIGEN_HAS_TENSOR  
+  else if (rank == 3) // special case: eigen x 3
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
+  
+  else if (rank == 4) // special case: eigen x 4
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
+  else if (rank == 5) // special case: eigen x 5
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
+  else if (rank == 6) // special case: eigen x 6
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
+  else if (rank == 7) // special case: eigen x 7
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
+  else if (rank == 8) // special case: eigen x 8
+  {
+ Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6], this->dim[7]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6], res->dim[7]);
+ mRes=mThis.shuffle(perm);
+ return res;
+  }
 
+#endif
+  
   SizeT nElem = dd.size();
   long chunksize = nElem;
   long nchunk = 1;

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -333,6 +333,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
@@ -349,9 +350,11 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
       }
     } else {
       if (off==0 && inc==1) { 
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=off+i*inc;
       }
@@ -372,6 +375,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
@@ -388,11 +392,13 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
       }
     } else {
       if (off == 0 && inc == 1) {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
@@ -412,6 +418,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
@@ -428,11 +435,13 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
       }
     } else {
       if (off == 0 && inc == 1) {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
@@ -460,6 +469,7 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
@@ -478,6 +488,7 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
@@ -497,6 +508,7 @@ Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), fal
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   }
@@ -554,6 +566,7 @@ BaseGDL* Data_<SpDFloat>::Log() {
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
@@ -573,6 +586,7 @@ BaseGDL* Data_<SpDDouble>::Log()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
@@ -591,6 +605,7 @@ BaseGDL* Data_<SpDComplex>::Log()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
@@ -609,6 +624,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
@@ -638,6 +654,7 @@ BaseGDL* Data_<SpDFloat>::LogThis() {
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
@@ -656,6 +673,7 @@ BaseGDL* Data_<SpDDouble>::LogThis()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
@@ -674,6 +692,7 @@ BaseGDL* Data_<SpDComplex>::LogThis()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
@@ -691,6 +710,7 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
@@ -718,6 +738,7 @@ BaseGDL* Data_<SpDFloat>::Log10()
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
@@ -737,6 +758,7 @@ BaseGDL* Data_<SpDDouble>::Log10()
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
@@ -756,6 +778,7 @@ BaseGDL* Data_<SpDComplex>::Log10()
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
@@ -775,6 +798,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
@@ -801,6 +825,7 @@ BaseGDL* Data_<SpDFloat>::Log10This()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
@@ -819,6 +844,7 @@ BaseGDL* Data_<SpDDouble>::Log10This()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
@@ -836,6 +862,7 @@ BaseGDL* Data_<SpDComplex>::Log10This()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
@@ -853,6 +880,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
@@ -1374,6 +1402,7 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) {
     }
   } else {
 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) 
     {
 #pragma omp for 
@@ -1428,6 +1457,7 @@ void Data_<Sp>::Reverse(DLong dim) {
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
     {
 #pragma omp for
@@ -1473,6 +1503,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) {
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
     {
 #pragma omp for
@@ -1518,6 +1549,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
     {
 #pragma omp for
@@ -1563,6 +1595,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) {
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
     {
 #pragma omp for
@@ -1681,6 +1714,7 @@ typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
   if (!parallelize) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel shared( s)
     {
 #pragma omp for reduction(+:s)
@@ -1716,6 +1750,7 @@ Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const {
       si += dd[i].imag();
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel shared( sr,si)
     {
 #pragma omp for reduction(+:si,sr)
@@ -1740,6 +1775,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const {
       si += dd[i].imag();
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared( sr,si)
     {
 #pragma omp for reduction(+:si,sr)
@@ -3049,26 +3085,17 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
       if( ixList == NULL)
 	{
 	  SizeT nCp=Data_::N_Elements();
-
-	  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	    {
-	    #pragma omp for*/
 	  for( int c=0; c<nCp; ++c)
 	    (*this)[ c]=scalar;
-	  // }
 	}
       else
 	{
 	  SizeT nCp=ixList->N_Elements();
 	  
 	  AllIxBaseT* allIx = ixList->BuildIx();
-	  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	    {
-	    #pragma omp for*/
 	  (*this)[ allIx->InitSeqAccess()]=scalar;
 	  for( SizeT c=1; c<nCp; ++c)
 	    (*this)[ allIx->SeqAccess()]=scalar;
-	  //}	  //	    (*this)[ ixList->GetIx( c)]=scalar;
  	}
     }
   else
@@ -3084,12 +3111,9 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
 	    else
 	      throw GDLException("Source expression contains not enough elements.");
 	  }
-	  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	    {
-	    #pragma omp for*/
 	  for( int c=0; c<nCp; ++c)
 	    (*this)[ c]=(*src)[c+offset];
-	}//}
+	}
       else
 	{
  	  // crucial part
@@ -3113,13 +3137,9 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-		    {
-		    #pragma omp for*/
 		  (*this)[ allIx->InitSeqAccess()]=(*src)[0];
 		  for( SizeT c=1; c<nCp; ++c)
 		    (*this)[ allIx->SeqAccess()]=(*src)[c];
-		  // }		  //		(*this)[ ixList->GetIx( c)]=(*src)[c+offset];
 		}
 	      else
 		{
@@ -3128,13 +3148,9 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-		    {
-		    #pragma omp for*/
 		  (*this)[ allIx->InitSeqAccess()]=(*src)[offset];
 		  for( SizeT c=1; c<nCp; ++c)
 		    (*this)[ allIx->SeqAccess()]=(*src)[c+offset];
-		  // }		  //		(*this)[ ixList->GetIx( c)]=(*src)[c+offset];
 		}
 	    }
 	}
@@ -3163,15 +3179,8 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 	  Ty scalar=(*src)[0];
 	  AllIxBaseT* allIx = ixList->BuildIx();
 	  (*this)[ allIx->InitSeqAccess()]=scalar;
-	  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	    {
-	    #pragma omp for*/
 	  for( int c=1; c<nCp; ++c)
 	    (*this)[ allIx->SeqAccess()]=scalar;
-	  // 	    (*this)[ (*allIx)[ c]]=scalar;
-
-
-	  // }	  //	    (*this)[ ixList->GetIx( c)]=scalar;
 	}
     }
   else
@@ -3191,13 +3200,8 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 	  
 	  AllIxBaseT* allIx = ixList->BuildIx();
 	  (*this)[ allIx->InitSeqAccess()]=(*src)[0];
-	  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	    {
-	    #pragma omp for*/
 	  for( int c=1; c<nCp; ++c)
 	    (*this)[ allIx->SeqAccess()]=(*src)[c];
-	  // 	    (*this)[ (*allIx)[ c]]=(*src)[c];
-	  // }	  //		(*this)[ ixList->GetIx( c)]=(*src)[c+offset];
 	}
     }
 }
@@ -3215,18 +3219,8 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn)
 
       /*      dd = scalar;*/
       SizeT nCp=Data_::N_Elements();
-      
-      
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
 	(*this)[ c]=scalar;
-      // }      
-      //       SizeT nCp=Data_::N_Elements();
-
-      //       for( SizeT c=0; c<nCp; ++c)
-      // 	(*this)[ c]=scalar;
     }
   else
     {
@@ -3234,13 +3228,8 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn)
       
       // if (non-indexed) src is smaller -> just copy its number of elements
       if( nCp > srcElem) nCp=srcElem;
-      
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
 	(*this)[ c]=(*src)[c];
-      // }
     }
 }
 
@@ -3262,13 +3251,10 @@ void Data_<Sp>::DecAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
 
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()]--;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()]--;
-    }//    }
+    }
 }
 template<class Sp>
 void Data_<Sp>::IncAt( ArrayIndexListT* ixList) 
@@ -3286,13 +3272,10 @@ void Data_<Sp>::IncAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()]++;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()]++;
-    }//    }
+    }
 }
 // float, double
 template<>
@@ -3312,13 +3295,10 @@ void Data_<SpDFloat>::DecAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
 
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] -= 1.0f;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] -=1.0f;
-    }//    }
+    }
 }
 template<>
 void Data_<SpDFloat>::IncAt( ArrayIndexListT* ixList) 
@@ -3337,13 +3317,10 @@ void Data_<SpDFloat>::IncAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] += 1.0f;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] +=1.0f;
-    }//    }
+    }
 }
 template<>
 void Data_<SpDDouble>::DecAt( ArrayIndexListT* ixList) 
@@ -3362,13 +3339,10 @@ void Data_<SpDDouble>::DecAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] -= 1.0;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] -=1.0;
-    }//    }
+    }
 }
 template<>
 void Data_<SpDDouble>::IncAt( ArrayIndexListT* ixList) 
@@ -3387,13 +3361,10 @@ void Data_<SpDDouble>::IncAt( ArrayIndexListT* ixList)
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] += 1.0f;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] +=1.0f;
-    }//    }
+    }
 }
 // complex
 template<>
@@ -3405,26 +3376,19 @@ void Data_<SpDComplex>::DecAt( ArrayIndexListT* ixList)
 
       SizeT nCp=Data_::N_Elements();
       
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
+      TRACEOMP(__FILE__,__LINE__)
       for( int c=0; c<nCp; ++c)
 	(*this)[ c] -= 1.0;
-    }//    }
+    }
   else
     {
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] -= 1.0;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] -=1.0;
-      //       for( SizeT c=0; c<nCp; ++c)
-      // 	(*this)[ (*allIx)[ c]] -= 1.0;
-    }//    }
+    }
 }
 template<>
 void Data_<SpDComplex>::IncAt( ArrayIndexListT* ixList) 
@@ -3434,27 +3398,18 @@ void Data_<SpDComplex>::IncAt( ArrayIndexListT* ixList)
       //       dd += 1.0f;
 
       SizeT nCp=Data_::N_Elements();
-      
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
       	(*this)[ c] += 1.0;
-    }//    }
+    }
   else
     {
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] += 1.0;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] +=1.0;
-      //       for( SizeT c=0; c<nCp; ++c)
-      // 	(*this)[ (*allIx)[ c]] += 1.0;
-    }//    }
+    }
 }
 template<>
 void Data_<SpDComplexDbl>::DecAt( ArrayIndexListT* ixList) 
@@ -3464,27 +3419,18 @@ void Data_<SpDComplexDbl>::DecAt( ArrayIndexListT* ixList)
       //       dd -= 1.0;
 
       SizeT nCp=Data_::N_Elements();
-      
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
       	(*this)[ c] -= 1.0;
-    }//    }
+    }
   else
     {
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] -= 1.0;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] -=1.0;
-      //       for( SizeT c=0; c<nCp; ++c)
-      // 	(*this)[ (*allIx)[ c]] -= 1.0;
-    } //   }
+    }
 }
 template<>
 void Data_<SpDComplexDbl>::IncAt( ArrayIndexListT* ixList) 
@@ -3494,27 +3440,18 @@ void Data_<SpDComplexDbl>::IncAt( ArrayIndexListT* ixList)
       //       dd += 1.0;
 
       SizeT nCp=Data_::N_Elements();
-      
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
       	(*this)[ c] += 1.0;
-    }//    }
+    }
   else
     {
       SizeT nCp=ixList->N_Elements();
       
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ allIx->InitSeqAccess()] += 1.0;
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ allIx->SeqAccess()] +=1.0;
-      //       for( SizeT c=0; c<nCp; ++c)
-      // 	(*this)[ (*allIx)[ c]] += 1.0;
-    }//    }
+    }
 }
 // forbidden types
 template<>
@@ -3560,25 +3497,17 @@ void Data_<Sp>::InsertAt( SizeT offset, BaseGDL* srcIn,
   if( ixList == NULL)
     {
       SizeT nCp=src->N_Elements();
-
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       for( int c=0; c<nCp; ++c)
 	(*this)[ c+offset]=(*src)[c];
-    }//    }
+    }
   else
     {
       SizeT nCp=ixList->N_Elements();
 
       AllIxBaseT* allIx = ixList->BuildIx();
-      /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-	{
-	#pragma omp for*/
       (*this)[ offset]=(*src)[ allIx->InitSeqAccess()];
       for( SizeT c=1; c<nCp; ++c)
 	(*this)[ c+offset]=(*src)[ allIx->SeqAccess()];
-      //}      //	(*this)[ c+offset]=(*src)[ ixList->GetIx( c)];
     }
 }
 
@@ -3666,17 +3595,9 @@ Data_<Sp>* Data_<Sp>::Index( ArrayIndexListT* ixList)
       (*res)[0]=(*this)[ (*allIx)[ 0]];
       return res;
     }
-  //   else
-  //   {
-  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-    {
-    #pragma omp for*/
   (*res)[0]=(*this)[ allIx->InitSeqAccess()];
   for( SizeT c=1; c<nCp; ++c)
     (*res)[c]=(*this)[ allIx->SeqAccess()];
-  //}  //    res_(*this)[c]=(*this)[ (*allIx)[ c]];
-  //    (*res)[c]=(*this)[ ixList->GetIx(c)];
-  //   }
   return res;
 }
 
@@ -3825,6 +3746,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
       for (SizeT destIx = 0; destIx < len; destIx++) (*this)[destIx + destStart + c * gap] = (*srcArr)[ destIx + c * len];
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) collapse(2)
     for (OMPInt c = 0; c < nCp; ++c)
       {
@@ -4674,13 +4596,11 @@ void Data_<Sp>::Assign( BaseGDL* src, SizeT nEl)
   {
     srcT = static_cast<Data_*>( src);
   }
-  /*#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-    #pragma omp for*/
+  TRACEOMP(__FILE__,__LINE__)
   for(long k=0; k < nEl; ++k)
     {
       (*this)[ k] = (*srcT)[ k];
-    }//    }
+    }
 }
 
 
@@ -4698,12 +4618,9 @@ Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 {
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-    {
-    #pragma omp for*/
+  TRACEOMP(__FILE__,__LINE__)
   for( int c=0; c<nCp; ++c)
     (*res)[c]=(*this)[ (*ix)[ c]];
-  // }
   return res;
 }
 template<class Sp>
@@ -4711,12 +4628,8 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
 {
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-    {
-    #pragma omp for*/
   for( int c=0; c<nCp; ++c)
     (*res)[c]=(*this)[ s+c];
-  // }
   return res;
 }
 template<class Sp>
@@ -4724,12 +4637,8 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
 {
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  /*#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
-    {
-    #pragma omp for*/
   for( int c=0; c<nCp; ++c)
     (*res)[c]=(*this)[ s+c];
-  // }
   return res;
 }
 template<class Sp>

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -334,7 +334,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
@@ -351,11 +351,11 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     } else {
       if (off==0 && inc==1) { 
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
       } else {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=off+i*inc;
       }
     }
@@ -376,7 +376,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
@@ -393,13 +393,13 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     } else {
       if (off == 0 && inc == 1) {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
     }
@@ -419,7 +419,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
@@ -436,13 +436,13 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     } else {
       if (off == 0 && inc == 1) {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
       } else {
         DFloat f_off = off;
         DFloat f_inc = inc;
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = f_off + i * f_inc;
       }
     }
@@ -470,7 +470,7 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
@@ -489,7 +489,7 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     }
   }
@@ -509,7 +509,7 @@ Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), fal
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   }
 }
@@ -567,7 +567,7 @@ BaseGDL* Data_<SpDFloat>::Log() {
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -587,7 +587,7 @@ BaseGDL* Data_<SpDDouble>::Log()
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -606,7 +606,7 @@ BaseGDL* Data_<SpDComplex>::Log()
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -625,7 +625,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   }
   return n;
@@ -655,7 +655,7 @@ BaseGDL* Data_<SpDFloat>::LogThis() {
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -674,7 +674,7 @@ BaseGDL* Data_<SpDDouble>::LogThis()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -693,7 +693,7 @@ BaseGDL* Data_<SpDComplex>::LogThis()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -711,7 +711,7 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   }
   return this;
@@ -739,7 +739,7 @@ BaseGDL* Data_<SpDFloat>::Log10()
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -759,7 +759,7 @@ BaseGDL* Data_<SpDDouble>::Log10()
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -779,7 +779,7 @@ BaseGDL* Data_<SpDComplex>::Log10()
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -799,7 +799,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   }
   return n;
@@ -826,7 +826,7 @@ BaseGDL* Data_<SpDFloat>::Log10This()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -845,7 +845,7 @@ BaseGDL* Data_<SpDDouble>::Log10This()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -863,7 +863,7 @@ BaseGDL* Data_<SpDComplex>::Log10This()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -881,7 +881,7 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   }
   return this;
@@ -3747,7 +3747,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) collapse(2)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) collapse(2)
     for (OMPInt c = 0; c < nCp; ++c)
       {
         //            // copy one segment

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -1328,7 +1328,11 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   this->dim.Stride(srcStride, rank);
   
 #ifdef USE_EIGEN
-  if (rank == 2) // special case: eigen x 2
+  //for some reason, this simple eigen::code dos not like dimensions == 1, so cannot be used if this is the case.
+  bool try_eigen=true;
+  for (auto i=0; i< MAXRANK; ++i) if (this->dim[i]==1) try_eigen=false;
+
+  if (try_eigen && rank == 2) // special case: eigen x 2
   {
     Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mThis(&(*this)[0],  this->dim[0],  this->dim[1]);
     Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mRes(&(*res)[0],  res->dim[0],  res->dim[1]);
@@ -1337,7 +1341,7 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   }
 #endif
 #ifdef EIGEN_HAS_TENSOR  
-  else if (rank == 3) // special case: eigen x 3
+  else if (try_eigen && rank == 3) // special case: eigen x 3
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2]);
@@ -1345,35 +1349,35 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
  return res;
   }
   
-  else if (rank == 4) // special case: eigen x 4
+  else if (try_eigen && rank == 4) // special case: eigen x 4
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3]);
  mRes=mThis.shuffle(perm);
  return res;
   }
-  else if (rank == 5) // special case: eigen x 5
+  else if (try_eigen && rank == 5) // special case: eigen x 5
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4]);
  mRes=mThis.shuffle(perm);
  return res;
   }
-  else if (rank == 6) // special case: eigen x 6
+  else if (try_eigen && rank == 6) // special case: eigen x 6
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5]);
  mRes=mThis.shuffle(perm);
  return res;
   }
-  else if (rank == 7) // special case: eigen x 7
+  else if (try_eigen && rank == 7) // special case: eigen x 7
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6]);
  mRes=mThis.shuffle(perm);
  return res;
   }
-  else if (rank == 8) // special case: eigen x 8
+  else if (try_eigen && rank == 8) // special case: eigen x 8
   {
  Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6], this->dim[7]); 
  Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6], res->dim[7]);
@@ -1555,7 +1559,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
   if (this->dim[dim] % 2) halfDim++;
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT span = outerStride - revStride;
-  if (GDL_NTHREADS = parallelize(nEl, TP_MEMORY_ACCESS) == 1) { //most frequent
+  if ((GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS)) == 1) { //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = o; i < o + revStride; ++i) {
         for (SizeT s = i, opp = span + i; s < halfDim + i; s += revStride, opp -= revStride) {
@@ -1597,7 +1601,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim)  {
   if (this->dim[dim] % 2) halfDim++;
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT span = outerStride - revStride;
-  if (GDL_NTHREADS = parallelize(nEl, TP_MEMORY_ACCESS) == 1) { //most frequent
+  if ((GDL_NTHREADS=parallelize(nEl, TP_MEMORY_ACCESS)) == 1) { //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = o; i < o + revStride; ++i) {
         for (SizeT s = i, opp = span + i; s < halfDim + i; s += revStride, opp -= revStride) {

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -1331,11 +1331,15 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
   //for some reason, this simple eigen::code dos not like dimensions == 1, so cannot be used if this is the case.
   bool try_eigen=true;
   for (auto i=0; i< MAXRANK; ++i) if (this->dim[i]==1) try_eigen=false;
-
+  // eigen dims are long, and template deduction mechanism may throw on a narrowing of SizeT dim to long .
+  long indim[ MAXRANK ];
+   for (auto i=0; i< MAXRANK; ++i) indim[i]=this->dim[i];
+  long outdim[ MAXRANK ];
+   for (auto i=0; i< MAXRANK; ++i) outdim[i]=res->dim[i];     
   if (try_eigen && rank == 2) // special case: eigen x 2
   {
-    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mThis(&(*this)[0],  this->dim[0],  this->dim[1]);
-    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mRes(&(*res)[0],  res->dim[0],  res->dim[1]);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mThis(&(*this)[0],  indim[0],  indim[1]);
+    Eigen::Map<Eigen::Array<Ty, Eigen::Dynamic, Eigen::Dynamic>, Eigen::Aligned> mRes(&(*res)[0],  outdim[0],  outdim[1]);
     mRes=mThis.transpose();
     return res;
   }
@@ -1343,44 +1347,44 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__
 #ifdef EIGEN_HAS_TENSOR  
   else if (try_eigen && rank == 3) // special case: eigen x 3
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mThis(&(*this)[0], indim[0],  indim[1], indim[2]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 3>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2]);
  mRes=mThis.shuffle(perm);
  return res;
   }
   
   else if (try_eigen && rank == 4) // special case: eigen x 4
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mThis(&(*this)[0], indim[0],  indim[1], indim[2], indim[3]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 4>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2], outdim[3]);
  mRes=mThis.shuffle(perm);
  return res;
   }
   else if (try_eigen && rank == 5) // special case: eigen x 5
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mThis(&(*this)[0], indim[0],  indim[1], indim[2], indim[3], indim[4]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 5>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2], outdim[3], outdim[4]);
  mRes=mThis.shuffle(perm);
  return res;
   }
   else if (try_eigen && rank == 6) // special case: eigen x 6
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mThis(&(*this)[0], indim[0],  indim[1], indim[2], indim[3], indim[4], indim[5]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 6>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2], outdim[3], outdim[4], outdim[5]);
  mRes=mThis.shuffle(perm);
  return res;
   }
   else if (try_eigen && rank == 7) // special case: eigen x 7
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mThis(&(*this)[0], indim[0],  indim[1], indim[2], indim[3], indim[4], indim[5], indim[6]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 7>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2], outdim[3], outdim[4], outdim[5], outdim[6]);
  mRes=mThis.shuffle(perm);
  return res;
   }
   else if (try_eigen && rank == 8) // special case: eigen x 8
   {
- Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mThis(&(*this)[0], this->dim[0],  this->dim[1], this->dim[2], this->dim[3], this->dim[4], this->dim[5], this->dim[6], this->dim[7]); 
- Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mRes(&(*res)[0], res->dim[0],  res->dim[1], res->dim[2], res->dim[3], res->dim[4], res->dim[5], res->dim[6], res->dim[7]);
+ Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mThis(&(*this)[0], indim[0],  indim[1], indim[2], indim[3], indim[4], indim[5], indim[6], indim[7]); 
+ Eigen::TensorMap<Eigen::Tensor<Ty, 8>> mRes(&(*res)[0], outdim[0],  outdim[1], outdim[2], outdim[3], outdim[4], outdim[5], outdim[6], outdim[7]);
  mRes=mThis.shuffle(perm);
  return res;
   }

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -51,7 +51,7 @@
 #include "test_template_grouping.cpp"
 template<class Sp>
 void Data_<Sp>::TestTemplateGrouping()              
-{ 
+{  
 //   Ty ty = Test1();
   bool b = Test2();
 }
@@ -66,7 +66,7 @@ FreeListT Data_<Sp>::freeList;
 #ifdef GDLARRAY_DEBUG
 
 inline void TraceCache( SizeT& cacheSize, SizeT sz, bool cacheIsNull, SizeT smallArraySize)
-{
+{ 
   // 	if( cacheSize > smallArraySize && cacheSize == sz  && !cacheIsNull)
   // 			std::cout << "+++ CACHE HIT\tID: ("  << &cacheSize  << ")   sz: " << cacheSize << std::endl;
   // 	else
@@ -91,7 +91,7 @@ typename	GDLArray<Sp>::Ty* GDLArray<Sp>::cache = NULL;
 
 template<class Sp>
 typename GDLArray<Sp>::Ty* GDLArray<Sp>::Cached( SizeT newSize)
-{
+{ 
   assert( newSize > smallArraySize);
   if( cache != NULL && cacheSize == newSize)
     {
@@ -106,7 +106,7 @@ typename GDLArray<Sp>::Ty* GDLArray<Sp>::Cached( SizeT newSize)
 }
 
 template<class Sp>GDLArray<Sp>::GDLArray( const GDLArray<Sp>& cp) : sz( cp.size())
-{
+{ 
   TraceCache( cacheSize, sz, cache==NULL, smallArraySize);
 	  
   try {
@@ -117,7 +117,7 @@ template<class Sp>GDLArray<Sp>::GDLArray( const GDLArray<Sp>& cp) : sz( cp.size(
 }
 
 template<class Sp>GDLArray<Sp>::	GDLArray( SizeT s, bool b) : sz( s)
-{
+{ 
   TraceCache( cacheSize, sz, cache==NULL, smallArraySize);
 
   try {
@@ -126,7 +126,7 @@ template<class Sp>GDLArray<Sp>::	GDLArray( SizeT s, bool b) : sz( s)
 }
 
 template<class Sp>GDLArray<Sp>::	GDLArray( Ty val, SizeT s) : sz( s)
-{
+{ 
   TraceCache( cacheSize, sz, cache==NULL, smallArraySize);
 
   try {
@@ -137,7 +137,7 @@ template<class Sp>GDLArray<Sp>::	GDLArray( Ty val, SizeT s) : sz( s)
 }
 
 template<class Sp>GDLArray<Sp>::	GDLArray( const Ty* arr, SizeT s) : sz( s)
-{
+{ 
   TraceCache( cacheSize, sz, cache==NULL, smallArraySize);
 	  
   try {
@@ -147,7 +147,7 @@ template<class Sp>GDLArray<Sp>::	GDLArray( const Ty* arr, SizeT s) : sz( s)
 }
 
 template<class Sp>GDLArray<Sp>::~GDLArray() throw()
-{
+{ 
 #ifdef GDLARRAY_DEBUG
   if( buf == cache)
     std::cout << "~~~ recycled cache\tID: ("  << &cacheSize << ")   sz: " << sz << "\tcacheSize: " << cacheSize << std::endl;
@@ -180,7 +180,7 @@ template<class Sp>GDLArray<Sp>::~GDLArray() throw()
 // note: Structs are ok, since GDL cleans up the strings they may contain and uses GDLArray as raw memory
 template<>
 GDLArray<DString>::~GDLArray() throw()
-{
+{ 
   if ( buf != scalar )
     {
       delete[] buf;
@@ -194,7 +194,7 @@ template class GDLArray<char>;
 
 template<typename T>
 inline bool gdlValid( const T &value )
-{
+{ 
     T max_value = std::numeric_limits<T>::max();
     T min_value = - max_value;
     return ( ( min_value <= value && value <= max_value ) &&  (value == value));
@@ -217,7 +217,7 @@ inline bool gdlValid( const DComplexDbl &value )
 
 
 template<class Sp> void* Data_<Sp>::operator new( size_t bytes)
-{
+{ 
   assert( bytes == sizeof( Data_));
 
   if( freeList.size() > 0)
@@ -268,68 +268,68 @@ template<class Sp> void* Data_<Sp>::operator new( size_t bytes)
 }
 
 template<class Sp> void Data_<Sp>::operator delete( void *ptr)
-{
+{ 
   freeList.push_back( ptr);
 }
 
 
 
 // destructor
-template<class Sp> Data_<Sp>::~Data_() {}
+template<class Sp> Data_<Sp>::~Data_() { }
 template<> Data_<SpDPtr>::~Data_()
-{
+{ 
   if( this->dd.GetBuffer() != NULL)
     GDLInterpreter::DecRef( this);
 }
 template<> Data_<SpDObj>::~Data_()
-{
+{ 
   if( this->dd.GetBuffer() != NULL)
     GDLInterpreter::DecRefObj( this);
 }
 
 // default
-template<class Sp> Data_<Sp>::Data_(): Sp(), dd() {}
+template<class Sp> Data_<Sp>::Data_(): Sp(), dd() { }
 
 // scalar
 template<class Sp> Data_<Sp>::Data_(const Ty& d_): Sp(), dd(d_)
-{}
+{ }
 // template<> Data_<SpDPtr>::Data_(const Ty& d_): SpDPtr(), dd(d_)
-// {GDLInterpreter::IncRef(d_);}
+// { GDLInterpreter::IncRef(d_);}
 // template<> Data_<SpDObj>::Data_(const Ty& d_): SpDObj(), dd(d_)
-// {GDLInterpreter::IncRefObj(d_);}
+// { GDLInterpreter::IncRefObj(d_);}
 
 // new array, zero fields
 template<class Sp> Data_<Sp>::Data_(const dimension& dim_): 
   Sp( dim_), dd( Sp::zero, this->dim.NDimElements())
-{
+{ 
   this->dim.Purge();
 }
 
 // new one-dim array from Ty*
 template<class Sp> Data_<Sp>::Data_( const Ty* p, const SizeT nEl): 
   Sp( dimension( nEl)), dd( p, nEl)
-{}
+{ }
 template<> Data_<SpDPtr>::Data_( const Ty* p, const SizeT nEl):
   SpDPtr( dimension( nEl)), dd( p, nEl)
-{GDLInterpreter::IncRef(this);}
+{ GDLInterpreter::IncRef(this);}
 template<> Data_<SpDObj>::Data_( const Ty* p, const SizeT nEl):
   SpDObj( dimension( nEl)), dd( p, nEl)
-{GDLInterpreter::IncRefObj(this);}
+{ GDLInterpreter::IncRefObj(this);}
 
 // c-i 
 // template<class Sp> Data_<Sp>::Data_(const Data_& d_): 
-// Sp(d_.dim), dd(d_.dd) {}
+// Sp(d_.dim), dd(d_.dd) { }
 
 template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble off, DDouble inc):
   Sp( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
-{
+{ 
   this->dim.Purge();
   
   if (iT == BaseGDL::NOZERO) return;  //very frequent
   
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
@@ -341,7 +341,7 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
   
   else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       if (off==0 && inc==1) { 
          for (SizeT i = 0; i < sz; ++i) (*this)[i]=i;
@@ -364,14 +364,14 @@ template<class Sp> Data_<Sp>::Data_(const dimension& dim_, BaseGDL::InitType iT,
 
 //IDL uses floats increments and offset for floats and complex (normal) .
 template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble off, DDouble inc):
-  SpDFloat( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) {
+  SpDFloat( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) { 
   this->dim.Purge();
 
   if (iT == BaseGDL::NOZERO) return; //very frequent
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
@@ -381,7 +381,7 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
@@ -407,14 +407,14 @@ template<> Data_<SpDFloat>::Data_(const dimension& dim_, BaseGDL::InitType iT, D
 }
 
 template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble off, DDouble inc):
-  SpDComplex( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) {
+  SpDComplex( dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) { 
   this->dim.Purge();
 
   if (iT == BaseGDL::NOZERO) return; //very frequent
 
   if (iT == BaseGDL::ZERO) { //rather frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
@@ -424,7 +424,7 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
     }
   } else if (iT == BaseGDL::INDGEN) { //less frequent
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       if (off == 0 && inc == 1) {
         for (SizeT i = 0; i < sz; ++i) (*this)[i] = i;
@@ -451,21 +451,21 @@ template<> Data_<SpDComplex>::Data_(const dimension& dim_, BaseGDL::InitType iT,
 
 template<> Data_<SpDString>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble):
   SpDString(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
-{
+{ 
   dim.Purge();
   
   if( iT == BaseGDL::INDGEN) throw GDLException("DStringGDL(dim,InitType=INDGEN) called.");
 }
 
 template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DDouble, DDouble):
-  SpDPtr(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) {
+  SpDPtr(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false) { 
   dim.Purge();
 
   if (iT == BaseGDL::INDGEN) throw GDLException("DPtrGDL(dim,InitType=INDGEN) called.");
 
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
@@ -477,14 +477,14 @@ template<> Data_<SpDPtr>::Data_(const dimension& dim_,  BaseGDL::InitType iT, DD
 }
 template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDouble, DDouble):
   SpDObj(dim_), dd( (iT == BaseGDL::NOALLOC) ? 0 : this->dim.NDimElements(), false)
-{
+{ 
   dim.Purge();
 
   if( iT == BaseGDL::INDGEN) throw GDLException("DObjGDL(dim,InitType=INDGEN) called.");
   
   if (iT != BaseGDL::NOALLOC && iT != BaseGDL::NOZERO) {
     SizeT sz = dd.size();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) { //most frequent
       for (SizeT i = 0; i < sz; ++i) (*this)[i] = 0;
     } else {
@@ -497,14 +497,14 @@ template<> Data_<SpDObj>::Data_(const dimension& dim_, BaseGDL::InitType iT, DDo
 
 // c-i
 //template<class Sp>
-//Data_<Sp>::Data_(const Data_& d_): Sp(d_.dim), dd(d_.dd) { }
+//Data_<Sp>::Data_(const Data_& d_): Sp(d_.dim), dd(d_.dd) {  }
 
 //faster, C++ initializer is probably too shy. 
 template<class Sp>
-Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), false) {
+Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), false) { 
   this->dim.Purge(); //useful?
   SizeT sz = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < sz; i++) dd[i] = d_.dd[i];
   } else {
@@ -516,29 +516,29 @@ Data_<Sp>::Data_(const Data_& d_) : Sp(d_.dim), dd(this->dim.NDimElements(), fal
 
 template<>
 Data_<SpDPtr>::Data_(const Data_& d_): SpDPtr(d_.dim), dd(d_.dd)
-{
+{ 
   GDLInterpreter::IncRef( this);
 }
 template<>
 Data_<SpDObj>::Data_(const Data_& d_): SpDObj(d_.dim), dd(d_.dd)
-{
+{ 
   GDLInterpreter::IncRefObj( this);
 }
 
 
 template<class Sp>
-Data_<Sp>* Data_<Sp>::Dup() const { return new Data_(*this);}
+Data_<Sp>* Data_<Sp>::Dup() const {  return new Data_(*this);}
 
 // template<>
 // Data_<SpDPtr>* Data_<SpDPtr>::Dup() const
-//   {
+//   { 
 //   Data_<SpDPtr>* p =new Data_(*this);
 //   GDLInterpreter::IncRef( p);
 //   return p;
 //   }
 // template<>
 //   Data_<SpDObj>* Data_<SpDObj>::Dup() const
-//   {
+//   { 
 //   Data_<SpDObj>* p =new Data_(*this);
 //   GDLInterpreter::IncRefObj( p);
 //   return p;
@@ -548,21 +548,21 @@ Data_<Sp>* Data_<Sp>::Dup() const { return new Data_(*this);}
   
 template<class Sp>
 BaseGDL* Data_<Sp>::Log()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   DFloatGDL* res = static_cast<DFloatGDL*> (this->Convert2( GDL_FLOAT, BaseGDL::COPY));
   res->LogThis();
   return res;
 }
 
 template<>
-BaseGDL* Data_<SpDFloat>::Log() {
+BaseGDL* Data_<SpDFloat>::Log() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
@@ -575,14 +575,14 @@ BaseGDL* Data_<SpDFloat>::Log() {
 
 template<>
 BaseGDL* Data_<SpDDouble>::Log()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
@@ -594,14 +594,14 @@ BaseGDL* Data_<SpDDouble>::Log()
 }
 template<>
 BaseGDL* Data_<SpDComplex>::Log()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
@@ -613,14 +613,14 @@ BaseGDL* Data_<SpDComplex>::Log()
 }
 template<>
 BaseGDL* Data_<SpDComplexDbl>::Log()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*n)[ i] = log((*this)[ i]);
   } else {
@@ -637,20 +637,20 @@ BaseGDL* Data_<SpDComplexDbl>::Log()
 // complex types
 template<class Sp>
 BaseGDL* Data_<Sp>::LogThis()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   DFloatGDL* res = static_cast<DFloatGDL*>(this->Convert2( GDL_FLOAT, BaseGDL::COPY));
   res->LogThis(); // calls correct LogThis for float
   return res;
 }
 
 template<>
-BaseGDL* Data_<SpDFloat>::LogThis() {
+BaseGDL* Data_<SpDFloat>::LogThis() { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
@@ -663,13 +663,13 @@ BaseGDL* Data_<SpDFloat>::LogThis() {
 
 template<>
 BaseGDL* Data_<SpDDouble>::LogThis()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
@@ -682,13 +682,13 @@ BaseGDL* Data_<SpDDouble>::LogThis()
 
 template<>
 BaseGDL* Data_<SpDComplex>::LogThis()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
@@ -700,13 +700,13 @@ BaseGDL* Data_<SpDComplex>::LogThis()
 }
 template<>
 BaseGDL* Data_<SpDComplexDbl>::LogThis()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log((*this)[ i]);
   } else {
@@ -719,7 +719,7 @@ BaseGDL* Data_<SpDComplexDbl>::LogThis()
 
 template<class Sp>
 BaseGDL* Data_<Sp>::Log10()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   DFloatGDL* res = static_cast<DFloatGDL*> (this->Convert2( GDL_FLOAT, BaseGDL::COPY));
   res->Log10This();
   return res;
@@ -727,14 +727,14 @@ BaseGDL* Data_<Sp>::Log10()
 
 template<>
 BaseGDL* Data_<SpDFloat>::Log10()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
@@ -747,14 +747,14 @@ BaseGDL* Data_<SpDFloat>::Log10()
 
 template<>
 BaseGDL* Data_<SpDDouble>::Log10()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
@@ -767,14 +767,14 @@ BaseGDL* Data_<SpDDouble>::Log10()
 
 template<>
 BaseGDL* Data_<SpDComplex>::Log10()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
@@ -787,14 +787,14 @@ BaseGDL* Data_<SpDComplex>::Log10()
 
 template<>
 BaseGDL* Data_<SpDComplexDbl>::Log10()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   Data_* n = this->New(this->dim, BaseGDL::NOZERO);
   SizeT nEl = n->N_Elements();
   if (nEl == 1) {
     (*n)[ 0] = log10((*this)[ 0]);
     return n;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for( SizeT i=0; i<nEl; ++i) (*n)[ i] = log10( (*this)[ i]);
   } else {
@@ -808,20 +808,20 @@ BaseGDL* Data_<SpDComplexDbl>::Log10()
 // see comment at void Data_<Sp>::LogThis()              
 template<class Sp>
 BaseGDL* Data_<Sp>::Log10This()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   DFloatGDL* res = static_cast<DFloatGDL*> (this->Convert2( GDL_FLOAT, BaseGDL::COPY));
   res->Log10This(); // calls correct Log10This for float
   return res;
 }
 template<>
 BaseGDL* Data_<SpDFloat>::Log10This()              
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
@@ -834,13 +834,13 @@ BaseGDL* Data_<SpDFloat>::Log10This()
 
 template<>
 BaseGDL* Data_<SpDDouble>::Log10This()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
@@ -852,13 +852,13 @@ BaseGDL* Data_<SpDDouble>::Log10This()
 }
 template<>
 BaseGDL* Data_<SpDComplex>::Log10This()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
@@ -870,13 +870,13 @@ BaseGDL* Data_<SpDComplex>::Log10This()
 }
 template<>
 BaseGDL* Data_<SpDComplexDbl>::Log10This()              
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   SizeT nEl = N_Elements();
   if (nEl == 1) {
     (*this)[ 0] = log10((*this)[ 0]);
     return this;
   }
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 0; i < nEl; ++i) (*this)[ i] = log10((*this)[ i]);
   } else {
@@ -891,25 +891,25 @@ BaseGDL* Data_<SpDComplexDbl>::Log10This()
 
 // template<class Sp>
 // BaseGDL* Data_<Sp>::Abs() const
-// {
+// { 
 //   return new Data_( this->dim, dd.abs());
 // }
 
 template<class Sp>
 inline bool Data_<Sp>::Greater(SizeT i1, SizeT i2) const
-{ return ((*this)[i1] > (*this)[i2]);}
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) return ((*this)[i1] > (*this)[i2]);}
 
 template<>
 inline bool Data_<SpDComplex>::Greater(SizeT i1, SizeT i2) const
-{ return (abs((*this)[i1]) > abs((*this)[i2]));}
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) return (abs((*this)[i1]) > abs((*this)[i2]));}
 template<>
 inline bool Data_<SpDComplexDbl>::Greater(SizeT i1, SizeT i2) const
-{ return (abs((*this)[i1]) > abs((*this)[i2]));}
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) return (abs((*this)[i1]) > abs((*this)[i2]));}
 
 
 template<class Sp>
 inline bool Data_<Sp>::Equal(SizeT i1, SizeT i2) const
-{ return ((*this)[i1] == (*this)[i2]);}
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) return ((*this)[i1] == (*this)[i2]);}
 
 
 
@@ -930,7 +930,7 @@ inline SizeT CShiftNormalize( DLong s, SizeT this_dim)
 
 template<class Sp>
 BaseGDL* Data_<Sp>::CShift( DLong d) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   SizeT shift = CShiftNormalize( d, nEl);
 
@@ -949,7 +949,7 @@ BaseGDL* Data_<Sp>::CShift( DLong d) const
 
 template<>
 BaseGDL* Data_<SpDString>::CShift( DLong d) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   SizeT shift = CShiftNormalize( d, nEl);
 
@@ -973,7 +973,7 @@ BaseGDL* Data_<SpDString>::CShift( DLong d) const
 }
 template<>
 BaseGDL* Data_<SpDPtr>::CShift( DLong d) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   SizeT shift = CShiftNormalize( d, nEl);
 
@@ -998,7 +998,7 @@ BaseGDL* Data_<SpDPtr>::CShift( DLong d) const
 }
 template<>
 BaseGDL* Data_<SpDObj>::CShift( DLong d) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size();
   SizeT shift = CShiftNormalize( d, nEl);
 
@@ -1025,7 +1025,7 @@ BaseGDL* Data_<SpDObj>::CShift( DLong d) const
 template<typename Ty>
 inline void CShift1( Ty* dst, SizeT& dstLonIx, const Ty* src, SizeT& srcLonIx,
 		     SizeT stride_1, SizeT chunk0, SizeT chunk1)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   memcpy(  &dst[ dstLonIx], &src[ srcLonIx], chunk0 * sizeof(Ty));
   dstLonIx += chunk0;
   srcLonIx += chunk0;
@@ -1042,7 +1042,7 @@ inline void CShift1( Ty* dst, SizeT& dstLonIx, const Ty* src, SizeT& srcLonIx,
 #undef TEST_GOOD_OL_VERSION
 
 template<class Sp>
-BaseGDL* Data_<Sp>::CShift( DLong s[ MAXRANK]) const {
+BaseGDL* Data_<Sp>::CShift( DLong s[ MAXRANK]) const { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* sh = new Data_(this->dim, BaseGDL::NOZERO);
 
   SizeT nDim = this->Rank();
@@ -1293,7 +1293,7 @@ DUInt* InitPermDefault()
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::Transpose(DUInt* perm) {
+BaseGDL* Data_<Sp>::Transpose(DUInt* perm) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT rank = this->Rank();
 
   if (rank == 1) // special case: vector
@@ -1433,7 +1433,7 @@ BaseGDL* Data_<Sp>::Transpose(DUInt* perm) {
 // used by reverse
 
 template<class Sp>
-void Data_<Sp>::Reverse(DLong dim) {
+void Data_<Sp>::Reverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // SA: based on total_over_dim_template()
   //   static Data_* tmp = new Data_(dimension(1), BaseGDL::NOZERO);
   //Guard<Data_> tmp_guard(tmp);
@@ -1441,8 +1441,8 @@ void Data_<Sp>::Reverse(DLong dim) {
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride));
-  if (!parallelize) { //most frequent
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride));
+  if (!parallelize) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1458,7 +1458,7 @@ void Data_<Sp>::Reverse(DLong dim) {
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
+#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1479,7 +1479,7 @@ void Data_<Sp>::Reverse(DLong dim) {
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::DupReverse(DLong dim) {
+BaseGDL* Data_<Sp>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // SA: based on total_over_dim_template()
   Data_* res = new Data_(this->dim, BaseGDL::NOZERO);
   Guard<Data_> res_guard(res);
@@ -1487,8 +1487,8 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) {
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * revStride));
-  if (!parallelize) { //most frequent
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
+  if (!parallelize) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1504,7 +1504,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) {
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
+#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1526,7 +1526,7 @@ BaseGDL* Data_<Sp>::DupReverse(DLong dim) {
 }
 
 template<>
-BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
+BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // SA: based on total_over_dim_template()
   Data_* res = new Data_(this->dim, BaseGDL::NOZERO);
   Guard<Data_> res_guard(res);
@@ -1534,8 +1534,8 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * revStride));
-  if (!parallelize) { //most frequent
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
+  if (!parallelize) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1550,7 +1550,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
+#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1572,7 +1572,7 @@ BaseGDL* Data_<SpDPtr>::DupReverse(DLong dim) {
 }
 
 template<>
-BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) {
+BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // SA: based on total_over_dim_template()
   Data_* res = new Data_(this->dim, BaseGDL::NOZERO);
   Guard<Data_> res_guard(res);
@@ -1580,8 +1580,8 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) {
   SizeT revStride = this->dim.Stride(dim);
   SizeT outerStride = this->dim.Stride(dim + 1);
   SizeT revLimit = this->dim[dim] * revStride;
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl / outerStride) * revStride));
-  if (!parallelize) { //most frequent
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl / outerStride) * revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl / outerStride) * revStride));
+  if (!parallelize) {  //most frequent
     for (SizeT o = 0; o < nEl; o += outerStride) {
       for (SizeT i = 0; i < revStride; ++i) {
         SizeT oi = o + i;
@@ -1596,7 +1596,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) {
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= (nEl/outerStride)*revStride))
+#pragma omp parallel //if ((nEl/outerStride)*revStride >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= (nEl/outerStride)*revStride))
     {
 #pragma omp for
       for (SizeT o = 0; o < nEl; o += outerStride) {
@@ -1619,7 +1619,7 @@ BaseGDL* Data_<SpDObj>::DupReverse(DLong dim) {
 
 // rank must be 1 or 2 (already checked)
 template<class Sp> 
-BaseGDL* Data_<Sp>::Rotate( DLong dir) {
+BaseGDL* Data_<Sp>::Rotate( DLong dir) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   dir = (dir % 8 + 8) % 8; // bring into 0..7 range
 
   if (dir == 0) return Dup();
@@ -1707,10 +1707,10 @@ BaseGDL* Data_<Sp>::Rotate( DLong dir) {
 }
 
 template<class Sp>
-typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
+typename Data_<Sp>::Ty Data_<Sp>::Sum() const { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s = dd[ 0];
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) s += dd[ i];
   } else {
@@ -1728,7 +1728,7 @@ typename Data_<Sp>::Ty Data_<Sp>::Sum() const {
 
 template<> 
 Data_<SpDString>::Ty Data_<SpDString>::Sum() const 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s= dd[ 0];
   SizeT nEl = dd.size();
   for( SizeT i=1; i<nEl; ++i)
@@ -1739,11 +1739,11 @@ Data_<SpDString>::Ty Data_<SpDString>::Sum() const
 }
 
 template<>
-Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const {
+Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DDouble sr = dd[ 0].real();
   DDouble si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
@@ -1764,11 +1764,11 @@ Data_<SpDComplexDbl>::Ty Data_<SpDComplexDbl>::Sum() const {
 }
 
 template<>
-Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const {
+Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   DFloat sr = dd[ 0].real();
   DFloat si = dd[ 0].imag();
   SizeT nEl = dd.size();
-  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+  bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
   if (!parallelize) { //most frequent
     for (SizeT i = 1; i < nEl; ++i) {
       sr += dd[i].real();
@@ -1776,7 +1776,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const {
     }
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)) shared( sr,si)
+#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)) shared( sr,si)
     {
 #pragma omp for reduction(+:si,sr)
       for (SizeT i = 1; i < nEl; ++i) {
@@ -1790,7 +1790,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const {
 
 // template<class Sp> 
 // typename Data_<Sp>::DataT& Data_<Sp>:: Resize( SizeT n)
-// {
+// { 
 //   if( n > dd.size())
 //     throw GDLException("Internal error: Data_::Resize(...) tried to grow.");
 //   if( dd.size() != n) 
@@ -1805,12 +1805,12 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const {
 
 // template<class Sp> 
 // typename Data_<Sp>::Ty& Data_<Sp>::operator[] (const SizeT d1) 
-// { return (*this)[d1];}
+// {  return (*this)[d1];}
 
 // only used from DStructGDL
 template<class Sp> 
 Data_<Sp>&  Data_<Sp>::operator=(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_<Sp>& right = static_cast<const Data_<Sp>&>( r);
   assert( &right != this);
@@ -1822,7 +1822,7 @@ Data_<Sp>&  Data_<Sp>::operator=(const BaseGDL& r)
 // only used from DStructGDL
 template<>
 Data_<SpDPtr>& Data_<SpDPtr>::operator=(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_& right = static_cast<const Data_&>( r);
   assert( &right != this);
@@ -1836,7 +1836,7 @@ Data_<SpDPtr>& Data_<SpDPtr>::operator=(const BaseGDL& r)
 // only used from DStructGDL
 template<>
 Data_<SpDObj>& Data_<SpDObj>::operator=(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_& right = static_cast<const Data_&>( r);
   assert( &right != this);
@@ -1851,7 +1851,7 @@ Data_<SpDObj>& Data_<SpDObj>::operator=(const BaseGDL& r)
 
 template<class Sp> 
 void Data_<Sp>::InitFrom(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_<Sp>& right = static_cast<const Data_<Sp>&>( r);
   assert( &right != this);
@@ -1863,7 +1863,7 @@ void Data_<Sp>::InitFrom(const BaseGDL& r)
 // only used from DStructGDL::DStructGDL(const DStructGDL& d_)
 template<>
 void Data_<SpDPtr>::InitFrom(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_& right = static_cast<const Data_&>( r);
   assert( &right != this);
@@ -1877,7 +1877,7 @@ void Data_<SpDPtr>::InitFrom(const BaseGDL& r)
 // only used from DStructGDL::DStructGDL(const DStructGDL& d_)
 template<>
 void Data_<SpDObj>::InitFrom(const BaseGDL& r)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r.Type() == this->Type());
   const Data_& right = static_cast<const Data_&>( r);
   assert( &right != this);
@@ -1891,38 +1891,38 @@ void Data_<SpDObj>::InitFrom(const BaseGDL& r)
 
 template< class Sp>
 bool Data_<Sp>::EqType( const BaseGDL* r) const 
-{ return (this->Type() == r->Type());}
+{  return (this->Type() == r->Type());}
 
 template< class Sp>
 void* Data_<Sp>::DataAddr()// SizeT elem)
-{ return &(*this)[0];}//elem];}
+{  return &(*this)[0];}//elem];}
 
 // template<>
 // void* Data_<SpDString>::DataAddr()// SizeT elem)
-// { 
+// {  
 //  throw GDLException("STRING not allowed in this context.");
 // return NULL;
 // }
 // template<>
 // void* Data_<SpDPtr>::DataAddr()// SizeT elem)
-// { 
+// {  
 //  throw GDLException("PTR not allowed in this context.");
 // return NULL;
 // }
 // template<>
 // void* Data_<SpDObj>::DataAddr()// SizeT elem)
-// { 
+// {  
 //  throw GDLException("Object expression not allowed in this context.");
 // return NULL;
 // }
 
 template< class Sp>
 SizeT Data_<Sp>::N_Elements() const 
-{ return dd.size();}
+{  return dd.size();}
 
 template<>
 SizeT Data_<SpDObj>::N_Elements() const 
-{ 
+{  
   if( !this->StrictScalar())
     return dd.size();
 #if 1  // GJ change this and see how many problems it solves, creates. 2016/5/5 
@@ -1960,14 +1960,14 @@ SizeT Data_<SpDObj>::N_Elements() const
 
 template< class Sp>
 SizeT Data_<Sp>::Size() const 
-{ return dd.size();}
+{  return dd.size();}
 template< class Sp>
 SizeT Data_<Sp>::Sizeof() const 
-{ return sizeof(Ty);}
+{  return sizeof(Ty);}
 
 template< class Sp>
 void Data_<Sp>::Clear() 
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   SizeT nEl = dd.size(); 
   for( SizeT i = 0; i<nEl; ++i) (*this)[ i] = Sp::zero;
 }
@@ -1975,7 +1975,7 @@ void Data_<Sp>::Clear()
 // first time initialization (construction)
 template< class Sp>
 void Data_<Sp>::Construct() 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // note that this is not possible in cases where an operation 
   // (here: 'new' which is ok) isn't defined for any POD
   // (although this code never executes and should be optimized away anyway)
@@ -1990,14 +1990,14 @@ void Data_<Sp>::Construct()
 
 template<>
 void Data_<SpDPtr>::Construct() 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size(); 
   for( SizeT i = 0; i<nEl; ++i) dd[ i] = 0;
 }
 
 template<>
 void Data_<SpDObj>::Construct()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = dd.size(); 
   for( SizeT i = 0; i<nEl; ++i) dd[ i] = 0;
 }
@@ -2005,7 +2005,7 @@ void Data_<SpDObj>::Construct()
 // construction and initalization to zero
 template< class Sp>
 void Data_<Sp>::ConstructTo0() 
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   if( Sp::IS_POD)
   {
   SizeT nEl = dd.size(); 
@@ -2020,7 +2020,7 @@ void Data_<Sp>::ConstructTo0()
 
 template< class Sp>
 void Data_<Sp>::Destruct() 
-{ 
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__) 
   // no destruction for POD
   if( !Sp::IS_POD)
   {
@@ -2031,30 +2031,30 @@ void Data_<Sp>::Destruct()
 }
 template<>
 void Data_< SpDPtr>::Destruct()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   GDLInterpreter::DecRef( this);
 }
 template<>
 void Data_< SpDObj>::Destruct()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   GDLInterpreter::DecRefObj( this);
 }
 
 template< class Sp>
 BaseGDL* Data_<Sp>::SetBuffer( const void* b)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   dd.SetBuffer( static_cast< Ty*>(const_cast<void*>( b)));
   return this;
 }
 template< class Sp>
 void Data_<Sp>::SetBufferSize( SizeT s)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   dd.SetBufferSize( s);
 }
 
 template< class Sp>
 Data_<Sp>* Data_<Sp>::New( const dimension& dim_, BaseGDL::InitType noZero) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( noZero == BaseGDL::NOZERO) return new Data_(dim_, BaseGDL::NOZERO);
   if( noZero == BaseGDL::INIT)
     {
@@ -2069,18 +2069,18 @@ Data_<Sp>* Data_<Sp>::New( const dimension& dim_, BaseGDL::InitType noZero) cons
 
 template< class Sp>
 Data_<Sp>* Data_<Sp>::NewResult() const 
-{
+{ 
   return new Data_(this->dim, BaseGDL::NOZERO);
 }
 
 template<class Sp>
 SizeT Data_<Sp>::NBytes() const 
-{ return (dd.size() * sizeof(Ty));}
+{  return (dd.size() * sizeof(Ty));}
 
 // string, ptr, obj cannot calculate their bytes
 // only used by assoc function
 template<> SizeT Data_<SpDString>::NBytes() const
-{
+{ 
   SizeT nEl = dd.size();
   SizeT nB = 0;
   for( SizeT i=0; i<nEl; ++i)  nB += (*this)[i].size();
@@ -2089,32 +2089,32 @@ template<> SizeT Data_<SpDString>::NBytes() const
 
 template<class Sp>
 SizeT Data_<Sp>::ToTransfer() const
-{
+{ 
   return dd.size();
 }
 // complex has 2 elements to transfer
 template<> SizeT Data_<SpDComplex>::ToTransfer() const
-{
+{ 
   return N_Elements() * 2;
 }
 template<> SizeT Data_<SpDComplexDbl>::ToTransfer() const
-{
+{ 
   return N_Elements() * 2;
 }
 
 template<class Sp> 
 DDouble Data_<Sp>::HashValue() const
-{
+{ 
   return static_cast<DDouble>((*this)[0]);
 }
 template<> 
 DDouble Data_<SpDComplex>::HashValue() const
-{
+{ 
   return real((*this)[0]);
 }
 template<> 
 DDouble Data_<SpDComplexDbl>::HashValue() const
-{
+{ 
   return real((*this)[0]);
 }
 template<> 
@@ -2146,7 +2146,7 @@ DDouble Data_<SpDObj>::HashValue() const
 // this should not be called on non-numeric types (also for p2)
 template<class Sp> 
 int Data_<Sp>::HashCompare( BaseGDL* p2) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( dd.size() == 1);
   assert( p2->N_Elements() == 1);
   if( p2->Type() == GDL_STRING)
@@ -2178,7 +2178,7 @@ int Data_<Sp>::HashCompare( BaseGDL* p2) const
 
 template<> 
 int Data_<SpDString>::HashCompare( BaseGDL* p2) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( dd.size() == 1);
   assert( p2->N_Elements() == 1);
   if( p2->Type() != this->Type())
@@ -2210,7 +2210,7 @@ int Data_<SpDString>::HashCompare( BaseGDL* p2) const
 // 2   one-element array
 template<class Sp> 
 int Data_<Sp>::Scalar2Index( SizeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
 
   // the next statement gives a warning for unsigned integer types:
@@ -2235,7 +2235,7 @@ int Data_<Sp>::Scalar2Index( SizeT& st) const
 
 template<class Sp> 
 int Data_<Sp>::Scalar2RangeT( RangeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
 
   st= static_cast<RangeT>((*this)[0]);
@@ -2245,7 +2245,7 @@ int Data_<Sp>::Scalar2RangeT( RangeT& st) const
 
 template<> 
 int Data_<SpDComplex>::Scalar2Index( SizeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
   float r=real((*this)[0]);
   if( r < 0.0) return -1;
@@ -2256,7 +2256,7 @@ int Data_<SpDComplex>::Scalar2Index( SizeT& st) const
 
 template<> 
 int Data_<SpDComplex>::Scalar2RangeT( RangeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
   float r=real((*this)[0]);
   st= static_cast<RangeT>(r);
@@ -2266,7 +2266,7 @@ int Data_<SpDComplex>::Scalar2RangeT( RangeT& st) const
 
 template<>
 int Data_<SpDComplexDbl>::Scalar2Index( SizeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
   double r=real((*this)[0]);
   if( r < 0.0) return -1;
@@ -2277,7 +2277,7 @@ int Data_<SpDComplexDbl>::Scalar2Index( SizeT& st) const
 
 template<> 
 int Data_<SpDComplexDbl>::Scalar2RangeT( RangeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
   double r=real((*this)[0]);
   st= static_cast<RangeT>(r);
@@ -2288,7 +2288,7 @@ int Data_<SpDComplexDbl>::Scalar2RangeT( RangeT& st) const
 
 template<> 
 int Data_<SpDString>::Scalar2Index( SizeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
 
   SizeT tSize=(*this)[0].size();
@@ -2309,7 +2309,7 @@ int Data_<SpDString>::Scalar2Index( SizeT& st) const
 
 template<> 
 int Data_<SpDString>::Scalar2RangeT( RangeT& st) const
-{
+{ 
   if( dd.size() != 1) return 0;
 
   SizeT tSize=(*this)[0].size();
@@ -2362,7 +2362,7 @@ int Data_<SpDObj>::Scalar2RangeT( RangeT& st) const
 // for FOR loop *indices*
 template<class Sp> 
 RangeT Data_<Sp>::LoopIndex() const
-{
+{ 
   //  if( dd.size() != 1) return 0;
 
   // the next statement gives a warning for unsigned integer types:
@@ -2380,7 +2380,7 @@ RangeT Data_<Sp>::LoopIndex() const
 }
 template<> 
 RangeT Data_<SpDFloat>::LoopIndex() const
-{
+{ 
   //   if( (*this)[0] < 0.0f)
   //     //if( (*this)[0] <= 1.0f)
   //       throw GDLException( "Index variable <0.");
@@ -2391,7 +2391,7 @@ RangeT Data_<SpDFloat>::LoopIndex() const
 }
 template<> 
 RangeT Data_<SpDDouble>::LoopIndex() const
-{
+{ 
   //   if( (*this)[0] < 0.0)
   //     //if( (*this)[0] <= 1.0)
   //       throw GDLException( "Index variable <0.");
@@ -2414,7 +2414,7 @@ RangeT Data_<SpDComplexDbl>::LoopIndex() const
 }
 template<> 
 RangeT Data_<SpDString>::LoopIndex() const
-{
+{ 
   if( (*this)[0] == "")
     return 0;
 	
@@ -2449,7 +2449,7 @@ RangeT Data_<SpDObj>::LoopIndex() const
 // True
 template<class Sp>
 bool Data_<Sp>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2458,7 +2458,7 @@ bool Data_<Sp>::True()
 
 template<>
 bool Data_<SpDFloat>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2467,7 +2467,7 @@ bool Data_<SpDFloat>::True()
 
 template<>
 bool Data_<SpDDouble>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2476,7 +2476,7 @@ bool Data_<SpDDouble>::True()
 
 template<>
 bool Data_<SpDString>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2485,7 +2485,7 @@ bool Data_<SpDString>::True()
 
 template<>
 bool Data_<SpDComplex>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2493,7 +2493,7 @@ bool Data_<SpDComplex>::True()
 }
 template<>
 bool Data_<SpDComplexDbl>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2502,7 +2502,7 @@ bool Data_<SpDComplexDbl>::True()
 
 template<>
 bool Data_<SpDPtr>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2511,7 +2511,7 @@ bool Data_<SpDPtr>::True()
 
 template<>
 bool Data_<SpDObj>::True()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2595,14 +2595,14 @@ bool Data_<SpDObj>::True()
 // False
 template<class Sp>
 bool Data_<Sp>::False()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return !True();
 }
 
 // Sgn
 template<class Sp>
 int Data_<Sp>::Sgn() // -1,0,1
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -2647,7 +2647,7 @@ int Data_<SpDObj>::Sgn() // -1,0,1
 // Equal (deletes r) only used in ForCheck(...)
 template<class Sp>
 bool Data_<Sp>::Equal( BaseGDL* r) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r->StrictScalar());
   //   if( !r->Scalar())
   //     {
@@ -2663,7 +2663,7 @@ bool Data_<Sp>::Equal( BaseGDL* r) const
 }
 template<>
 bool Data_<SpDFloat>::Equal( BaseGDL* r) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r->StrictScalar());
   //   if( !r->Scalar())
   //     {
@@ -2679,7 +2679,7 @@ bool Data_<SpDFloat>::Equal( BaseGDL* r) const
 }
 template<>
 bool Data_<SpDDouble>::Equal( BaseGDL* r) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( r->StrictScalar());
   //   if( !r->Scalar())
   //     {
@@ -2697,7 +2697,7 @@ bool Data_<SpDDouble>::Equal( BaseGDL* r) const
 // Equal (does not delete r)
 template<class Sp>
 bool Data_<Sp>::EqualNoDelete( const BaseGDL* r) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( !r->Scalar())
     {
       throw GDLException("Expression must be a scalar in this context.");
@@ -2726,7 +2726,7 @@ bool DStructGDL::Equal( BaseGDL* r) const
 
 // For array_equal r must be of same type
 template<class Sp>
-bool Data_<Sp>::ArrayEqual( BaseGDL* rIn) {
+bool Data_<Sp>::ArrayEqual( BaseGDL* rIn) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_<Sp>* r = static_cast<Data_<Sp>*> (rIn);
   SizeT nEl = N_Elements();
   SizeT rEl = r->N_Elements();
@@ -2755,7 +2755,7 @@ bool DStructGDL::ArrayEqual( BaseGDL* r)
 // For array_equal r must be of same type
 template<class Sp>
 bool Data_<Sp>::ArrayNeverEqual( BaseGDL* rIn)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_<Sp>* r = static_cast< Data_<Sp>*>( rIn);
   SizeT nEl = N_Elements();
   SizeT rEl = r->N_Elements();
@@ -2787,29 +2787,29 @@ bool DStructGDL::ArrayNeverEqual( BaseGDL* r)
 //Not used
 //template<class Sp>
 //bool Data_<Sp>::OutOfRangeOfInt() const 
-//{
+//{ 
 //  assert( this->StrictScalar());
 //  return (*this)[0] > std::numeric_limits< DInt>::max() || (*this)[0] < std::numeric_limits< DInt>::min();
 //}
 //
 //template<>
 //bool Data_<SpDString>::OutOfRangeOfInt() const 
-//{
+//{ 
 //  return false;
 //}
 //template<>
 //bool Data_<SpDByte>::OutOfRangeOfInt() const 
-//{
+//{ 
 //  return false;
 //}
 //template<>
 //bool Data_<SpDComplex>::OutOfRangeOfInt() const 
-//{
+//{ 
 //  return false;
 //}
 //template<>
 //bool Data_<SpDComplexDbl>::OutOfRangeOfInt() const 
-//{
+//{ 
 //  return false;
 //}
 
@@ -2817,7 +2817,7 @@ bool DStructGDL::ArrayNeverEqual( BaseGDL* r)
 // (convert strings to floats here (not for first argument)
 
 template<class Sp>
-bool Data_<Sp>::ForCheck(BaseGDL** lEnd, BaseGDL** lStep) {
+bool Data_<Sp>::ForCheck(BaseGDL** lEnd, BaseGDL** lStep) { 
   // all scalars?
   if (!StrictScalar())
     throw GDLException("Loop INIT must be a scalar in this context.");
@@ -2923,7 +2923,7 @@ bool DStructGDL::ForCheck( BaseGDL** lEnd, BaseGDL** lStep)
 // ForCheck must have been called before
 template<class Sp>
 bool Data_<Sp>::ForAddCondUp( BaseGDL* endLoopVar)
-{
+{ 
   if( endLoopVar->Type() != this->t) throw GDLException("Type of FOR index variable changed.");
   Data_* lEnd=static_cast<Data_*>(endLoopVar);
   bool what=true;
@@ -2938,14 +2938,14 @@ bool Data_<Sp>::ForAddCondUp( BaseGDL* endLoopVar)
 // ForCheck must have been called before
 template<class Sp>
 bool Data_<Sp>::ForCondUp( BaseGDL* lEndIn)
-{
+{ 
   if( lEndIn->Type() != this->t) throw GDLException("Type of FOR index variable changed.");
   Data_* lEnd=static_cast<Data_*>(lEndIn);
   return (*this)[0] <= (*lEnd)[0];
 }
 template<class Sp>
 bool Data_<Sp>::ForCondDown( BaseGDL* lEndIn)
-{
+{ 
   if( lEndIn->Type() != this->t) throw GDLException("Type of FOR index variable changed.");
   Data_* lEnd=static_cast<Data_*>(lEndIn);
   return (*this)[0] >= (*lEnd)[0];
@@ -2964,7 +2964,7 @@ bool DStructGDL::ForCondDown( BaseGDL*)
 }
 template<>
 bool Data_<SpDComplex>::ForCondUp( BaseGDL*)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to COMPLEX.");
   return false; 
 }
@@ -2972,13 +2972,13 @@ bool Data_<SpDComplex>::ForCondUp( BaseGDL*)
 template<>
 bool Data_<SpDComplex>::ForAddCondUp( BaseGDL* loopInfo)
 // bool Data_<SpDComplex>::ForAddCondUp( ForLoopInfoT& loopInfo)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to COMPLEX.");
   return false; 
 }
 template<>
 bool Data_<SpDComplex>::ForCondDown( BaseGDL*)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to COMPLEX.");
   return false; 
 }
@@ -2986,19 +2986,19 @@ bool Data_<SpDComplex>::ForCondDown( BaseGDL*)
 template<>
 bool Data_<SpDComplexDbl>::ForAddCondUp( BaseGDL* loopInfo)
 // bool Data_<SpDComplexDbl>::ForAddCondUp( ForLoopInfoT& loopInfo)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to DCOMPLEX.");
   return false; 
 }
 template<>
 bool Data_<SpDComplexDbl>::ForCondUp( BaseGDL*)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to DCOMPLEX.");
   return false; 
 }
 template<>
 bool Data_<SpDComplexDbl>::ForCondDown( BaseGDL*)
-{ 
+{
   throw GDLException("Type of FOR index variable changed to DCOMPLEX.");
   return false; 
 }
@@ -3007,7 +3007,7 @@ bool Data_<SpDComplexDbl>::ForCondDown( BaseGDL*)
 // general version
 template<class Sp>
 void Data_<Sp>::ForAdd( BaseGDL* addIn)
-{
+{ 
   if( addIn == NULL)
     {
       (*this)[0] += 1;
@@ -3024,7 +3024,7 @@ void DStructGDL::ForAdd( BaseGDL* addIn) {}
 //// normal (+1) version
 //template<class Sp>
 //void Data_<Sp>::ForAdd()
-//{
+//{ 
 //  (*this)[0] += 1;
 //}
 // cannnot be called, just to make the compiler shut-up
@@ -3032,7 +3032,7 @@ void DStructGDL::ForAdd( BaseGDL* addIn) {}
 
 template<class Sp>
 void Data_<Sp>::AssignAtIx( RangeT ixR, BaseGDL* srcIn)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixR < 0)
     {
       SizeT nEl = this->N_Elements();
@@ -3071,7 +3071,7 @@ void Data_<Sp>::AssignAtIx( RangeT ixR, BaseGDL* srcIn)
 //         GDLInterpreter::l_array_expr
 template<class Sp>
 void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   //  breakpoint(); // gdbg can not handle breakpoints in template functions
   Data_* src = static_cast<Data_*>(srcIn);  
 
@@ -3158,7 +3158,7 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT offset)
 }
 template<class Sp>
 void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( ixList != NULL);
 
   //  breakpoint(); // gdbg can not handle breakpoints in template functions
@@ -3167,7 +3167,7 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
   SizeT srcElem= src->N_Elements();
   bool  isScalar= (srcElem == 1);
   if( isScalar) 
-    { // src is scalar
+    {// src is scalar
       SizeT nCp=ixList->N_Elements();
 
       if( nCp == 1)
@@ -3207,7 +3207,7 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 }
 template<class Sp>
 void Data_<Sp>::AssignAt( BaseGDL* srcIn)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   //  breakpoint(); // gdbg can not handle breakpoints in template functions
   Data_* src = static_cast<Data_*>(srcIn);  
 
@@ -3237,7 +3237,7 @@ void Data_<Sp>::AssignAt( BaseGDL* srcIn)
 // integers
 template<class Sp>
 void Data_<Sp>::DecAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd -= 1;
@@ -3258,7 +3258,7 @@ void Data_<Sp>::DecAt( ArrayIndexListT* ixList)
 }
 template<class Sp>
 void Data_<Sp>::IncAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd += 1;
@@ -3280,7 +3280,7 @@ void Data_<Sp>::IncAt( ArrayIndexListT* ixList)
 // float, double
 template<>
 void Data_<SpDFloat>::DecAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd -= 1.0f;
@@ -3302,7 +3302,7 @@ void Data_<SpDFloat>::DecAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDFloat>::IncAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd += 1.0f;
@@ -3324,7 +3324,7 @@ void Data_<SpDFloat>::IncAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDDouble>::DecAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd -= 1.0;
@@ -3346,7 +3346,7 @@ void Data_<SpDDouble>::DecAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDDouble>::IncAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       dd += 1.0;
@@ -3369,7 +3369,7 @@ void Data_<SpDDouble>::IncAt( ArrayIndexListT* ixList)
 // complex
 template<>
 void Data_<SpDComplex>::DecAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       //       dd -= 1.0f;
@@ -3392,7 +3392,7 @@ void Data_<SpDComplex>::DecAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDComplex>::IncAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       //       dd += 1.0f;
@@ -3413,7 +3413,7 @@ void Data_<SpDComplex>::IncAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDComplexDbl>::DecAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       //       dd -= 1.0;
@@ -3434,7 +3434,7 @@ void Data_<SpDComplexDbl>::DecAt( ArrayIndexListT* ixList)
 }
 template<>
 void Data_<SpDComplexDbl>::IncAt( ArrayIndexListT* ixList) 
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( ixList == NULL)
     {
       //       dd += 1.0;
@@ -3492,7 +3492,7 @@ void Data_<SpDObj>::IncAt( ArrayIndexListT* ixList)
 template<class Sp>
 void Data_<Sp>::InsertAt( SizeT offset, BaseGDL* srcIn, 
 			  ArrayIndexListT* ixList)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* src=static_cast<Data_* >(srcIn);
   if( ixList == NULL)
     {
@@ -3517,7 +3517,7 @@ template<class Sp>
 Data_<Sp>* Data_<Sp>::CatArray( ExprListT& exprList,
 				const SizeT catRankIx, 
 				const SizeT rank)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   //  breakpoint();
   SizeT rankIx = RankIx( rank);
   SizeT maxIx = (catRankIx > rankIx)? catRankIx : rankIx;
@@ -3577,7 +3577,7 @@ Data_<Sp>* Data_<Sp>::CatArray( ExprListT& exprList,
 // returns (*this)[ ixList]
 template<class Sp>
 Data_<Sp>* Data_<Sp>::Index( ArrayIndexListT* ixList)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   //  ixList->SetVariable( this);
 
   Data_* res=Data_::New( ixList->GetDim(), BaseGDL::NOZERO);
@@ -3605,7 +3605,7 @@ Data_<Sp>* Data_<Sp>::Index( ArrayIndexListT* ixList)
 // respects the exact structure of srcIn
 template<class Sp>
 void Data_<Sp>::InsAt( Data_* srcIn, ArrayIndexListT* ixList, SizeT offset)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // max. number of dimensions to copy
   SizeT nDim = ixList->NDim();
  
@@ -3724,7 +3724,7 @@ void Data_<Sp>::InsAt( Data_* srcIn, ArrayIndexListT* ixList, SizeT offset)
 // assumes that everything is checked (see CatInfo)
 template<class Sp>
 void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // length of one segment to copy
   SizeT len = srcArr->dim.Stride (atDim + 1); // src array
 
@@ -3740,7 +3740,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
   SizeT gap = this->dim.Stride (atDim + 1); // dest array
   
 //GD: speed up by using indexing that permit parallel and collapse.
-  bool parallelize=(CpuTPOOL_NTHREADS >1 && len*nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= len*nCp));
+  bool parallelize=(CpuTPOOL_NTHREADS >1 && len*nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= len*nCp));
   if (!parallelize) { //most frequent
     for (OMPInt c = 0; c < nCp; ++c) {
       for (SizeT destIx = 0; destIx < len; destIx++) (*this)[destIx + destStart + c * gap] = (*srcArr)[ destIx + c * len];
@@ -3767,7 +3767,7 @@ void Data_<Sp>::CatInsert (const Data_* srcArr, const SizeT atDim, SizeT& at)
 // integers
 template<class Sp>
 bool Data_<Sp>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3775,7 +3775,7 @@ bool Data_<Sp>::LogTrue()
 }
 template<>
 bool Data_<SpDFloat>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3783,7 +3783,7 @@ bool Data_<SpDFloat>::LogTrue()
 }
 template<>
 bool Data_<SpDDouble>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3791,7 +3791,7 @@ bool Data_<SpDDouble>::LogTrue()
 }
 template<>
 bool Data_<SpDString>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3799,7 +3799,7 @@ bool Data_<SpDString>::LogTrue()
 }
 template<>
 bool Data_<SpDComplex>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3807,7 +3807,7 @@ bool Data_<SpDComplex>::LogTrue()
 }
 template<>
 bool Data_<SpDComplexDbl>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3815,7 +3815,7 @@ bool Data_<SpDComplexDbl>::LogTrue()
 }
 template<>
 bool Data_<SpDPtr>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Ty s;
   if( !Scalar( s))
     throw GDLException("Expression must be a scalar or 1 element array in this context.",true,false);
@@ -3823,7 +3823,7 @@ bool Data_<SpDPtr>::LogTrue()
 }
 template<>
 bool Data_<SpDObj>::LogTrue()
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   // ::_overloadIsTrue is handled in True()
   
   return this->True();
@@ -3834,42 +3834,42 @@ bool Data_<SpDObj>::LogTrue()
 // integers
 template<class Sp>
 bool Data_<Sp>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i] != 0);
 }
 template<>
 bool Data_<SpDFloat>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i] != 0.0f);
 }
 template<>
 bool Data_<SpDDouble>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i] != 0.0);
 }
 template<>
 bool Data_<SpDString>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i] != "");
 }
 template<>
 bool Data_<SpDComplex>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i].real() != 0.0 || (*this)[i].imag() != 0.0);
 }
 template<>
 bool Data_<SpDComplexDbl>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return ((*this)[i].real() != 0.0 || (*this)[i].imag() != 0.0);
 }
 template<>
 bool Data_<SpDPtr>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return (*this)[i] != 0;
 }
 template<>
 bool Data_<SpDObj>::LogTrue(SizeT i)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return (*this)[i] != 0;
 }
 
@@ -3896,7 +3896,7 @@ BaseGDL* Data_<SpDComplexDbl>::Rebin( const dimension& newDim, bool sample)
 template< typename T>
 T* Rebin1(T* src,
   const dimension& srcDim,
-  SizeT dimIx, SizeT newDim, bool sample) {
+	  SizeT dimIx, SizeT newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = src->N_Elements();
 
   if (newDim == 0) newDim = 1;
@@ -4010,7 +4010,7 @@ T* Rebin1(T* src,
 template< typename T, typename TNext>
 T* Rebin1Int(T* src,
   const dimension& srcDim,
-  SizeT dimIx, SizeT newDim, bool sample) {
+	     SizeT dimIx, SizeT newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nEl = src->N_Elements();
 
   if (newDim == 0) newDim = 1;
@@ -4122,7 +4122,7 @@ T* Rebin1Int(T* src,
 }
 
 template<class Sp>
-BaseGDL* Data_<Sp>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<Sp>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4192,7 +4192,7 @@ BaseGDL* Data_<Sp>::Rebin(const dimension& newDim, bool sample) {
 // integer types
 
 template<>
-BaseGDL* Data_<SpDByte>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDByte>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4257,7 +4257,7 @@ BaseGDL* Data_<SpDByte>::Rebin(const dimension& newDim, bool sample) {
 }
 
 template<>
-BaseGDL* Data_<SpDInt>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDInt>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4322,7 +4322,7 @@ BaseGDL* Data_<SpDInt>::Rebin(const dimension& newDim, bool sample) {
 }
 
 template<>
-BaseGDL* Data_<SpDUInt>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDUInt>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4387,7 +4387,7 @@ BaseGDL* Data_<SpDUInt>::Rebin(const dimension& newDim, bool sample) {
 }
 
 template<>
-BaseGDL* Data_<SpDLong>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDLong>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4452,7 +4452,7 @@ BaseGDL* Data_<SpDLong>::Rebin(const dimension& newDim, bool sample) {
 }
 
 template<>
-BaseGDL* Data_<SpDULong>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDULong>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4516,7 +4516,7 @@ BaseGDL* Data_<SpDULong>::Rebin(const dimension& newDim, bool sample) {
   return actIn;
 }
 template<>
-BaseGDL* Data_<SpDLong64>::Rebin(const dimension& newDim, bool sample) {
+BaseGDL* Data_<SpDLong64>::Rebin(const dimension& newDim, bool sample) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT resRank = newDim.Rank();
   SizeT srcRank = this->Rank();
 
@@ -4583,7 +4583,7 @@ BaseGDL* Data_<SpDLong64>::Rebin(const dimension& newDim, bool sample) {
 // no checking
 template<class Sp>
 void Data_<Sp>::Assign( BaseGDL* src, SizeT nEl)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* srcT; // = dynamic_cast<Data_*>( src);
 
   Guard< Data_> srcTGuard;
@@ -4610,12 +4610,12 @@ void Data_<Sp>::Assign( BaseGDL* src, SizeT nEl)
 // return a new type of itself (only for one dimensional case)
 template<class Sp>
 BaseGDL* Data_<Sp>::NewIx( SizeT ix)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return new Data_( (*this)[ ix]);
 }
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
   TRACEOMP(__FILE__,__LINE__)
@@ -4625,7 +4625,7 @@ Data_<Sp>* Data_<Sp>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 }
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
   for( int c=0; c<nCp; ++c)
@@ -4634,7 +4634,7 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s)
 }
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
   for( int c=0; c<nCp; ++c)
@@ -4643,7 +4643,7 @@ Data_<Sp>* Data_<Sp>::NewIxFrom( SizeT s, SizeT e)
 }
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT stride)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = (dd.size() - s + stride - 1)/stride;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
   for( SizeT c=0; c<nCp; ++c, s += stride)
@@ -4652,7 +4652,7 @@ Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT stride)
 }
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT e, SizeT stride)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   SizeT nCp = (e - s + stride)/stride;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
   for( SizeT c=0; c<nCp; ++c, s += stride)
@@ -4664,7 +4664,7 @@ Data_<Sp>* Data_<Sp>::NewIxFromStride( SizeT s, SizeT e, SizeT stride)
 
 template<class Sp>
 Data_<Sp>* Data_<Sp>::NewIx( BaseGDL* ix, bool strict)
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   assert( ix->Type() != GDL_UNDEF);
 
   // no type checking needed here: GetAsIndex() will fail with grace
@@ -4707,24 +4707,24 @@ Data_<Sp>* Data_<Sp>::NewIx( BaseGDL* ix, bool strict)
 
 // unsigned types
 template<class Sp> SizeT Data_<Sp>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return (*this)[ i];
 }
 template<class Sp> SizeT Data_<Sp>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return (*this)[ i]; // good for unsigned types
 }
 
 template<>
 SizeT Data_<SpDInt>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     return 0;
   return (*this)[i];
 }	
 template<>
 SizeT Data_<SpDInt>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4732,14 +4732,14 @@ SizeT Data_<SpDInt>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDLong>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     return 0;
   return (*this)[i];
 }	
 template<>
 SizeT Data_<SpDLong>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4747,14 +4747,14 @@ SizeT Data_<SpDLong>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDLong64>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     return 0;
   return (*this)[i];
 }	
 template<>
 SizeT Data_<SpDLong64>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] < 0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4762,14 +4762,14 @@ SizeT Data_<SpDLong64>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDFloat>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] <= 0.0)
     return 0;
   return Real2Int<SizeT,float>((*this)[i]);
 }	
 template<>
 SizeT Data_<SpDFloat>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] <= -1.0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4779,14 +4779,14 @@ SizeT Data_<SpDFloat>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDDouble>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] <= 0.0)
     return 0;
   return Real2Int<SizeT,double>((*this)[i]);
 }	
 template<>
 SizeT Data_<SpDDouble>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( (*this)[i] <= -1.0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4796,7 +4796,7 @@ SizeT Data_<SpDDouble>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDString>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   const char* cStart=(*this)[i].c_str();
   char* cEnd;
   long l=strtol(cStart,&cEnd,10);
@@ -4811,7 +4811,7 @@ SizeT Data_<SpDString>::GetAsIndex( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDString>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   const char* cStart=(*this)[i].c_str();
   char* cEnd;
   long l=strtol(cStart,&cEnd,10);
@@ -4828,14 +4828,14 @@ SizeT Data_<SpDString>::GetAsIndexStrict( SizeT i) const
 
 template<>
 SizeT Data_<SpDComplex>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( real((*this)[i]) <= 0.0)
     return 0;
   return Real2Int<SizeT,float>(real((*this)[i]));
 }	
 template<>
 SizeT Data_<SpDComplex>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( real((*this)[i]) <= -1.0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);
@@ -4845,14 +4845,14 @@ SizeT Data_<SpDComplex>::GetAsIndexStrict( SizeT i) const
 }	
 template<>
 SizeT Data_<SpDComplexDbl>::GetAsIndex( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( real((*this)[i]) <= 0.0)
     return 0;
   return Real2Int<SizeT,double>(real((*this)[i]));
 }	
 template<>
 SizeT Data_<SpDComplexDbl>::GetAsIndexStrict( SizeT i) const
-{
+{ TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   if( real((*this)[i]) <= -1.0)
     throw GDLException(-1,NULL,"Array used to subscript array "
 		       "contains out of range (<0) subscript (at index: " + i2s(i) + ").",true,false);

--- a/src/datatypesref.cpp
+++ b/src/datatypesref.cpp
@@ -29,7 +29,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::New( const dimension& dim_, BaseGDL::InitType noZe
     {
       Data_* res =  new Data_(dim_, BaseGDL::NOZERO);
       SizeT nEl = res->dd.size();
-      /*#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      /*#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
 	{
 	#pragma omp for*/
       for( OMPInt i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
@@ -49,7 +49,7 @@ Data_<SpDObj>* Data_<SpDObj>::New( const dimension& dim_, BaseGDL::InitType noZe
     {
       Data_* res =  new Data_(dim_, BaseGDL::NOZERO);
       SizeT nEl = res->dd.size();
-      /*#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      /*#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
 	{
 	#pragma omp for*/
       for( OMPInt i=0; i<nEl; ++i) (*res)[ i] = (*this)[ 0]; // set all to scalar
@@ -342,7 +342,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 
 	  GDLInterpreter::AddRef( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -360,7 +360,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 	  
 	  GDLInterpreter::AddRef( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -385,7 +385,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 	    else
 	      throw GDLException("Source expression contains not enough elements.");
 	  }
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -421,7 +421,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 		  {
 		    //#pragma omp for
 		    for( SizeT c=0; c<nCp; ++c)
@@ -441,7 +441,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 		  {
 		    //#pragma omp for
 		    for( SizeT c=0; c<nCp; ++c)
@@ -478,7 +478,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 
 	  GDLInterpreter::AddRefObj( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -496,7 +496,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 	  
 	  GDLInterpreter::AddRefObj( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -521,7 +521,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 	    else
 	      throw GDLException("Source expression contains not enough elements.");
 	  }
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -557,7 +557,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 		  {
 		    //#pragma omp for
 		    for( SizeT c=0; c<nCp; ++c)
@@ -577,7 +577,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList, SizeT off
 				       " source expression.");
 		  
 		  AllIxBaseT* allIx = ixList->BuildIx();
-		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+		  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 		  {
 		    //#pragma omp for
 		    for( SizeT c=0; c<nCp; ++c)
@@ -656,7 +656,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 	
 	  GDLInterpreter::AddRef( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -685,7 +685,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 			       " source expression.");
 
 	  AllIxBaseT* allIx = ixList->BuildIx();
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -716,7 +716,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn)
       SizeT nCp=Data_::N_Elements();
 	
       GDLInterpreter::AddRef( scalar, nCp);
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -739,7 +739,7 @@ void Data_<SpDPtr>::AssignAt( BaseGDL* srcIn)
       // if (non-indexed) src is smaller -> just copy its number of elements
       if( nCp > srcElem) nCp=srcElem;
 	
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -784,7 +784,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 	
 	  GDLInterpreter::AddRefObj( scalar, nCp);
 
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -812,7 +812,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 			       " source expression.");
 
 	  AllIxBaseT* allIx = ixList->BuildIx();
-	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+	  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
 	  {
 	    //#pragma omp for
 	    for( SizeT c=0; c<nCp; ++c)
@@ -844,7 +844,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn)
 	
       GDLInterpreter::AddRefObj( scalar, nCp);
 	
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -867,7 +867,7 @@ void Data_<SpDObj>::AssignAt( BaseGDL* srcIn)
       // if (non-indexed) src is smaller -> just copy its number of elements
       if( nCp > srcElem) nCp=srcElem;
 	
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -899,7 +899,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::Index( ArrayIndexListT* ixList)
 
   //  DataT& res_dd = res->dd;
   AllIxBaseT* allIx = ixList->BuildIx();
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -928,7 +928,7 @@ Data_<SpDObj>* Data_<SpDObj>::Index( ArrayIndexListT* ixList)
 
   //  DataT& res_dd = res->dd;
   AllIxBaseT* allIx = ixList->BuildIx();
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -957,7 +957,7 @@ void Data_<SpDPtr>::InsertAt( SizeT offset, BaseGDL* srcIn,
     {
       SizeT nCp=src->N_Elements();
 
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -974,7 +974,7 @@ void Data_<SpDPtr>::InsertAt( SizeT offset, BaseGDL* srcIn,
       SizeT nCp=ixList->N_Elements();
 
       AllIxBaseT* allIx = ixList->BuildIx();
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -1010,7 +1010,7 @@ void Data_<SpDPtr>::CatInsert( const Data_* srcArr, const SizeT atDim, SizeT& at
 
 #ifdef _OPENMP
   SizeT nEl = srcArr->N_Elements();
-  //#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  //#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   for( SizeT c=0; c<nCp; ++c)
     {
       // set new destination pointer
@@ -1063,7 +1063,7 @@ void Data_<SpDObj>::InsertAt( SizeT offset, BaseGDL* srcIn,
     {
       SizeT nCp=src->N_Elements();
 
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -1080,7 +1080,7 @@ void Data_<SpDObj>::InsertAt( SizeT offset, BaseGDL* srcIn,
       SizeT nCp=ixList->N_Elements();
 
       AllIxBaseT* allIx = ixList->BuildIx();
-      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+      //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
       {
 	//#pragma omp for
 	for( SizeT c=0; c<nCp; ++c)
@@ -1116,7 +1116,7 @@ void Data_<SpDObj>::CatInsert( const Data_* srcArr, const SizeT atDim, SizeT& at
 
 #ifdef _OPENMP
   SizeT nEl = srcArr->N_Elements();
-  //#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  //#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   for( SizeT c=0; c<nCp; ++c)
     {
       // set new destination pointer
@@ -1181,7 +1181,7 @@ void Data_<SpDPtr>::Assign( BaseGDL* src, SizeT nEl)
     srcT = static_cast<Data_*>( src);
   }
 
-  //#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  //#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   {
     //#pragma omp for
     for(long k=0; k < nEl; ++k)
@@ -1218,7 +1218,7 @@ void Data_<SpDObj>::Assign( BaseGDL* src, SizeT nEl)
     srcT = static_cast<Data_*>( src);
   }
 
-  //#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+  //#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
   {
     //#pragma omp for
     for(long k=0; k < nEl; ++k)
@@ -1355,7 +1355,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 {
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -1372,7 +1372,7 @@ Data_<SpDObj>* Data_<SpDObj>::NewIx( AllIxBaseT* ix, const dimension* dIn)
 {
   SizeT nCp = ix->size();
   Data_* res=Data_::New( *dIn, BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -1390,7 +1390,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::NewIxFrom( SizeT s)
 {
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -1407,7 +1407,7 @@ Data_<SpDObj>* Data_<SpDObj>::NewIxFrom( SizeT s)
 {
   SizeT nCp = dd.size() - s;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -1425,7 +1425,7 @@ Data_<SpDPtr>* Data_<SpDPtr>::NewIxFrom( SizeT s, SizeT e)
 {
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)
@@ -1443,7 +1443,7 @@ Data_<SpDObj>* Data_<SpDObj>::NewIxFrom( SizeT s, SizeT e)
 {
   SizeT nCp = e - s + 1;
   Data_* res=Data_::New( dimension( nCp), BaseGDL::NOZERO);
-  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nCp))
+  //#pragma omp parallel if (nCp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nCp))
   {
     //#pragma omp for
     for( SizeT c=0; c<nCp; ++c)

--- a/src/dimension.hpp
+++ b/src/dimension.hpp
@@ -418,7 +418,7 @@ public:
   }
 
   // set the rank to r (pads 1s) if it is smaller than r
-  void MakeRank(SizeT r)
+  void InsureRankAtLeast(SizeT r)
   {
     SizeT rNow=rank;
     if( rNow >= r) return;

--- a/src/dpro.cpp
+++ b/src/dpro.cpp
@@ -44,7 +44,7 @@ DSub::~DSub() {}
 // DLib ******************************************************
 DLib::DLib( const string& n, const string& o, const int nPar_, 
 	    const string keyNames[],
-	    const string warnKeyNames[], const int nParMin_)
+	    const string warnKeyNames[], const int nParMin_, const bool use_threadpool)
   : DSub(n,o)
   , hideHelp( false)
 {
@@ -57,9 +57,10 @@ DLib::DLib( const string& n, const string& o, const int nPar_,
     {
       while( keyNames[nKey_] != "") ++nKey_;
     }
-
+  
   key.resize(nKey_);
-  for( SizeT k=0; k<nKey_; ++k) key[k]=keyNames[k];
+  SizeT k=0;
+  for( ; k<nKey_; ++k) key[k]=keyNames[k];
 
   if( nKey_ >= 1) {
     if( keyNames[0] == "_EXTRA")
@@ -81,7 +82,16 @@ DLib::DLib( const string& n, const string& o, const int nPar_,
     }
 
   warnKey.resize(nWarnKey_);
-  for( SizeT wk=0; wk<nWarnKey_; ++wk) warnKey[wk]=warnKeyNames[wk];
+  SizeT wk=0;
+  for( ; wk<nWarnKey_; ++wk) warnKey[wk]=warnKeyNames[wk];
+//finally add threadpool kw if any, in warnkeys at the moment, since we do not really honor those kws.
+  if (use_threadpool) {
+    nWarnKey_ += 3;
+    warnKey.resize(nWarnKey_);
+    warnKey[wk++] = "TPOOL_MAX_ELTS";
+    warnKey[wk++] = "TPOOL_MIN_ELTS";
+    warnKey[wk++] = "TPOOL_NOTHREAD";
+  }
 }
 
 const string DLibPro::ToString()
@@ -182,8 +192,8 @@ DLibPro::DLibPro( LibPro p, const string& n, const string& o, const int nPar_,
 //  sort(libProList.begin(), libProList.end(),CompLibFunName());
 }
 DLibPro::DLibPro( LibPro p, const string& n, const int nPar_, 
-		  const string keyNames[], const string warnKeyNames[], const int nParMin_)
-  : DLib(n,"",nPar_,keyNames, warnKeyNames, nParMin_), pro(p)
+		  const string keyNames[], const string warnKeyNames[], const int nParMin_, const bool use_threadpool)
+  : DLib(n,"",nPar_,keyNames, warnKeyNames, nParMin_, use_threadpool), pro(p)
 {
   libProList.push_back(this);
 //  sort(libProList.begin(), libProList.end(),CompLibFunName());
@@ -198,12 +208,13 @@ DLibFun::DLibFun( LibFun f, const string& n, const string& o, const int nPar_,
 }
 
 DLibFun::DLibFun( LibFun f, const string& n, const int nPar_, 
-		  const string keyNames[], const string warnKeyNames[], const int nParMin_)
-  : DLib(n,"",nPar_,keyNames, warnKeyNames, nParMin_), fun(f)
+		  const string keyNames[], const string warnKeyNames[], const int nParMin_, const bool use_threadpool)
+  : DLib(n,"",nPar_,keyNames, warnKeyNames, nParMin_, use_threadpool), fun(f)
 {
   libFunList.push_back(this);
 //  sort(libFunList.begin(), libFunList.end(),CompLibFunName());
 }
+
 DLibFunRetNew::DLibFunRetNew( LibFun f, const string& n, 
 			      const string& o, const int nPar_, 
 			      const string keyNames[], const string warnKeyNames[], const int nParMin_)
@@ -214,6 +225,12 @@ DLibFunRetNew::DLibFunRetNew( LibFun f, const string& n, const int nPar_,
 			      const string keyNames[], const string warnKeyNames[], bool rConstant,
 			      const int nParMin_)
   : DLibFun(f,n,nPar_,keyNames, warnKeyNames, nParMin_), retConstant( rConstant)
+{}
+
+DLibFunRetNewTP::DLibFunRetNewTP( LibFun f, const string& n, const int nPar_, 
+			      const string keyNames[], const string warnKeyNames[], bool rConstant,
+			      const int nParMin_)
+  : DLibFun(f,n,nPar_,keyNames, warnKeyNames, nParMin_, true), retConstant( rConstant)
 {}
 // DLibFunRetNew::DLibFunRetNew( LibFun f, const string& n, const int nPar_, 
 // 			bool rConstant)
@@ -226,6 +243,9 @@ DLibFunDirect::DLibFunDirect( LibFunDirect f, const std::string& n, bool rConsta
   : DLibFunRetNew(NULL,n,1,NULL,NULL,rConstant,1), funDirect(f)
 {}
 
+DLibFunDirectTP::DLibFunDirectTP( LibFunDirect f, const std::string& n, bool rConstant)
+  : DLibFunRetNewTP(NULL,n,1,NULL,NULL,rConstant,1), funDirect(f)
+{}
 
 // DSubUD ****************************************************
 DSubUD::~DSubUD()

--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -199,7 +199,7 @@ class DLib: public DSub
 public:
   DLib( const std::string& n, const std::string& o, const int nPar_,
 	const std::string keyNames[],
-	const std::string warnKeyNames[], const int nParMin_);
+	const std::string warnKeyNames[], const int nParMin_, const bool use_threadpool=false);
 
   virtual const std::string ToString() = 0;
   
@@ -229,7 +229,7 @@ public:
   // on which a value is returned.
   DLibPro( LibPro p, const std::string& n, const int nPar_=0, 
 	   const std::string keyNames[]=NULL,
-	   const std::string warnKeyNames[]=NULL, const int nParMin_=0);
+	   const std::string warnKeyNames[]=NULL, const int nParMin_=0, const bool use_threadpool=false);
 
   DLibPro( LibPro p, const std::string& n, const std::string& o, 
 	   const int nPar_=0, 
@@ -248,7 +248,7 @@ class DLibFun: public DLib
 public:
   DLibFun( LibFun f, const std::string& n, const int nPar_=0, 
 	   const std::string keyNames[]=NULL,
-	   const std::string warnKeyNames[]=NULL, const int nParMin_=0);
+	   const std::string warnKeyNames[]=NULL, const int nParMin_=0, const bool use_threadpool=false);
 
   DLibFun( LibFun f, const std::string& n, const std::string& o, 
 	   const int nPar_=0, 
@@ -273,7 +273,7 @@ public:
 		 const std::string keyNames[]=NULL,
 		 const std::string warnKeyNames[]=NULL, bool rConstant=false, const int nParMin_=0);
 
-
+  
   DLibFunRetNew( LibFun f, const std::string& n, const std::string& o, 
 		 const int nPar_=0, 
 		 const std::string keyNames[]=NULL,
@@ -283,6 +283,17 @@ public:
   bool RetConstant() { return this->retConstant;}
 };
 
+class DLibFunRetNewTP: public DLibFun
+{
+  bool   retConstant; // means: can be pre-evaluated with constant input 
+public:
+  DLibFunRetNewTP( LibFun f, const std::string& n, const int nPar_=0, 
+		 const std::string keyNames[]=NULL,
+		 const std::string warnKeyNames[]=NULL, bool rConstant=false, const int nParMin_=0);
+
+  bool RetNew() { return true;}
+  bool RetConstant() { return this->retConstant;}
+};
 // direct call functions must have:
 // ony one parameter, no keywords
 // these functions are called "direct", no environment is created
@@ -297,7 +308,20 @@ public:
 //   bool RetNew() { return true;}
   bool DirectCall() { return true;}
 };
+//The ThreadPool supplementary options (TPOOL_NOTHREAD, etc) have no effect on DLibFunDirectTP
+//as the otions are NEVER checked by a DLibFunDirect, one can type a=sin(dist(4),/ezcezc) without problem.
+//This is a bug, but not noticed by the community, so let it be, as the changes woudl imply removing the Direct functions.
+class DLibFunDirectTP: public DLibFunRetNewTP
+{
+  LibFunDirect funDirect;
+public:
+  DLibFunDirectTP( LibFunDirect f, const std::string& n, bool retConstant_=true);
 
+  LibFunDirect FunDirect() { return funDirect;}
+
+//   bool RetNew() { return true;}
+  bool DirectCall() { return true;}
+};
 // UD pro/fun ********************************************************
 // function/procedure (differ because they are in different lists)
 // User Defined

--- a/src/dstructgdl.cpp
+++ b/src/dstructgdl.cpp
@@ -659,7 +659,7 @@ DStructGDL* DStructGDL::CatArray( ExprListT& exprList,
 
   dimension     catArrDim(dim); // list contains at least one element
 
-  catArrDim.MakeRank( maxIx+1);
+  catArrDim.InsureRankAtLeast( maxIx+1);
   catArrDim.SetOneDim(catRankIx,0);     // clear rank which is added up
 
   SizeT dimSum=0;

--- a/src/dstructgdl.hpp
+++ b/src/dstructgdl.hpp
@@ -23,7 +23,6 @@
 
 #include "typedefs.hpp"
 #include "datatypes.hpp" // for friend declaration
-//#include "typetraits.hpp"
 #include "dstructdesc.hpp"
 
 // NOTE: lot of the code together with Data_<...>::functions

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -90,7 +90,7 @@ namespace lib {
 
       if (direct == -1)
       {
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i) {
             out[i][0] /= nEl;
             out[i][1] /= nEl;
@@ -126,7 +126,7 @@ TRACEOMP(__FILE__, __LINE__)
 
       if (direct == -1)
       {
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out_f[i][0] /= nEl;

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -161,7 +161,7 @@ TRACEOMP(__FILE__, __LINE__)
 
   BaseGDL* fftw_fun( EnvT* e)
   {
-    SizeT nParam=e->NParam();
+    SizeT nParam=e->NParam(1);
     SizeT overwrite=0, dbl=0;
     bool recenter=false;
     SizeT stride;
@@ -176,10 +176,6 @@ TRACEOMP(__FILE__, __LINE__)
     }
 
     double direct=-1.0;
-
-    if( nParam == 0)
-      throw GDLException( e->CallingNode(), 
-			  "FFT: Incorrect number of arguments.");
 
     BaseGDL* p0 = e->GetParDefined( 0);
 

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -90,14 +90,14 @@ namespace lib {
 
       if (direct == -1)
       {
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i) {
             out[i][0] /= nEl;
             out[i][1] /= nEl;
           }          
         } else {
 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out[i][0] /= nEl;
@@ -126,7 +126,7 @@ TRACEOMP(__FILE__, __LINE__)
 
       if (direct == -1)
       {
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out_f[i][0] /= nEl;
@@ -134,7 +134,7 @@ TRACEOMP(__FILE__, __LINE__)
           }          
         } else {
 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out_f[i][0] /= nEl;

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -74,7 +74,6 @@ namespace lib {
 
     DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (data);
     DComplexGDL* p0CF = static_cast<DComplexGDL*> (data);
-    bool parallelize= (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (data->Type() == GDL_COMPLEXDBL)
     {
       double *dptr;
@@ -91,7 +90,7 @@ namespace lib {
 
       if (direct == -1)
       {
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i) {
             out[i][0] /= nEl;
             out[i][1] /= nEl;
@@ -127,7 +126,7 @@ TRACEOMP(__FILE__, __LINE__)
 
       if (direct == -1)
       {
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out_f[i][0] /= nEl;

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -74,7 +74,7 @@ namespace lib {
 
     DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (data);
     DComplexGDL* p0CF = static_cast<DComplexGDL*> (data);
-
+    bool parallelize= (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
     if (data->Type() == GDL_COMPLEXDBL)
     {
       double *dptr;
@@ -91,10 +91,14 @@ namespace lib {
 
       if (direct == -1)
       {
-        //        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        {
-#pragma omp for
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i) {
+            out[i][0] /= nEl;
+            out[i][1] /= nEl;
+          }          
+        } else {
+TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out[i][0] /= nEl;
@@ -123,10 +127,15 @@ namespace lib {
 
       if (direct == -1)
       {
-        //        TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        {
-#pragma omp for
+        if (!parallelize) {
+          for (OMPInt i = 0; i < nEl; ++i)
+          {
+            out_f[i][0] /= nEl;
+            out_f[i][1] /= nEl;
+          }          
+        } else {
+TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i)
           {
             out_f[i][0] /= nEl;

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -74,7 +74,7 @@ namespace lib {
 
     DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (data);
     DComplexGDL* p0CF = static_cast<DComplexGDL*> (data);
-    bool parallelize= (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl));
+    bool parallelize= (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
     if (data->Type() == GDL_COMPLEXDBL)
     {
       double *dptr;

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -431,7 +431,7 @@ int main(int argc, char *argv[])
   InitGDL(); 
 
   // must be after !cpu initialisation
-  InitOpenMP();
+  InitOpenMP(); //will supersede values for CpuTPOOL_NTHREADS
 
   if (gdlde || (isatty(0) && !quiet)) StartupMessage();
 

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -80,7 +80,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     } else {
@@ -106,7 +106,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     } else {
@@ -123,7 +123,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     } else {
@@ -160,7 +160,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
       if (!parallelize) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
@@ -178,7 +178,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
       if (!parallelize) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
@@ -192,7 +192,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     } else {
@@ -205,7 +205,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     } else {
@@ -218,14 +218,16 @@ template<class T, bool IsPOD>
 template<>
   GDLArray<DString,true>& GDLArray<DString,true>::operator-=(const GDLArray<DString,true>& right) throw () {
    assert(false);
+   return *this;
   }
 template<>
   GDLArray<DString,false>& GDLArray<DString,false>::operator-=(const GDLArray<DString,false>& right) throw () {
    assert(false);
+   return *this;
   }
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     } else {
@@ -238,7 +240,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
     if (!parallelize) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     } else {
@@ -251,10 +253,12 @@ template<class T, bool IsPOD>
 template<>
   GDLArray<DString,true>& GDLArray<DString,true>::operator-=(const DString& right) throw () {
    assert(false);
+    return *this;
   }
 template<>
   GDLArray<DString,false>& GDLArray<DString,false>::operator-=(const DString& right) throw () {
    assert(false);
+    return *this;
   }
 template<class T, bool IsPOD>
   void GDLArray<T,IsPOD>::SetSize(SizeT newSz) // only used in DStructGDL::DStructGDL( const string& name_) (dstructgdl.cpp)

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -80,7 +80,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -105,7 +105,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -121,7 +121,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+    if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -157,7 +157,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+      if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -174,7 +174,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+      if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -187,7 +187,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
-  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -199,7 +199,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
-  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -220,7 +220,7 @@ template<>
   }
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
-  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -232,7 +232,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
-  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -80,11 +80,11 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     }
   }
@@ -105,11 +105,11 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     }
   }
@@ -121,11 +121,11 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+    if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     }
   }
@@ -157,11 +157,11 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+      if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       }
     }
@@ -174,11 +174,11 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+      if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       }
     }
@@ -187,11 +187,11 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
-  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     }
     return *this;
@@ -199,11 +199,11 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
-  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     }
     return *this;
@@ -220,11 +220,11 @@ template<>
   }
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
-  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     }
     return *this;
@@ -232,11 +232,11 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
-  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
+  if (GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION)==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     }
     return *this;

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -1,0 +1,291 @@
+/***************************************************************************
+                          gdlarray.cpp  -  basic typedefs
+                             -------------------
+    begin                : July 22 2002
+    copyright            : (C) 2002 by Marc Schellens
+    email                : m_schellens@users.sf.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "basegdl.hpp"
+#include "dstructdesc.hpp"
+#include "gdlarray.hpp"
+template<class T, bool IsPOD>
+T* GDLArray<T,IsPOD>::InitScalar() {
+    assert(sz <= smallArraySize);
+    if (IsPOD) {
+      return reinterpret_cast<T*> (scalarBuf);
+    } else {
+      T* b = reinterpret_cast<T*> (scalarBuf);
+      for (int i = 0; i < sz; ++i) new (&(b[ i])) T(); //not parallel as ALWAYS SMALL NUMBER!
+      return b;
+    }
+  }
+
+template<class T, bool IsPOD>
+  T* GDLArray<T,IsPOD>::New(SizeT s) {
+    // We should align all our arrays on the boundary that will be beneficial for the acceleration of the machine GDL is built,
+    // as sse and other avx need 32,64..512 alignment. Not necessary on the EIGEN_ALIGN_16, and not only if we use Eigen:: as some code (median filter, random)
+    // uses hardware acceleration independently of whatever speedup Eigen:: may propose. Note that according to http://eigen.tuxfamily.org/dox/group__CoeffwiseMathFunctions.html
+    // Eigen:: may eventually use sse2 or avx on reals but not doubles, etc.
+    // As Eigen::internal::aligned_new is SLOW FOR NON-PODS and sdt::complex is a NON-POD for the compiler (but not for us), we use gdlAlignedMalloc for all PODS.
+    // Normally, Everything should be allocated using gdlAlignedMalloc with the 'good' alignment, not only in the USE_EIGEN case.
+    // Unfortunately gdlAlignedMalloc uses Eigen::internal::alogned_malloc at the moment. Todo Next.
+#ifdef USE_EIGEN
+    if (IsPOD) return (T*) gdlAlignedMalloc(s * sizeof (T));
+    else return Eigen::internal::aligned_new<T>(s);
+#else
+    return new T[ s];
+#endif
+  }
+
+#ifndef GDLARRAY_CACHE
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::~GDLArray() throw () {
+    if (IsPOD) {
+#ifdef USE_EIGEN  
+      if (buf != reinterpret_cast<T*> (scalarBuf)) gdlAlignedFree(buf);
+      //	Eigen::internal::aligned_delete( buf, sz);
+#else
+      if (buf != reinterpret_cast<T*> (scalarBuf))
+        delete[] buf; // buf == NULL also possible
+#endif
+      // no cleanup of "buf" here
+    } else {
+#ifdef USE_EIGEN  
+      if (buf != reinterpret_cast<T*> (scalarBuf)) Eigen::internal::aligned_delete(buf, sz);
+      else
+        for (int i = 0; i < sz; ++i) buf[i].~T();
+#else
+      if (buf != reinterpret_cast<T*> (scalarBuf)) delete[] buf; // buf == NULL also possible
+      else
+        for (int i = 0; i < sz; ++i) buf[i].~T();
+#endif
+    }
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::GDLArray(const GDLArray& cp) : sz(cp.size()) {
+    try {
+      buf = (cp.size() > smallArraySize) ? New(cp.size()) /*new T[ cp.size()]*/ : InitScalar();
+    } catch (std::bad_alloc&) {
+      ThrowGDLException("Array requires more memory than available");
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
+    }
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::GDLArray(SizeT s, bool dummy) : sz(s) {
+    try {
+      buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
+    } catch (std::bad_alloc&) {
+      ThrowGDLException("Array requires more memory than available");
+    }
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::GDLArray(T val, SizeT s) : sz(s) {
+    try {
+      buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
+    } catch (std::bad_alloc&) {
+      ThrowGDLException("Array requires more memory than available");
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
+    }
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::GDLArray(const T* arr, SizeT s) : sz(s) {
+    try {
+      buf = (s > smallArraySize) ? New(s) /*new T[ s]*/ : InitScalar();
+    } catch (std::bad_alloc&) {
+      ThrowGDLException("Array requires more memory than available");
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
+    }
+  }
+
+
+#endif // GDLARRAY_CACHE
+
+  // scalar
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>::GDLArray(const T& s) throw () : sz(1) {
+    if (IsPOD) {
+      buf = reinterpret_cast<T*> (scalarBuf);
+      buf[0] = s;
+    } else {
+      T* b = reinterpret_cast<T*> (scalarBuf);
+      new (&(b[ 0])) T(s);
+      buf = b;
+    }
+  }
+
+  // private: // disable
+  // only used (indirect) by DStructGDL::DStructGDL(const DStructGDL& d_)
+
+template<class T, bool IsPOD>
+  void GDLArray<T,IsPOD>::InitFrom(const GDLArray& right) {
+    assert(&right != this);
+    assert(sz == right.size());
+    if (IsPOD) {
+      std::memcpy(buf, right.buf, sz * sizeof (T));
+    } else {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+      if (!parallelize) {
+        for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+      } else {
+        GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+      }
+    }
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator=(const GDLArray<T,IsPOD>& right) {
+    assert(this != &right);
+    assert(sz == right.size());
+    if (IsPOD) {
+      std::memcpy(buf, right.buf, sz * sizeof (T));
+    } else {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+      if (!parallelize) {
+        for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+      } else {
+        GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+      }
+    }
+    return *this;
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
+    }
+    return *this;
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
+    }
+    return *this;
+  }
+template<>
+  GDLArray<DString,true>& GDLArray<DString,true>::operator-=(const GDLArray<DString,true>& right) throw () {
+   assert(false);
+  }
+template<>
+  GDLArray<DString,false>& GDLArray<DString,false>::operator-=(const GDLArray<DString,false>& right) throw () {
+   assert(false);
+  }
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
+    }
+    return *this;
+  }
+
+template<class T, bool IsPOD>
+  GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz));
+    if (!parallelize) {
+      for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
+    } else {
+      GDLARRAY_TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
+    }
+    return *this;
+  }
+template<>
+  GDLArray<DString,true>& GDLArray<DString,true>::operator-=(const DString& right) throw () {
+   assert(false);
+  }
+template<>
+  GDLArray<DString,false>& GDLArray<DString,false>::operator-=(const DString& right) throw () {
+   assert(false);
+  }
+template<class T, bool IsPOD>
+  void GDLArray<T,IsPOD>::SetSize(SizeT newSz) // only used in DStructGDL::DStructGDL( const string& name_) (dstructgdl.cpp)
+  {
+    assert(sz == 0);
+    sz = newSz;
+    if (sz > smallArraySize) {
+      try {
+        buf = New(sz) /*new T[ newSz]*/;
+      }      catch (std::bad_alloc&) {
+        ThrowGDLException("Array requires more memory than available");
+      }
+    } else {
+      // default constructed instances have buf == NULL and size == 0
+      // make sure buf is set corectly if such instances are resized
+      buf = InitScalar();
+    }
+  }
+
+template class GDLArray< DByte,true>;
+template class GDLArray< DInt,true>;
+template class GDLArray< DUInt,true>;
+template class GDLArray< DLong,true>;
+template class GDLArray< DULong,true>;
+template class GDLArray< DLong64,true>;
+template class GDLArray< DULong64,true>;
+template class GDLArray< DFloat,true>;
+template class GDLArray< DDouble,true>;
+template class GDLArray< DString,true>;
+template class GDLArray< DString,false>;
+template class GDLArray< DComplex,true>;
+template class GDLArray< DComplexDbl,true>;
+template class GDLArray< char,true>;
+template class GDLArray< char,false>;

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -80,8 +80,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -106,8 +105,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -123,8 +121,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+    if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -160,8 +157,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-      if (!parallelize) {
+      if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -178,8 +174,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy(buf, right.buf, sz * sizeof (T));
     } else {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-      if (!parallelize) {
+      if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
         GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -192,8 +187,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -205,8 +199,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -227,8 +220,7 @@ template<>
   }
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -240,8 +232,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= sz));
-    if (!parallelize) {
+  if (!parallelize( sz, TP_ARRAY_INITIALISATION)) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)

--- a/src/gdlarray.hpp
+++ b/src/gdlarray.hpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -24,283 +24,118 @@
 //#define GDLARRAY_DEBUG
 #undef GDLARRAY_DEBUG
 
+#define TRACE_GDLARRAY_OMP_CALLS
+//#undef TRACE_GDLARRAY_OMP_CALLS
+#if defined(_OPENMP) && defined(TRACE_GDLARRAY_OMP_CALLS)
+#define GDLARRAY_TRACEOMP( file, line)  TRACEOMP( file, line) 
+#else
+#define GDLARRAY_TRACEOMP( file, line) 
+#endif
 // for complex (of POD)
 const bool TreatPODComplexAsPOD = true;
 
 template <typename T, bool IsPOD>
-class GDLArray
-{
+class GDLArray {
 private:
-	enum GDLArrayConstants
-	{
-		smallArraySize = 27,
-		maxCache = 1000 * 1000 // ComplexDbl is 16 bytes
-	};
-		
-	typedef T Ty;
+
+  enum GDLArrayConstants {
+    smallArraySize = 27,
+    maxCache = 1000 * 1000 // ComplexDbl is 16 bytes
+  };
+
+  typedef T Ty;
 
 #ifdef USE_EIGEN  
-  EIGEN_ALIGN16 char scalarBuf[ smallArraySize * sizeof(Ty)];
+  EIGEN_ALIGN16 char scalarBuf[ smallArraySize * sizeof (Ty)];
 #else
-  char scalarBuf[ smallArraySize * sizeof(Ty)];
+  char scalarBuf[ smallArraySize * sizeof (Ty)];
 #endif
-  
-  Ty* InitScalar()
-  {
-    assert( sz <= smallArraySize);
-    if( IsPOD)
-    {
-      return reinterpret_cast<Ty*>(scalarBuf);
-    }
-    else
-    {
-      Ty* b = reinterpret_cast<Ty*>(scalarBuf);
-#pragma omp parallel for if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))      
-      for( int i = 0; i<sz; ++i) new (&(b[ i])) Ty();
-      return b;
-    }
-  }
+
+  Ty* InitScalar();
 
 #ifdef GDLARRAY_CACHE
 #error "GDLARRAY_CACHE defined"
   static SizeT cacheSize;
   static Ty* cache;
-  static Ty* Cached( SizeT newSize);
+  static Ty* Cached(SizeT newSize);
 #endif
-  
-  Ty*   buf;
+
+  Ty* buf;
   SizeT sz;
 
-  Ty* New( SizeT s)
-  {
-// We should align all our arrays on the boundary that will be beneficial for the acceleration of the machine GDL is built,
-// as sse and other avx need 32,64..512 alignment. Not necessary on the EIGEN_ALIGN_16, and not only if we use Eigen:: as some code (median filter, random)
-// uses hardware acceleration independently of whatever speedup Eigen:: may propose. Note that according to http://eigen.tuxfamily.org/dox/group__CoeffwiseMathFunctions.html
-// Eigen:: may eventually use sse2 or avx on reals but not doubles, etc.
-// As Eigen::internal::aligned_new is SLOW FOR NON-PODS and sdt::complex is a NON-POD for the compiler (but not for us), we use gdlAlignedMalloc for all PODS.
-// Normally, Everything should be allocated using gdlAlignedMalloc with the 'good' alignment, not only in the USE_EIGEN case.
-// Unfortunately gdlAlignedMalloc uses Eigen::internal::alogned_malloc at the moment. Todo Next.
-#ifdef USE_EIGEN
-   if (IsPOD) return (Ty*) gdlAlignedMalloc(s*sizeof(Ty)); else return Eigen::internal::aligned_new<Ty>( s);
-#else
-    return new Ty[ s];
-#endif
-  }
-    
+  Ty* New(SizeT s);
+
 public:
-  GDLArray() throw() : buf( NULL), sz( 0) {}
-  
+
+  GDLArray() throw () : buf(NULL), sz(0) {
+  }
+
 #ifndef GDLARRAY_CACHE
 
-  ~GDLArray() throw()
-  {
-  if( IsPOD)
-    {
-#ifdef USE_EIGEN  
-    if ( buf != reinterpret_cast<Ty*>(scalarBuf)) gdlAlignedFree(buf);
-//	Eigen::internal::aligned_delete( buf, sz);
-#else
-    if( buf != reinterpret_cast<Ty*>(scalarBuf)) 
-	delete[] buf; // buf == NULL also possible
-#endif
-    // no cleanup of "buf" here
-    }
-  else
-    {
-#ifdef USE_EIGEN  
-    if( buf != reinterpret_cast<Ty*>(scalarBuf)) Eigen::internal::aligned_delete( buf, sz);
-    else
-      for( int i = 0; i<sz; ++i) buf[i].~Ty();
-#else
-    if( buf != reinterpret_cast<Ty*>(scalarBuf)) delete[] buf; // buf == NULL also possible
-    else
-      for( int i = 0; i<sz; ++i) buf[i].~Ty();
-#endif
-    }
-  }
+  ~GDLArray() throw();
 
-  GDLArray( const GDLArray& cp) : sz( cp.size())
-  {
-      try {
-	buf = (cp.size() > smallArraySize) ? New(cp.size()) /*new Ty[ cp.size()]*/ : InitScalar();
-      } catch (std::bad_alloc&) { ThrowGDLException("Array requires more memory than available"); }
-#pragma omp parallel for if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-      for( SizeT i=0; i<sz; ++i)	buf[ i] = cp.buf[ i];
-  }
-
-  GDLArray( SizeT s, bool dummy) : sz( s)
-  {
-    try {
-      buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
-    } catch (std::bad_alloc&) { ThrowGDLException("Array requires more memory than available"); }
-  }
-  
-  GDLArray( T val, SizeT s) : sz( s)
-  {
-    try {
-	    buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
-    } catch (std::bad_alloc&) { ThrowGDLException("Array requires more memory than available"); }
-#pragma omp parallel for if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for( SizeT i=0; i<sz; ++i) buf[ i] = val;
-  }
-  
-  GDLArray( const T* arr, SizeT s) : sz( s)
-  {   
-      try {
-	buf = (s > smallArraySize) ? New(s) /*new Ty[ s]*/: InitScalar();
-      } catch (std::bad_alloc&) { ThrowGDLException("Array requires more memory than available"); }
-#pragma omp parallel for if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz)) 
-      for( SizeT i=0; i<sz; ++i)	buf[ i] = arr[ i];
-  }
+  GDLArray(const GDLArray& cp);
+  GDLArray(SizeT s, bool dummy);
+  GDLArray(T val, SizeT s);
+  GDLArray(const T* arr, SizeT s);
 
 #else // GDLARRAY_CACHE
 
   // use definition in datatypes.cpp
-  GDLArray( const GDLArray& cp) ;
-  GDLArray( SizeT s, bool b) ;
-  GDLArray( T val, SizeT s) ;
-  GDLArray( const T* arr, SizeT s) ;
-  ~GDLArray() throw();
+  GDLArray(const GDLArray& cp);
+  GDLArray(SizeT s, bool b);
+  GDLArray(T val, SizeT s);
+  GDLArray(const T* arr, SizeT s);
+  ~GDLArray() throw ();
 
 #endif // GDLARRAY_CACHE
-  
+
   // scalar
-  explicit GDLArray( const T& s) throw() : sz( 1)
-  { 
-    if( IsPOD)
-    {
-      buf = reinterpret_cast<Ty*>(scalarBuf);
-      buf[0] = s;    
-    }
-    else
-    {
-      Ty* b = reinterpret_cast<Ty*>(scalarBuf); 
-      new (&(b[ 0])) Ty( s);
-      buf = b;
-    }
-  }
 
-  T& operator[]( SizeT ix) throw()
-  {
-    assert( ix < sz);
-    return buf[ ix];
-  }
-  const T& operator[]( SizeT ix) const throw()
-  {
-    assert( ix < sz);
+  explicit GDLArray(const T& s) throw () ;
+
+  T& operator[](SizeT ix){
+    assert(ix < sz);
     return buf[ ix];
   }
 
-// private: // disable
-// only used (indirect) by DStructGDL::DStructGDL(const DStructGDL& d_)
-void InitFrom( const GDLArray& right )
-{
-  assert( &right != this);
-  assert ( sz == right.size() );
-  if( IsPOD)
-  {
-    std::memcpy(buf,right.buf,sz*sizeof(Ty));
-  }
-  else
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for ( SizeT i=0; i<sz; ++i )
-	buf[ i] = right.buf[ i];
-  }    
-}
-
-GDLArray& operator= ( const GDLArray& right )
-{
-  assert( this != &right);
-  assert( sz == right.size());
-  if( IsPOD)
-  {
-    std::memcpy(buf,right.buf,sz*sizeof(Ty));
-  }
-  else
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for ( SizeT i=0; i<sz; ++i )
-      buf[ i] = right.buf[ i];
-  }
-  return *this;
-}
-
-  GDLArray& operator+=( const GDLArray& right) throw()
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for( SizeT i=0; i<sz; ++i)
-      buf[ i] += right.buf[ i];
-    return *this;
-  }
-  GDLArray& operator-=( const GDLArray& right) throw()
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for( SizeT i=0; i<sz; ++i)
-      buf[ i] -= right.buf[ i];
-    return *this;
+  const T& operator[](SizeT ix) const{
+    assert(ix < sz);
+    return buf[ ix];
   }
 
-  GDLArray& operator+=( const T& right) throw()
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for( SizeT i=0; i<sz; ++i)
-      buf[ i] += right;
-    return *this;
-  }
-  GDLArray& operator-=( const T& right) throw()
-  {
-#pragma omp parallel for   if (sz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= sz))
-    for( SizeT i=0; i<sz; ++i)
-      buf[ i] -= right;
-    return *this;
-  }
+  // private: // disable
+  // only used (indirect) by DStructGDL::DStructGDL(const DStructGDL& d_)
 
-  void SetBuffer( T* b) throw()
-  {
+  void InitFrom(const GDLArray& right);
+
+  GDLArray& operator=(const GDLArray& right);
+
+  GDLArray& operator+=(const GDLArray& right) throw();
+
+  GDLArray& operator-=(const GDLArray& right) throw();
+
+  GDLArray& operator+=(const T& right) throw();
+
+  GDLArray& operator-=(const T& right) throw() ;
+
+  void SetBuffer(T* b) throw () {
     buf = b;
   }
-  T* GetBuffer() throw()
-  {
+
+  T* GetBuffer() throw () {
     return buf;
   }
-  void SetBufferSize( SizeT s) throw()
-  {
+
+  void SetBufferSize(SizeT s) throw () {
     sz = s;
   }
 
-  SizeT size() const throw()
-  {
+  SizeT size() const throw () {
     return sz;
   }
 
-  void SetSize( SizeT newSz ) // only used in DStructGDL::DStructGDL( const string& name_) (dstructgdl.cpp)
-  {
-    assert ( sz == 0);
-    sz = newSz;
-    if ( sz > smallArraySize )
-    {
-      try
-      {
-	buf = New(sz) /*new T[ newSz]*/;
-      }
-      catch ( std::bad_alloc& )
-      {
-	ThrowGDLException ( "Array requires more memory than available" );
-      }
-    }
-    else
-    {
-      // default constructed instances have buf == NULL and size == 0
-      // make sure buf is set corectly if such instances are resized
-      buf = InitScalar();
-    }
-  }
-  
-// protected:
-//     void assert(ix<sz arg1);
-// protected:
-//     void assert(ix<sz arg1);
+  void SetSize(SizeT newSz);
 }; // GDLArray
 
 #endif

--- a/src/gdlarray.hpp
+++ b/src/gdlarray.hpp
@@ -24,8 +24,8 @@
 //#define GDLARRAY_DEBUG
 #undef GDLARRAY_DEBUG
 
-#define TRACE_GDLARRAY_OMP_CALLS
-//#undef TRACE_GDLARRAY_OMP_CALLS
+//#define TRACE_GDLARRAY_OMP_CALLS
+#undef TRACE_GDLARRAY_OMP_CALLS
 #if defined(_OPENMP) && defined(TRACE_GDLARRAY_OMP_CALLS)
 #define GDLARRAY_TRACEOMP( file, line)  TRACEOMP( file, line) 
 #else

--- a/src/gsl_fun.cpp
+++ b/src/gsl_fun.cpp
@@ -558,18 +558,12 @@ namespace lib {
       cp2data_2_template (real only)
     */
 
-    SizeT nParam=e->NParam();
+    SizeT nParam=e->NParam(1);
     SizeT overwrite=0, dbl=0;
     SizeT stride;
     SizeT offset;
 
     double direct=-1.0;
-
-
-    if( nParam == 0)
-      e->Throw( 
-	       "Incorrect number of arguments.");
-
 
     //BaseGDL* p0 = e->GetNumericArrayParDefined( 0); 
     BaseGDL* p0 = e->GetParDefined( 0);

--- a/src/gsl_fun.cpp
+++ b/src/gsl_fun.cpp
@@ -826,7 +826,7 @@ namespace lib {
     assert(false);
     return 0;
   }
-  /* following are modified codes taken from the GNU Scientific Library (gauss.c)
+/* following are modified codes taken from the GNU Scientific Library (gauss.c)
    * 
    * Copyright (C) 1996, 1997, 1998, 1999, 2000, 2006, 2007 James Theiler, Brian Gough
    * Copyright (C) 2006 Charles Karney
@@ -845,8 +845,7 @@ namespace lib {
    * along with this program; if not, write to the Free Software
    * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
    */
-  inline double high_prec_gsl_rng_uniform_pos_d(const gsl_rng * r)
-  {
+  inline double high_prec_gsl_rng_uniform_pos_d(const gsl_rng * r) {
     unsigned long A, B;
     long double C;
     A = gsl_rng_uniform_pos(r)*0xFFFFFFFFUL;
@@ -857,8 +856,7 @@ namespace lib {
     return C * pow(2, -53);
   }
 
-  float modified_gsl_ran_gaussian_f(const gsl_rng * r, const double sigma, bool reset = false)
-  {
+  float modified_gsl_ran_gaussian_f(const gsl_rng * r, const double sigma, bool reset = false) {
     //modified from GSL code to use the trick described in NumRec, that is,
     //use also the angle of the 'draw" as a no-cost random variable.
     //This trick is used by IDL.
@@ -872,12 +870,12 @@ namespace lib {
     float x, y, r2;
     if (available == 0) {
       do {
-	/* choose x,y in uniform square (-1,-1) to (+1,+1) */
-	x = -1 + 2 * gsl_rng_uniform_pos(r);
-	y = -1 + 2 * gsl_rng_uniform_pos(r);
+        /* choose x,y in uniform square (-1,-1) to (+1,+1) */
+        x = -1 + 2 * gsl_rng_uniform_pos(r);
+        y = -1 + 2 * gsl_rng_uniform_pos(r);
 
-	/* see if it is in the unit circle */
-	r2 = x * x + y * y;
+        /* see if it is in the unit circle */
+        r2 = x * x + y * y;
       } while (r2 > 1.0 || r2 == 0);
 
       /* Box-Muller transform */
@@ -892,8 +890,7 @@ namespace lib {
     }
   }
 
-  double modified_gsl_ran_gaussian_d(const gsl_rng * r, const double sigma, bool reset = false)
-  {
+  double modified_gsl_ran_gaussian_d(const gsl_rng * r, const double sigma, bool reset = false) {
     //modified from GSL code to use the trick described in NumRec, that is,
     //use also the angle of the 'draw" as a no-cost random variable.
     //This trick is used by IDL.
@@ -911,11 +908,11 @@ namespace lib {
     double x, y, r2;
     if (available == 0) {
       do {
-	/* choose x,y in uniform square (-1,-1) to (+1,+1) */
-	x = -1 + 2 * high_prec_gsl_rng_uniform_pos_d(r);
-	y = -1 + 2 * high_prec_gsl_rng_uniform_pos_d(r);
-	/* see if it is in the unit circle */
-	r2 = x * x + y * y;
+        /* choose x,y in uniform square (-1,-1) to (+1,+1) */
+        x = -1 + 2 * high_prec_gsl_rng_uniform_pos_d(r);
+        y = -1 + 2 * high_prec_gsl_rng_uniform_pos_d(r);
+        /* see if it is in the unit circle */
+        r2 = x * x + y * y;
       } while (r2 > 1.0 || r2 == 0);
 
       /* Box-Muller transform */
@@ -933,17 +930,15 @@ namespace lib {
   //template uses gsl, certified to give identical results to IDL8+. This is SLOW and not the default.
 
   template< typename T1, typename T2>
-  int random_gamma(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DLong n)
-  {
+  int random_gamma(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DLong n) {
     SizeT nEl = res->N_Elements();
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] =
-				      (T2) gsl_ran_gamma_knuth(gsl_rng_mem, 1.0 * n, 1.0); //differs from idl above gamma=6. ?//IDL says it's the Knuth algo used.
+      (T2) gsl_ran_gamma_knuth(gsl_rng_mem, 1.0 * n, 1.0); //differs from idl above gamma=6. ?//IDL says it's the Knuth algo used.
     return 0;
   }
 
   template< typename T1, typename T2>
-  int random_binomial(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DDoubleGDL* binomialKey)
-  {
+  int random_binomial(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DDoubleGDL* binomialKey) {
     SizeT nEl = res->N_Elements();
     //Note: Binomial values are not same IDL.    
     DULong n = (DULong) (*binomialKey)[0];
@@ -953,8 +948,7 @@ namespace lib {
   }
 
   template< typename T1, typename T2>
-  int random_poisson(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DDoubleGDL* poissonKey)
-  {
+  int random_poisson(T1* res, gsl_rng *gsl_rng_mem, dimension dim, DDoubleGDL* poissonKey) {
     SizeT nEl = res->N_Elements();
     //Removed old code that would return non-integer values for high mu values.
     DDouble mu = (DDouble) (*poissonKey)[0];
@@ -963,8 +957,7 @@ namespace lib {
   }
 
   template< typename T1, typename T2>
-  int random_uniform(T1* res, gsl_rng *gsl_rng_mem, dimension dim)
-  {
+  int random_uniform(T1* res, gsl_rng *gsl_rng_mem, dimension dim) {
     SizeT nEl = res->N_Elements();
 
     if (sizeof (T2) == sizeof (float)) {
@@ -975,21 +968,20 @@ namespace lib {
       unsigned long A, B;
       long double C;
       for (SizeT i = 0; i < nEl; ++i) {
-	A = gsl_rng_uniform(gsl_rng_mem)*0xFFFFFFFFUL;
-	B = gsl_rng_uniform(gsl_rng_mem)*0xFFFFFFFFUL;
-	A = (A >> 5);
-	B = (B >> 6);
-	C = A * pow(2, 26) + B;
-	C = C * pow(2, -53);
-	(*res)[ i] = (T2) C; //gives the same as IDL 8
+        A = gsl_rng_uniform(gsl_rng_mem)*0xFFFFFFFFUL;
+        B = gsl_rng_uniform(gsl_rng_mem)*0xFFFFFFFFUL;
+        A = (A >> 5);
+        B = (B >> 6);
+        C = A * pow(2, 26) + B;
+        C = C * pow(2, -53);
+        (*res)[ i] = (T2) C; //gives the same as IDL 8
       }
       return 0;
     }
   }
 
   template< typename T1, typename T2>
-  int random_normal(T1* res, gsl_rng *gsl_rng_mem, dimension dim)
-  {
+  int random_normal(T1* res, gsl_rng *gsl_rng_mem, dimension dim) {
     SizeT nEl = res->N_Elements();
     if (sizeof (T2) == sizeof (float)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = (T2) modified_gsl_ran_gaussian_f(gsl_rng_mem, 1.0); //does reproduct IDL values.
@@ -1008,8 +1000,7 @@ namespace lib {
     int mti;
   } mt_state_t;
 
-  void set_random_state(gsl_rng* r, const unsigned long int* seed, const int pos, const int n)
-  {
+  void set_random_state(gsl_rng* r, const unsigned long int* seed, const int pos, const int n) {
     assert(n == MERSENNE_GSL_N);
     mt_state_t *state = (mt_state_t *) (r->state);
     unsigned long * mt = state->mt;
@@ -1017,13 +1008,12 @@ namespace lib {
     state->mti = pos;
   }
 
-  void get_random_state(EnvT* e, const gsl_rng* r, const DULong seed)
-  {
+  void get_random_state(EnvT* e, const gsl_rng* r, const DULong seed) {
     if (e->GlobalPar(0)) {
       int pos;
       mt_state_t *mt_state = (mt_state_t *) (r->state);
       pos = mt_state->mti;
-      unsigned long int* state= mt_state->mt;
+      unsigned long int* state = mt_state->mt;
       DULongGDL* ret = new DULongGDL(dimension(MERSENNE_GSL_N + 4), BaseGDL::ZERO); //ZERO as not all elements are initialized here
       DULong* newstate = (DULong*) (ret->DataAddr());
       newstate[0] = seed;
@@ -1034,8 +1024,8 @@ namespace lib {
   }
 
   //GSL version of random_fun. See randomgenerators.cpp
-  BaseGDL* random_fun_gsl(EnvT* e)
-  {
+
+  BaseGDL* random_fun_gsl(EnvT* e) {
 
     //used in RANDOMU and RANDOMN, which share the SAME KEYLIST. It is safe to speed up by using static ints KeywordIx.
     //Note: LONG or ULONG are obeyed irrespectively of the presence of GAMMA etc which are ignored.
@@ -1068,33 +1058,33 @@ namespace lib {
     if (nParam > 1) arr(e, dim, 1);
 
     DULong seed;
-    bool initialized=false;
+    bool initialized = false;
 
     bool isAnull = NullGDL::IsNULLorNullGDL(e->GetPar(0));
     if (!isAnull) {
       DULongGDL* p0L = e->IfDefGetParAs< DULongGDL>(0);
       if (p0L != NULL) // some non-null value passed -> can be a seed state, 628 integers, or use first value:
-	{
-	  // IDL does not check that the seed sequence has been changed: as long as it is a 628 element Ulong, it takes it
-	  // and use it as the current sequence (try with "all zeroes").
-	  if (p0L->N_Elements() == MERSENNE_GSL_N + 4 && p0L->Type() == GDL_ULONG ) { //a (valid?) seed sequence
-	    seed = (*p0L)[0];
-	    int pos = (*p0L)[1];
-	    int n = MERSENNE_GSL_N;
-	    unsigned long int sequence[n];
-	    for (int i = 0; i < n; ++i) sequence[i] = (unsigned long int) (*p0L)[i + 2];
-	    set_random_state(gsl_rng_mem, sequence, pos, n); //the seed 
-	    initialized=true;
-	  } else { // not a seed sequence: take first (IDL does more than this...)
-	    if (p0L->N_Elements() >= 1) {
-	      seed = (*p0L)[0];
-	      gsl_rng_set(gsl_rng_mem, seed);
-	      initialized=true;
-	    }
-	  }
-	}
+      {
+        // IDL does not check that the seed sequence has been changed: as long as it is a 628 element Ulong, it takes it
+        // and use it as the current sequence (try with "all zeroes").
+        if (p0L->N_Elements() == MERSENNE_GSL_N + 4 && p0L->Type() == GDL_ULONG) { //a (valid?) seed sequence
+          seed = (*p0L)[0];
+          int pos = (*p0L)[1];
+          int n = MERSENNE_GSL_N;
+          unsigned long int sequence[n];
+          for (int i = 0; i < n; ++i) sequence[i] = (unsigned long int) (*p0L)[i + 2];
+          set_random_state(gsl_rng_mem, sequence, pos, n); //the seed 
+          initialized = true;
+        } else { // not a seed sequence: take first (IDL does more than this...)
+          if (p0L->N_Elements() >= 1) {
+            seed = (*p0L)[0];
+            gsl_rng_set(gsl_rng_mem, seed);
+            initialized = true;
+          }
+        }
+      }
     }
-  
+
     if (!initialized) {
       struct timeval tval;
       struct timezone tzone;
@@ -1102,10 +1092,10 @@ namespace lib {
       long long int tt = tval.tv_sec * 1e6 + tval.tv_usec; // time in UTC microseconds
       seed = tt;
       gsl_rng_set(gsl_rng_mem, seed);
-      initialized=true;
+      initialized = true;
     }
 
-    if (e->KeywordSet(LONGIx)) { 
+    if (e->KeywordSet(LONGIx)) {
       DLongGDL* res = new DLongGDL(dim, BaseGDL::NOZERO);
       SizeT nEl = res->N_Elements();
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = (DLong) (gsl_rng_uniform(gsl_rng_mem) * 2147483646) + 1; //apparently IDL rounds up.
@@ -1113,61 +1103,61 @@ namespace lib {
       return res;
     }
 
-    if (e->KeywordSet(ULONGIx)) { 
+    if (e->KeywordSet(ULONGIx)) {
       DULongGDL* res = new DULongGDL(dim, BaseGDL::NOZERO);
       SizeT nEl = res->N_Elements();
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = (DULong) (gsl_rng_uniform(gsl_rng_mem) * 0xFFFFFFFFUL) + 1; //apparently IDL rounds up.
       get_random_state(e, gsl_rng_mem, seed);
       return res;
     }
-  
-  
+
+
     if (e->KeywordPresent(GAMMAIx)) {
       DLong n = -1; //please initialize everything!
       e->AssureLongScalarKW(GAMMAIx, n);
       if (n == 0) {
-	DDouble test_n;
-	e->AssureDoubleScalarKW(GAMMAIx, test_n);
-	if (test_n > 0.0) n = 1;
+        DDouble test_n;
+        e->AssureDoubleScalarKW(GAMMAIx, test_n);
+        if (test_n > 0.0) n = 1;
       }
       if (n <= 0) e->Throw("Value of (Int/Long) GAMMA is out of allowed range: Gamma = 1, 2, 3, ...");
       if (!e->KeywordSet(0)) { //hence:float
-	if (n >= 10000000) e->Throw("Value of GAMMA is out of allowed range: Try /DOUBLE.");
+        if (n >= 10000000) e->Throw("Value of GAMMA is out of allowed range: Try /DOUBLE.");
       }
       if (e->KeywordSet(0)) { // GDL_DOUBLE
-	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-	random_gamma< DDoubleGDL, double>(res, gsl_rng_mem, dim, n);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+        random_gamma< DDoubleGDL, double>(res, gsl_rng_mem, dim, n);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       } else {
-	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
-	random_gamma< DFloatGDL, float>(res, gsl_rng_mem, dim, n);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+        random_gamma< DFloatGDL, float>(res, gsl_rng_mem, dim, n);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       }
     }
-  
+
     DDoubleGDL* binomialKey = e->IfDefGetKWAs<DDoubleGDL>(BINOMIALIx);
     if (binomialKey != NULL) {
       SizeT nBinomialKey = binomialKey->N_Elements();
       if (nBinomialKey != 2)
-	e->Throw("Keyword array parameter BINOMIAL must have 2 elements.");
+        e->Throw("Keyword array parameter BINOMIAL must have 2 elements.");
 
       if ((*binomialKey)[0] < 1.0)
-	e->Throw(" Value of BINOMIAL[0] is out of allowed range: n = 1, 2, 3, ...");
+        e->Throw(" Value of BINOMIAL[0] is out of allowed range: n = 1, 2, 3, ...");
 
       if (((*binomialKey)[1] < 0.0) || ((*binomialKey)[1] > 1.0))
-	e->Throw(" Value of BINOMIAL[1] is out of allowed range: 0.0 <= p <= 1.0");
+        e->Throw(" Value of BINOMIAL[1] is out of allowed range: 0.0 <= p <= 1.0");
       if (e->KeywordSet(0)) { // GDL_DOUBLE
-	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-	random_binomial< DDoubleGDL, double>(res, gsl_rng_mem, dim, binomialKey);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+        random_binomial< DDoubleGDL, double>(res, gsl_rng_mem, dim, binomialKey);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       } else {
-	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
-	random_binomial< DFloatGDL, float>(res, gsl_rng_mem, dim, binomialKey);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+        random_binomial< DFloatGDL, float>(res, gsl_rng_mem, dim, binomialKey);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       }
     }
 
@@ -1175,50 +1165,50 @@ namespace lib {
     if (poissonKey != NULL) {
       SizeT nPoissonKey = poissonKey->N_Elements();
       if (nPoissonKey != 1)
-	e->Throw("Expression must be a scalar or 1 element array in this context: " + e->GetString(POISSONIx));
+        e->Throw("Expression must be a scalar or 1 element array in this context: " + e->GetString(POISSONIx));
       if ((*poissonKey)[0] < 0.0)
-	  e->Throw("Value of POISSON is out of allowed range: Poisson > 0.0");
+        e->Throw("Value of POISSON is out of allowed range: Poisson > 0.0");
 
       if (e->KeywordSet("DOUBLE")) {
-	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-	random_poisson< DDoubleGDL, double>(res, gsl_rng_mem, dim, poissonKey);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+        random_poisson< DDoubleGDL, double>(res, gsl_rng_mem, dim, poissonKey);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       } else {
-	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
-	if ((*poissonKey)[0] > 1.0e7)
-	  e->Throw("Value of POISSON is out of allowed range: Try /DOUBLE.");
-	random_poisson< DFloatGDL, float>(res, gsl_rng_mem, dim, poissonKey);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+        if ((*poissonKey)[0] > 1.0e7)
+          e->Throw("Value of POISSON is out of allowed range: Try /DOUBLE.");
+        random_poisson< DFloatGDL, float>(res, gsl_rng_mem, dim, poissonKey);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       }
     }
 
     if (e->KeywordSet(UNIFORMIx) || ((e->GetProName() == "RANDOMU") && !e->KeywordSet(NORMALIx))) {
       if (e->KeywordSet(0)) { // GDL_DOUBLE
-	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-	random_uniform< DDoubleGDL, double>(res, gsl_rng_mem, dim);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+        random_uniform< DDoubleGDL, double>(res, gsl_rng_mem, dim);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       } else {
-	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
-	random_uniform< DFloatGDL, float>(res, gsl_rng_mem, dim);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+        random_uniform< DFloatGDL, float>(res, gsl_rng_mem, dim);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       }
     }
-  
+
     if (e->KeywordSet(NORMALIx) || ((e->GetProName() == "RANDOMN") && !e->KeywordSet(UNIFORMIx))) {
       if (e->KeywordSet(0)) { // GDL_DOUBLE
-	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-	random_normal< DDoubleGDL, double>(res, gsl_rng_mem, dim);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+        random_normal< DDoubleGDL, double>(res, gsl_rng_mem, dim);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       } else {
-	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
-	random_normal< DFloatGDL, float>(res, gsl_rng_mem, dim);
-	get_random_state(e, gsl_rng_mem, seed);
-	return res;
+        DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+        random_normal< DFloatGDL, float>(res, gsl_rng_mem, dim);
+        get_random_state(e, gsl_rng_mem, seed);
+        return res;
       }
     }
     assert(false);

--- a/src/includefirst.hpp
+++ b/src/includefirst.hpp
@@ -91,7 +91,11 @@ inline void gdlAlignedFree(void* ptr) {
 inline int currentNumberOfThreads() {
   return omp_get_num_threads();
 }
-inline int maxNumberOfThreads() {
+#define DSFMT_MAX_PARALLEL_SEEDS 4
+inline int maxNumberOfThreadsForDSFMT() {
+  return std::min (DSFMT_MAX_PARALLEL_SEEDS,omp_get_num_procs());
+}
+inline int numberOfProcs() {
   return omp_get_num_procs();
 }
 inline int currentThreadNumber() {
@@ -102,7 +106,7 @@ inline int currentNumberOfThreads() {
   return 1;
 }
 
-inline int maxNumberOfThreads() {
+inline int maxNumberOfThreadsForDSFMT() {
   return 1;
 }
 

--- a/src/interpol.cpp
+++ b/src/interpol.cpp
@@ -347,8 +347,7 @@ const gdl_interpol_type* gdl_interpol_cspline = &cspline_type;
 namespace lib {
   
   BaseGDL* interpol_fun(EnvT* e){
-    SizeT nParam = e->NParam();
-    if (nParam < 2 || nParam > 3) e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(2);
 
     const gdl_interpol_type* interpol=gdl_interpol_linear;
     // options

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -186,6 +186,7 @@ void interpolate_1d_nearest(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Siz
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(ix,x,v0,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
   {
 #pragma omp for 
@@ -211,6 +212,7 @@ void interpolate_1d_nearest_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* r
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(ix,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
   {
 #pragma omp for 
@@ -239,6 +241,7 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x,v0,v1,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -265,6 +268,7 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
     }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x,v0,v1,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
       {
 #pragma omp for 
@@ -305,6 +309,7 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -327,6 +332,7 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
     }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -362,6 +368,7 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x,v0,v1,v2,v3,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -413,6 +420,7 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
     }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x,v0,v1,v2,v3,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -475,6 +483,7 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -518,6 +527,7 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
     }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
     {
 #pragma omp for 
@@ -568,6 +578,7 @@ void interpolate_2d_nearest_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT 
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,x,y,vx0,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
   {
 #pragma omp for collapse(2)
@@ -605,6 +616,7 @@ void interpolate_2d_nearest_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx,
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
   {
 #pragma omp for collapse(2)
@@ -643,6 +655,7 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) { //following behaviour validated.
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
     {
 #pragma omp for 
@@ -688,6 +701,7 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
       }
     }
   } else { //following behaviour validated.
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
     {
 #pragma omp for 
@@ -746,6 +760,7 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -793,6 +808,7 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
     }
     }
   } else { //following behaviour validated.
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -847,6 +863,7 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -887,6 +904,7 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
     }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -941,6 +959,7 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) { 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
     {
 #pragma omp for 
@@ -1043,6 +1062,7 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
   {
 #pragma omp for 
@@ -1152,6 +1172,7 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -1255,6 +1276,7 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
     }
     }
   } else { 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -1361,6 +1383,7 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -1442,6 +1465,7 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
     }
     }
   } else { 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
     {
 #pragma omp for collapse(2)
@@ -1528,6 +1552,7 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
   ssize_t n3 = un3;
   ssize_t n1n2=n1*n2;
   if (use_missing) { 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,x,y,z,umdx,umdy,umdz,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
     {
 #pragma omp for
@@ -1595,6 +1620,7 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
     {
 #pragma omp for
@@ -1662,6 +1688,7 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
     {
 #pragma omp for collapse(3)
@@ -1736,6 +1763,7 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
     {
 #pragma omp for collapse(2)   //2 is a good compromise as some values (yi and zi) are not computed nx times. 
@@ -1811,6 +1839,7 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
     {
 #pragma omp for collapse(3)
@@ -1873,6 +1902,7 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
       }
     }
   } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
     {
 #pragma omp for collapse(2)   //2 is a good compromise as some values (yi and zi) are not computed nx times. 

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -186,7 +186,7 @@ void interpolate_1d_nearest(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Siz
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+  if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_nearest.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -201,7 +201,7 @@ void interpolate_1d_nearest_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* r
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+  if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_nearest_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -221,7 +221,7 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -229,7 +229,7 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize (nx)==1) {
+    if ((GDL_NTHREADS=parallelize (nx))==1) {
 #include "snippets/interpolate_1d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -249,7 +249,7 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -257,7 +257,7 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_linear_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -279,7 +279,7 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -287,7 +287,7 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -307,7 +307,7 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -315,7 +315,7 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx)==1) {
+    if ((GDL_NTHREADS=parallelize( nx))==1) {
 #include "snippets/interpolate_1d_cubic_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -332,7 +332,7 @@ void interpolate_2d_nearest_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT 
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+  if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_nearest_grid.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -347,7 +347,7 @@ void interpolate_2d_nearest_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx,
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+  if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_nearest_grid_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -367,7 +367,7 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) { //following behaviour validated.
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -375,7 +375,7 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
 #include "snippets/interpolate_2d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -396,7 +396,7 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -404,7 +404,7 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -423,7 +423,7 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -431,7 +431,7 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -458,14 +458,14 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
   ssize_t n2 = un2;
   if (use_missing) { 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
   } else {
     TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
 #include "snippets/interpolate_2d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -491,7 +491,7 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -499,7 +499,7 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
     }
   } else { 
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_cubic_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -520,7 +520,7 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -528,7 +528,7 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
     }
   } else { 
-  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny))==1) {
 #include "snippets/interpolate_2d_cubic_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -553,7 +553,7 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
   ssize_t n3 = un3;
   ssize_t n1n2=n1*n2;
   if (use_missing) { 
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -561,7 +561,7 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( n)==1) {
+    if ((GDL_NTHREADS=parallelize( n))==1) {
 #include "snippets/interpolate_3d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -586,7 +586,7 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny*nz))==1) {
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -594,7 +594,7 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny*nz))==1) {
 #include "snippets/interpolate_3d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -618,7 +618,7 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
-  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny*nz))==1) {
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -626,7 +626,7 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
+    if ((GDL_NTHREADS=parallelize( nx*ny*nz))==1) {
 #include "snippets/interpolate_3d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -657,8 +657,7 @@ namespace lib {
 
   BaseGDL* interpolate_fun(EnvT* e) {
 
-    SizeT nParam = e->NParam();
-    if (nParam < 2) e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(2);
 
     // options
     static int cubicIx = e->KeywordIx("CUBIC");

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -186,8 +186,7 @@ void interpolate_1d_nearest(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Siz
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_nearest.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -202,8 +201,7 @@ void interpolate_1d_nearest_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* r
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_nearest_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -222,9 +220,8 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
   ssize_t ix = 0;
   ssize_t xi[2];
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -232,7 +229,7 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize (nx)) {
 #include "snippets/interpolate_1d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -251,9 +248,8 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
   ssize_t ix = 0;
   ssize_t xi[2];
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -261,7 +257,7 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_linear_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -282,9 +278,8 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
   ssize_t ix = 0;
   ssize_t xi[4];
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -292,7 +287,7 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -311,9 +306,8 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
   ssize_t ix = 0;
   ssize_t xi[4];
   ssize_t n1 = un1;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -321,7 +315,7 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx)) {
 #include "snippets/interpolate_1d_cubic_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -338,8 +332,7 @@ void interpolate_2d_nearest_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT 
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny)); 
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_nearest_grid.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -354,8 +347,7 @@ void interpolate_2d_nearest_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx,
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize =  (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_nearest_grid_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
@@ -374,9 +366,8 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { //following behaviour validated.
-  if (!parallelize) {
+  if (!parallelize( n)) {
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -384,7 +375,7 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (!parallelize) {
+  if (!parallelize( n)) {
 #include "snippets/interpolate_2d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -404,9 +395,8 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {  //following behaviour validated.
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -414,7 +404,7 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -432,9 +422,8 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {  //following behaviour validated.
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -442,7 +431,7 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -467,17 +456,16 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
-  if (!parallelize) {
+  if (!parallelize( n)) {
   } else {
     TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( n)) {
 #include "snippets/interpolate_2d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -502,9 +490,8 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -512,7 +499,7 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
     }
   } else { 
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_cubic_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -532,9 +519,8 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -542,7 +528,7 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
     }
   } else { 
-  if (!parallelize) {
+  if (!parallelize( nx*ny)) {
 #include "snippets/interpolate_2d_cubic_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -566,9 +552,8 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2=n1*n2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { 
-  if (!parallelize) {
+  if (!parallelize( n)) {
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -576,7 +561,7 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( n)) {
 #include "snippets/interpolate_3d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -600,9 +585,8 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny*nz));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx*ny*nz)) {
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -610,7 +594,7 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx*ny*nz)) {
 #include "snippets/interpolate_3d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -633,9 +617,8 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
-  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny*nz));
   if (use_missing) {
-  if (!parallelize) {
+  if (!parallelize( nx*ny*nz)) {
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -643,7 +626,7 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize) {
+  if (!parallelize( nx*ny*nz)) {
 #include "snippets/interpolate_3d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -186,23 +186,13 @@ void interpolate_1d_nearest(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Siz
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
+  if (!parallelize) {
+#include "snippets/interpolate_1d_nearest.incpp"
+  } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(ix,x,v0,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-  {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) {
-      vres = &(res[ncontiguous * j]);
-      x = xx[j];
-      if (x < 0) {
-        v0 = &(array[0]);
-      } else if (x < n1 - 1) {
-        ix = floor(x); //floor  ix is [0 .. n1[
-        v0 = &(array[ncontiguous * ix]);
-      } else {
-        v0 = &(array[ncontiguous * (n1 - 1)]);
-      }
-      for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
-    }
+#pragma omp parallel for private(ix,x,v0,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_nearest.incpp"
   }
 }
 
@@ -212,21 +202,13 @@ void interpolate_1d_nearest_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* r
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
+  if (!parallelize) {
+#include "snippets/interpolate_1d_nearest_single.incpp"
+  } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(ix,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-  {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) {
-      x = xx[j];
-      if (x < 0) {
-        res[j] = array[0];
-      } else if (x < n1 - 1) {
-        ix = floor(x); //floor  ix is [0 .. n1[
-        res[j] = array[ix];
-      } else {
-        res[j] = array[n1 - 1];
-      }
-    }
+#pragma omp parallel for private(ix,x) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_nearest_single.incpp"
   }
 }
 
@@ -240,62 +222,23 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
   ssize_t ix = 0;
   ssize_t xi[2];
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x,v0,v1,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      vres = &(res[ncontiguous * j]);
-      x = xx[j];
-      if (x < 0) {
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-      } else if (x < n1) {
-        ix = floor(x);
-        xi[0]=ix; xi[1]=ix+1;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        dx = (x - xi[0]);
-        v0 = &(array[ncontiguous * xi[0]]);
-        v1 = &(array[ncontiguous * xi[1]]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = (1. - dx) * v0[i] + dx * v1[i];
-        }
-      } else {
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-      }
-    }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_1d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x,v0,v1,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-      {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) {
-      vres = &(res[ncontiguous * j]);
-      x = xx[j];
-      if (x < 0) {
-        v0 = &(array[0]);
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
-      } else if (x < n1 - 1) {
-        ix = floor(x);
-        xi[0]=ix; xi[1]=ix+1;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        dx = (x - xi[0]);
-        v0 = &(array[ncontiguous * xi[0]]);
-        v1 = &(array[ncontiguous * xi[1]]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = (1. - dx) * v0[i] + dx * v1[i];
-        }
-      } else {
-        v0 = &(array[ncontiguous * (n1 - 1)]);
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
-      }
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_linear_use_missing.incpp"
     }
-      }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_1d_linear.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_linear.incpp"
+    }
   }
 }
 
@@ -308,50 +251,22 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
   ssize_t ix = 0;
   ssize_t xi[2];
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      x = xx[j];
-      if (x < 0) {
-        res[j] = missing;
-      }
-      else if (x < n1) {
-        ix = floor(x);
-        xi[0]=ix; xi[1]=ix+1;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        dx = (x - xi[0]);
-        res[j] = (1. - dx) * array[xi[0]] + dx * array[xi[1]];
-      } else {
-        res[j] = missing;
-      }
-    }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_1d_linear_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) {
-      x = xx[j];
-      if (x < 0) {
-        res[j] = array[0];
-      } else if (x < n1) {
-        ix = floor(x);
-        xi[0]=ix; xi[1]=ix+1;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        dx = (x - xi[0]);
-        res[j] = (1. - dx) * array[xi[0]] + dx * array[xi[1]];
-      } else {
-        res[j] = array[n1-1];
-      }
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_linear_use_missing_single.incpp"
     }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_1d_linear_single.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_linear_single.incpp"
     }
   }
 }
@@ -367,108 +282,22 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
   ssize_t ix = 0;
   ssize_t xi[4];
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x,v0,v1,v2,v3,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      vres = &(res[ncontiguous * j]);
-      x = xx[j];
-     if (x < 0) {
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-      } else if (x  < n1-1 ) { 
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0]=ix-1; xi[1]=ix; xi[2]=ix+1; xi[3]=ix+2;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        if (xi[2]<0) xi[2]=0; else if (xi[2]>n1-1) xi[2]=n1-1; 
-        if (xi[3]<0) xi[3]=0; else if (xi[3]>n1-1) xi[3]=n1-1; 
-        v0 = &(array[ncontiguous * xi[0]]);
-        v1 = &(array[ncontiguous * xi[1]]);
-        v2 = &(array[ncontiguous * xi[2]]);
-        v3 = &(array[ncontiguous * xi[3]]);
-        dx = (x - xi[1]);
-        double d2 = dx*dx;
-        double d3 = d2*dx;
-        double omd = 1 - dx;
-        double omd2 = omd*omd;
-        double omd3 = omd2*omd;
-        double opd = 1 + dx;
-        double opd2 = opd*opd;
-        double opd3 = opd2*opd;
-        double dmd = 2 - dx;
-        double dmd2 = dmd*dmd;
-        double dmd3 = dmd2*dmd;
-        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
-        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
-        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
-        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
-
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = c1 * v1[i] + c2 * v2[i] + c0 * v0[i] + c3 * v3[i];
-        }
-      } else if (x < n1) {
-        v0 = &(array[ncontiguous * (n1-1)]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = v0[i];
-        }
-      } else {
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-      }
-    }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_1d_cubic_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x,v0,v1,v2,v3,vres) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      vres = &(res[ncontiguous * j]);
-      x = xx[j];
-     if (x < 0) {
-        v0 = &(array[0]);
-        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
-      } else if (x  < n1-1 ) { 
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0]=ix-1; xi[1]=ix; xi[2]=ix+1; xi[3]=ix+2;
-      //make in range
-        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
-        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
-        if (xi[2]<0) xi[2]=0; else if (xi[2]>n1-1) xi[2]=n1-1; 
-        if (xi[3]<0) xi[3]=0; else if (xi[3]>n1-1) xi[3]=n1-1; 
-        v0 = &(array[ncontiguous * xi[0]]);
-        v1 = &(array[ncontiguous * xi[1]]);
-        v2 = &(array[ncontiguous * xi[2]]);
-        v3 = &(array[ncontiguous * xi[3]]);
-        dx = (x - xi[1]);
-        double d2 = dx*dx;
-        double d3 = d2*dx;
-        double omd = 1 - dx;
-        double omd2 = omd*omd;
-        double omd3 = omd2*omd;
-        double opd = 1 + dx;
-        double opd2 = opd*opd;
-        double opd3 = opd2*opd;
-        double dmd = 2 - dx;
-        double dmd2 = dmd*dmd;
-        double dmd3 = dmd2*dmd;
-        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
-        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
-        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
-        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
-
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = c1 * v1[i] + c2 * v2[i] + c0 * v0[i] + c3 * v3[i];
-        }
-      } else {
-        v0 = &(array[ncontiguous * (n1-1)]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          vres[i] = v0[i];
-        }
-      }
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_cubic_use_missing.incpp"
     }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_1d_cubic.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_cubic.incpp"
     }
   }
 }
@@ -482,91 +311,22 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
   ssize_t ix = 0;
   ssize_t xi[4];
   ssize_t n1 = un1;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      x = xx[j];
-      if (x < 0) {
-        res[j] = missing;
-      } else if (x < n1 - 1) {
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0] = ix - 1;
-        xi[1] = ix;
-        xi[2] = ix + 1;
-        xi[3] = ix + 2;
-        //make in range
-        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
-        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
-        dx = (x - xi[1]);
-        double d2 = dx*dx;
-        double d3 = d2*dx;
-        double omd = 1 - dx;
-        double omd2 = omd*omd;
-        double omd3 = omd2*omd;
-        double opd = 1 + dx;
-        double opd2 = opd*opd;
-        double opd3 = opd2*opd;
-        double dmd = 2 - dx;
-        double dmd2 = dmd*dmd;
-        double dmd3 = dmd2*dmd;
-        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
-        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
-        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
-        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
-        res[j] = c1 * array[xi[1]] + c2 * array[xi[2]] + c0 * array[xi[0]] + c3 * array[xi[3]];
-      } else if (x < n1) {
-        res[j] = array[n1 - 1];
-      } else {
-        res[j] = missing;
-      }
-    }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,ix,dx,x) if (CpuTPOOL_NTHREADS> 1 && nx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx))
-    {
-#pragma omp for 
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      x = xx[j];
-      if (x < 0) {
-        res[j] = array[0];
-      } else if (x < n1 - 1) {
-        ix = floor(x);  if (x<0)x=0; if(x>n1-1)x=n1-1; //floor  ix is [0 .. n1[
-        xi[0] = ix - 1;
-        xi[1] = ix;
-        xi[2] = ix + 1;
-        xi[3] = ix + 2;
-        //make in range
-        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
-        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
-        dx = (x - xi[1]);
-        double d2 = dx*dx;
-        double d3 = d2*dx;
-        double omd = 1 - dx;
-        double omd2 = omd*omd;
-        double omd3 = omd2*omd;
-        double opd = 1 + dx;
-        double opd2 = opd*opd;
-        double opd3 = opd2*opd;
-        double dmd = 2 - dx;
-        double dmd2 = dmd*dmd;
-        double dmd3 = dmd2*dmd;
-        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
-        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
-        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
-        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
-        res[j] = c1 * array[xi[1]] + c2 * array[xi[2]] + c0 * array[xi[0]] + c3 * array[xi[3]];
-      } else {
-        res[j] = array[n1-1];
-      }
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
     }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_1d_cubic_single.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_1d_cubic_single.incpp"
     }
   }
 }
@@ -578,35 +338,13 @@ void interpolate_2d_nearest_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT 
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny)); 
+  if (!parallelize) {
+#include "snippets/interpolate_2d_nearest_grid.incpp"
+  } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,x,y,vx0,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-  {
-#pragma omp for collapse(2)
-  for (SizeT k = 0; k < ny; ++k) {
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      vres = &(res[ncontiguous * (k * nx + j) ]);
-      x = xx[j];
-      if (x < 0) {
-        xi = 0;
-      } else if (x >= n1-1 ) {
-        xi = n1-1;
-      } else {
-        xi = floor(x);
-      }
-      y = yy[k];
-      if (y < 0) {
-        yi = 0; 
-      } else if (y >= n2-1 ) {
-        yi = n2-1; 
-      } else {
-        yi = floor(y);
-      }
-      vx0 = &(array[ncontiguous * (yi * n1 + xi)]);
-      for (SizeT i = 0; i < ncontiguous; ++i) {
-        vres[i] = vx0[i];
-      }
-    }
-  }
+#pragma omp parallel for collapse(2) private(xi,yi,x,y,vx0,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_2d_nearest_grid.incpp"
   }
 }
 
@@ -616,31 +354,13 @@ void interpolate_2d_nearest_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx,
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize =  (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
+  if (!parallelize) {
+#include "snippets/interpolate_2d_nearest_grid_single.incpp"
+  } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-  {
-#pragma omp for collapse(2)
-  for (SizeT k = 0; k < ny; ++k) {
-    for (SizeT j = 0; j < nx; ++j) { //nb output points
-      x = xx[j];
-      if (x < 0) {
-        xi = 0;
-      } else if (x >= n1-1 ) {
-        xi = n1-1;
-      } else {
-        xi = floor(x);
-      }
-      y = yy[k];
-      if (y < 0) {
-        yi = 0; 
-      } else if (y >= n2-1 ) {
-        yi = n2-1; 
-      } else {
-        yi = floor(y);
-      }
-      res[k * nx + j] = array[yi * n1 + xi];
-    }
-  }
+#pragma omp parallel for collapse(2) private(xi,yi,x,y) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_2d_nearest_grid_single.incpp"
   }
 }
 
@@ -654,97 +374,22 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { //following behaviour validated.
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear_use_missing.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-    {
-#pragma omp for 
-      for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j ]);
-        x = xx[j];
-        if (x < 0) {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[j];
-          if (y < 0) {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x);
-            xi[0] = ix;
-            xi[1] = ix + 1;
-            //make in range
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            dx = (x - xi[0]);
-            iy = floor(y);
-            yi[0] = iy;
-            yi[1] = iy + 1;
-            //make in range
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            dy = (y - yi[0]);
-            vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-            vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-            vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-            vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-            for (SizeT i = 0; i < ncontiguous; ++i) {
-              double dxdy = dx*dy;
-              double c0 = (1 - dy - dx + dxdy);
-              double c1 = (dy - dxdy);
-              double c2 = (dx - dxdy);
-              vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i] * dxdy;
-            }
-          } else {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          }
-        } else {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        }
-      }
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear_use_missing.incpp"
     }
   } else { //following behaviour validated.
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-    {
-#pragma omp for 
-      for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j ]);
-        x = xx[j];
-        if (x < 0) {
-          xi[0] = 0;
-          xi[1] = 0;
-        } else if (x >= n1 - 1) {
-          xi[0] = n1 - 1;
-          xi[1] = n1 - 1;
-        } else {
-          ix = floor(x);
-          xi[0] = ix;
-          xi[1] = ix + 1;
-        }
-        y = yy[j];
-        if (y < 0) {
-          yi[0] = 0;
-          yi[1] = 0;
-        } else if (y >= n2 - 1) {
-          yi[0] = n2 - 1;
-          yi[1] = n2 - 1;
-        } else {
-          iy = floor(y);
-          yi[0] = iy;
-          yi[1] = iy + 1;
-        }
-        dx = (x - xi[0]);
-        dy = (y - yi[0]);
-        vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-        vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-        vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-        vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          double dxdy = dx*dy;
-          double c0 = (1 - dy - dx + dxdy);
-          double c1 = (dy - dxdy);
-          double c2 = (dx - dxdy);
-          vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i] * dxdy;
-        }
-      }
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear.incpp"
     }
   }
 }
@@ -759,97 +404,22 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {  //following behaviour validated.
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-      for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        vres = &(res[ncontiguous * (k * nx + j) ]);
-        x = xx[j];
-        if (x < 0) {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[k];
-          if (y < 0) {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x);
-            xi[0] = ix;
-            xi[1] = ix + 1;
-            //make in range
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            dx = (x - xi[0]);
-            iy = floor(y);
-            yi[0] = iy;
-            yi[1] = iy + 1;
-            //make in range
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            dy = (y - yi[0]);
-            vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-            vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-            vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-            vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-            for (SizeT i = 0; i < ncontiguous; ++i) {
-              double dxdy=dx*dy;
-              double c0=(1-dy-dx+dxdy);
-              double c1=(dy-dxdy);
-              double c2=(dx-dxdy);
-              vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i]*dxdy;
-            }
-          } else {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          }
-        } else {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        }
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
     }
   } else { //following behaviour validated.
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear_grid.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        vres = &(res[ncontiguous * (k * nx + j) ]);
-        x = xx[j];
-        if (x < 0) {
-          xi[0] = 0; xi[1] = 0;
-        } else if (x >= n1-1 ) {
-          xi[0] = n1-1; xi[1] = n1-1;
-        } else {
-          ix = floor(x);
-          xi[0] = ix;
-          xi[1] = ix + 1;
-        }
-        y = yy[k];
-        if (y < 0) {
-          yi[0] = 0; yi[1] = 0;
-        } else if (y >= n2-1 ) {
-          yi[0] = n2-1; yi[1] = n2-1;
-        } else {
-          iy = floor(y);
-          yi[0] = iy;
-          yi[1] = iy + 1;
-        }
-        dx = (x - xi[0]);
-        dy = (y - yi[0]);
-        vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-        vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-        vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-        vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          double dxdy=dx*dy;
-          double c0=(1-dy-dx+dxdy);
-          double c1=(dy-dxdy);
-          double c2=(dx-dxdy);
-          vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i]*dxdy;
-        }
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear_grid.incpp"
     }
   }
 }
@@ -862,83 +432,22 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
   ssize_t xi[2], yi[2]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {  //following behaviour validated.
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        x = xx[j];
-        if (x < 0) {
-          res[k * nx + j] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[k];
-          if (y < 0) {
-            res[k * nx + j] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x);
-            xi[0] = ix;
-            xi[1] = ix + 1;
-            //make in range
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            dx = (x - xi[0]);
-            iy = floor(y);
-            yi[0] = iy;
-            yi[1] = iy + 1;
-            //make in range
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            dy = (y - yi[0]);
-            double dxdy=dx*dy;
-            double c0=(1-dy-dx+dxdy);
-            double c1=(dy-dxdy);
-            double c2=(dx-dxdy);
-            res[k * nx + j] = array[yi[0] * n1 + xi[0]] * c0 + array[yi[1] * n1 + xi[0]] * c1 + array[yi[0] * n1 + xi[1]] * c2 + array[yi[1] * n1 + xi[1]] * dxdy;
-          } else {
-            res[k * nx + j] = missing;
-          }
-        } else {
-          res[k * nx + j] = missing;
-        }
-      }
-    }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { 
-        x = xx[j];
-        if (x < 0) {
-          xi[0] = 0; xi[1] = 0;
-        } else if (x >= n1-1 ) {
-          xi[0] = n1-1; xi[1] = n1-1;
-        } else {
-          ix = floor(x);
-          xi[0] = ix;
-          xi[1] = ix + 1;
-        }
-        y = yy[k];
-        if (y < 0) {
-          yi[0] = 0; yi[1] = 0;
-        } else if (y >= n2-1 ) {
-          yi[0] = n2-1; yi[1] = n2-1;
-        } else {
-          iy = floor(y);
-          yi[0] = iy;
-          yi[1] = iy + 1;
-        }
-        dx = (x - xi[0]);
-        dy = (y - yi[0]);
-        double dxdy=dx*dy;
-        double c0=(1-dy-dx+dxdy);
-        double c1=(dy-dxdy);
-        double c2=(dx-dxdy);
-        res[k * nx + j] = array[yi[0] * n1 + xi[0]] * c0 + array[yi[1] * n1 + xi[0]] * c1 + array[yi[0] * n1 + xi[1]] * c2 + array[yi[1] * n1 + xi[1]] * dxdy;
-      }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
     }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_2d_linear_grid_single.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_linear_grid_single.incpp"
     }
   }
 }
@@ -958,200 +467,22 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { 
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-    {
-#pragma omp for 
-      for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j]);
-        x = xx[j];
-        if (x < 0) {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[j];
-          if (y < 0) {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x); //floor  ix is [0 .. n1[
-            xi[0] = ix - 1;
-            xi[1] = ix;
-            xi[2] = ix + 1;
-            xi[3] = ix + 2;
-            //make in range
-            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
-            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
-            dx = (x - xi[1]);
-            double dx2 = dx*dx;
-            double dx3 = dx2*dx;
-            double omdx = 1 - dx;
-            double omdx2 = omdx*omdx;
-            double omdx3 = omdx2*omdx;
-            double opdx = 1 + dx;
-            double opdx2 = opdx*opdx;
-            double opdx3 = opdx2*opdx;
-            double dmdx = 2 - dx;
-            double dmdx2 = dmdx*dmdx;
-            double dmdx3 = dmdx2*dmdx;
-            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-            iy = floor(y);
-            yi[0] = iy - 1;
-            yi[1] = iy;
-            yi[2] = iy + 1;
-            yi[3] = iy + 2;
-            //make in range
-            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
-            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
-            dy = (y - yi[1]);
-            double dy2 = dy*dy;
-            double dy3 = dy2*dy;
-            double omdy = 1 - dy;
-            double omdy2 = omdy*omdy;
-            double omdy3 = omdy2*omdy;
-            double opdy = 1 + dy;
-            double opdy2 = opdy*opdy;
-            double opdy3 = opdy2*opdy;
-            double dmdy = 2 - dy;
-            double dmdy2 = dmdy*dmdy;
-            double dmdy3 = dmdy2*dmdy;
-            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-            vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-            vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-            vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
-            vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
-
-            vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-            vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-            vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
-            vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
-
-            vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
-            vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
-            vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
-            vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
-
-            vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
-            vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
-            vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
-            vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
-
-            for (SizeT i = 0; i < ncontiguous; ++i) {
-              double r0=cx1*vx1y0[i]+cx2*vx2y0[i]+cx0*vx0y0[i]+cx3*vx3y0[i];
-              double r1=cx1*vx1y1[i]+cx2*vx2y1[i]+cx0*vx0y1[i]+cx3*vx3y1[i];
-              double r2=cx1*vx1y2[i]+cx2*vx2y2[i]+cx0*vx0y2[i]+cx3*vx3y2[i];
-              double r3=cx1*vx1y3[i]+cx2*vx2y3[i]+cx0*vx0y3[i]+cx3*vx3y3[i];
-              vres[i] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
-            }
-          } else {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          }
-        } else {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        }
-      }
-    }
+#include "snippets/interpolate_2d_cubic_use_missing.incpp"
+  if (!parallelize) {
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-  {
-#pragma omp for 
-    for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j ]);
-        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0] = ix - 1;
-        xi[1] = ix;
-        xi[2] = ix + 1;
-        xi[3] = ix + 2;
-        //make in range
-        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
-        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
-        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
-        dx = (x - xi[1]);
-        double dx2 = dx*dx;
-        double dx3 = dx2*dx;
-        double omdx = 1 - dx;
-        double omdx2 = omdx*omdx;
-        double omdx3 = omdx2*omdx;
-        double opdx = 1 + dx;
-        double opdx2 = opdx*opdx;
-        double opdx3 = opdx2*opdx;
-        double dmdx = 2 - dx;
-        double dmdx2 = dmdx*dmdx;
-        double dmdx3 = dmdx2*dmdx;
-        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-        y = yy[j]; if (y<0)y=0; if(y>n2-1)y=n2-1;
-        iy = floor(y);
-        yi[0] = iy - 1;
-        yi[1] = iy;
-        yi[2] = iy + 1;
-        yi[3] = iy + 2;
-        //make in range
-        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
-        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
-        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
-        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
-        dy = (y - yi[1]);
-        double dy2 = dy*dy;
-        double dy3 = dy2*dy;
-        double omdy = 1 - dy;
-        double omdy2 = omdy*omdy;
-        double omdy3 = omdy2*omdy;
-        double opdy = 1 + dy;
-        double opdy2 = opdy*opdy;
-        double opdy3 = opdy2*opdy;
-        double dmdy = 2 - dy;
-        double dmdy2 = dmdy*dmdy;
-        double dmdy3 = dmdy2*dmdy;
-        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-
-        vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-        vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-        vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
-        vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
-
-        vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-        vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-        vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
-        vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
-
-        vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
-        vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
-        vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
-        vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
-
-        vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
-        vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
-        vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
-        vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
-
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          double r0 = cx1 * vx1y0[i] + cx2 * vx2y0[i] + cx0 * vx0y0[i] + cx3 * vx3y0[i];
-          double r1 = cx1 * vx1y1[i] + cx2 * vx2y1[i] + cx0 * vx0y1[i] + cx3 * vx3y1[i];
-          double r2 = cx1 * vx1y2[i] + cx2 * vx2y2[i] + cx0 * vx0y2[i] + cx3 * vx3y2[i];
-          double r3 = cx1 * vx1y3[i] + cx2 * vx2y3[i] + cx0 * vx0y3[i] + cx3 * vx3y3[i];
-          vres[i] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
-        }
-      }
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_cubic_use_missing.incpp"
+    }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_2d_cubic.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_cubic.incpp"
   }
   }
 }
@@ -1171,203 +502,22 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {
+  if (!parallelize) {
+#include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        vres = &(res[ncontiguous * (k * nx + j) ]);
-        x = xx[j];
-        if (x < 0) {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[k];
-          if (y < 0) {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x); //floor  ix is [0 .. n1[
-            xi[0] = ix - 1;
-            xi[1] = ix;
-            xi[2] = ix + 1;
-            xi[3] = ix + 2;
-            //make in range
-            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
-            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
-            dx = (x - xi[1]);
-            double dx2 = dx*dx;
-            double dx3 = dx2*dx;
-            double omdx = 1 - dx;
-            double omdx2 = omdx*omdx;
-            double omdx3 = omdx2*omdx;
-            double opdx = 1 + dx;
-            double opdx2 = opdx*opdx;
-            double opdx3 = opdx2*opdx;
-            double dmdx = 2 - dx;
-            double dmdx2 = dmdx*dmdx;
-            double dmdx3 = dmdx2*dmdx;
-            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-            iy = floor(y);
-            yi[0] = iy - 1;
-            yi[1] = iy;
-            yi[2] = iy + 1;
-            yi[3] = iy + 2;
-            //make in range
-            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
-            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
-            dy = (y - yi[1]);
-            double dy2 = dy*dy;
-            double dy3 = dy2*dy;
-            double omdy = 1 - dy;
-            double omdy2 = omdy*omdy;
-            double omdy3 = omdy2*omdy;
-            double opdy = 1 + dy;
-            double opdy2 = opdy*opdy;
-            double opdy3 = opdy2*opdy;
-            double dmdy = 2 - dy;
-            double dmdy2 = dmdy*dmdy;
-            double dmdy3 = dmdy2*dmdy;
-            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-            vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-            vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-            vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
-            vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
-
-            vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-            vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-            vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
-            vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
-
-            vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
-            vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
-            vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
-            vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
-
-            vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
-            vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
-            vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
-            vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
-            for (SizeT i = 0; i < ncontiguous; ++i) {
-              double r0=cx1*vx1y0[i]+cx2*vx2y0[i]+cx0*vx0y0[i]+cx3*vx3y0[i];
-              double r1=cx1*vx1y1[i]+cx2*vx2y1[i]+cx0*vx0y1[i]+cx3*vx3y1[i];
-              double r2=cx1*vx1y2[i]+cx2*vx2y2[i]+cx0*vx0y2[i]+cx3*vx3y2[i];
-              double r3=cx1*vx1y3[i]+cx2*vx2y3[i]+cx0*vx0y3[i]+cx3*vx3y3[i];
-              vres[i] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
-            }
-          } else {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          }
-        } else {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        }
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
     }
   } else { 
+  if (!parallelize) {
+#include "snippets/interpolate_2d_cubic_grid.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        vres = &(res[ncontiguous * (k * nx + j) ]);
-        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0] = ix - 1;
-        xi[1] = ix;
-        xi[2] = ix + 1;
-        xi[3] = ix + 2;
-        //make in range
-        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
-        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
-        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
-        dx = (x - xi[1]);
-        double dx2 = dx*dx;
-        double dx3 = dx2*dx;
-        double omdx = 1 - dx;
-        double omdx2 = omdx*omdx;
-        double omdx3 = omdx2*omdx;
-        double opdx = 1 + dx;
-        double opdx2 = opdx*opdx;
-        double opdx3 = opdx2*opdx;
-        double dmdx = 2 - dx;
-        double dmdx2 = dmdx*dmdx;
-        double dmdx3 = dmdx2*dmdx;
-        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-        y = yy[k]; if (y<0)y=0; if(y>n2-1)y=n2-1;
-        iy = floor(y);
-        yi[0] = iy - 1;
-        yi[1] = iy;
-        yi[2] = iy + 1;
-        yi[3] = iy + 2;
-        //make in range
-        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
-        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
-        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
-        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
-        dy = (y - yi[1]);
-        double dy2 = dy*dy;
-        double dy3 = dy2*dy;
-        double omdy = 1 - dy;
-        double omdy2 = omdy*omdy;
-        double omdy3 = omdy2*omdy;
-        double opdy = 1 + dy;
-        double opdy2 = opdy*opdy;
-        double opdy3 = opdy2*opdy;
-        double dmdy = 2 - dy;
-        double dmdy2 = dmdy*dmdy;
-        double dmdy3 = dmdy2*dmdy;
-        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-
-        vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
-        vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
-        vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
-        vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
-
-        vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
-        vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
-        vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
-        vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
-
-        vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
-        vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
-        vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
-        vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
-
-        vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
-        vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
-        vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
-        vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
-
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          double r0 = cx1 * vx1y0[i] + cx2 * vx2y0[i] + cx0 * vx0y0[i] + cx3 * vx3y0[i];
-          double r1 = cx1 * vx1y1[i] + cx2 * vx2y1[i] + cx0 * vx0y1[i] + cx3 * vx3y1[i];
-          double r2 = cx1 * vx1y2[i] + cx2 * vx2y2[i] + cx0 * vx0y2[i] + cx3 * vx3y2[i];
-          double r3 = cx1 * vx1y3[i] + cx2 * vx2y3[i] + cx0 * vx0y3[i] + cx3 * vx3y3[i];
-          vres[i] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
-        }
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_cubic_grid.incpp"
   }
   }
 }
@@ -1382,157 +532,22 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
   ssize_t xi[4], yi[4]; //operations on unsigned are not what you think, signed are ok
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny));
   if (use_missing) {
+  if (!parallelize) {
+#include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        x = xx[j];
-        if (x < 0) {
-          res[k * nx + j] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[k];
-          if (y < 0) {
-            res[k * nx + j] = missing;
-          } else if (y <= n2 - 1) {
-            ix = floor(x); //floor  ix is [0 .. n1[
-            xi[0] = ix - 1;
-            xi[1] = ix;
-            xi[2] = ix + 1;
-            xi[3] = ix + 2;
-            //make in range
-            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
-            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
-            dx = (x - xi[1]);
-            double dx2 = dx*dx;
-            double dx3 = dx2*dx;
-            double omdx = 1 - dx;
-            double omdx2 = omdx*omdx;
-            double omdx3 = omdx2*omdx;
-            double opdx = 1 + dx;
-            double opdx2 = opdx*opdx;
-            double opdx3 = opdx2*opdx;
-            double dmdx = 2 - dx;
-            double dmdx2 = dmdx*dmdx;
-            double dmdx3 = dmdx2*dmdx;
-            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-            iy = floor(y);
-            yi[0] = iy - 1;
-            yi[1] = iy;
-            yi[2] = iy + 1;
-            yi[3] = iy + 2;
-            //make in range
-            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
-            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
-            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
-            dy = (y - yi[1]);
-            double dy2 = dy*dy;
-            double dy3 = dy2*dy;
-            double omdy = 1 - dy;
-            double omdy2 = omdy*omdy;
-            double omdy3 = omdy2*omdy;
-            double opdy = 1 + dy;
-            double opdy2 = opdy*opdy;
-            double opdy3 = opdy2*opdy;
-            double dmdy = 2 - dy;
-            double dmdy2 = dmdy*dmdy;
-            double dmdy3 = dmdy2*dmdy;
-            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-            double r0=cx1*array[yi[0] * n1 + xi[1]]+cx2*array[yi[0] * n1 + xi[2]]+cx0*array[yi[0] * n1 + xi[0]]+cx3*array[yi[0] * n1 + xi[3]];
-            double r1=cx1*array[yi[1] * n1 + xi[1]]+cx2*array[yi[1] * n1 + xi[2]]+cx0*array[yi[1] * n1 + xi[0]]+cx3*array[yi[1] * n1 + xi[3]];
-            double r2=cx1*array[yi[2] * n1 + xi[1]]+cx2*array[yi[2] * n1 + xi[2]]+cx0*array[yi[2] * n1 + xi[0]]+cx3*array[yi[2] * n1 + xi[3]];
-            double r3=cx1*array[yi[3] * n1 + xi[1]]+cx2*array[yi[3] * n1 + xi[2]]+cx0*array[yi[3] * n1 + xi[0]]+cx3*array[yi[3] * n1 + xi[3]];
-            res[k * nx + j] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
-          } else {
-            res[k * nx + j] = missing;
-          }
-        } else {
-          res[k * nx + j] = missing;
-        }
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
     }
   } else { 
+  if (!parallelize) {
+#include "snippets/interpolate_2d_cubic_grid_single.incpp"
+  } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,ix,iy,dx,dy,x,y) if (CpuTPOOL_NTHREADS> 1 && nx*ny >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny))
-    {
-#pragma omp for collapse(2)
-    for (SizeT k = 0; k < ny; ++k) {
-      for (SizeT j = 0; j < nx; ++j) { //nb output points
-        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
-        ix = floor(x); //floor  ix is [0 .. n1[
-        xi[0] = ix - 1;
-        xi[1] = ix;
-        xi[2] = ix + 1;
-        xi[3] = ix + 2;
-        //make in range
-        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
-        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
-        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
-        dx = (x - xi[1]);
-        double dx2 = dx*dx;
-        double dx3 = dx2*dx;
-        double omdx = 1 - dx;
-        double omdx2 = omdx*omdx;
-        double omdx3 = omdx2*omdx;
-        double opdx = 1 + dx;
-        double opdx2 = opdx*opdx;
-        double opdx3 = opdx2*opdx;
-        double dmdx = 2 - dx;
-        double dmdx2 = dmdx*dmdx;
-        double dmdx3 = dmdx2*dmdx;
-        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
-        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
-        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
-        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
-
-        y = yy[k]; if (y<0)y=0; if(y>n2-1)y=n2-1;
-        iy = floor(y);
-        yi[0] = iy - 1;
-        yi[1] = iy;
-        yi[2] = iy + 1;
-        yi[3] = iy + 2;
-        //make in range
-        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
-        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
-        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
-        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
-        dy = (y - yi[1]);
-        double dy2 = dy*dy;
-        double dy3 = dy2*dy;
-        double omdy = 1 - dy;
-        double omdy2 = omdy*omdy;
-        double omdy3 = omdy2*omdy;
-        double opdy = 1 + dy;
-        double opdy2 = opdy*opdy;
-        double opdy3 = opdy2*opdy;
-        double dmdy = 2 - dy;
-        double dmdy2 = dmdy*dmdy;
-        double dmdy3 = dmdy2*dmdy;
-        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
-        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
-        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
-        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
-        double r0 = cx1 * array[yi[0] * n1 + xi[1]] + cx2 * array[yi[0] * n1 + xi[2]] + cx0 * array[yi[0] * n1 + xi[0]] + cx3 * array[yi[0] * n1 + xi[3]];
-        double r1 = cx1 * array[yi[1] * n1 + xi[1]] + cx2 * array[yi[1] * n1 + xi[2]] + cx0 * array[yi[1] * n1 + xi[0]] + cx3 * array[yi[1] * n1 + xi[3]];
-        double r2 = cx1 * array[yi[2] * n1 + xi[1]] + cx2 * array[yi[2] * n1 + xi[2]] + cx0 * array[yi[2] * n1 + xi[0]] + cx3 * array[yi[2] * n1 + xi[3]];
-        double r3 = cx1 * array[yi[3] * n1 + xi[1]] + cx2 * array[yi[3] * n1 + xi[2]] + cx0 * array[yi[3] * n1 + xi[0]] + cx3 * array[yi[3] * n1 + xi[3]];
-        res[k * nx + j] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
-      }
-    }
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_2d_cubic_grid_single.incpp"
   }
   }
 }
@@ -1551,124 +566,22 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2=n1*n2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n));
   if (use_missing) { 
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,x,y,z,umdx,umdy,umdz,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-    {
-#pragma omp for
-      for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j ]);
-        x = xx[j];
-        if (x < 0) {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        } else if (x <= n1 - 1) {
-          y = yy[j];
-          if (y < 0) {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          } else if (y <= n2 - 1) {
-            z = zz[j];
-            if (z < 0) {
-              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-            } else if (z <= n3 - 1) {
-              ix = floor(x);
-              xi[0] = ix;
-              xi[1] = ix + 1;
-              //make in range
-              if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-              dx = (x - xi[0]); umdx=1-dx;
-              
-              iy = floor(y);
-              yi[0] = iy;
-              yi[1] = iy + 1;
-              //make in range
-              if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-              dy = (y - yi[0]); umdy=1-dy;
-                
-              iz = floor(z);
-              zi[0] = iz;
-              zi[1] = iz + 1;
-              //make in range
-              if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-              dz = (z - zi[0]); umdz=1-dz;
-
-              vx0y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[0])] );
-              vx1y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[1])] );
-              vx0y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[0])] );
-              vx1y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[1])] );
-              vx0y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[0])] );
-              vx1y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[1])] );
-              vx0y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[0])] );
-              vx1y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[1])] );
-              for (SizeT i = 0; i < ncontiguous; ++i) {
-                double y0z0=umdx*vx0y0z0[i]+dx*vx1y0z0[i];
-                double y1z0=umdx*vx0y1z0[i]+dx*vx1y1z0[i];
-                double y0z1=umdx*vx0y0z1[i]+dx*vx1y0z1[i];
-                double y1z1=umdx*vx0y1z1[i]+dx*vx1y1z1[i];
-                double   z0=umdy*y0z0+dy*y1z0;
-                double   z1=umdy*y0z1+dy*y1z1;
-                vres[i] = umdz*z0+dz*z1; 
-              }
-            } else {
-              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-            }
-          } else {
-            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-          }
-        } else {
-          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-        }
-      }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
-    {
-#pragma omp for
-      for (SizeT j = 0; j < n; ++j) { //nb output points
-        vres = &(res[ncontiguous * j ]);
-        x = xx[j]; if (x<0) x=0; if (x>n1-1) x=n1-1;
-        y = yy[j]; if (y<0) y=0; if (y>n2-1) y=n2-1;
-        z = zz[j]; if (z<0) z=0; if (z>n3-1) z=n3-1;
-
-        ix = floor(x); 
-        xi[0] = ix;
-        xi[1] = ix + 1;
-        //make in range
-        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-        dx = (x - xi[0]); umdx=1-dx;
-
-        iy = floor(y);
-        yi[0] = iy;
-        yi[1] = iy + 1;
-        //make in range
-        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-        dy = (y - yi[0]); umdy=1-dy;
-
-        iz = floor(z);
-        zi[0] = iz;
-        zi[1] = iz + 1;
-        //make in range
-        if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-        dz = (z - zi[0]); umdz=1-dz;
-
-        vx0y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[0])] );
-        vx1y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[1])] );
-        vx0y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[0])] );
-        vx1y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[1])] );
-        vx0y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[0])] );
-        vx1y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[1])] );
-        vx0y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[0])] );
-        vx1y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[1])] );
-        for (SizeT i = 0; i < ncontiguous; ++i) {
-          double y0z0=umdx*vx0y0z0[i]+dx*vx1y0z0[i];
-          double y1z0=umdx*vx0y1z0[i]+dx*vx1y1z0[i];
-          double y0z1=umdx*vx0y0z1[i]+dx*vx1y0z1[i];
-          double y1z1=umdx*vx0y1z1[i]+dx*vx1y1z1[i];
-          double   z0=umdy*y0z0+dy*y1z0;
-          double   z1=umdy*y0z1+dy*y1z1;
-          vres[i] = umdz*z0+dz*z1; 
-        }
-      }
+#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,x,y,z,umdx,umdy,umdz,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_3d_linear_use_missing.incpp"
+    }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_3d_linear.incpp"
     }
   }
 }
@@ -1687,140 +600,22 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny*nz));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
-    {
-#pragma omp for collapse(3)
-      for (SizeT l = 0; l < nz; ++l) {
-        for (SizeT k = 0; k < ny; ++k) {
-          for (SizeT j = 0; j < nx; ++j) { //nb output points
-            vres = &(res[ncontiguous * ( l*nx*ny + k * nx + j) ]);
-            x = xx[j];
-            if (x < 0) {
-              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-            } else if (x <= n1 - 1) {
-              y = yy[k];
-              if (y < 0) {
-                for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-              } else if (y <= n2 - 1) {
-                z = zz[l];
-                if (z < 0) {
-                  for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-                } else if (z <= n3 - 1) {
-                  ix = floor(x);
-                  xi[0] = ix;
-                  xi[1] = ix + 1;
-                  //make in range
-                  if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-                  dx = (x - xi[0]);
-                  umdx = 1 - dx;
-
-                  iy = floor(y);
-                  yi[0] = iy;
-                  yi[1] = iy + 1;
-                  //make in range
-                  if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-                  dy = (y - yi[0]);
-                  umdy = 1 - dy;
-
-                  iz = floor(z);
-                  zi[0] = iz;
-                  zi[1] = iz + 1;
-                  //make in range
-                  if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-                  dz = (z - zi[0]);
-                  umdz = 1 - dz;
-
-                  vx0y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[0])]);
-                  vx1y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[1])]);
-                  vx0y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[0])]);
-                  vx1y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[1])]);
-                  vx0y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[0])]);
-                  vx1y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[1])]);
-                  vx0y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[0])]);
-                  vx1y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[1])]);
-                  for (SizeT i = 0; i < ncontiguous; ++i) {
-                    double y0z0 = umdx * vx0y0z0[i] + dx * vx1y0z0[i];
-                    double y1z0 = umdx * vx0y1z0[i] + dx * vx1y1z0[i];
-                    double y0z1 = umdx * vx0y0z1[i] + dx * vx1y0z1[i];
-                    double y1z1 = umdx * vx0y1z1[i] + dx * vx1y1z1[i];
-                    double z0 = umdy * y0z0 + dy*y1z0;
-                    double z1 = umdy * y0z1 + dy*y1z1;
-                    vres[i] = umdz * z0 + dz*z1;
-                  }
-                } else {
-                  for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-                }
-              } else {
-                for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-              }
-            } else {
-              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
-            }
-          }
-        }
-      }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
-    {
-#pragma omp for collapse(2)   //2 is a good compromise as some values (yi and zi) are not computed nx times. 
-      for (SizeT l = 0; l < nz; ++l) {
-        for (SizeT k = 0; k < ny; ++k) {
-          z = zz[l];
-          if (z < 0) z = 0; if (z > n3 - 1) z = n3 - 1;
-          iz = floor(z);
-          zi[0] = iz;
-          zi[1] = iz + 1;
-          //make in range
-          if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-          dz = (z - zi[0]);
-          umdz = 1 - dz;
-
-          y = yy[k];
-          if (y < 0) y = 0; if (y > n2 - 1) y = n2 - 1;
-          iy = floor(y);
-          yi[0] = iy;
-          yi[1] = iy + 1;
-          //make in range
-          if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-          dy = (y - yi[0]);
-          umdy = 1 - dy;
-
-          for (SizeT j = 0; j < nx; ++j) { //nb output points
-            vres = &(res[ncontiguous * ( l*nx*ny + k * nx + j) ]);
-            x = xx[j];
-            if (x < 0) x = 0; if (x > n1 - 1) x = n1 - 1;
-            ix = floor(x);
-            xi[0] = ix;
-            xi[1] = ix + 1;
-            //make in range
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            dx = (x - xi[0]);
-            umdx = 1 - dx;
-
-            vx0y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[0])]);
-            vx1y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[1])]);
-            vx0y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[0])]);
-            vx1y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[1])]);
-            vx0y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[0])]);
-            vx1y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[1])]);
-            vx0y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[0])]);
-            vx1y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[1])]);
-            for (SizeT i = 0; i < ncontiguous; ++i) {
-              double y0z0 = umdx * vx0y0z0[i] + dx * vx1y0z0[i];
-              double y1z0 = umdx * vx0y1z0[i] + dx * vx1y1z0[i];
-              double y0z1 = umdx * vx0y0z1[i] + dx * vx1y0z1[i];
-              double y1z1 = umdx * vx0y1z1[i] + dx * vx1y1z1[i];
-              double z0 = umdy * y0z0 + dy*y1z0;
-              double z1 = umdy * y0z1 + dy*y1z1;
-              vres[i] = umdz * z0 + dz*z1;
-            }
-          }
-        }
-      }
+#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
+    }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear_grid.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS) //2 is a good compromise as some values (yi and zi) are not computed nx times. 
+#include "snippets/interpolate_3d_linear_grid.incpp"
     }
   }
 }
@@ -1838,117 +633,22 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
   ssize_t n2 = un2;
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
+  bool parallelize = (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nx*ny*nz));
   if (use_missing) {
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
-    {
-#pragma omp for collapse(3)
-      for (SizeT l = 0; l < nz; ++l) {
-        for (SizeT k = 0; k < ny; ++k) {
-          for (SizeT j = 0; j < nx; ++j) { //nb output points
-            x = xx[j];
-            if (x < 0) {
-              res[l*nx*ny + k * nx + j ] = missing;
-            } else if (x <= n1 - 1) {
-              y = yy[k];
-              if (y < 0) {
-                res[l*nx*ny + k * nx + j ] = missing;
-              } else if (y <= n2 - 1) {
-                z = zz[l];
-                if (z < 0) {
-                  res[l*nx*ny + k * nx + j ] = missing;
-                } else if (z <= n3 - 1) {
-                  ix = floor(x);
-                  xi[0] = ix;
-                  xi[1] = ix + 1;
-                  //make in range
-                  if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-                  dx = (x - xi[0]);
-                  umdx = 1 - dx;
-
-                  iy = floor(y);
-                  yi[0] = iy;
-                  yi[1] = iy + 1;
-                  //make in range
-                  if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-                  dy = (y - yi[0]);
-                  umdy = 1 - dy;
-
-                  iz = floor(z);
-                  zi[0] = iz;
-                  zi[1] = iz + 1;
-                  //make in range
-                  if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-                  dz = (z - zi[0]);
-                  umdz = 1 - dz;
-                  double y0z0 = umdx * array[zi[0] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[0] * n1 + xi[1]];
-                  double y1z0 = umdx * array[zi[0] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[1] * n1 + xi[1]];
-                  double y0z1 = umdx * array[zi[1] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[0] * n1 + xi[1]];
-                  double y1z1 = umdx * array[zi[1] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[1] * n1 + xi[1]];
-                  double z0 = umdy * y0z0 + dy*y1z0;
-                  double z1 = umdy * y0z1 + dy*y1z1;
-                  res[l*nx*ny + k * nx + j ] = umdz * z0 + dz*z1;
-                } else {
-                  res[l*nx*ny + k * nx + j ] = missing;
-                }
-              } else {
-                res[l*nx*ny + k * nx + j ] = missing;
-              }
-            } else {
-              res[l*nx*ny + k * nx + j ] = missing;
-            }
-          }
-        }
-      }
-    }
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) if (CpuTPOOL_NTHREADS> 1 && nx*ny*nz >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nx*ny*nz))
-    {
-#pragma omp for collapse(2)   //2 is a good compromise as some values (yi and zi) are not computed nx times. 
-      for (SizeT l = 0; l < nz; ++l) {
-        for (SizeT k = 0; k < ny; ++k) {
-          z = zz[l];
-          if (z < 0) z = 0; if (z > n3 - 1) z = n3 - 1;
-          iz = floor(z);
-          zi[0] = iz;
-          zi[1] = iz + 1;
-          //make in range
-          if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
-          dz = (z - zi[0]);
-          umdz = 1 - dz;
-
-          y = yy[k];
-          if (y < 0) y = 0; if (y > n2 - 1) y = n2 - 1;
-          iy = floor(y);
-          yi[0] = iy;
-          yi[1] = iy + 1;
-          //make in range
-          if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
-          dy = (y - yi[0]);
-          umdy = 1 - dy;
-
-          for (SizeT j = 0; j < nx; ++j) { //nb output points
-            x = xx[j];
-            if (x < 0) x = 0; if (x > n1 - 1) x = n1 - 1;
-            ix = floor(x);
-            xi[0] = ix;
-            xi[1] = ix + 1;
-            //make in range
-            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
-            dx = (x - xi[0]);
-            umdx = 1 - dx;
-
-            double y0z0 = umdx * array[zi[0] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[0] * n1 + xi[1]];
-            double y1z0 = umdx * array[zi[0] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[1] * n1 + xi[1]];
-            double y0z1 = umdx * array[zi[1] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[0] * n1 + xi[1]];
-            double y1z1 = umdx * array[zi[1] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[1] * n1 + xi[1]];
-            double z0 = umdy * y0z0 + dy*y1z0;
-            double z1 = umdy * y0z1 + dy*y1z1;
-            res[l*nx*ny + k * nx + j ] = umdz * z0 + dz*z1;
-          }
-        }
-      }
+#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(CpuTPOOL_NTHREADS) 
+#include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
+    }
+  } else {
+  if (!parallelize) {
+#include "snippets/interpolate_3d_linear_grid_single.incpp"
+  } else {
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(CpuTPOOL_NTHREADS)
+#include "snippets/interpolate_3d_linear_grid_single.incpp"
     }
   }
 }

--- a/src/interpolate.cpp
+++ b/src/interpolate.cpp
@@ -186,11 +186,11 @@ void interpolate_1d_nearest(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Siz
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_nearest.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(ix,x,v0,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(ix,x,v0,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_nearest.incpp"
   }
 }
@@ -201,11 +201,11 @@ void interpolate_1d_nearest_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* r
   //operations on unsigned are not what you think, signed are ok
   ssize_t ix = 0;
   ssize_t n1 = un1;
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_nearest_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(ix,x) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(ix,x) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_nearest_single.incpp"
   }
 }
@@ -221,19 +221,19 @@ void interpolate_1d_linear(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, Size
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_linear_use_missing.incpp"
     }
   } else {
-  if (!parallelize (nx)) {
+  if (GDL_NTHREADS=parallelize (nx)==1) {
 #include "snippets/interpolate_1d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_linear.incpp"
     }
   }
@@ -249,19 +249,19 @@ void interpolate_1d_linear_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* re
   ssize_t xi[2];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_linear_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_linear_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_linear_single.incpp"
     }
   }
@@ -279,19 +279,19 @@ void interpolate_1d_cubic(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res, SizeT
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_cubic_use_missing.incpp"
     }
   } else {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x,v0,v1,v2,v3,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_cubic.incpp"
     }
   }
@@ -307,19 +307,19 @@ void interpolate_1d_cubic_single(T1* array, SizeT un1, T2* xx, SizeT nx, T1* res
   ssize_t xi[4];
   ssize_t n1 = un1;
   if (use_missing) {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_cubic_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize( nx)) {
+  if (GDL_NTHREADS=parallelize( nx)==1) {
 #include "snippets/interpolate_1d_cubic_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,ix,dx,x) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,ix,dx,x) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_1d_cubic_single.incpp"
     }
   }
@@ -332,11 +332,11 @@ void interpolate_2d_nearest_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT 
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_nearest_grid.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,x,y,vx0,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) private(xi,yi,x,y,vx0,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_2d_nearest_grid.incpp"
   }
 }
@@ -347,11 +347,11 @@ void interpolate_2d_nearest_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx,
   ssize_t xi, yi; //operations on unsigned are not what you think, signed are ok
   ssize_t n1 = un1;
   ssize_t n2 = un2;
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_nearest_grid_single.incpp"
   } else {
   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,x,y) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) private(xi,yi,x,y) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_2d_nearest_grid_single.incpp"
   }
 }
@@ -367,19 +367,19 @@ void interpolate_2d_linear(T1* array, SizeT un1,  SizeT un2, T2* xx, SizeT n, T2
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) { //following behaviour validated.
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
 #include "snippets/interpolate_2d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear.incpp"
     }
   }
@@ -396,19 +396,19 @@ void interpolate_2d_linear_grid(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear_grid_use_missing.incpp"
     }
   } else { //following behaviour validated.
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0,vx1,vy0,vy1,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear_grid.incpp"
     }
   }
@@ -423,19 +423,19 @@ void interpolate_2d_linear_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, 
   ssize_t n1 = un1;
   ssize_t n2 = un2;
   if (use_missing) {  //following behaviour validated.
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_linear_grid_single.incpp"
     }
   }
@@ -458,18 +458,18 @@ void interpolate_2d_cubic(T1* array, SizeT un1, SizeT un2, T2* xx, SizeT n, T2* 
   ssize_t n2 = un2;
   if (use_missing) { 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_use_missing.incpp"
     }
   } else {
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
 #include "snippets/interpolate_2d_cubic.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic.incpp"
   }
   }
@@ -491,19 +491,19 @@ void interpolate_2d_cubic_grid(T1* array, SizeT un1, SizeT un2, T2* xx, const Si
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_use_missing_grid.incpp"
     }
   } else { 
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_cubic_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y,vx0y0,vx1y0,vx2y0,vx3y0,vx0y1,vx1y1,vx2y1,vx3y1,vx0y2,vx1y2,vx2y2,vx3y2,vx0y3,vx1y3,vx2y3,vx3y3,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_grid.incpp"
   }
   }
@@ -520,19 +520,19 @@ void interpolate_2d_cubic_grid_single(T1* array, SizeT un1, SizeT un2, T2* xx, c
   const ssize_t n1 = un1;
   const ssize_t n2 = un2;
   if (use_missing) {
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_2d_cubic_use_missing_grid_single.incpp"
     }
   } else { 
-  if (!parallelize( nx*ny)) {
+  if (GDL_NTHREADS=parallelize( nx*ny)==1) {
 #include "snippets/interpolate_2d_cubic_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) private(xi,yi,ix,iy,dx,dy,x,y) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_2d_cubic_grid_single.incpp"
   }
   }
@@ -553,19 +553,19 @@ void interpolate_3d_linear(T1* array, SizeT un1,  SizeT un2, SizeT un3, T2* xx, 
   ssize_t n3 = un3;
   ssize_t n1n2=n1*n2;
   if (use_missing) { 
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,x,y,z,umdx,umdy,umdz,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,x,y,z,umdx,umdy,umdz,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_3d_linear_use_missing.incpp"
     }
   } else {
-  if (!parallelize( n)) {
+  if (GDL_NTHREADS=parallelize( n)==1) {
 #include "snippets/interpolate_3d_linear.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_3d_linear.incpp"
     }
   }
@@ -586,19 +586,19 @@ void interpolate_3d_linear_grid(T1* array, SizeT un1, SizeT un2, SizeT un3, T2* 
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
-  if (!parallelize( nx*ny*nz)) {
+  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_3d_linear_grid_use_missing.incpp"
     }
   } else {
-  if (!parallelize( nx*ny*nz)) {
+  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
 #include "snippets/interpolate_3d_linear_grid.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(CpuTPOOL_NTHREADS) //2 is a good compromise as some values (yi and zi) are not computed nx times. 
+#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z,vx0y0z0,vx1y0z0,vx0y1z0,vx1y1z0,vx0y0z1,vx1y0z1,vx0y1z1,vx1y1z1,vres) num_threads(GDL_NTHREADS) //2 is a good compromise as some values (yi and zi) are not computed nx times. 
 #include "snippets/interpolate_3d_linear_grid.incpp"
     }
   }
@@ -618,19 +618,19 @@ void interpolate_3d_linear_grid_single(T1* array, SizeT un1, SizeT un2, SizeT un
   ssize_t n3 = un3;
   ssize_t n1n2 = n1*n2;
   if (use_missing) {
-  if (!parallelize( nx*ny*nz)) {
+  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for collapse(3) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(GDL_NTHREADS) 
 #include "snippets/interpolate_3d_linear_grid_use_missing_single.incpp"
     }
   } else {
-  if (!parallelize( nx*ny*nz)) {
+  if (GDL_NTHREADS=parallelize( nx*ny*nz)==1) {
 #include "snippets/interpolate_3d_linear_grid_single.incpp"
   } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) private(xi,yi,zi,ix,iy,iz,dx,dy,dz,umdx,umdy,umdz,x,y,z) num_threads(GDL_NTHREADS)
 #include "snippets/interpolate_3d_linear_grid_single.incpp"
     }
   }

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -498,7 +498,7 @@ void LibInit()
 
   new DLibFun(lib::uint_fun,string("UINT"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
   new DLibFun(lib::long_fun,string("LONG"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
-  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL),0,true;  //UsesThreadPOOL 
+  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
   new DLibFun(lib::long64_fun,string("LONG64"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
   new DLibFun(lib::ulong64_fun,string("ULONG64"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
   new DLibFun(lib::float_fun,string("FLOAT"),10,NULL,NULL,0,true);  //UsesThreadPOOL 

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -151,7 +151,7 @@ void LibInit()
   new DLibPro(lib::spawn_pro,string("SPAWN"),3,spawnKey);
 
   const string bytsclKey[]={"MIN","MAX","TOP","NAN",KLISTEND};
-  new DLibFunRetNew(lib::bytscl,string("BYTSCL"),3,bytsclKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::bytscl,string("BYTSCL"),3,bytsclKey);  //UsesThreadPOOL 
 
   const string n_tagsKey[]={"DATA_LENGTH","LENGTH",KLISTEND};
   new DLibFunRetNew(lib::n_tags,string("N_TAGS"),1,n_tagsKey);
@@ -163,7 +163,7 @@ void LibInit()
 			       "FTOXDR","DTOXDR","XDRTOF","XDRTOD",
              "DTOGFLOAT","GFLOATTOD", // obsoleted 2  keywords only on the VMS platform
 			       KLISTEND};
-  new DLibPro(lib::byteorder,string("BYTEORDER"),-1,byteorderKey);  //UsesThreadPOOL 
+  new DLibPro(lib::byteorder,string("BYTEORDER"),-1,byteorderKey,NULL,0,true);  //UsesThreadPOOL 
 
   const string obj_classKey[]={"COUNT","SUPERCLASS",KLISTEND};
   new DLibFunRetNew(lib::obj_class,string("OBJ_CLASS"),1,obj_classKey);
@@ -176,7 +176,7 @@ void LibInit()
 
   const string convolKey[]={"CENTER","EDGE_TRUNCATE","EDGE_WRAP","EDGE_ZERO", "EDGE_MIRROR",
 			    "BIAS","NORMALIZE","NAN", "INVALID", "MISSING",KLISTEND};
-  new DLibFunRetNew(lib::convol_fun,string("CONVOL"),3,convolKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::convol_fun,string("CONVOL"),3,convolKey);  //UsesThreadPOOL 
 
   const string smoothKey[]={"NAN", "EDGE_MIRROR", "EDGE_WRAP","EDGE_TRUNCATE", "EDGE_ZERO", "MISSING", KLISTEND};
   new DLibFunRetNew(lib::smooth_fun,string("SMOOTH"),2,smoothKey);
@@ -273,7 +273,7 @@ void LibInit()
   new DLibPro(lib::file_mkdir,string("FILE_MKDIR"),-1,file_mkdirKey);
 
   new DLibFunRetNew(lib::shift_fun,string("SHIFT"),9,NULL,NULL,true);
-  new DLibFunRetNew(lib::ishft_fun,string("ISHFT"),2,NULL,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::ishft_fun,string("ISHFT"),2,NULL,NULL,true);  //UsesThreadPOOL 
 
   const string sortKey[]={"L64",KLISTEND};
   new DLibFunRetNew(lib::sort_fun,string("SORT"),1,sortKey,NULL,true);
@@ -407,18 +407,18 @@ void LibInit()
 			 "STRING","UINT","UL64","ULONG",
 			 "START", "INCREMENT", KLISTEND};
   const string xindKey[]={"START", "INCREMENT", KLISTEND};
-  new DLibFunRetNew(lib::bindgen,string("BINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::indgen,string("INDGEN"),MAXRANK,indKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::uindgen,string("UINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::sindgen,string("SINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::lindgen,string("LINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::ulindgen,string("ULINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::l64indgen,string("L64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::findgen,string("FINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::dindgen,string("DINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::cindgen,string("CINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::dcindgen,string("DCINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::bindgen,string("BINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::indgen,string("INDGEN"),MAXRANK,indKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::uindgen,string("UINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::sindgen,string("SINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::lindgen,string("LINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::ulindgen,string("ULINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::l64indgen,string("L64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::findgen,string("FINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::dindgen,string("DINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::cindgen,string("CINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::dcindgen,string("DCINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::n_elements,string("N_ELEMENTS"),1,NULL,NULL,true,1);
 
@@ -478,7 +478,7 @@ void LibInit()
   const string assocKey[]={"PACKED",KLISTEND};
   new DLibFunRetNew(lib::assoc,string("ASSOC"),3,assocKey);
 
-  new DLibFun(lib::byte_fun,string("BYTE"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::byte_fun,string("BYTE"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
 
 /*
   new DLibFunRetNew(lib::fix_fun,string("FIX"),10,fixKey,NULL,true);
@@ -494,69 +494,68 @@ void LibInit()
 */
 // that's apparently the desired bahaviour, see bug no. 3151760
   const string fixKey[]={"TYPE","PRINT","IMPLIED_PRINT",KLISTEND}; //Fix never uses IMPLIED_PRINT, but called print_os does.
-  new DLibFun(lib::fix_fun,string("FIX"),10,fixKey);  //UsesThreadPOOL 
+  new DLibFun(lib::fix_fun,string("FIX"),10,fixKey,NULL,0,true);  //UsesThreadPOOL 
 
-  new DLibFun(lib::uint_fun,string("UINT"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::long_fun,string("LONG"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::long64_fun,string("LONG64"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::ulong64_fun,string("ULONG64"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::float_fun,string("FLOAT"),10,NULL,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::double_fun,string("DOUBLE"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::uint_fun,string("UINT"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::long_fun,string("LONG"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL),0,true;  //UsesThreadPOOL 
+  new DLibFun(lib::long64_fun,string("LONG64"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::ulong64_fun,string("ULONG64"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::float_fun,string("FLOAT"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::double_fun,string("DOUBLE"),10,NULL,NULL,0,true);  //UsesThreadPOOL 
 
   const string complexKey[]={"DOUBLE",KLISTEND};
-  new DLibFun(lib::complex_fun,string("COMPLEX"),MAXRANK+2,complexKey,NULL);  //UsesThreadPOOL 
-  new DLibFun(lib::dcomplex_fun,string("DCOMPLEX"),MAXRANK+2,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::complex_fun,string("COMPLEX"),MAXRANK+2,complexKey,NULL,0,true);  //UsesThreadPOOL 
+  new DLibFun(lib::dcomplex_fun,string("DCOMPLEX"),MAXRANK+2,NULL,NULL,0,true);  //UsesThreadPOOL 
 
-  new DLibFunRetNew(lib::gdl_logical_and,string("LOGICAL_AND"),2,NULL,NULL,true);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::gdl_logical_or,string("LOGICAL_OR"),2,NULL,NULL,true);  //UsesThreadPOOL 
-  new DLibFunDirect(lib::logical_true,string("LOGICAL_TRUE"));  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::gdl_logical_and,string("LOGICAL_AND"),2,NULL,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::gdl_logical_or,string("LOGICAL_OR"),2,NULL,NULL,true);  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::logical_true,string("LOGICAL_TRUE"));  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::replicate,string("REPLICATE"),9,NULL,NULL,true);
-  new DLibPro(lib::replicate_inplace_pro,string("REPLICATE_INPLACE"),6);  //UsesThreadPOOL 
+  new DLibPro(lib::replicate_inplace_pro,string("REPLICATE_INPLACE"),6,NULL,NULL,0,true);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sin_fun,string("SIN"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::cos_fun,string("COS"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::tan_fun,string("TAN"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::sin_fun,string("SIN"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::cos_fun,string("COS"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::tan_fun,string("TAN"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sinh_fun,string("SINH"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::cosh_fun,string("COSH"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::tanh_fun,string("TANH"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::sinh_fun,string("SINH"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::cosh_fun,string("COSH"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::tanh_fun,string("TANH"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::asin_fun,string("ASIN"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::acos_fun,string("ACOS"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::asin_fun,string("ASIN"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::acos_fun,string("ACOS"));  //UsesThreadPOOL 
   const string atanKey[] = {"PHASE", KLISTEND};
-  new DLibFunRetNew(lib::atan_fun,string("ATAN"),2,atanKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::atan_fun,string("ATAN"),2,atanKey,NULL,true);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::alog_fun,string("ALOG"));  //UsesThreadPOOL 
-// NOT PROGRAMMED ?  
-//  new DLibFunDirect(lib::alog2_fun,string("ALOG2"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::alog10_fun,string("ALOG10"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::alog_fun,string("ALOG"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::alog2_fun,string("ALOG2"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::alog10_fun,string("ALOG10"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sqrt_fun,string("SQRT"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::abs_fun,string("ABS"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::sqrt_fun,string("SQRT"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::abs_fun,string("ABS"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::exp_fun,string("EXP"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::exp_fun,string("EXP"));  //UsesThreadPOOL 
 
   const string roundKey[]={"L64",KLISTEND};
   // retConstant: check definition of the rounding functions if they depend 
   // from some sys var (defining a round mode) 
   // (probably nobody rounds a constant anyway)
   const string roundceilfloorKey[]={"L64",KLISTEND};
-  new DLibFunRetNew(lib::round_fun,string("ROUND"),1,roundceilfloorKey);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::ceil_fun,string("CEIL"),1,roundceilfloorKey);  //UsesThreadPOOL 
-  new DLibFunRetNew(lib::floor_fun,string("FLOOR"),1,roundceilfloorKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::round_fun,string("ROUND"),1,roundceilfloorKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::ceil_fun,string("CEIL"),1,roundceilfloorKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::floor_fun,string("FLOOR"),1,roundceilfloorKey);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::conj_fun,string("CONJ"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::imaginary_fun,string("IMAGINARY"));  //UsesThreadPOOL 
-  new DLibFunDirect(lib::real_part_fun,string("REAL_PART"));
+  new DLibFunDirectTP(lib::conj_fun,string("CONJ"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::imaginary_fun,string("IMAGINARY"));  //UsesThreadPOOL 
+  new DLibFunDirectTP(lib::real_part_fun,string("REAL_PART"));
 
   const string strcompressKey[]={"REMOVE_ALL",KLISTEND};
   new DLibFunRetNew(lib::strcompress,string("STRCOMPRESS"),1,strcompressKey,NULL,true);
   
-  new DLibFunDirect(lib::strlowcase,string("STRLOWCASE"));
-  new DLibFunDirect(lib::strupcase,string("STRUPCASE"));
-  new DLibFunDirect(lib::strlen,string("STRLEN"));
+  new DLibFunDirectTP(lib::strlowcase,string("STRLOWCASE"));
+  new DLibFunDirectTP(lib::strupcase,string("STRUPCASE"));
+  new DLibFunDirectTP(lib::strlen,string("STRLEN"));
 
   const string strmidKey[]={"REVERSE_OFFSET",KLISTEND};
   new DLibFunRetNew(lib::strmid,string("STRMID"),3,strmidKey,NULL,true);
@@ -566,13 +565,13 @@ void LibInit()
   new DLibPro(lib::strput,string("STRPUT"),3,NULL,NULL,2);
   
   const string whereKey[]={"COMPLEMENT","NCOMPLEMENT","NULL","L64",KLISTEND};
-  new DLibFunRetNew(lib::where_fun,string("WHERE"),2,whereKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::where_fun,string("WHERE"),2,whereKey);  //UsesThreadPOOL 
 
   const string totalKey[]={"CUMULATIVE","DOUBLE","NAN","INTEGER","PRESERVE_TYPE",KLISTEND};
-  new DLibFunRetNew(lib::total_fun,string("TOTAL"),2,totalKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::total_fun,string("TOTAL"),2,totalKey,NULL,true);  //UsesThreadPOOL 
 
   const string productKey[]={"CUMULATIVE","NAN","INTEGER","PRESERVE_TYPE",KLISTEND};
-  new DLibFunRetNew(lib::product_fun,string("PRODUCT"),2,productKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::product_fun,string("PRODUCT"),2,productKey,NULL,true);  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::n_params,string("N_PARAMS"),1); // IDL allows one parameter
   new DLibFunRetNew(lib::keyword_set,string("KEYWORD_SET"),1);
@@ -581,9 +580,9 @@ void LibInit()
   new DLibFunRetNew(lib::array_equal,string("ARRAY_EQUAL"),2,array_equalKey,NULL,true);
   
   const string minKey[]={"MAX","NAN","SUBSCRIPT_MAX","DIMENSION","ABSOLUTE",KLISTEND};
-  new DLibFunRetNew(lib::min_fun,string("MIN"),2,minKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::min_fun,string("MIN"),2,minKey,NULL,true);  //UsesThreadPOOL 
   const string maxKey[]={"MIN","NAN","SUBSCRIPT_MIN","DIMENSION","ABSOLUTE",KLISTEND};
-  new DLibFunRetNew(lib::max_fun,string("MAX"),2,maxKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::max_fun,string("MAX"),2,maxKey,NULL,true);  //UsesThreadPOOL 
 
   // retConstant: structs are tricky: struct resolution depends from !PATH
   // and this might change during runtime, but if treated as retConstant

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -595,10 +595,6 @@ void LibInit()
   const string reverseKey[] = {"OVERWRITE", KLISTEND};
   new DLibFun(lib::reverse, string("REVERSE"), 2, reverseKey, NULL, true);
 
-//   const string minKey[]={"MAX",KLISTEND};
-//   new DLibFun(lib::min_fun,string("MIN"),2,minKey);
-//   const string maxKey[]={"MIN",KLISTEND};
-//   new DLibFun(lib::max_fun,string("MAX"),2,maxKey);
 
 #ifdef USE_PYTHON
   const string python_funKey[]={"ARGV","DEFAULTRETURNVALUE",KLISTEND};

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -151,7 +151,7 @@ void LibInit()
   new DLibPro(lib::spawn_pro,string("SPAWN"),3,spawnKey);
 
   const string bytsclKey[]={"MIN","MAX","TOP","NAN",KLISTEND};
-  new DLibFunRetNew(lib::bytscl,string("BYTSCL"),3,bytsclKey);
+  new DLibFunRetNew(lib::bytscl,string("BYTSCL"),3,bytsclKey);  //UsesThreadPOOL 
 
   const string n_tagsKey[]={"DATA_LENGTH","LENGTH",KLISTEND};
   new DLibFunRetNew(lib::n_tags,string("N_TAGS"),1,n_tagsKey);
@@ -163,7 +163,7 @@ void LibInit()
 			       "FTOXDR","DTOXDR","XDRTOF","XDRTOD",
              "DTOGFLOAT","GFLOATTOD", // obsoleted 2  keywords only on the VMS platform
 			       KLISTEND};
-  new DLibPro(lib::byteorder,string("BYTEORDER"),-1,byteorderKey);
+  new DLibPro(lib::byteorder,string("BYTEORDER"),-1,byteorderKey);  //UsesThreadPOOL 
 
   const string obj_classKey[]={"COUNT","SUPERCLASS",KLISTEND};
   new DLibFunRetNew(lib::obj_class,string("OBJ_CLASS"),1,obj_classKey);
@@ -176,7 +176,7 @@ void LibInit()
 
   const string convolKey[]={"CENTER","EDGE_TRUNCATE","EDGE_WRAP","EDGE_ZERO", "EDGE_MIRROR",
 			    "BIAS","NORMALIZE","NAN", "INVALID", "MISSING",KLISTEND};
-  new DLibFunRetNew(lib::convol_fun,string("CONVOL"),3,convolKey);
+  new DLibFunRetNew(lib::convol_fun,string("CONVOL"),3,convolKey);  //UsesThreadPOOL 
 
   const string smoothKey[]={"NAN", "EDGE_MIRROR", "EDGE_WRAP","EDGE_TRUNCATE", "EDGE_ZERO", "MISSING", KLISTEND};
   new DLibFunRetNew(lib::smooth_fun,string("SMOOTH"),2,smoothKey);
@@ -273,7 +273,7 @@ void LibInit()
   new DLibPro(lib::file_mkdir,string("FILE_MKDIR"),-1,file_mkdirKey);
 
   new DLibFunRetNew(lib::shift_fun,string("SHIFT"),9,NULL,NULL,true);
-  new DLibFunRetNew(lib::ishft_fun,string("ISHFT"),2,NULL,NULL,true);
+  new DLibFunRetNew(lib::ishft_fun,string("ISHFT"),2,NULL,NULL,true);  //UsesThreadPOOL 
 
   const string sortKey[]={"L64",KLISTEND};
   new DLibFunRetNew(lib::sort_fun,string("SORT"),1,sortKey,NULL,true);
@@ -407,18 +407,18 @@ void LibInit()
 			 "STRING","UINT","UL64","ULONG",
 			 "START", "INCREMENT", KLISTEND};
   const string xindKey[]={"START", "INCREMENT", KLISTEND};
-  new DLibFunRetNew(lib::bindgen,string("BINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::indgen,string("INDGEN"),MAXRANK,indKey,NULL,true);
-  new DLibFunRetNew(lib::uindgen,string("UINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::sindgen,string("SINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::lindgen,string("LINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::ulindgen,string("ULINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::l64indgen,string("L64INDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::findgen,string("FINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::dindgen,string("DINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::cindgen,string("CINDGEN"),MAXRANK,xindKey,NULL,true);
-  new DLibFunRetNew(lib::dcindgen,string("DCINDGEN"),MAXRANK,xindKey,NULL,true);
+  new DLibFunRetNew(lib::bindgen,string("BINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::indgen,string("INDGEN"),MAXRANK,indKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::uindgen,string("UINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::sindgen,string("SINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::lindgen,string("LINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::ulindgen,string("ULINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::l64indgen,string("L64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::ul64indgen,string("UL64INDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::findgen,string("FINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::dindgen,string("DINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::cindgen,string("CINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::dcindgen,string("DCINDGEN"),MAXRANK,xindKey,NULL,true);  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::n_elements,string("N_ELEMENTS"),1,NULL,NULL,true,1);
 
@@ -478,7 +478,7 @@ void LibInit()
   const string assocKey[]={"PACKED",KLISTEND};
   new DLibFunRetNew(lib::assoc,string("ASSOC"),3,assocKey);
 
-  new DLibFun(lib::byte_fun,string("BYTE"),10,NULL,NULL);
+  new DLibFun(lib::byte_fun,string("BYTE"),10,NULL,NULL);  //UsesThreadPOOL 
 
 /*
   new DLibFunRetNew(lib::fix_fun,string("FIX"),10,fixKey,NULL,true);
@@ -494,61 +494,61 @@ void LibInit()
 */
 // that's apparently the desired bahaviour, see bug no. 3151760
   const string fixKey[]={"TYPE","PRINT","IMPLIED_PRINT",KLISTEND}; //Fix never uses IMPLIED_PRINT, but called print_os does.
-  new DLibFun(lib::fix_fun,string("FIX"),10,fixKey);
+  new DLibFun(lib::fix_fun,string("FIX"),10,fixKey);  //UsesThreadPOOL 
 
-  new DLibFun(lib::uint_fun,string("UINT"),10,NULL,NULL);
-  new DLibFun(lib::long_fun,string("LONG"),10,NULL,NULL);
-  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL);
-  new DLibFun(lib::long64_fun,string("LONG64"),10,NULL,NULL);
-  new DLibFun(lib::ulong64_fun,string("ULONG64"),10,NULL,NULL);
-  new DLibFun(lib::float_fun,string("FLOAT"),10,NULL,NULL);
-  new DLibFun(lib::double_fun,string("DOUBLE"),10,NULL,NULL);
+  new DLibFun(lib::uint_fun,string("UINT"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::long_fun,string("LONG"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::ulong_fun,string("ULONG"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::long64_fun,string("LONG64"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::ulong64_fun,string("ULONG64"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::float_fun,string("FLOAT"),10,NULL,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::double_fun,string("DOUBLE"),10,NULL,NULL);  //UsesThreadPOOL 
 
   const string complexKey[]={"DOUBLE",KLISTEND};
-  new DLibFun(lib::complex_fun,string("COMPLEX"),MAXRANK+2,complexKey,NULL);
-  new DLibFun(lib::dcomplex_fun,string("DCOMPLEX"),MAXRANK+2,NULL,NULL);
+  new DLibFun(lib::complex_fun,string("COMPLEX"),MAXRANK+2,complexKey,NULL);  //UsesThreadPOOL 
+  new DLibFun(lib::dcomplex_fun,string("DCOMPLEX"),MAXRANK+2,NULL,NULL);  //UsesThreadPOOL 
 
-  new DLibFunRetNew(lib::gdl_logical_and,string("LOGICAL_AND"),2,NULL,NULL,true);
-  new DLibFunRetNew(lib::gdl_logical_or,string("LOGICAL_OR"),2,NULL,NULL,true);
-  new DLibFunDirect(lib::logical_true,string("LOGICAL_TRUE"));
+  new DLibFunRetNew(lib::gdl_logical_and,string("LOGICAL_AND"),2,NULL,NULL,true);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::gdl_logical_or,string("LOGICAL_OR"),2,NULL,NULL,true);  //UsesThreadPOOL 
+  new DLibFunDirect(lib::logical_true,string("LOGICAL_TRUE"));  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::replicate,string("REPLICATE"),9,NULL,NULL,true);
-  new DLibPro(lib::replicate_inplace_pro,string("REPLICATE_INPLACE"),6);
+  new DLibPro(lib::replicate_inplace_pro,string("REPLICATE_INPLACE"),6);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sin_fun,string("SIN"));
-  new DLibFunDirect(lib::cos_fun,string("COS"));
-  new DLibFunDirect(lib::tan_fun,string("TAN"));//,1,NULL,NULL,true);
+  new DLibFunDirect(lib::sin_fun,string("SIN"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::cos_fun,string("COS"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::tan_fun,string("TAN"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sinh_fun,string("SINH"));//,1,NULL,NULL,true);
-  new DLibFunDirect(lib::cosh_fun,string("COSH"));//,1,NULL,NULL,true);
-  new DLibFunDirect(lib::tanh_fun,string("TANH"));//,1,NULL,NULL,true);
+  new DLibFunDirect(lib::sinh_fun,string("SINH"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::cosh_fun,string("COSH"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::tanh_fun,string("TANH"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::asin_fun,string("ASIN"));
-  new DLibFunDirect(lib::acos_fun,string("ACOS"));
+  new DLibFunDirect(lib::asin_fun,string("ASIN"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::acos_fun,string("ACOS"));  //UsesThreadPOOL 
   const string atanKey[] = {"PHASE", KLISTEND};
-  new DLibFunRetNew(lib::atan_fun,string("ATAN"),2,atanKey,NULL,true);
+  new DLibFunRetNew(lib::atan_fun,string("ATAN"),2,atanKey,NULL,true);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::alog_fun,string("ALOG"));
-  new DLibFunDirect(lib::alog10_fun,string("ALOG10"));
-//   new DLibFunRetNew(lib::alog_fun,string("ALOG"),1,NULL,NULL,true,1);
-//   new DLibFunRetNew(lib::alog10_fun,string("ALOG10"),1,NULL,NULL,true,1);
+  new DLibFunDirect(lib::alog_fun,string("ALOG"));  //UsesThreadPOOL 
+// NOT PROGRAMMED ?  
+//  new DLibFunDirect(lib::alog2_fun,string("ALOG2"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::alog10_fun,string("ALOG10"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::sqrt_fun,string("SQRT"));
-  new DLibFunDirect(lib::abs_fun,string("ABS"));
+  new DLibFunDirect(lib::sqrt_fun,string("SQRT"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::abs_fun,string("ABS"));  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::exp_fun,string("EXP"));
+  new DLibFunDirect(lib::exp_fun,string("EXP"));  //UsesThreadPOOL 
 
   const string roundKey[]={"L64",KLISTEND};
   // retConstant: check definition of the rounding functions if they depend 
   // from some sys var (defining a round mode) 
   // (probably nobody rounds a constant anyway)
   const string roundceilfloorKey[]={"L64",KLISTEND};
-  new DLibFunRetNew(lib::round_fun,string("ROUND"),1,roundceilfloorKey);
-  new DLibFunRetNew(lib::ceil_fun,string("CEIL"),1,roundceilfloorKey);
-  new DLibFunRetNew(lib::floor_fun,string("FLOOR"),1,roundceilfloorKey);
+  new DLibFunRetNew(lib::round_fun,string("ROUND"),1,roundceilfloorKey);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::ceil_fun,string("CEIL"),1,roundceilfloorKey);  //UsesThreadPOOL 
+  new DLibFunRetNew(lib::floor_fun,string("FLOOR"),1,roundceilfloorKey);  //UsesThreadPOOL 
 
-  new DLibFunDirect(lib::conj_fun,string("CONJ"));
-  new DLibFunDirect(lib::imaginary_fun,string("IMAGINARY"));
+  new DLibFunDirect(lib::conj_fun,string("CONJ"));  //UsesThreadPOOL 
+  new DLibFunDirect(lib::imaginary_fun,string("IMAGINARY"));  //UsesThreadPOOL 
   new DLibFunDirect(lib::real_part_fun,string("REAL_PART"));
 
   const string strcompressKey[]={"REMOVE_ALL",KLISTEND};
@@ -566,13 +566,13 @@ void LibInit()
   new DLibPro(lib::strput,string("STRPUT"),3,NULL,NULL,2);
   
   const string whereKey[]={"COMPLEMENT","NCOMPLEMENT","NULL","L64",KLISTEND};
-  new DLibFunRetNew(lib::where_fun,string("WHERE"),2,whereKey);
+  new DLibFunRetNew(lib::where_fun,string("WHERE"),2,whereKey);  //UsesThreadPOOL 
 
   const string totalKey[]={"CUMULATIVE","DOUBLE","NAN","INTEGER","PRESERVE_TYPE",KLISTEND};
-  new DLibFunRetNew(lib::total_fun,string("TOTAL"),2,totalKey,NULL,true);
+  new DLibFunRetNew(lib::total_fun,string("TOTAL"),2,totalKey,NULL,true);  //UsesThreadPOOL 
 
   const string productKey[]={"CUMULATIVE","NAN","INTEGER","PRESERVE_TYPE",KLISTEND};
-  new DLibFunRetNew(lib::product_fun,string("PRODUCT"),2,productKey,NULL,true);
+  new DLibFunRetNew(lib::product_fun,string("PRODUCT"),2,productKey,NULL,true);  //UsesThreadPOOL 
 
   new DLibFunRetNew(lib::n_params,string("N_PARAMS"),1); // IDL allows one parameter
   new DLibFunRetNew(lib::keyword_set,string("KEYWORD_SET"),1);
@@ -581,9 +581,9 @@ void LibInit()
   new DLibFunRetNew(lib::array_equal,string("ARRAY_EQUAL"),2,array_equalKey,NULL,true);
   
   const string minKey[]={"MAX","NAN","SUBSCRIPT_MAX","DIMENSION","ABSOLUTE",KLISTEND};
-  new DLibFunRetNew(lib::min_fun,string("MIN"),2,minKey,NULL,true);
+  new DLibFunRetNew(lib::min_fun,string("MIN"),2,minKey,NULL,true);  //UsesThreadPOOL 
   const string maxKey[]={"MIN","NAN","SUBSCRIPT_MIN","DIMENSION","ABSOLUTE",KLISTEND};
-  new DLibFunRetNew(lib::max_fun,string("MAX"),2,maxKey,NULL,true);
+  new DLibFunRetNew(lib::max_fun,string("MAX"),2,maxKey,NULL,true);  //UsesThreadPOOL 
 
   // retConstant: structs are tricky: struct resolution depends from !PATH
   // and this might change during runtime, but if treated as retConstant

--- a/src/libinit_ac.cpp
+++ b/src/libinit_ac.cpp
@@ -101,7 +101,7 @@ void LibInit_ac()
 
 
   const string matrix_multiplyKey[]={"ATRANSPOSE","BTRANSPOSE",KLISTEND};
-  new DLibFunRetNew(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);  //UsesThreadPOOL 
 
 // Levan Loria and Alain Coulais, September 2014 : to be extensively tested
 // please replace smooth with one of these functions only when thoroughly tested.

--- a/src/libinit_ac.cpp
+++ b/src/libinit_ac.cpp
@@ -101,7 +101,7 @@ void LibInit_ac()
 
 
   const string matrix_multiplyKey[]={"ATRANSPOSE","BTRANSPOSE",KLISTEND};
-  new DLibFunRetNew(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);
+  new DLibFunRetNew(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);  //UsesThreadPOOL 
 
 // Levan Loria and Alain Coulais, September 2014 : to be extensively tested
 // please replace smooth with one of these functions only when thoroughly tested.

--- a/src/libinit_ac.cpp
+++ b/src/libinit_ac.cpp
@@ -103,11 +103,5 @@ void LibInit_ac()
   const string matrix_multiplyKey[]={"ATRANSPOSE","BTRANSPOSE",KLISTEND};
   new DLibFunRetNewTP(lib::matrix_multiply,string("MATRIX_MULTIPLY"),2,matrix_multiplyKey);  //UsesThreadPOOL 
 
-// Levan Loria and Alain Coulais, September 2014 : to be extensively tested
-// please replace smooth with one of these functions only when thoroughly tested.
-//  const string smoothKey[]={"NAN",KLISTEND};
-//  new DLibFunRetNew(lib::smooth2_fun,string("SMOOTH2"),2,smoothKey);
-//  new DLibFunRetNew(lib::smooth3_fun,string("SMOOTH3"),2,smoothKey);
-  
 }
 

--- a/src/libinit_cl.cpp
+++ b/src/libinit_cl.cpp
@@ -53,7 +53,7 @@ void LibInit_cl()
   new DLibPro(lib::journal,string("JOURNAL"),1);
 
   const string timestampKey[]={"DAY","HOUR","MINUTE","MONTH","OFFSET","SECOND","UTC","YEAR","ZERO",KLISTEND};
-  new DLibFunRetNew(lib::timestamp,string("TIMESTAMP"),2,timestampKey);
+  new DLibFunRetNew(lib::timestamp,string("TIMESTAMP"),0,timestampKey);
 
   const string timestamptovaluesKey[]={"DAY","HOUR","MINUTE","MONTH","OFFSET","SECOND","YEAR",KLISTEND};
   new DLibPro (lib::timestamptovalues,string("TIMESTAMPTOVALUES"),1,timestamptovaluesKey);

--- a/src/libinit_gm.cpp
+++ b/src/libinit_gm.cpp
@@ -35,41 +35,41 @@ void LibInit_gm()
 #if defined(HAVE_LIBGSL)
 
   const string erfKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::erf_fun,string("ERF"),1,erfKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::erf_fun,string("ERF"),1,erfKey);  //UsesThreadPOOL 
 
   const string errorfKey[]={"DOUBLE",KLISTEND};
   new DLibFunRetNew(lib::errorf_fun,string("ERRORF"),1,errorfKey);
 
   const string erfcKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::erfc_fun,string("ERFC"),1,erfcKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::erfc_fun,string("ERFC"),1,erfcKey);  //UsesThreadPOOL 
 
   const string gammaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::gamma_fun,string("GAMMA"),1,gammaKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::gamma_fun,string("GAMMA"),1,gammaKey);  //UsesThreadPOOL 
   // undocumented function ...
   new DLibFunRetNew(lib::gamma_fun,string("NR_GAMMA"),1,gammaKey);
 
   const string lngammaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::lngamma_fun,string("LNGAMMA"),1,lngammaKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::lngamma_fun,string("LNGAMMA"),1,lngammaKey);  //UsesThreadPOOL 
 
   //  const string igammaKey[]={"DOUBLE","EPS","ITER","ITMAX","METHOD",KLISTEND};
   const string igammaKey[]={"DOUBLE","METHOD",KLISTEND};
   const string igammaWarnKey[]={"EPS","ITER","ITMAX",KLISTEND};
   new DLibFunRetNew(lib::igamma_fun,string("IGAMMA"),2,igammaKey,igammaWarnKey);
   // undocumented function ...
-  new DLibFunRetNew(lib::igamma_fun,string("IDL_IGAMMA"),2,igammaKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::igamma_fun,string("IDL_IGAMMA"),2,igammaKey);  //UsesThreadPOOL 
 
   const string betaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::beta_fun,string("BETA"),2,betaKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::beta_fun,string("BETA"),2,betaKey);  //UsesThreadPOOL 
 
   const string ibetaKey[]={"DOUBLE",KLISTEND};
   const string ibetaWarnKey[]={"EPS","ITER","ITMAX",KLISTEND};
-  new DLibFunRetNew(lib::ibeta_fun,string("IBETA"),3,ibetaKey, ibetaWarnKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::ibeta_fun,string("IBETA"),3,ibetaKey, ibetaWarnKey);  //UsesThreadPOOL 
 
   const string expintKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::expint_fun,string("EXPINT"),2,expintKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::expint_fun,string("EXPINT"),2,expintKey);  //UsesThreadPOOL 
 
   const string gaussintKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::gaussint_fun,string("GAUSSINT"),2,gaussintKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::gaussint_fun,string("GAUSSINT"),2,gaussintKey);  //UsesThreadPOOL 
 
 #endif
 

--- a/src/libinit_gm.cpp
+++ b/src/libinit_gm.cpp
@@ -35,41 +35,41 @@ void LibInit_gm()
 #if defined(HAVE_LIBGSL)
 
   const string erfKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::erf_fun,string("ERF"),1,erfKey);
+  new DLibFunRetNew(lib::erf_fun,string("ERF"),1,erfKey);  //UsesThreadPOOL 
 
   const string errorfKey[]={"DOUBLE",KLISTEND};
   new DLibFunRetNew(lib::errorf_fun,string("ERRORF"),1,errorfKey);
 
   const string erfcKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::erfc_fun,string("ERFC"),1,erfcKey);
+  new DLibFunRetNew(lib::erfc_fun,string("ERFC"),1,erfcKey);  //UsesThreadPOOL 
 
   const string gammaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::gamma_fun,string("GAMMA"),1,gammaKey);
+  new DLibFunRetNew(lib::gamma_fun,string("GAMMA"),1,gammaKey);  //UsesThreadPOOL 
   // undocumented function ...
   new DLibFunRetNew(lib::gamma_fun,string("NR_GAMMA"),1,gammaKey);
 
   const string lngammaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::lngamma_fun,string("LNGAMMA"),1,lngammaKey);
+  new DLibFunRetNew(lib::lngamma_fun,string("LNGAMMA"),1,lngammaKey);  //UsesThreadPOOL 
 
   //  const string igammaKey[]={"DOUBLE","EPS","ITER","ITMAX","METHOD",KLISTEND};
   const string igammaKey[]={"DOUBLE","METHOD",KLISTEND};
   const string igammaWarnKey[]={"EPS","ITER","ITMAX",KLISTEND};
   new DLibFunRetNew(lib::igamma_fun,string("IGAMMA"),2,igammaKey,igammaWarnKey);
   // undocumented function ...
-  new DLibFunRetNew(lib::igamma_fun,string("IDL_IGAMMA"),2,igammaKey);
+  new DLibFunRetNew(lib::igamma_fun,string("IDL_IGAMMA"),2,igammaKey);  //UsesThreadPOOL 
 
   const string betaKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::beta_fun,string("BETA"),2,betaKey);
+  new DLibFunRetNew(lib::beta_fun,string("BETA"),2,betaKey);  //UsesThreadPOOL 
 
   const string ibetaKey[]={"DOUBLE",KLISTEND};
   const string ibetaWarnKey[]={"EPS","ITER","ITMAX",KLISTEND};
-  new DLibFunRetNew(lib::ibeta_fun,string("IBETA"),3,ibetaKey, ibetaWarnKey);
+  new DLibFunRetNew(lib::ibeta_fun,string("IBETA"),3,ibetaKey, ibetaWarnKey);  //UsesThreadPOOL 
 
   const string expintKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::expint_fun,string("EXPINT"),2,expintKey);
+  new DLibFunRetNew(lib::expint_fun,string("EXPINT"),2,expintKey);  //UsesThreadPOOL 
 
   const string gaussintKey[]={"DOUBLE",KLISTEND};
-  new DLibFunRetNew(lib::gaussint_fun,string("GAUSSINT"),2,gaussintKey);
+  new DLibFunRetNew(lib::gaussint_fun,string("GAUSSINT"),2,gaussintKey);  //UsesThreadPOOL 
 
 #endif
 

--- a/src/libinit_jmg.cpp
+++ b/src/libinit_jmg.cpp
@@ -110,9 +110,9 @@ void LibInit_jmg()
   // if FFTw not available, FFT in the GSL used (slower)
   const string fftKey[]={"DOUBLE","INVERSE","OVERWRITE","DIMENSION","CENTER",KLISTEND};
 #if defined(USE_FFTW)
-  new DLibFun(lib::fftw_fun,string("FFT"),2,fftKey);
+  new DLibFun(lib::fftw_fun,string("FFT"),2,fftKey);  //UsesThreadPOOL 
 #else
-  new DLibFun(lib::fft_fun,string("FFT"),2,fftKey);
+  new DLibFun(lib::fft_fun,string("FFT"),2,fftKey); 
 #endif
 
   const string randomKey[]={"DOUBLE","GAMMA","LONG","NORMAL",
@@ -133,7 +133,7 @@ void LibInit_jmg()
   new DLibFunRetNew(lib::interpol_fun,string("INTERPOL"),3,interpolKey);
   
   const string interpolateKey[]={"CUBIC","DOUBLE","GRID","MISSING","NEAREST_NEIGHBOUR",KLISTEND};
-  new DLibFunRetNew(lib::interpolate_fun,string("INTERPOLATE"),4,interpolateKey);
+  new DLibFunRetNew(lib::interpolate_fun,string("INTERPOLATE"),4,interpolateKey);  //UsesThreadPOOL 
 
   const string la_triredKey[]={"DOUBLE","UPPER",KLISTEND};
   new DLibPro(lib::la_trired_pro,string("LA_TRIRED"),3,la_triredKey);
@@ -145,11 +145,11 @@ void LibInit_jmg()
 #if defined(USE_LIBPROJ)
   const string map_proj_forwardKey[]={"MAP_STRUCTURE","RADIANS","POLYGONS","POLYLINES","CONNECTIVITY","FILL",KLISTEND};  //WARNING FIXED ORDER for GetMapAsMapStructureKeyword()
   new DLibFunRetNew(lib::map_proj_forward_fun,
-	      string("MAP_PROJ_FORWARD"),2,map_proj_forwardKey,NULL);
+	      string("MAP_PROJ_FORWARD"),2,map_proj_forwardKey,NULL);  //UsesThreadPOOL 
 
   const string map_proj_inverseKey[]={"MAP_STRUCTURE","RADIANS",KLISTEND}; //WARNING FIXED ORDER for GetMapAsMapStructureKeyword()
   new DLibFunRetNew(lib::map_proj_inverse_fun,
-	      string("MAP_PROJ_INVERSE"),2,map_proj_inverseKey);
+	      string("MAP_PROJ_INVERSE"),2,map_proj_inverseKey);  //UsesThreadPOOL 
 //dummy functions for compatibility support of GCTP projections 
   new DLibPro(lib::map_proj_gctp_forinit,string("MAP_PROJ_GCTP_FORINIT"),4);
   new DLibPro(lib::map_proj_gctp_revinit,string("MAP_PROJ_GCTP_REVINIT"),4);
@@ -164,7 +164,7 @@ void LibInit_jmg()
 
 
   const string finiteKey[]={"INFINITY","NAN","SIGN",KLISTEND};
-  new DLibFunRetNew(lib::finite_fun,string("FINITE"),1,finiteKey);
+  new DLibFunRetNew(lib::finite_fun,string("FINITE"),1,finiteKey);  //UsesThreadPOOL 
 
   const string radonKey[]={"BACKPROJECT","DOUBLE","DRHO","DX","DY",
 			   "GRAY","LINEAR","NRHO","NTHETA","NX","NY",
@@ -194,7 +194,7 @@ void LibInit_jmg()
   new DLibFunRetNew(lib::trigrid_fun,string("TRIGRID"),6,trigridKey,trigridWarnKey);
 
   const string poly_2dKey[]={"CUBIC","MISSING",KLISTEND};
-  new DLibFunRetNew(lib::poly_2d_fun,string("POLY_2D"),6,poly_2dKey);
+  new DLibFunRetNew(lib::poly_2d_fun,string("POLY_2D"),6,poly_2dKey);  //UsesThreadPOOL 
 
   const string make_arrayKey[]={"DIMENSION", "INCREMENT", "INDEX", "NOZERO",
                                  "SIZE", "START", "TYPE", "VALUE", "BOOLEAN",

--- a/src/libinit_jmg.cpp
+++ b/src/libinit_jmg.cpp
@@ -110,7 +110,7 @@ void LibInit_jmg()
   // if FFTw not available, FFT in the GSL used (slower)
   const string fftKey[]={"DOUBLE","INVERSE","OVERWRITE","DIMENSION","CENTER",KLISTEND};
 #if defined(USE_FFTW)
-  new DLibFun(lib::fftw_fun,string("FFT"),2,fftKey);  //UsesThreadPOOL 
+  new DLibFun(lib::fftw_fun,string("FFT"),2,fftKey,NULL,0,true);  //UsesThreadPOOL 
 #else
   new DLibFun(lib::fft_fun,string("FFT"),2,fftKey); 
 #endif
@@ -133,7 +133,7 @@ void LibInit_jmg()
   new DLibFunRetNew(lib::interpol_fun,string("INTERPOL"),3,interpolKey);
   
   const string interpolateKey[]={"CUBIC","DOUBLE","GRID","MISSING","NEAREST_NEIGHBOUR",KLISTEND};
-  new DLibFunRetNew(lib::interpolate_fun,string("INTERPOLATE"),4,interpolateKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::interpolate_fun,string("INTERPOLATE"),4,interpolateKey);  //UsesThreadPOOL 
 
   const string la_triredKey[]={"DOUBLE","UPPER",KLISTEND};
   new DLibPro(lib::la_trired_pro,string("LA_TRIRED"),3,la_triredKey);
@@ -144,12 +144,10 @@ void LibInit_jmg()
 
 #if defined(USE_LIBPROJ)
   const string map_proj_forwardKey[]={"MAP_STRUCTURE","RADIANS","POLYGONS","POLYLINES","CONNECTIVITY","FILL",KLISTEND};  //WARNING FIXED ORDER for GetMapAsMapStructureKeyword()
-  new DLibFunRetNew(lib::map_proj_forward_fun,
-	      string("MAP_PROJ_FORWARD"),2,map_proj_forwardKey,NULL);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::map_proj_forward_fun,string("MAP_PROJ_FORWARD"),2,map_proj_forwardKey,NULL);  //UsesThreadPOOL 
 
   const string map_proj_inverseKey[]={"MAP_STRUCTURE","RADIANS",KLISTEND}; //WARNING FIXED ORDER for GetMapAsMapStructureKeyword()
-  new DLibFunRetNew(lib::map_proj_inverse_fun,
-	      string("MAP_PROJ_INVERSE"),2,map_proj_inverseKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::map_proj_inverse_fun,string("MAP_PROJ_INVERSE"),2,map_proj_inverseKey);  //UsesThreadPOOL 
 //dummy functions for compatibility support of GCTP projections 
   new DLibPro(lib::map_proj_gctp_forinit,string("MAP_PROJ_GCTP_FORINIT"),4);
   new DLibPro(lib::map_proj_gctp_revinit,string("MAP_PROJ_GCTP_REVINIT"),4);
@@ -164,12 +162,12 @@ void LibInit_jmg()
 
 
   const string finiteKey[]={"INFINITY","NAN","SIGN",KLISTEND};
-  new DLibFunRetNew(lib::finite_fun,string("FINITE"),1,finiteKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::finite_fun,string("FINITE"),1,finiteKey);  //UsesThreadPOOL 
 
   const string radonKey[]={"BACKPROJECT","DOUBLE","DRHO","DX","DY",
 			   "GRAY","LINEAR","NRHO","NTHETA","NX","NY",
 			   "RHO","RMIN","THETA","XMIN","YMIN",KLISTEND};
-  new DLibFunRetNew(lib::radon_fun,string("RADON"),1,radonKey);
+  new DLibFunRetNewTP(lib::radon_fun,string("RADON"),1,radonKey);
   
 
   const string grid_inputKey[]={"SPHERE", "POLAR", "DEGREES", "DUPLICATES", "EPSILON", "EXCLUDE", KLISTEND};
@@ -194,14 +192,14 @@ void LibInit_jmg()
   new DLibFunRetNew(lib::trigrid_fun,string("TRIGRID"),6,trigridKey,trigridWarnKey);
 
   const string poly_2dKey[]={"CUBIC","MISSING",KLISTEND};
-  new DLibFunRetNew(lib::poly_2d_fun,string("POLY_2D"),6,poly_2dKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::poly_2d_fun,string("POLY_2D"),6,poly_2dKey);  //UsesThreadPOOL 
 
   const string make_arrayKey[]={"DIMENSION", "INCREMENT", "INDEX", "NOZERO",
                                  "SIZE", "START", "TYPE", "VALUE", "BOOLEAN",
                                  "BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE",
                                  "FLOAT", "INTEGER", "L64", "LONG", "OBJ",
                                  "PTR", "STRING", "UINT", "UL64", "ULONG", KLISTEND};
-  new DLibFunRetNew(lib::make_array,string("MAKE_ARRAY"),MAXRANK,make_arrayKey);
+  new DLibFunRetNewTP(lib::make_array,string("MAKE_ARRAY"),MAXRANK,make_arrayKey);  //UsesThreadPOOL //not yet
 
   const string reformKey[]={"OVERWRITE",KLISTEND};
   new DLibFun(lib::reform,string("REFORM"),MAXRANK+1,reformKey);

--- a/src/libinit_ng.cpp
+++ b/src/libinit_ng.cpp
@@ -29,7 +29,7 @@ void LibInit_ng()
   new DLibFunRetNew(lib::rk4_fun,string("RK4"),5,rk4Key);
 
   const string voigtKey[]={"DOUBLE","ITER",KLISTEND};
-  new DLibFunRetNew(lib::voigt_fun,string("VOIGT"),2,voigtKey);
+  new DLibFunRetNew(lib::voigt_fun,string("VOIGT"),2,voigtKey);  //UsesThreadPOOL 
  
 }
 

--- a/src/libinit_ng.cpp
+++ b/src/libinit_ng.cpp
@@ -29,7 +29,7 @@ void LibInit_ng()
   new DLibFunRetNew(lib::rk4_fun,string("RK4"),5,rk4Key);
 
   const string voigtKey[]={"DOUBLE","ITER",KLISTEND};
-  new DLibFunRetNew(lib::voigt_fun,string("VOIGT"),2,voigtKey);  //UsesThreadPOOL 
+  new DLibFunRetNewTP(lib::voigt_fun,string("VOIGT"),2,voigtKey);  //UsesThreadPOOL 
  
 }
 

--- a/src/magick_cl.cpp
+++ b/src/magick_cl.cpp
@@ -983,13 +983,9 @@ namespace lib {
       index = image->getIndexes();
 
       SizeT nEl = columns*rows;
-      // #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
-        // #pragma omp for
         for (SizeT cx = 0; cx < nEl; ++cx) {
           index[cx] = static_cast<unsigned int> ((*bImage)[cx]);
-          /*	    *index=(unsigned int)(*bImage)[cx];
-                  index++;*/
         }
       }
       image->syncPixels();

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -1319,6 +1319,21 @@ namespace lib {
     return p0->Log10();
   }
 
+  //   BaseGDL* alog2_fun( EnvT* e)
+  //very quick and dirty.
+  BaseGDL* alog2_fun(BaseGDL* p0, bool isReference) {
+    static const double logue2=log(2.);
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    BaseGDL* ret;
+    if (!isReference) //e->StealLocalPar( 0))
+    {
+      ret=p0->LogThis();
+    } else  ret=p0->Log();
+    DFloatGDL* val = static_cast<DFloatGDL*> (ret->Convert2(GDL_FLOAT, BaseGDL::COPY));
+    for (SizeT i=0; i< p0->N_Elements(); ++i) (*val)[i] /= logue2;
+    return val;
+  }
+
   //Following produce Float or doubles for complex.
 
   template< typename T>

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -2065,7 +2065,7 @@ namespace lib {
   // by medericboquien@users.sourceforge.net
 
   BaseGDL* t_pdf(EnvT* e) {
-    //    SizeT nParam = e->NParam(2);
+    SizeT nParam = e->NParam(2);
     DDoubleGDL* v = e->GetParAs<DDoubleGDL>(0);
     DDoubleGDL* df = e->GetParAs<DDoubleGDL>(1);
     DDoubleGDL* res;

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -58,7 +58,7 @@ namespace lib {
 
   template< typename srcT, typename destT>
   void FromToGSL(srcT* src, destT* dest, SizeT nEl) {
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -221,7 +221,7 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -235,7 +235,7 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -267,7 +267,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -283,7 +283,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -304,7 +304,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -320,7 +320,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -345,7 +345,7 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -359,7 +359,7 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -389,7 +389,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -405,7 +405,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -426,7 +426,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -442,7 +442,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -467,7 +467,7 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -481,7 +481,7 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -511,7 +511,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -527,7 +527,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -548,7 +548,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -564,7 +564,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -592,7 +592,7 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -610,7 +610,7 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -638,7 +638,7 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -660,7 +660,7 @@ namespace lib {
       (*res)[0] = sin((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -678,7 +678,7 @@ namespace lib {
       (*p0C)[0] = sin((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -706,7 +706,7 @@ namespace lib {
       else return sin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -728,7 +728,7 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -746,7 +746,7 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -774,7 +774,7 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -796,7 +796,7 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -814,7 +814,7 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -842,7 +842,7 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -864,7 +864,7 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -882,7 +882,7 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -910,7 +910,7 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -932,7 +932,7 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -950,7 +950,7 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -978,7 +978,7 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1000,7 +1000,7 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1018,7 +1018,7 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1046,7 +1046,7 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1066,7 +1066,7 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1084,7 +1084,7 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1112,7 +1112,7 @@ namespace lib {
       else return asin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1132,7 +1132,7 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1150,7 +1150,7 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1178,7 +1178,7 @@ namespace lib {
       else return acos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1200,7 +1200,7 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1218,7 +1218,7 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1246,7 +1246,7 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1308,7 +1308,7 @@ namespace lib {
       (*res)[ 0] = abs((*p0C)[ 0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1328,7 +1328,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1344,7 +1344,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1388,7 +1388,7 @@ namespace lib {
       (*res)[ 0] = abs((*res)[ 0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1411,7 +1411,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult();
       else res = static_cast<DComplexGDL*> (p0);
       DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1425,7 +1425,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
       else res = res = static_cast<DComplexDblGDL*> (p0);
       DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1454,7 +1454,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1466,7 +1466,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1498,7 +1498,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1510,7 +1510,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1639,7 +1639,7 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1648,7 +1648,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1657,7 +1657,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1686,7 +1686,7 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1695,7 +1695,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1704,7 +1704,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1733,7 +1733,7 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1742,7 +1742,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1751,7 +1751,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1780,7 +1780,7 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1789,7 +1789,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1798,7 +1798,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1819,7 +1819,7 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1828,7 +1828,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1837,7 +1837,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (GDL_NTHREADS=parallelize( nElMin)==1) {
+          if ((GDL_NTHREADS=parallelize( nElMin))==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1857,7 +1857,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1872,7 +1872,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1889,7 +1889,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1904,7 +1904,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1919,7 +1919,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1934,7 +1934,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1948,7 +1948,7 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
-          if (GDL_NTHREADS=parallelize( nEl)==1) {
+          if ((GDL_NTHREADS=parallelize( nEl))==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2076,7 +2076,7 @@ namespace lib {
     DInt n = (*nval)[0];
     SizeT nEx = xvals->N_Elements();
 
-    if (GDL_NTHREADS=parallelize( nEx)==1) {
+    if ((GDL_NTHREADS=parallelize( nEx))==1) {
       for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
     } else {
       TRACEOMP(__FILE__, __LINE__)

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -237,6 +237,7 @@ namespace lib {
             (*res)[ 0] = round ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i]);
         return res;
@@ -249,6 +250,7 @@ namespace lib {
             (*res)[ 0] = round ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i]);
 
@@ -278,6 +280,7 @@ namespace lib {
                   (*res)[ 0] = round ((*p0C)[ 0].real ());
                   return res;
                 }
+	      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
               return res;
@@ -292,6 +295,7 @@ namespace lib {
                   (*res)[ 0] = round ((*p0C)[ 0].real ());
                   return res;
                 }
+	      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
               return res;
@@ -313,6 +317,7 @@ namespace lib {
                   (*res)[ 0] = round ((*p0C)[ 0].real ());
                   return res;
                 }
+	      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
               return res;
@@ -327,6 +332,7 @@ namespace lib {
                   (*res)[ 0] = round ((*p0C)[ 0].real ());
                   return res;
                 }
+	      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
               return res;
@@ -351,6 +357,7 @@ namespace lib {
             (*res)[ 0] = ceil ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i]);
         return res;
@@ -363,6 +370,7 @@ namespace lib {
             (*res)[ 0] = ceil ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i]);
 
@@ -392,6 +400,7 @@ namespace lib {
                 (*res)[ 0] = ceil ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
             return res;
@@ -406,6 +415,7 @@ namespace lib {
                 (*res)[ 0] = ceil ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
             return res;
@@ -427,6 +437,7 @@ namespace lib {
                 (*res)[ 0] = ceil ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
             return res;
@@ -441,6 +452,7 @@ namespace lib {
                 (*res)[ 0] = ceil ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
             return res;
@@ -465,6 +477,7 @@ namespace lib {
             (*res)[ 0] = floor ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i]);
         return res;
@@ -477,6 +490,7 @@ namespace lib {
             (*res)[ 0] = floor ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i]);
 
@@ -506,6 +520,7 @@ namespace lib {
                 (*res)[ 0] = floor ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
             return res;
@@ -520,6 +535,7 @@ namespace lib {
                 (*res)[ 0] = floor ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
             return res;
@@ -541,6 +557,7 @@ namespace lib {
                 (*res)[ 0] = floor ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
             return res;
@@ -555,6 +572,7 @@ namespace lib {
                 (*res)[ 0] = floor ((*p0C)[ 0].real ());
                 return res;
               }
+	    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
             return res;
@@ -578,6 +596,7 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     return res;
@@ -591,6 +610,7 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     return p0;
@@ -614,6 +634,7 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       return res;
@@ -632,6 +653,7 @@ namespace lib {
         (*res)[0] = sin ((*p0C)[0]);
         return res;
       }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin ((*p0C)[ i]);
     return res;
@@ -647,6 +669,7 @@ namespace lib {
         (*p0C)[0] = sin ((*p0C)[0]);
         return p0;
       }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin ((*p0C)[ i]);
     return p0;
@@ -668,6 +691,7 @@ namespace lib {
     else
       {
         DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin ((*res)[ i]);
         return res;
@@ -684,6 +708,7 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     return res;
@@ -697,6 +722,7 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     return p0;
@@ -720,6 +746,7 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       return res;
@@ -736,6 +763,7 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     return res;
@@ -749,6 +777,7 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     return p0;
@@ -772,6 +801,7 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       return res;
@@ -788,6 +818,7 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     return res;
@@ -801,6 +832,7 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     return p0;
@@ -824,6 +856,7 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       return res;
@@ -840,6 +873,7 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     return res;
@@ -853,6 +887,7 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     return p0;
@@ -876,6 +911,7 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       return res;
@@ -892,6 +928,7 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     return res;
@@ -905,6 +942,7 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     return p0;
@@ -928,6 +966,7 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       return res;
@@ -943,6 +982,7 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     return res;
@@ -956,6 +996,7 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     return p0;
@@ -977,6 +1018,7 @@ namespace lib {
     else
       {
         DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin ((*res)[ i]);
         return res;
@@ -992,6 +1034,7 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     return res;
@@ -1005,6 +1048,7 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     return p0;
@@ -1026,6 +1070,7 @@ namespace lib {
     else
       {
         DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos ((*res)[ i]);
         return res;
@@ -1042,6 +1087,7 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     return res;
@@ -1055,6 +1101,7 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     return p0;
@@ -1078,6 +1125,7 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       return res;
@@ -1122,6 +1170,7 @@ namespace lib {
         (*res)[ 0] = abs ((*p0C)[ 0]);
         return res;
       }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]);
     return res;
@@ -1140,6 +1189,7 @@ namespace lib {
             (*res)[ 0] = abs ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
         return res;
@@ -1154,6 +1204,7 @@ namespace lib {
             (*res)[ 0] = abs ((*p0C)[ 0]);
             return res;
           }
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
         return res;
@@ -1198,6 +1249,7 @@ namespace lib {
         (*res)[ 0] = abs ((*res)[ 0]);
         return res;
       }
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*res)[ i]);
     return res;
@@ -1215,6 +1267,7 @@ namespace lib {
         DComplexGDL* res;
         if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult (); else res=static_cast<DComplexGDL*>(p0);
         DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj ((*p0C)[i]);
         return res;
@@ -1224,6 +1277,7 @@ namespace lib {
         DComplexDblGDL* res;
         if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult (); else res=res=static_cast<DComplexDblGDL*>(p0);
         DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj ((*p0C)[i]);
         return res;
@@ -1249,6 +1303,7 @@ namespace lib {
       {
         DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
         DFloatGDL* res = new DFloatGDL (c0->Dim (), BaseGDL::NOZERO);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag ((*c0)[i]);
         return res;
@@ -1257,6 +1312,7 @@ namespace lib {
       {
         DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
         DDoubleGDL* res = new DDoubleGDL (c0->Dim (), BaseGDL::NOZERO);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag ((*c0)[i]);
         return res;
@@ -1286,6 +1342,7 @@ namespace lib {
       {
         DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
         DFloatGDL* res = new DFloatGDL (c0->Dim (), BaseGDL::NOZERO);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real ((*c0)[i]);
         return res;
@@ -1294,6 +1351,7 @@ namespace lib {
       {
         DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
         DDoubleGDL* res = new DDoubleGDL (c0->Dim (), BaseGDL::NOZERO);
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real ((*c0)[i]);
         return res;
@@ -1418,14 +1476,17 @@ namespace lib {
         }
         switch (cas) {
         case 0:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           return res;
         case 1:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           return res;
         case 2:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           return res;
@@ -1450,14 +1511,17 @@ namespace lib {
         }
         switch (cas) {
         case 0:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
           return res;
         case 1:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
           return res;
         case 2:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
           return res;
@@ -1482,14 +1546,17 @@ namespace lib {
         }
         switch (cas) {
         case 0:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
           return res;
         case 1:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
           return res;
         case 2:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
           return res;
@@ -1514,14 +1581,17 @@ namespace lib {
         }
         switch (cas) {
         case 0:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
           return res;
         case 1:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
           return res;
         case 2:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
           return res;
@@ -1538,14 +1608,17 @@ namespace lib {
         }
         switch (cas) {
         case 0:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           return res;
         case 1:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           return res;
         case 2:
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
           for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           return res;
@@ -1561,6 +1634,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           return res;
@@ -1571,6 +1645,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           return res;
@@ -1583,6 +1658,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           return res;
@@ -1593,6 +1669,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           return res;
@@ -1603,6 +1680,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           return res;
@@ -1613,6 +1691,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           return res;
@@ -1622,6 +1701,7 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
+	  TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           return res;
@@ -1747,6 +1827,7 @@ namespace lib {
     SizeT nEx = xvals->N_Elements();
 
 //is this really useful? parallelizing Laguerre? Do not forget openmp uses time.
+//    TRACEOMP(__FILE__,__LINE__)
 //#pragma omp parallel for if (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEx))
     for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
 
@@ -1759,6 +1840,7 @@ namespace lib {
 
 //GD: parallelizing this complicated loop cannot be done just like that.
 //I further doubt Laguerre is going to be used on large arrays.
+//      TRACEOMP(__FILE__,__LINE__)
 //#pragma omp parallel for if (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
       for (SizeT count = 0; count <= n; ++count) {
         double dcount = static_cast<double> (count);

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -4,7 +4,7 @@
     begin                : July 22 2002
     copyright            : (C) 2002 by Marc Schellens
     email                : m_schellens@users.sf.net
-***************************************************************************/
+ ***************************************************************************/
 
 /***************************************************************************
  *                                                                         *
@@ -45,548 +45,551 @@
 namespace lib {
 
   using namespace std;
-  
-  template< typename srcT, typename destT>
-  void TransposeFromToGSL(  srcT* src, destT* dest, SizeT srcStride1, SizeT nEl)
-  {
-    for( SizeT d = 0, ix = 0, srcDim0 = 0; d<nEl; ++d)
-      {
-	dest[ d] = src[ ix];
-	ix += srcStride1;
-	if( ix >= nEl) 
-	  ix = ++srcDim0;
-      }
-  }
 
   template< typename srcT, typename destT>
-  void FromToGSL(  srcT* src, destT* dest, SizeT nEl)
-  {
-    #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-    #pragma omp for
-      for( SizeT d = 0; d<nEl; ++d)
-	{
-	  dest[ d] = src[ d];
-	}
+  void TransposeFromToGSL(srcT* src, destT* dest, SizeT srcStride1, SizeT nEl) {
+    for (SizeT d = 0, ix = 0, srcDim0 = 0; d < nEl; ++d) {
+      dest[ d] = src[ ix];
+      ix += srcStride1;
+      if (ix >= nEl)
+        ix = ++srcDim0;
     }
   }
 
-  void svdc( EnvT* e)
-  {
-    e->NParam( 4);
+  template< typename srcT, typename destT>
+  void FromToGSL(srcT* src, destT* dest, SizeT nEl) {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
+    }
+  }
 
-    static int doubleKWIx = e->KeywordIx( "DOUBLE");
-    bool doubleKW = e->KeywordSet( doubleKWIx);
+  void svdc(EnvT* e) {
+    e->NParam(4);
 
-    BaseGDL* A = e->GetParDefined( 0);
+    static int doubleKWIx = e->KeywordIx("DOUBLE");
+    bool doubleKW = e->KeywordSet(doubleKWIx);
+
+    BaseGDL* A = e->GetParDefined(0);
     doubleKW = doubleKW || (A->Type() == GDL_DOUBLE) || (A->Type() == GDL_COMPLEXDBL);
 
-    if( doubleKW)
-      {
-	A = e->GetParAs< DDoubleGDL>( 0);
-      }
-    else
-      {
-	A = e->GetParAs< DFloatGDL>( 0);
-      }
-    if( A->Rank() != 2)
-      e->Throw( "Argument must be a 2-D matrix: "+e->GetParString(0));
-    
-    e->AssureGlobalPar( 1); // W
-    e->AssureGlobalPar( 2); // U
-    e->AssureGlobalPar( 3); // V
-    
-    static int columnKWIx = e->KeywordIx( "COLUMN");
-    bool columnKW = e->KeywordSet( columnKWIx);
-    static int itmaxKWIx  = e->KeywordIx( "ITMAX");
+    if (doubleKW) {
+      A = e->GetParAs< DDoubleGDL>(0);
+    } else {
+      A = e->GetParAs< DFloatGDL>(0);
+    }
+    if (A->Rank() != 2)
+      e->Throw("Argument must be a 2-D matrix: " + e->GetParString(0));
+
+    e->AssureGlobalPar(1); // W
+    e->AssureGlobalPar(2); // U
+    e->AssureGlobalPar(3); // V
+
+    static int columnKWIx = e->KeywordIx("COLUMN");
+    bool columnKW = e->KeywordSet(columnKWIx);
+    static int itmaxKWIx = e->KeywordIx("ITMAX");
     DLong itMax = 30;
-    e->AssureLongScalarKWIfPresent( itmaxKWIx, itMax);
+    e->AssureLongScalarKWIfPresent(itmaxKWIx, itMax);
 
     DLong n;
     DLong m;
-    if( columnKW)
-      {
-	n = A->Dim( 1);
-	m = A->Dim( 0);
-      }
-    else
-      {
-	n = A->Dim( 0);
-	m = A->Dim( 1);
-      }
-    if( m < n)
-      e->Throw( "SVD of NxM matrix with N>M is not implemented yet.");
+    if (columnKW) {
+      n = A->Dim(1);
+      m = A->Dim(0);
+    } else {
+      n = A->Dim(0);
+      m = A->Dim(1);
+    }
+    if (m < n)
+      e->Throw("SVD of NxM matrix with N>M is not implemented yet.");
 
     DLong nEl = A->N_Elements();
 
-    if( doubleKW)
-      {
-	DDoubleGDL* AA = static_cast<DDoubleGDL*>( A);
+    if (doubleKW) {
+      DDoubleGDL* AA = static_cast<DDoubleGDL*> (A);
 
-	gsl_matrix *aGSL = gsl_matrix_alloc( m, n);
-	GDLGuard<gsl_matrix> g1( aGSL, gsl_matrix_free);
-	if( !columnKW)
-	  memcpy(aGSL->data, &(*AA)[0], nEl*sizeof( DDouble));
-	else
-	  TransposeFromToGSL< DDouble, double>( &(*AA)[0], aGSL->data, AA->Dim( 0), nEl);
+      gsl_matrix *aGSL = gsl_matrix_alloc(m, n);
+      GDLGuard<gsl_matrix> g1(aGSL, gsl_matrix_free);
+      if (!columnKW)
+        memcpy(aGSL->data, &(*AA)[0], nEl * sizeof ( DDouble));
+      else
+        TransposeFromToGSL< DDouble, double>(&(*AA)[0], aGSL->data, AA->Dim(0), nEl);
 
-	gsl_matrix *vGSL = gsl_matrix_alloc( n, n);
-	GDLGuard<gsl_matrix> g2( vGSL, gsl_matrix_free);
-	gsl_vector *wGSL = gsl_vector_alloc( n);
-	GDLGuard<gsl_vector> g3( wGSL, gsl_vector_free);
+      gsl_matrix *vGSL = gsl_matrix_alloc(n, n);
+      GDLGuard<gsl_matrix> g2(vGSL, gsl_matrix_free);
+      gsl_vector *wGSL = gsl_vector_alloc(n);
+      GDLGuard<gsl_vector> g3(wGSL, gsl_vector_free);
 
-	gsl_vector *work = gsl_vector_alloc( n);
-	GDLGuard<gsl_vector> g4( work, gsl_vector_free);
-	gsl_linalg_SV_decomp( aGSL, vGSL, wGSL, work);
-	// 	gsl_vector_free( work);
+      gsl_vector *work = gsl_vector_alloc(n);
+      GDLGuard<gsl_vector> g4(work, gsl_vector_free);
+      gsl_linalg_SV_decomp(aGSL, vGSL, wGSL, work);
+      // 	gsl_vector_free( work);
 
-	// aGSL -> uGSL
-	gsl_matrix *uGSL = aGSL; // why?
+      // aGSL -> uGSL
+      gsl_matrix *uGSL = aGSL; // why?
 
-	// U
-	DDoubleGDL* U = new DDoubleGDL( AA->Dim(), BaseGDL::NOZERO);
-	if( !columnKW)
-	  memcpy( &(*U)[0], uGSL->data, nEl*sizeof( DDouble));
-	else
-	  TransposeFromToGSL< double, DDouble>( uGSL->data, &(*U)[0], U->Dim( 1), nEl);
-	// 	gsl_matrix_free( uGSL);
-	e->SetPar( 2, U);
+      // U
+      DDoubleGDL* U = new DDoubleGDL(AA->Dim(), BaseGDL::NOZERO);
+      if (!columnKW)
+        memcpy(&(*U)[0], uGSL->data, nEl * sizeof ( DDouble));
+      else
+        TransposeFromToGSL< double, DDouble>(uGSL->data, &(*U)[0], U->Dim(1), nEl);
+      // 	gsl_matrix_free( uGSL);
+      e->SetPar(2, U);
 
-	// V
-	DDoubleGDL* V = new DDoubleGDL( dimension( n, n), BaseGDL::NOZERO);
-	if( !columnKW)
-	  memcpy( &(*V)[0], vGSL->data, n*n*sizeof( DDouble));
-	else
-	  TransposeFromToGSL< double, DDouble>( vGSL->data, &(*V)[0], n, n*n);
-	// 	gsl_matrix_free( vGSL);
-	e->SetPar( 3, V);
+      // V
+      DDoubleGDL* V = new DDoubleGDL(dimension(n, n), BaseGDL::NOZERO);
+      if (!columnKW)
+        memcpy(&(*V)[0], vGSL->data, n * n * sizeof ( DDouble));
+      else
+        TransposeFromToGSL< double, DDouble>(vGSL->data, &(*V)[0], n, n * n);
+      // 	gsl_matrix_free( vGSL);
+      e->SetPar(3, V);
 
-	// W
-	DDoubleGDL* W = new DDoubleGDL( dimension( n), BaseGDL::NOZERO);
-	memcpy( &(*W)[0], wGSL->data, n*sizeof( DDouble));
-	// 	gsl_vector_free( wGSL);
-	e->SetPar( 1, W);
-      }
-    else // float
-      {
-	DFloatGDL* AA = static_cast<DFloatGDL*>( A);
+      // W
+      DDoubleGDL* W = new DDoubleGDL(dimension(n), BaseGDL::NOZERO);
+      memcpy(&(*W)[0], wGSL->data, n * sizeof ( DDouble));
+      // 	gsl_vector_free( wGSL);
+      e->SetPar(1, W);
+    } else // float
+    {
+      DFloatGDL* AA = static_cast<DFloatGDL*> (A);
 
-	gsl_matrix *aGSL = gsl_matrix_alloc( m, n);
-	GDLGuard<gsl_matrix> g1( aGSL, gsl_matrix_free);
-	if( !columnKW)
-	  FromToGSL< DFloat, double>( &(*AA)[0], aGSL->data, nEl);
-	else
-	  TransposeFromToGSL< DFloat, double>( &(*AA)[0], aGSL->data, AA->Dim( 0), nEl);
+      gsl_matrix *aGSL = gsl_matrix_alloc(m, n);
+      GDLGuard<gsl_matrix> g1(aGSL, gsl_matrix_free);
+      if (!columnKW)
+        FromToGSL< DFloat, double>(&(*AA)[0], aGSL->data, nEl);
+      else
+        TransposeFromToGSL< DFloat, double>(&(*AA)[0], aGSL->data, AA->Dim(0), nEl);
 
-	gsl_matrix *vGSL = gsl_matrix_alloc( n, n);
-	GDLGuard<gsl_matrix> g2( vGSL, gsl_matrix_free);
-	gsl_vector *wGSL = gsl_vector_alloc( n);
-	GDLGuard<gsl_vector> g3( wGSL, gsl_vector_free);
+      gsl_matrix *vGSL = gsl_matrix_alloc(n, n);
+      GDLGuard<gsl_matrix> g2(vGSL, gsl_matrix_free);
+      gsl_vector *wGSL = gsl_vector_alloc(n);
+      GDLGuard<gsl_vector> g3(wGSL, gsl_vector_free);
 
-	gsl_vector *work = gsl_vector_alloc( n);
-	GDLGuard<gsl_vector> g4( work, gsl_vector_free);
-	gsl_linalg_SV_decomp( aGSL, vGSL, wGSL, work);
-	// 	gsl_vector_free( work);
+      gsl_vector *work = gsl_vector_alloc(n);
+      GDLGuard<gsl_vector> g4(work, gsl_vector_free);
+      gsl_linalg_SV_decomp(aGSL, vGSL, wGSL, work);
+      // 	gsl_vector_free( work);
 
-	// aGSL -> uGSL
-	gsl_matrix *uGSL = aGSL; // why?
+      // aGSL -> uGSL
+      gsl_matrix *uGSL = aGSL; // why?
 
-	// U
-	DFloatGDL* U = new DFloatGDL( AA->Dim(), BaseGDL::NOZERO);
-	if( !columnKW)
-	  FromToGSL< double, DFloat>( uGSL->data, &(*U)[0], nEl);
-	else
-	  TransposeFromToGSL< double, DFloat>( uGSL->data, &(*U)[0], U->Dim( 1), nEl);
-	// 	gsl_matrix_free( uGSL);
-	e->SetPar( 2, U);
+      // U
+      DFloatGDL* U = new DFloatGDL(AA->Dim(), BaseGDL::NOZERO);
+      if (!columnKW)
+        FromToGSL< double, DFloat>(uGSL->data, &(*U)[0], nEl);
+      else
+        TransposeFromToGSL< double, DFloat>(uGSL->data, &(*U)[0], U->Dim(1), nEl);
+      // 	gsl_matrix_free( uGSL);
+      e->SetPar(2, U);
 
-	// V
-	DFloatGDL* V = new DFloatGDL( dimension( n, n), BaseGDL::NOZERO);
-	if( !columnKW)
-	  FromToGSL< double, DFloat>( vGSL->data, &(*V)[0], n*n);
-	else
-	  TransposeFromToGSL< double, DFloat>( vGSL->data, &(*V)[0], n, n*n);
-	// 	gsl_matrix_free( vGSL);
-	e->SetPar( 3, V);
+      // V
+      DFloatGDL* V = new DFloatGDL(dimension(n, n), BaseGDL::NOZERO);
+      if (!columnKW)
+        FromToGSL< double, DFloat>(vGSL->data, &(*V)[0], n * n);
+      else
+        TransposeFromToGSL< double, DFloat>(vGSL->data, &(*V)[0], n, n * n);
+      // 	gsl_matrix_free( vGSL);
+      e->SetPar(3, V);
 
-	// W
-	DFloatGDL* W = new DFloatGDL( dimension( n), BaseGDL::NOZERO);
-	FromToGSL< double, DFloat>( wGSL->data, &(*W)[0], n);
-	// 	gsl_vector_free( wGSL);
-	e->SetPar( 1, W);
-      }
+      // W
+      DFloatGDL* W = new DFloatGDL(dimension(n), BaseGDL::NOZERO);
+      FromToGSL< double, DFloat>(wGSL->data, &(*W)[0], n);
+      // 	gsl_vector_free( wGSL);
+      e->SetPar(1, W);
+    }
   }
 
-  ////These functions return LONG or LONG64. 
-////  Note: IDL adds the supplementary optization that they are not called at all if they are applied on integer types, as, e.g., round(integer)==integer.
-//// TBD: This trick must be performed at interpreter level.
-/// O3 compiled code speed is OK wrt IDL in all cases.
+  ////These functions return LONG or LONG64.
+  ////  Note: IDL adds the supplementary optization that they are not called at all if they are applied on integer types, as, e.g., round(integer)==integer.
+  //// TBD: This trick must be performed at interpreter level.
+  /// O3 compiled code speed is OK wrt IDL in all cases.
 
   template< typename T> //ONLY USED FOR FLOATS AND DOUBLE
   BaseGDL*
-  round_fun_template (BaseGDL* p0, bool isKWSetL64)
-  {
+  round_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
-    SizeT nEl = p0->N_Elements ();
+    SizeT nEl = p0->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
     // L64 keyword support
-    if (isKWSetL64)
-      {
-        DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = round ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i]);
+    if (isKWSetL64) {
+      DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-    else
-      {
-        DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = round ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i]);
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
+      }
+      return res;
+    } else {
+      DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = round((*p0C)[ 0]);
+        return res;
+      }
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
+      }
 
-        return res;
-      }
+      return res;
+    }
   }
 
   BaseGDL*
-  round_fun (EnvT* e) {
-      e->NParam (1); //, "ROUND");
-      BaseGDL* p0 = e->GetParDefined (0); //, "ROUND");
+  round_fun(EnvT* e) {
+    e->NParam(1); //, "ROUND");
+    BaseGDL* p0 = e->GetParDefined(0); //, "ROUND");
 
-      SizeT nEl = p0->N_Elements ();
-      if (nEl == 0) e->Throw ("Variable is undefined: " + e->GetParString (0));
-      if (!(NumericType (p0->Type ()))) e->Throw (p0->TypeStr () + " expression: not allowed in this context: " + e->GetParString (0));
+    SizeT nEl = p0->N_Elements();
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
 
-      //L64 means it: output IS ALWAYS L64.
-      if (e->KeywordSet (0))
-        { //L64
-          if (p0->Type () == GDL_COMPLEX)
-            {
-              DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-              SizeT nEl = p0->N_Elements ();
-              DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-              if (nEl == 1)
-                {
-                  (*res)[ 0] = round ((*p0C)[ 0].real ());
-                  return res;
-                }
-	      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
-              return res;
-            }
-          else if (p0->Type () == GDL_COMPLEXDBL)
-            {
-              DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-              SizeT nEl = p0->N_Elements ();
-              DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-              if (nEl == 1)
-                {
-                  (*res)[ 0] = round ((*p0C)[ 0].real ());
-                  return res;
-                }
-	      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
-              return res;
-            }
-          else if (p0->Type () == GDL_DOUBLE) return round_fun_template< DDoubleGDL>(p0, true);
-          else if (p0->Type () == GDL_FLOAT) return round_fun_template< DFloatGDL>(p0, true);
-          else if (p0->Type () == GDL_LONG64) return p0->Dup ();
-          else return p0->Convert2 (GDL_LONG64, BaseGDL::COPY);
-        }
-      else
-        {
-          if (p0->Type () == GDL_COMPLEX)
-            {
-              DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-              SizeT nEl = p0->N_Elements ();
-              DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-              if (nEl == 1)
-                {
-                  (*res)[ 0] = round ((*p0C)[ 0].real ());
-                  return res;
-                }
-	      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
-              return res;
-            }
-          else if (p0->Type () == GDL_COMPLEXDBL)
-            {
-              DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-              SizeT nEl = p0->N_Elements ();
-              DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-              if (nEl == 1)
-                {
-                  (*res)[ 0] = round ((*p0C)[ 0].real ());
-                  return res;
-                }
-	      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round ((*p0C)[ i].real ());
-              return res;
-            }
-          else if (p0->Type () == GDL_DOUBLE) return round_fun_template< DDoubleGDL>(p0, false);
-          else if (p0->Type () == GDL_FLOAT) return round_fun_template< DFloatGDL>(p0, false);
-          else return p0->Dup ();
-        }
-  }
-  
-  template< typename T>
-  BaseGDL* ceil_fun_template(BaseGDL* p0, bool isKWSetL64)
-  {
-    T* p0C = static_cast<T*> (p0);
-    SizeT nEl = p0->N_Elements ();
-    // L64 keyword support
-    if (isKWSetL64)
-      {
-        DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = ceil ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i]);
-        return res;
-      }
-    else
-      {
-        DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = ceil ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i]);
-
-        return res;
-      }
-  }
-
-  BaseGDL* ceil_fun(EnvT* e)
-  {
-    e->NParam (1); //, "CEIL");
-    BaseGDL* p0 = e->GetParDefined (0); //, "CEIL");
-
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 0) e->Throw ("Variable is undefined: " + e->GetParString (0));
-    if (!(NumericType (p0->Type ()))) e->Throw (p0->TypeStr () + " expression: not allowed in this context: " + e->GetParString (0));
+    if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
+    if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
-    if (e->KeywordSet (0))
-      { //L64
-        if (p0->Type () == GDL_COMPLEX)
-          {
-            DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = ceil ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_COMPLEXDBL)
-          {
-            DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = ceil ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_DOUBLE) return ceil_fun_template< DDoubleGDL>(p0, true);
-        else if (p0->Type () == GDL_FLOAT) return ceil_fun_template< DFloatGDL>(p0, true);
-        else if (p0->Type () == GDL_LONG64) return p0->Dup ();
-        else return p0->Convert2 (GDL_LONG64, BaseGDL::COPY);
-      }
-    else
-      {
-        if (p0->Type () == GDL_COMPLEX)
-          {
-            DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = ceil ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_COMPLEXDBL)
-          {
-            DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = ceil ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_DOUBLE) return ceil_fun_template< DDoubleGDL>(p0, false);
-        else if (p0->Type () == GDL_FLOAT) return ceil_fun_template< DFloatGDL>(p0, false);
-        else return p0->Dup ();
-      }
+    if (e->KeywordSet(0)) { //L64
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = round((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+ #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = round((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return round_fun_template< DDoubleGDL>(p0, true);
+      else if (p0->Type() == GDL_FLOAT) return round_fun_template< DFloatGDL>(p0, true);
+      else if (p0->Type() == GDL_LONG64) return p0->Dup();
+      else return p0->Convert2(GDL_LONG64, BaseGDL::COPY);
+    } else {
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = round((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = round((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return round_fun_template< DDoubleGDL>(p0, false);
+      else if (p0->Type() == GDL_FLOAT) return round_fun_template< DFloatGDL>(p0, false);
+      else return p0->Dup();
+    }
   }
 
   template< typename T>
-  BaseGDL* floor_fun_template(BaseGDL* p0, bool isKWSetL64)
-  {
+  BaseGDL* ceil_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
-    SizeT nEl = p0->N_Elements ();
+    SizeT nEl = p0->N_Elements();
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
     // L64 keyword support
-    if (isKWSetL64)
-      {
-        DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = floor ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i]);
+    if (isKWSetL64) {
+      DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-    else
-      {
-        DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-        if (nEl == 1)
-          {
-            (*res)[ 0] = floor ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i]);
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
+      }
+      return res;
+    } else {
+      DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = ceil((*p0C)[ 0]);
+        return res;
+      }
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
+      }
 
-        return res;
-      }
+      return res;
+    }
   }
 
-  BaseGDL* floor_fun(EnvT* e)
-  {
-    e->NParam (1); //, "floor");
-    BaseGDL* p0 = e->GetParDefined (0); //, "floor");
+  BaseGDL* ceil_fun(EnvT* e) {
+    e->NParam(1); //, "CEIL");
+    BaseGDL* p0 = e->GetParDefined(0); //, "CEIL");
 
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 0) e->Throw ("Variable is undefined: " + e->GetParString (0));
-    if (!(NumericType (p0->Type ()))) e->Throw (p0->TypeStr () + " expression: not allowed in this context: " + e->GetParString (0));
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
-    if (e->KeywordSet (0))
-      { //L64
-        if (p0->Type () == GDL_COMPLEX)
-          {
-            DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = floor ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_COMPLEXDBL)
-          {
-            DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLong64GDL* res = new DLong64GDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = floor ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_DOUBLE) return floor_fun_template< DDoubleGDL>(p0, true);
-        else if (p0->Type () == GDL_FLOAT) return floor_fun_template< DFloatGDL>(p0, true);
-        else if (p0->Type () == GDL_LONG64) return p0->Dup ();
-        else return p0->Convert2 (GDL_LONG64, BaseGDL::COPY);
-      }
-    else
-      {
-        if (p0->Type () == GDL_COMPLEX)
-          {
-            DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = floor ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_COMPLEXDBL)
-          {
-            DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-            SizeT nEl = p0->N_Elements ();
-            DLongGDL* res = new DLongGDL (p0C->Dim (), BaseGDL::NOZERO);
-            if (nEl == 1)
-              {
-                (*res)[ 0] = floor ((*p0C)[ 0].real ());
-                return res;
-              }
-	    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor ((*p0C)[ i].real ());
-            return res;
-          }
-        else if (p0->Type () == GDL_DOUBLE) return floor_fun_template< DDoubleGDL>(p0, false);
-        else if (p0->Type () == GDL_FLOAT) return floor_fun_template< DFloatGDL>(p0, false);
-        else return p0->Dup ();
-      }
+    if (e->KeywordSet(0)) { //L64
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = ceil((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = ceil((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return ceil_fun_template< DDoubleGDL>(p0, true);
+      else if (p0->Type() == GDL_FLOAT) return ceil_fun_template< DFloatGDL>(p0, true);
+      else if (p0->Type() == GDL_LONG64) return p0->Dup();
+      else return p0->Convert2(GDL_LONG64, BaseGDL::COPY);
+    } else {
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = ceil((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = ceil((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return ceil_fun_template< DDoubleGDL>(p0, false);
+      else if (p0->Type() == GDL_FLOAT) return ceil_fun_template< DFloatGDL>(p0, false);
+      else return p0->Dup();
+    }
   }
 
-// GDL Direct functions (no new environment created because the function has no keywords and only one parameter-->no overheads)
-//RETURNS: float (all 32 bits + strings), double, complex, double complex outputs.
+  template< typename T>
+  BaseGDL* floor_fun_template(BaseGDL* p0, bool isKWSetL64) {
+    T* p0C = static_cast<T*> (p0);
+    SizeT nEl = p0->N_Elements();
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    // L64 keyword support
+    if (isKWSetL64) {
+      DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = floor((*p0C)[ 0]);
+        return res;
+      }
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
+      }
+      return res;
+    } else {
+      DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+      if (nEl == 1) {
+        (*res)[ 0] = floor((*p0C)[ 0]);
+        return res;
+      }
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
+      }
+
+      return res;
+    }
+  }
+
+  BaseGDL* floor_fun(EnvT* e) {
+    e->NParam(1); //, "floor");
+    BaseGDL* p0 = e->GetParDefined(0); //, "floor");
+
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
+
+    //L64 means it: output IS ALWAYS L64.
+    if (e->KeywordSet(0)) { //L64
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = floor((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = floor((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return floor_fun_template< DDoubleGDL>(p0, true);
+      else if (p0->Type() == GDL_FLOAT) return floor_fun_template< DFloatGDL>(p0, true);
+      else if (p0->Type() == GDL_LONG64) return p0->Dup();
+      else return p0->Convert2(GDL_LONG64, BaseGDL::COPY);
+    } else {
+      if (p0->Type() == GDL_COMPLEX) {
+        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = floor((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_COMPLEXDBL) {
+        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+        SizeT nEl = p0->N_Elements();
+        DLongGDL* res = new DLongGDL(p0C->Dim(), BaseGDL::NOZERO);
+        if (nEl == 1) {
+          (*res)[ 0] = floor((*p0C)[ 0].real());
+          return res;
+        }
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
+        }
+        return res;
+      } else if (p0->Type() == GDL_DOUBLE) return floor_fun_template< DDoubleGDL>(p0, false);
+      else if (p0->Type() == GDL_FLOAT) return floor_fun_template< DFloatGDL>(p0, false);
+      else return p0->Dup();
+    }
+  }
+
+  // GDL Direct functions (no new environment created because the function has no keywords and only one parameter-->no overheads)
+  //RETURNS: float (all 32 bits + strings), double, complex, double complex outputs.
 
   //SQRT
+
   template< typename T>
   BaseGDL* sqrt_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -596,9 +599,14 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -610,9 +618,14 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -634,71 +647,91 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
+      }
       return res;
     }
   }
 
   //SIN
+
   template< typename T>
-  BaseGDL* sin_fun_template (BaseGDL* p0)
-  {
+  BaseGDL* sin_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
-    T* res = new T (p0C->Dim (), BaseGDL::NOZERO);
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 1)
-      {
-        (*res)[0] = sin ((*p0C)[0]);
-        return res;
-      }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin ((*p0C)[ i]);
+    T* res = new T(p0C->Dim(), BaseGDL::NOZERO);
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 1) {
+      (*res)[0] = sin((*p0C)[0]);
+      return res;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
+    }
     return res;
   }
-  
+
   template< typename T>
-  BaseGDL* sin_fun_template_grab (BaseGDL* p0)
-  {
+  BaseGDL* sin_fun_template_grab(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 1)
-      {
-        (*p0C)[0] = sin ((*p0C)[0]);
-        return p0;
-      }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin ((*p0C)[ i]);
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 1) {
+      (*p0C)[0] = sin((*p0C)[0]);
+      return p0;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
+    }
     return p0;
   }
-  
-  BaseGDL* sin_fun (BaseGDL* p0, bool isReference)
-  {
-    SizeT nEl = p0->N_Elements ();
-    DType p0Type = p0->Type ();
+
+  BaseGDL* sin_fun(BaseGDL* p0, bool isReference) {
+    SizeT nEl = p0->N_Elements();
+    DType p0Type = p0->Type();
     if (p0Type == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     if (p0Type == GDL_COMPLEX)
-      if (isReference) return sin_fun_template< DComplexGDL>(p0); else return sin_fun_template_grab< DComplexGDL>(p0);
+      if (isReference) return sin_fun_template< DComplexGDL>(p0);
+      else return sin_fun_template_grab< DComplexGDL>(p0);
     else if (p0Type == GDL_COMPLEXDBL)
-      if (isReference) return sin_fun_template< DComplexDblGDL>(p0); else return sin_fun_template_grab< DComplexDblGDL>(p0);
+      if (isReference) return sin_fun_template< DComplexDblGDL>(p0);
+      else return sin_fun_template_grab< DComplexDblGDL>(p0);
     else if (p0Type == GDL_DOUBLE)
-      if (isReference) return sin_fun_template< DDoubleGDL>(p0); else return sin_fun_template_grab< DDoubleGDL>(p0);
+      if (isReference) return sin_fun_template< DDoubleGDL>(p0);
+      else return sin_fun_template_grab< DDoubleGDL>(p0);
     else if (p0Type == GDL_FLOAT)
-      if (isReference) return sin_fun_template< DFloatGDL>(p0); else return sin_fun_template_grab< DFloatGDL>(p0);
-    else
-      {
-        DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin ((*res)[ i]);
-        return res;
+      if (isReference) return sin_fun_template< DFloatGDL>(p0);
+      else return sin_fun_template_grab< DFloatGDL>(p0);
+    else {
+      DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       }
+      return res;
+    }
   }
 
   //COS
+
   template< typename T>
   BaseGDL* cos_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -708,9 +741,14 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -722,9 +760,14 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -746,14 +789,20 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
+      }
       return res;
     }
   }
 
   //TAN
+
   template< typename T>
   BaseGDL* tan_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -763,9 +812,14 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -777,9 +831,14 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -801,14 +860,20 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
+      }
       return res;
     }
   }
 
   //SINH
+
   template< typename T>
   BaseGDL* sinh_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -818,9 +883,14 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -832,9 +902,14 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -856,14 +931,20 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
+      }
       return res;
     }
   }
 
   //COSH
+
   template< typename T>
   BaseGDL* cosh_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -873,9 +954,14 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -887,9 +973,14 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -911,14 +1002,20 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
+      }
       return res;
     }
   }
 
   //TANH
+
   template< typename T>
   BaseGDL* tanh_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -928,9 +1025,14 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -942,9 +1044,14 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -966,13 +1073,18 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
+      }
       return res;
     }
   }
-  
+
   template< typename T>
   BaseGDL* asin_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -982,9 +1094,14 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -996,35 +1113,47 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
+    }
     return p0;
   }
 
-  BaseGDL* asin_fun (BaseGDL* p0, bool isReference)
-  {
-    SizeT nEl = p0->N_Elements ();
-    DType p0Type = p0->Type ();
+  BaseGDL* asin_fun(BaseGDL* p0, bool isReference) {
+    SizeT nEl = p0->N_Elements();
+    DType p0Type = p0->Type();
     if (p0Type == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     if (p0Type == GDL_COMPLEX)
-      if (isReference) return asin_fun_template< DComplexGDL>(p0); else return asin_fun_template_grab< DComplexGDL>(p0);
+      if (isReference) return asin_fun_template< DComplexGDL>(p0);
+      else return asin_fun_template_grab< DComplexGDL>(p0);
     else if (p0Type == GDL_COMPLEXDBL)
-      if (isReference) return asin_fun_template< DComplexDblGDL>(p0); else return asin_fun_template_grab< DComplexDblGDL>(p0);
+      if (isReference) return asin_fun_template< DComplexDblGDL>(p0);
+      else return asin_fun_template_grab< DComplexDblGDL>(p0);
     else if (p0Type == GDL_DOUBLE)
-      if (isReference) return asin_fun_template< DDoubleGDL>(p0); else return asin_fun_template_grab< DDoubleGDL>(p0);
+      if (isReference) return asin_fun_template< DDoubleGDL>(p0);
+      else return asin_fun_template_grab< DDoubleGDL>(p0);
     else if (p0Type == GDL_FLOAT)
-      if (isReference) return asin_fun_template< DFloatGDL>(p0); else return asin_fun_template_grab< DFloatGDL>(p0);
-    else
-      {
-        DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin ((*res)[ i]);
-        return res;
+      if (isReference) return asin_fun_template< DFloatGDL>(p0);
+      else return asin_fun_template_grab< DFloatGDL>(p0);
+    else {
+      DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       }
+      return res;
+    }
   }
-  
+
   template< typename T>
   BaseGDL* acos_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -1034,9 +1163,14 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -1048,36 +1182,49 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
+    }
     return p0;
   }
 
-  BaseGDL* acos_fun (BaseGDL* p0, bool isReference)
-  {
-    SizeT nEl = p0->N_Elements ();
-    DType p0Type = p0->Type ();
+  BaseGDL* acos_fun(BaseGDL* p0, bool isReference) {
+    SizeT nEl = p0->N_Elements();
+    DType p0Type = p0->Type();
     if (p0Type == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     if (p0Type == GDL_COMPLEX)
-      if (isReference) return acos_fun_template< DComplexGDL>(p0); else return acos_fun_template_grab< DComplexGDL>(p0);
+      if (isReference) return acos_fun_template< DComplexGDL>(p0);
+      else return acos_fun_template_grab< DComplexGDL>(p0);
     else if (p0Type == GDL_COMPLEXDBL)
-      if (isReference) return acos_fun_template< DComplexDblGDL>(p0); else return acos_fun_template_grab< DComplexDblGDL>(p0);
+      if (isReference) return acos_fun_template< DComplexDblGDL>(p0);
+      else return acos_fun_template_grab< DComplexDblGDL>(p0);
     else if (p0Type == GDL_DOUBLE)
-      if (isReference) return acos_fun_template< DDoubleGDL>(p0); else return acos_fun_template_grab< DDoubleGDL>(p0);
+      if (isReference) return acos_fun_template< DDoubleGDL>(p0);
+      else return acos_fun_template_grab< DDoubleGDL>(p0);
     else if (p0Type == GDL_FLOAT)
-      if (isReference) return acos_fun_template< DFloatGDL>(p0); else return acos_fun_template_grab< DFloatGDL>(p0);
-    else
-      {
-        DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos ((*res)[ i]);
-        return res;
+      if (isReference) return acos_fun_template< DFloatGDL>(p0);
+      else return acos_fun_template_grab< DFloatGDL>(p0);
+    else {
+      DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       }
+      return res;
+    }
   }
-  
+
   //EXP
+
   template< typename T>
   BaseGDL* exp_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
@@ -1087,9 +1234,14 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
+    }
     return res;
   }
 
@@ -1101,9 +1253,14 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
+    }
     return p0;
   }
 
@@ -1125,287 +1282,325 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
+      }
       return res;
     }
   }
 
 
   //   BaseGDL* alog_fun( EnvT* e)
-  BaseGDL* alog_fun( BaseGDL* p0, bool isReference)
-  {
+
+  BaseGDL* alog_fun(BaseGDL* p0, bool isReference) {
     if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
 
-    if( !isReference) //e->StealLocalPar( 0))
-      {
-	return p0->LogThis();
-      }
+    if (!isReference) //e->StealLocalPar( 0))
+    {
+      return p0->LogThis();
+    }
     return p0->Log();
   }
 
   //   BaseGDL* alog10_fun( EnvT* e)
-  BaseGDL* alog10_fun( BaseGDL* p0, bool isReference)
-  {
+
+  BaseGDL* alog10_fun(BaseGDL* p0, bool isReference) {
     if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
 
-    if( !isReference) //e->StealLocalPar( 0))
-      {
-	return p0->Log10This();
-      }
+    if (!isReference) //e->StealLocalPar( 0))
+    {
+      return p0->Log10This();
+    }
     return p0->Log10();
   }
 
   //Following produce Float or doubles for complex.
-  
+
   template< typename T>
-  BaseGDL* abs_fun_template (BaseGDL* p0)
-  {
+  BaseGDL* abs_fun_template(BaseGDL* p0) {
     T* p0C = static_cast<T*> (p0);
-    T* res = new T (p0C->Dim (), BaseGDL::NOZERO);
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 1)
-      {
-        (*res)[ 0] = abs ((*p0C)[ 0]);
-        return res;
-      }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]);
+    T* res = new T(p0C->Dim(), BaseGDL::NOZERO);
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 1) {
+      (*res)[ 0] = abs((*p0C)[ 0]);
+      return res;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
+    }
     return res;
   }
 
-  BaseGDL* abs_fun (BaseGDL* p0, bool isReference)
-  {
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
-    if (p0->Type () == GDL_COMPLEX)
-      {
-        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-        DFloatGDL* res = new DFloatGDL (p0C->Dim (), BaseGDL::NOZERO);
-        SizeT nEl = p0->N_Elements ();
-        if (nEl == 1)
-          {
-            (*res)[ 0] = abs ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+  BaseGDL* abs_fun(BaseGDL* p0, bool isReference) {
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+    if (p0->Type() == GDL_COMPLEX) {
+      DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+      DFloatGDL* res = new DFloatGDL(p0C->Dim(), BaseGDL::NOZERO);
+      SizeT nEl = p0->N_Elements();
+      if (nEl == 1) {
+        (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-    else if (p0->Type () == GDL_COMPLEXDBL)
-      {
-        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-        DDoubleGDL* res = new DDoubleGDL (p0C->Dim (), BaseGDL::NOZERO);
-        SizeT nEl = p0->N_Elements ();
-        if (nEl == 1)
-          {
-            (*res)[ 0] = abs ((*p0C)[ 0]);
-            return res;
-          }
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+      }
+      return res;
+    } else if (p0->Type() == GDL_COMPLEXDBL) {
+      DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+      DDoubleGDL* res = new DDoubleGDL(p0C->Dim(), BaseGDL::NOZERO);
+      SizeT nEl = p0->N_Elements();
+      if (nEl == 1) {
+        (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-    else if (p0->Type () == GDL_DOUBLE)
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
+      }
+      return res;
+    } else if (p0->Type() == GDL_DOUBLE)
       return abs_fun_template< DDoubleGDL>(p0);
-    else if (p0->Type () == GDL_FLOAT)
+    else if (p0->Type() == GDL_FLOAT)
       return abs_fun_template< DFloatGDL>(p0);
-    else if (p0->Type () == GDL_LONG64)
+    else if (p0->Type() == GDL_LONG64)
       return abs_fun_template< DLong64GDL>(p0);
-    else if (p0->Type () == GDL_LONG)
+    else if (p0->Type() == GDL_LONG)
       return abs_fun_template< DLongGDL>(p0);
-    else if (p0->Type () == GDL_INT)
+    else if (p0->Type() == GDL_INT)
       return abs_fun_template< DIntGDL>(p0);
-    else if (isReference)
-      {
-        if (p0->Type () == GDL_ULONG64)
-          return p0->Dup ();
-        else if (p0->Type () == GDL_ULONG)
-          return p0->Dup ();
-        else if (p0->Type () == GDL_UINT)
-          return p0->Dup ();
-        else if (p0->Type () == GDL_BYTE)
-          return p0->Dup ();
-      }
-    else
-      {
-        if (p0->Type () == GDL_ULONG64)
-          return p0;
-        else if (p0->Type () == GDL_ULONG)
-          return p0;
-        else if (p0->Type () == GDL_UINT)
-          return p0;
-        else if (p0->Type () == GDL_BYTE)
-          return p0;
-      }
+    else if (isReference) {
+      if (p0->Type() == GDL_ULONG64)
+        return p0->Dup();
+      else if (p0->Type() == GDL_ULONG)
+        return p0->Dup();
+      else if (p0->Type() == GDL_UINT)
+        return p0->Dup();
+      else if (p0->Type() == GDL_BYTE)
+        return p0->Dup();
+    } else {
+      if (p0->Type() == GDL_ULONG64)
+        return p0;
+      else if (p0->Type() == GDL_ULONG)
+        return p0;
+      else if (p0->Type() == GDL_UINT)
+        return p0;
+      else if (p0->Type() == GDL_BYTE)
+        return p0;
+    }
     DFloatGDL* res = static_cast<DFloatGDL*>
-            (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
-    SizeT nEl = p0->N_Elements ();
-    if (nEl == 1)
-      {
-        (*res)[ 0] = abs ((*res)[ 0]);
-        return res;
-      }
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs ((*res)[ i]);
+      (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
+    SizeT nEl = p0->N_Elements();
+    if (nEl == 1) {
+      (*res)[ 0] = abs((*res)[ 0]);
+      return res;
+    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    if (!parallelize) {
+      for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
+    }
     return res;
   }
 
-//COMPLEX SPECIALS
-  BaseGDL* conj_fun (BaseGDL* p0, bool isReference)//( EnvT* e)
-  {
-    SizeT nEl = p0->N_Elements ();
-    
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+  //COMPLEX SPECIALS
 
-    if (p0->Type () == GDL_COMPLEX)
-      {
-        DComplexGDL* res;
-        if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult (); else res=static_cast<DComplexGDL*>(p0);
-        DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj ((*p0C)[i]);
-        return res;
+  BaseGDL* conj_fun(BaseGDL* p0, bool isReference)//( EnvT* e)
+  {
+    SizeT nEl = p0->N_Elements();
+
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+
+    if (p0->Type() == GDL_COMPLEX) {
+      DComplexGDL* res;
+      if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult();
+      else res = static_cast<DComplexGDL*> (p0);
+      DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       }
-    if (p0->Type () == GDL_COMPLEXDBL)
-      {
-        DComplexDblGDL* res;
-        if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult (); else res=res=static_cast<DComplexDblGDL*>(p0);
-        DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj ((*p0C)[i]);
-        return res;
+      return res;
+    }
+    if (p0->Type() == GDL_COMPLEXDBL) {
+      DComplexDblGDL* res;
+      if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
+      else res = res = static_cast<DComplexDblGDL*> (p0);
+      DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       }
-    if (p0->Type () == GDL_DOUBLE ||
-        p0->Type () == GDL_LONG64 ||
-        p0->Type () == GDL_ULONG64)
-      {
-        DComplexDblGDL* res = static_cast<DComplexDblGDL*> (p0->Convert2 (GDL_COMPLEXDBL, BaseGDL::COPY));
-        return res;
-      }
+      return res;
+    }
+    if (p0->Type() == GDL_DOUBLE ||
+      p0->Type() == GDL_LONG64 ||
+      p0->Type() == GDL_ULONG64) {
+      DComplexDblGDL* res = static_cast<DComplexDblGDL*> (p0->Convert2(GDL_COMPLEXDBL, BaseGDL::COPY));
+      return res;
+    }
 
     // all other types
-    return static_cast<DComplexGDL*> (p0->Convert2 (GDL_COMPLEX, BaseGDL::COPY));
+    return static_cast<DComplexGDL*> (p0->Convert2(GDL_COMPLEX, BaseGDL::COPY));
   }
-//returns Double or floats
-  BaseGDL* imaginary_fun (BaseGDL* p0, bool isReference)//( EnvT* e)
+  //returns Double or floats
+
+  BaseGDL* imaginary_fun(BaseGDL* p0, bool isReference)//( EnvT* e)
   {
-    SizeT nEl = p0->N_Elements ();
+    SizeT nEl = p0->N_Elements();
     if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     // complex types, return imaginary part
-    if (p0->Type () == GDL_COMPLEX)
-      {
-        DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
-        DFloatGDL* res = new DFloatGDL (c0->Dim (), BaseGDL::NOZERO);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag ((*c0)[i]);
-        return res;
+    if (p0->Type() == GDL_COMPLEX) {
+      DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
+      DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       }
-    if (p0->Type () == GDL_COMPLEXDBL)
-      {
-        DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
-        DDoubleGDL* res = new DDoubleGDL (c0->Dim (), BaseGDL::NOZERO);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag ((*c0)[i]);
-        return res;
+      return res;
+    }
+    if (p0->Type() == GDL_COMPLEXDBL) {
+      DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
+      DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       }
+      return res;
+    }
 
     // forbidden types
-    DType t = p0->Type ();
+    DType t = p0->Type();
     if (t == GDL_STRING)
-      throw GDLException ("String expression not allowed in this context.");
+      throw GDLException("String expression not allowed in this context.");
     if (t == GDL_STRUCT)
-      throw GDLException ("Struct expression not allowed in this context.");
+      throw GDLException("Struct expression not allowed in this context.");
     if (t == GDL_PTR)
-      throw GDLException ("Pointer expression not allowed in this context.");
+      throw GDLException("Pointer expression not allowed in this context.");
     if (t == GDL_OBJ)
-      throw GDLException ("Object reference not allowed in this context.");
+      throw GDLException("Object reference not allowed in this context.");
 
     // all other types (return array of zeros)
-    return new DFloatGDL (p0->Dim (), BaseGDL::ZERO); // ZERO
+    return new DFloatGDL(p0->Dim(), BaseGDL::ZERO); // ZERO
   }
 
-  BaseGDL* real_part_fun (BaseGDL* p0, bool isReference)
-  {
-    SizeT nEl = p0->N_Elements ();
-    if (p0->Type () == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
+  BaseGDL* real_part_fun(BaseGDL* p0, bool isReference) {
+    SizeT nEl = p0->N_Elements();
+    if (p0->Type() == GDL_UNDEF) throw GDLException("Variable is undefined: !NULL");
     // complex types, return real part
-    if (p0->Type () == GDL_COMPLEX)
-      {
-        DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
-        DFloatGDL* res = new DFloatGDL (c0->Dim (), BaseGDL::NOZERO);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real ((*c0)[i]);
-        return res;
+    if (p0->Type() == GDL_COMPLEX) {
+      DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
+      DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       }
-    if (p0->Type () == GDL_COMPLEXDBL)
-      {
-        DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
-        DDoubleGDL* res = new DDoubleGDL (c0->Dim (), BaseGDL::NOZERO);
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real ((*c0)[i]);
-        return res;
+      return res;
+    }
+    if (p0->Type() == GDL_COMPLEXDBL) {
+      DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
+      DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      if (!parallelize) {
+        for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       }
+      return res;
+    }
 
-    DType t = p0->Type ();
+    DType t = p0->Type();
     // avoid forbidden types
     if (t == GDL_STRUCT)
-      throw GDLException ("Struct expression not allowed in this context.");
+      throw GDLException("Struct expression not allowed in this context.");
     if (t == GDL_PTR)
-      throw GDLException ("Pointer expression not allowed in this context.");
+      throw GDLException("Pointer expression not allowed in this context.");
     if (t == GDL_OBJ)
-      throw GDLException ("Object reference not allowed in this context.");
+      throw GDLException("Object reference not allowed in this context.");
     // Doubles to double, copy
-    if (t == GDL_DOUBLE){
-      if (isReference) return p0->Dup (); else return p0;
+    if (t == GDL_DOUBLE) {
+      if (isReference) return p0->Dup();
+      else return p0;
     }
     // Floats to float, copy
-    if (t == GDL_FLOAT){
-      if (isReference) return p0->Dup (); else return p0;
+    if (t == GDL_FLOAT) {
+      if (isReference) return p0->Dup();
+      else return p0;
     }
     // all other types to float
-    return static_cast<DFloatGDL*> (p0->Convert2 (GDL_FLOAT, BaseGDL::COPY));
+    return static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
   }
 
 
   //atan() is different as complex is different. Note that atan(complex(0.888,0)) does not give exactly 0 for its imaginary part, as IDL does.
 
   // atan() for complex
-  // .. is now in C++11 
+  // .. is now in C++11
 
-//  template< typename C>
-//  inline C atanC(const C& c)
-//  {
-//    //     double x = c.real();
-//    //     double x2 = x * x;
-//    //     double y = c.imag();
-//    //     return C(0.5 * atan2(2.0*x, 1.0 - x2 - y*y), 0.25 * log( (x2 + (y+1)*(y+1)) / (x2 + (y-1)*(y-1)) ));
-//    const C i(0.0, 1.0);
-//    const C one(1.0, 0.0);
-//    return log((one + i * c) / (one - i * c)) / (C(2.0, 0.0) * i);
-//  }
+  //  template< typename C>
+  //  inline C atanC(const C& c)
+  //  {
+  //    //     double x = c.real();
+  //    //     double x2 = x * x;
+  //    //     double y = c.imag();
+  //    //     return C(0.5 * atan2(2.0*x, 1.0 - x2 - y*y), 0.25 * log( (x2 + (y+1)*(y+1)) / (x2 + (y-1)*(y-1)) ));
+  //    const C i(0.0, 1.0);
+  //    const C one(1.0, 0.0);
+  //    return log((one + i * c) / (one - i * c)) / (C(2.0, 0.0) * i);
+  //  }
 
   template< typename C>
-  inline C atanC(const C& c1, const C& c2)
-  {
+  inline C atanC(const C& c1, const C& c2) {
     const C i(0.0, 1.0);
     //const C one(1.0,0.0);
     //     return -i * log((c2 + i * c1) / (sqrt(pow(c2, 2) + pow(c1, 2))));
     return -i * log((c2 + i * c1) / sqrt((c2 * c2) + (c1 * c1)));
   }
 
-  BaseGDL* atan_fun(EnvT* e)
-  {
+  BaseGDL* atan_fun(EnvT* e) {
     //lots of different guards defined here to insure they do their work only at exit of atan_fun.
     Guard< DDoubleGDL> guardp0D;
     Guard< DDoubleGDL> guardp1D;
@@ -1423,17 +1618,17 @@ namespace lib {
     SizeT nEl = p0->N_Elements();
     if (nEl == 0)
       e->Throw(
-        "Variable is undefined: " + e->GetParString(0));
+      "Variable is undefined: " + e->GetParString(0));
 
     if (nParam == 2) {
       BaseGDL* p1 = e->GetPar(1);
       if (p1 == NULL)
         e->Throw(
-          "Variable is undefined: " + e->GetParString(1));
+        "Variable is undefined: " + e->GetParString(1));
       SizeT nEl1 = p1->N_Elements();
       if (nEl1 == 0)
         e->Throw(
-          "Variable is undefined: " + e->GetParString(1));
+        "Variable is undefined: " + e->GetParString(1));
 
       DType t = (DTypeOrder[ p0->Type()] > DTypeOrder[ p1->Type()]) ? p0->Type() : p1->Type();
 
@@ -1474,21 +1669,34 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
         switch (cas) {
         case 0:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          }
           return res;
         case 1:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          }
           return res;
         case 2:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          }
           return res;
         }
       } else if (t == GDL_FLOAT) {
@@ -1509,21 +1717,34 @@ namespace lib {
           (*res)[ 0] = atan2((*p0F)[0], (*p1F)[0]);
           return res;
         }
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
         switch (cas) {
         case 0:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
+          }
           return res;
         case 1:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
+          }
           return res;
         case 2:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
+          }
           return res;
         }
       } else if (t == GDL_COMPLEX) {
@@ -1544,21 +1765,34 @@ namespace lib {
           (*res)[ 0] = atanC((*p0C)[0], (*p1C)[0]);
           return res;
         }
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
         switch (cas) {
         case 0:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
+          }
           return res;
         case 1:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
+          }
           return res;
         case 2:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
+          }
           return res;
         }
       } else if (t == GDL_COMPLEXDBL) {
@@ -1579,21 +1813,34 @@ namespace lib {
           (*res)[ 0] = atanC((*p0DC)[0], (*p1DC)[0]);
           return res;
         }
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
         switch (cas) {
         case 0:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
+          }
           return res;
         case 1:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
+          }
           return res;
         case 2:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
+          }
           return res;
         }
       } else {
@@ -1606,21 +1853,34 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
         switch (cas) {
         case 0:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
+          }
           return res;
         case 1:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
+          }
           return res;
         case 2:
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin))
-          for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          if (!parallelize) {
+            for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
+          }
           return res;
         }
       }
@@ -1634,9 +1894,14 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          }
           return res;
         } else if (p0->Type() == GDL_COMPLEXDBL) {
           DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
@@ -1645,9 +1910,14 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
+          }
           return res;
         }
       } else {
@@ -1658,9 +1928,14 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
+          }
           return res;
         } else if (p0->Type() == GDL_FLOAT) {
           DFloatGDL* p0F = static_cast<DFloatGDL*> (p0);
@@ -1669,9 +1944,14 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
+          }
           return res;
         } else if (p0->Type() == GDL_COMPLEX) {
           DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
@@ -1680,9 +1960,14 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          }
           return res;
         } else if (p0->Type() == GDL_COMPLEXDBL) {
           DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
@@ -1691,9 +1976,14 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
+          }
           return res;
         } else {
           DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY)); //use same allocation
@@ -1701,9 +1991,14 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
-	  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          if (!parallelize) {
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
+          } else {
+            TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+              for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
+          }
           return res;
         }
       }
@@ -1713,80 +2008,80 @@ namespace lib {
   }
 
   // by medericboquien@users.sourceforge.net
-  BaseGDL* gauss_pdf(EnvT* e)
-  {
-//    SizeT nParam = e->NParam(1);
-    DDoubleGDL* v = static_cast<DDoubleGDL*>(e->GetParDefined(0)->
-					     Convert2(GDL_DOUBLE,BaseGDL::COPY));
+
+  BaseGDL* gauss_pdf(EnvT* e) {
+    //    SizeT nParam = e->NParam(1);
+    DDoubleGDL* v = static_cast<DDoubleGDL*> (e->GetParDefined(0)->
+      Convert2(GDL_DOUBLE, BaseGDL::COPY));
     SizeT nv = v->N_Elements();
 
-    for (int count = 0;count < nv;++count)
+    for (int count = 0; count < nv; ++count)
       (*v)[count] = gsl_cdf_ugaussian_P((*v)[count]);
 
     if (e->GetParDefined(0)->Type() == GDL_DOUBLE)
       return v;
     else
-      return v->Convert2(GDL_FLOAT,BaseGDL::CONVERT);
+      return v->Convert2(GDL_FLOAT, BaseGDL::CONVERT);
     return new DByteGDL(0);
   }
 
   // by medericboquien@users.sourceforge.net
-  BaseGDL* gauss_cvf(EnvT* e)
-  {
-//    SizeT nParam = e->NParam(1);
-    DDoubleGDL* p = static_cast<DDoubleGDL*>(e->GetParDefined(0)->
-					     Convert2(GDL_DOUBLE,BaseGDL::COPY));
-     
+
+  BaseGDL* gauss_cvf(EnvT* e) {
+    //    SizeT nParam = e->NParam(1);
+    DDoubleGDL* p = static_cast<DDoubleGDL*> (e->GetParDefined(0)->
+      Convert2(GDL_DOUBLE, BaseGDL::COPY));
+
     if (p->N_Elements() != 1)
-      e->Throw("Parameter must be scalar or one element array: "+
-	       e->GetParString(0));
+      e->Throw("Parameter must be scalar or one element array: " +
+      e->GetParString(0));
     if ((*p)[0] < 0. || (*p)[0] > 1.)
-      e->Throw("Parameter must be in [0,1]: "+e->GetParString(0));
+      e->Throw("Parameter must be in [0,1]: " + e->GetParString(0));
 
     (*p)[0] = gsl_cdf_ugaussian_Qinv((*p)[0]);
 
     if (e->GetParDefined(0)->Type() == GDL_DOUBLE)
       return p;
     else
-      return p->Convert2(GDL_FLOAT,BaseGDL::CONVERT);
+      return p->Convert2(GDL_FLOAT, BaseGDL::CONVERT);
     return new DByteGDL(0);
   }
 
   // by medericboquien@users.sourceforge.net
-  BaseGDL* t_pdf(EnvT* e)
-  {
-//    SizeT nParam = e->NParam(2);
+
+  BaseGDL* t_pdf(EnvT* e) {
+    //    SizeT nParam = e->NParam(2);
     DDoubleGDL* v = e->GetParAs<DDoubleGDL>(0);
     DDoubleGDL* df = e->GetParAs<DDoubleGDL>(1);
     DDoubleGDL* res;
-    
+
     SizeT nv = v->N_Elements();
     SizeT ndf = df->N_Elements();
 
-    for (int i=0;i<ndf;++i)
+    for (int i = 0; i < ndf; ++i)
       if ((*df)[i] <= 0.)
         e->Throw("Degrees of freedom must be positive.");
 
     if (nv == 1 && ndf == 1) {
       res = new DDoubleGDL(dimension(1), BaseGDL::NOZERO);
-      (*res)[0] = gsl_cdf_tdist_P((*v)[0],(*df)[0]);
+      (*res)[0] = gsl_cdf_tdist_P((*v)[0], (*df)[0]);
     } else if (nv > 1 && ndf == 1) {
       res = new DDoubleGDL(dimension(nv), BaseGDL::NOZERO);
       for (SizeT count = 0; count < nv; ++count)
-        (*res)[count] = gsl_cdf_tdist_P((*v)[count],(*df)[0]);
+        (*res)[count] = gsl_cdf_tdist_P((*v)[count], (*df)[0]);
     } else if (nv == 1 && ndf > 1) {
       res = new DDoubleGDL(dimension(ndf), BaseGDL::NOZERO);
       for (SizeT count = 0; count < ndf; ++count)
-        (*res)[count] = gsl_cdf_tdist_P((*v)[0],(*df)[count]);
+        (*res)[count] = gsl_cdf_tdist_P((*v)[0], (*df)[count]);
     } else {
-      SizeT nreturn = nv>ndf?ndf:nv;
+      SizeT nreturn = nv > ndf ? ndf : nv;
       res = new DDoubleGDL(dimension(nreturn), BaseGDL::NOZERO);
       for (SizeT count = 0; count < nreturn; ++count)
-        (*res)[count] = gsl_cdf_tdist_P((*v)[count],(*df)[count]);
+        (*res)[count] = gsl_cdf_tdist_P((*v)[count], (*df)[count]);
     }
-    
+
     if (e->GetParDefined(0)->Type() != GDL_DOUBLE && e->GetParDefined(0)->Type() != GDL_DOUBLE)
-      return res->Convert2(GDL_FLOAT,BaseGDL::CONVERT);
+      return res->Convert2(GDL_FLOAT, BaseGDL::CONVERT);
     else
       return res;
     return new DByteGDL(0);
@@ -1794,8 +2089,7 @@ namespace lib {
 
   // by medericboquien@users.sourceforge.net
 
-  BaseGDL* laguerre(EnvT* e)
-  {
+  BaseGDL* laguerre(EnvT* e) {
     SizeT nParam = e->NParam(2);
 
     DDoubleGDL* xvals = e->GetParAs<DDoubleGDL>(0);
@@ -1826,10 +2120,14 @@ namespace lib {
     DInt n = (*nval)[0];
     SizeT nEx = xvals->N_Elements();
 
-//is this really useful? parallelizing Laguerre? Do not forget openmp uses time.
-//    TRACEOMP(__FILE__,__LINE__)
-//#pragma omp parallel for if (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEx))
-    for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEx)));
+    if (!parallelize) {
+      for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
+    }
 
     static DInt doubleKWIx = e->KeywordIx("DOUBLE");
     static DInt coefKWIx = e->KeywordIx("COEFFICIENTS");
@@ -1838,20 +2136,20 @@ namespace lib {
       double gamma_kn1 = gsl_sf_gamma(k + n + 1.);
       DDoubleGDL* coefKW = new DDoubleGDL(dimension(n + 1), BaseGDL::NOZERO);
 
-//GD: parallelizing this complicated loop cannot be done just like that.
-//I further doubt Laguerre is going to be used on large arrays.
-//      TRACEOMP(__FILE__,__LINE__)
-//#pragma omp parallel for if (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
+      //GD: parallelizing this complicated loop cannot be done just like that.
+      //I further doubt Laguerre is going to be used on large arrays.
+      //      TRACEOMP(__FILE__,__LINE__)
+      //#pragma omp parallel for  (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
       for (SizeT count = 0; count <= n; ++count) {
         double dcount = static_cast<double> (count);
         (*coefKW)[count] = ((count & 0x0001) ? -1.0 : 1.0) * gamma_kn1 /
-            (gsl_sf_gamma(n - dcount + 1.) * gsl_sf_gamma(k + dcount + 1.) *
-            gsl_sf_gamma(dcount + 1.));
+          (gsl_sf_gamma(n - dcount + 1.) * gsl_sf_gamma(k + dcount + 1.) *
+          gsl_sf_gamma(dcount + 1.));
       }
-      
+
       if (e->GetParDefined(0)->Type() != GDL_DOUBLE && !e->KeywordSet(doubleKWIx))
         coefKW = static_cast<DDoubleGDL*> (coefKW->
-          Convert2(GDL_FLOAT, BaseGDL::CONVERT));
+        Convert2(GDL_FLOAT, BaseGDL::CONVERT));
       e->SetKW(coefKWIx, coefKW);
     }
 
@@ -1865,96 +2163,92 @@ namespace lib {
 
   // SA: based on equations 5-5 & 5-6 from Snyder (1987) USGS report no 1395 (page 31)
   //     available for download at: http://pubs.er.usgs.gov/djvu/PP/pp_1395.djvu
+
   template <typename T> inline void ll_arc_distance_helper(
-							   T c, T Az, T phi1, T l0, T& phi, T& l, bool degrees) 
-  {
+    T c, T Az, T phi1, T l0, T& phi, T& l, bool degrees) {
     // temporary variables
-    T pi = 4 * atan((T)1.), 
+    T pi = 4 * atan((T) 1.),
       dtor = degrees ? pi / 180. : 1,
-      sin_c = sin(c), 
-      cos_c = cos(c), 
-      cos_Az = cos(Az * dtor), 
+      sin_c = sin(c),
+      cos_c = cos(c),
+      cos_Az = cos(Az * dtor),
       sin_phi1 = sin(phi1 * dtor),
       cos_phi1 = cos(phi1 * dtor);
     // computing the results
     phi = asin(sin_phi1 * cos_c + cos_phi1 * sin_c * cos_Az) / dtor;
     l = l0 * dtor + atan2(
-			  sin_c * sin(Az * dtor), (cos_phi1 * cos_c - sin_phi1 * sin_c * cos_Az)
-			  ); 
+      sin_c * sin(Az * dtor), (cos_phi1 * cos_c - sin_phi1 * sin_c * cos_Az)
+      );
     // placing the result in (-pi, pi)
     while (l < -pi) l += 2 * pi;
     while (l > pi) l -= 2 * pi;
     // converting to degrees if needed
-    l /= dtor;                                      
+    l /= dtor;
   }
-  BaseGDL* ll_arc_distance(EnvT* e)
-  {
+
+  BaseGDL* ll_arc_distance(EnvT* e) {
     // sanity check (for number of parameters)
-//    SizeT nParam = e->NParam();
+    //    SizeT nParam = e->NParam();
 
     // 1-st argument : longitude/latitude values pair (in radians unless DEGREE kw. present)
     BaseGDL* p0 = e->GetNumericParDefined(0);
 
     // 2-nd argument : arc distance (in radians regardless of DEGREE kw. presence)
     BaseGDL* p1 = e->GetNumericParDefined(1);
-    if (p1->N_Elements() != 1) 
+    if (p1->N_Elements() != 1)
       e->Throw("second argument is expected to be a scalar or 1-element array");
 
     // 3-rd argument : azimuth (in radians unless DEGREE kw. present)
     BaseGDL* p2 = e->GetNumericParDefined(2);
-    if (p2->N_Elements() != 1) 
+    if (p2->N_Elements() != 1)
       e->Throw("third argument is expected to be a scalar or 1-element array");
 
-    // chosing a type for the return value 
-    bool args_complexdbl = 
+    // chosing a type for the return value
+    bool args_complexdbl =
       (p0->Type() == GDL_COMPLEXDBL || p1->Type() == GDL_COMPLEXDBL || p2->Type() == GDL_COMPLEXDBL);
-    bool args_complex = args_complexdbl ? false : 
+    bool args_complex = args_complexdbl ? false :
       (p0->Type() == GDL_COMPLEX || p1->Type() == GDL_COMPLEX || p2->Type() == GDL_COMPLEX);
     DType type = (
-		  p0->Type() == GDL_DOUBLE || p1->Type() == GDL_DOUBLE || p2->Type() == GDL_DOUBLE || args_complexdbl
-		  ) ? GDL_DOUBLE : GDL_FLOAT;
+      p0->Type() == GDL_DOUBLE || p1->Type() == GDL_DOUBLE || p2->Type() == GDL_DOUBLE || args_complexdbl
+      ) ? GDL_DOUBLE : GDL_FLOAT;
 
     // converting datatypes if neccesarry
     if (p0->Type() != type) p0 = p0->Convert2(type, BaseGDL::COPY);
     if (p1->Type() != type) p1 = p1->Convert2(type, BaseGDL::COPY);
-    if (p2->Type() != type) p2 = p2->Convert2(type, BaseGDL::COPY); 
-    
+    if (p2->Type() != type) p2 = p2->Convert2(type, BaseGDL::COPY);
+
     // calculating (by calling a helper template function for float/double versions)
     BaseGDL* rt = p0->New(dimension(2, BaseGDL::NOZERO));
-    if (type == GDL_FLOAT) 
-      {
-	ll_arc_distance_helper(
-			       (*static_cast<DFloatGDL*>(p1))[0], 
-			       (*static_cast<DFloatGDL*>(p2))[0], 
-			       (*static_cast<DFloatGDL*>(p0))[1], 
-			       (*static_cast<DFloatGDL*>(p0))[0], 
-			       (*static_cast<DFloatGDL*>(rt))[1], 
-			       (*static_cast<DFloatGDL*>(rt))[0],
-			       e->KeywordSet(0) //DEGREES (sole option)
-			       );
-      }
-    else
-      {
-	ll_arc_distance_helper(
-			       (*static_cast<DDoubleGDL*>(p1))[0], 
-			       (*static_cast<DDoubleGDL*>(p2))[0], 
-			       (*static_cast<DDoubleGDL*>(p0))[1], 
-			       (*static_cast<DDoubleGDL*>(p0))[0], 
-			       (*static_cast<DDoubleGDL*>(rt))[1], 
-			       (*static_cast<DDoubleGDL*>(rt))[0],
-			       e->KeywordSet(0)
-			       );
-      }
+    if (type == GDL_FLOAT) {
+      ll_arc_distance_helper(
+        (*static_cast<DFloatGDL*> (p1))[0],
+        (*static_cast<DFloatGDL*> (p2))[0],
+        (*static_cast<DFloatGDL*> (p0))[1],
+        (*static_cast<DFloatGDL*> (p0))[0],
+        (*static_cast<DFloatGDL*> (rt))[1],
+        (*static_cast<DFloatGDL*> (rt))[0],
+        e->KeywordSet(0) //DEGREES (sole option)
+        );
+    } else {
+      ll_arc_distance_helper(
+        (*static_cast<DDoubleGDL*> (p1))[0],
+        (*static_cast<DDoubleGDL*> (p2))[0],
+        (*static_cast<DDoubleGDL*> (p0))[1],
+        (*static_cast<DDoubleGDL*> (p0))[0],
+        (*static_cast<DDoubleGDL*> (rt))[1],
+        (*static_cast<DDoubleGDL*> (rt))[0],
+        e->KeywordSet(0)
+        );
+    }
 
     // handling complex/dcomplex conversion
     return rt->Convert2(
-			args_complexdbl ? GDL_COMPLEXDBL : args_complex ? GDL_COMPLEX : type,
-			BaseGDL::CONVERT
-			);
+      args_complexdbl ? GDL_COMPLEXDBL : args_complex ? GDL_COMPLEX : type,
+      BaseGDL::CONVERT
+      );
   }
 
-  BaseGDL* crossp(EnvT* e)
-  {
+  BaseGDL* crossp(EnvT* e) {
     BaseGDL* p0 = e->GetNumericParDefined(0);
     BaseGDL* p1 = e->GetNumericParDefined(1);
     if (p0->N_Elements() != 3 || p1->N_Elements() != 3)
@@ -1967,31 +2261,31 @@ namespace lib {
     // .--mem: new a (with the type and shape of the result)
     b = p0->CShift(-1)->Convert2(a->Type(), BaseGDL::CONVERT);
     // | .--mem: new b
-    a->Add(b);            // | | a = shift(p0, -1)
-    delete b;             // | `--mem: del b
+    a->Add(b); // | | a = shift(p0, -1)
+    delete b; // | `--mem: del b
     b = p1->CShift(-2)->Convert2(a->Type(), BaseGDL::CONVERT);
     // | .--mem: new b
-    a->Mult(b);           // | | a = shift(p0, -1) * shift(p1, -2)
-    b->Sub(b);            // | | b = 0
+    a->Mult(b); // | | a = shift(p0, -1) * shift(p1, -2)
+    b->Sub(b); // | | b = 0
     c = p0->CShift(1)->Convert2(a->Type(), BaseGDL::CONVERT);
     // | | .--mem: new c
-    b->Sub(c);            // | | | b = - shift(p0, 1)
-    delete c;             // | | `--mem: del c
-    c = p1->CShift(2)->Convert2(a->Type(), BaseGDL::CONVERT); 
+    b->Sub(c); // | | | b = - shift(p0, 1)
+    delete c; // | | `--mem: del c
+    c = p1->CShift(2)->Convert2(a->Type(), BaseGDL::CONVERT);
     // | | .--mem: new c
-    b->Mult(c);           // | | | b = - shift(p0, 1) * shift(p1, 2)
-    delete c;             // | | `--mem: del c
-    a->Add(b);            // | | a = shift(p0, -1) * shift(p1, -2) - shift(p0, 1) * shift(p1, 2)
-    delete b;             // | `--mem: del b
-    return a;             // `--->
+    b->Mult(c); // | | | b = - shift(p0, 1) * shift(p1, 2)
+    delete c; // | | `--mem: del c
+    a->Add(b); // | | a = shift(p0, -1) * shift(p1, -2) - shift(p0, 1) * shift(p1, 2)
+    delete b; // | `--mem: del b
+    return a; // `--->
   }
 
 
   // SA: adapted from the GPL-licensed GNU plotutils (plotutils-2.5/ode/specfun.c)
   // -----------------------------------------------------------------------------
-  template <typename T> 
-  T inverf (T p)               /* Inverse Error Function */
-  {
+
+  template <typename T>
+  T inverf(T p) /* Inverse Error Function */ {
     /*
      * Source: This routine was derived (using f2c) from the Fortran
      * subroutine MERFI found in ACM Algorithm 602, obtained from netlib.
@@ -2003,14 +2297,14 @@ namespace lib {
      */
 
     /* Initialized data */
-    static T a1 = -.5751703,   a2 = -1.896513,   a3 = -.05496261,
-      b0 = -.113773,    b1 = -3.293474,   b2 = -2.374996,  b3 = -1.187515,
-      c0 = -.1146666,   c1 = -.1314774,   c2 = -.2368201,  c3 = .05073975,
-      d0 = -44.27977,   d1 = 21.98546,    d2 = -7.586103, 
-      e0 = -.05668422,  e1 = .3937021,    e2 = -.3166501,  e3 = .06208963,
-      f0 = -6.266786,   f1 = 4.666263,    f2 = -2.962883,
-      g0 = 1.851159e-4, g1 = -.002028152, g2 = -.1498384,  g3 = .01078639,
-      h0 = .09952975,   h1 = .5211733,    h2 = -.06888301;
+    static T a1 = -.5751703, a2 = -1.896513, a3 = -.05496261,
+      b0 = -.113773, b1 = -3.293474, b2 = -2.374996, b3 = -1.187515,
+      c0 = -.1146666, c1 = -.1314774, c2 = -.2368201, c3 = .05073975,
+      d0 = -44.27977, d1 = 21.98546, d2 = -7.586103,
+      e0 = -.05668422, e1 = .3937021, e2 = -.3166501, e3 = .06208963,
+      f0 = -6.266786, f1 = 4.666263, f2 = -2.962883,
+      g0 = 1.851159e-4, g1 = -.002028152, g2 = -.1498384, g3 = .01078639,
+      h0 = .09952975, h1 = .5211733, h2 = -.06888301;
 
     /* Local variables */
     static T a, b, f, w, x, y, z, sigma, z2, sd, wi, sn;
@@ -2027,68 +2321,56 @@ namespace lib {
     /* z between 0.0 and 0.85, approx. f by a
        rational function in z  */
 
-    if (z <= 0.85)
-      {
-	z2 = z * z;
-	f = z + z * (b0 + a1 * z2 / (b1 + z2 + a2 / (b2 + z2 + a3 / (b3 + z2))));
+    if (z <= 0.85) {
+      z2 = z * z;
+      f = z + z * (b0 + a1 * z2 / (b1 + z2 + a2 / (b2 + z2 + a3 / (b3 + z2))));
+    } else /* z greater than 0.85 */ {
+      a = 1.0 - z;
+      b = z;
+
+      /* reduced argument is in (0.85,1.0), obtain the transformed variable */
+
+      w = sqrt(-(T) log(a + a * b));
+
+      if (w >= 4.0)
+        /* w greater than 4.0, approx. f by a rational function in 1.0 / w */ {
+        wi = 1.0 / w;
+        sn = ((g3 * wi + g2) * wi + g1) * wi;
+        sd = ((wi + h2) * wi + h1) * wi + h0;
+        f = w + w * (g0 + sn / sd);
+      } else if (w < 4.0 && w > 2.5)
+        /* w between 2.5 and 4.0, approx.  f by a rational function in w */ {
+        sn = ((e3 * w + e2) * w + e1) * w;
+        sd = ((w + f2) * w + f1) * w + f0;
+        f = w + w * (e0 + sn / sd);
+
+        /* w between 1.13222 and 2.5, approx. f by
+           a rational function in w */
+      } else if (w <= 2.5 && w > 1.13222) {
+        sn = ((c3 * w + c2) * w + c1) * w;
+        sd = ((w + d2) * w + d1) * w + d0;
+        f = w + w * (c0 + sn / sd);
       }
-    else  /* z greater than 0.85 */
-      {
-	a = 1.0 - z;
-	b = z;
-
-	/* reduced argument is in (0.85,1.0), obtain the transformed variable */
-
-	w = sqrt(-(T)log(a + a * b));
-
-	if (w >= 4.0)
-	  /* w greater than 4.0, approx. f by a rational function in 1.0 / w */
-	  {
-	    wi = 1.0 / w;
-	    sn = ((g3 * wi + g2) * wi + g1) * wi;
-	    sd = ((wi + h2) * wi + h1) * wi + h0;
-	    f = w + w * (g0 + sn / sd);
-	  }
-	else if (w < 4.0 && w > 2.5)
-	  /* w between 2.5 and 4.0, approx.  f by a rational function in w */
-	  {
-	    sn = ((e3 * w + e2) * w + e1) * w;
-	    sd = ((w + f2) * w + f1) * w + f0;
-	    f = w + w * (e0 + sn / sd);
-
-	    /* w between 1.13222 and 2.5, approx. f by
-	       a rational function in w */
-	  }
-	else if (w <= 2.5 && w > 1.13222)
-	  {
-	    sn = ((c3 * w + c2) * w + c1) * w;
-	    sd = ((w + d2) * w + d1) * w + d0;
-	    f = w + w * (c0 + sn / sd);
-	  }
-      }
+    }
     y = sigma * f;
 
     return y;
-  } 
+  }
   // -----------------------------------------------------------------------------
 
-  BaseGDL* gdl_erfinv_fun(EnvT* e)
-  {
-    BaseGDL* p0 = e->GetNumericParDefined(0);    
+  BaseGDL* gdl_erfinv_fun(EnvT* e) {
+    BaseGDL* p0 = e->GetNumericParDefined(0);
     SizeT n = p0->N_Elements();
     static int doubleIx = e->KeywordIx("DOUBLE");
-    if (e->KeywordSet(doubleIx) || p0->Type() == GDL_DOUBLE)
-      {
-	DDoubleGDL *ret = new DDoubleGDL(dimension(n)), *p0d = e->GetParAs<DDoubleGDL>(0);
-	while (n != 0) --n, (*ret)[n] = inverf((*p0d)[n]);
-	return ret;
-      }
-    else
-      {
-	DFloatGDL *ret = new DFloatGDL(dimension(n)), *p0f = e->GetParAs<DFloatGDL>(0);
-	while (n != 0) --n, (*ret)[n] = inverf((*p0f)[n]); 
-	return ret;
-      }
+    if (e->KeywordSet(doubleIx) || p0->Type() == GDL_DOUBLE) {
+      DDoubleGDL *ret = new DDoubleGDL(dimension(n)), *p0d = e->GetParAs<DDoubleGDL>(0);
+      while (n != 0) --n, (*ret)[n] = inverf((*p0d)[n]);
+      return ret;
+    } else {
+      DFloatGDL *ret = new DFloatGDL(dimension(n)), *p0f = e->GetParAs<DFloatGDL>(0);
+      while (n != 0) --n, (*ret)[n] = inverf((*p0f)[n]);
+      return ret;
+    }
   }
 
 } // namespace

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -58,7 +58,7 @@ namespace lib {
 
   template< typename srcT, typename destT>
   void FromToGSL(srcT* src, destT* dest, SizeT nEl) {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
     } else {
@@ -215,7 +215,7 @@ namespace lib {
   round_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -255,7 +255,7 @@ namespace lib {
     BaseGDL* p0 = e->GetParDefined(0); //, "ROUND");
 
     SizeT nEl = p0->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
 
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
@@ -341,7 +341,7 @@ namespace lib {
   BaseGDL* ceil_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -381,7 +381,7 @@ namespace lib {
 
     SizeT nEl = p0->N_Elements();
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
@@ -465,7 +465,7 @@ namespace lib {
   BaseGDL* floor_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -505,7 +505,7 @@ namespace lib {
 
     SizeT nEl = p0->N_Elements();
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
@@ -599,7 +599,7 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     } else {
@@ -618,7 +618,7 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     } else {
@@ -647,7 +647,7 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       } else {
@@ -670,7 +670,7 @@ namespace lib {
       (*res)[0] = sin((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
     } else {
@@ -689,7 +689,7 @@ namespace lib {
       (*p0C)[0] = sin((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
     } else {
@@ -718,7 +718,7 @@ namespace lib {
       else return sin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       } else {
@@ -741,7 +741,7 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     } else {
@@ -760,7 +760,7 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     } else {
@@ -789,7 +789,7 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       } else {
@@ -812,7 +812,7 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     } else {
@@ -831,7 +831,7 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     } else {
@@ -860,7 +860,7 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       } else {
@@ -883,7 +883,7 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     } else {
@@ -902,7 +902,7 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     } else {
@@ -931,7 +931,7 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       } else {
@@ -954,7 +954,7 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     } else {
@@ -973,7 +973,7 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     } else {
@@ -1002,7 +1002,7 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       } else {
@@ -1025,7 +1025,7 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     } else {
@@ -1044,7 +1044,7 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     } else {
@@ -1073,7 +1073,7 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       } else {
@@ -1094,7 +1094,7 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     } else {
@@ -1113,7 +1113,7 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     } else {
@@ -1142,7 +1142,7 @@ namespace lib {
       else return asin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       } else {
@@ -1163,7 +1163,7 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     } else {
@@ -1182,7 +1182,7 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     } else {
@@ -1211,7 +1211,7 @@ namespace lib {
       else return acos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       } else {
@@ -1234,7 +1234,7 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     } else {
@@ -1253,7 +1253,7 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     } else {
@@ -1282,7 +1282,7 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       } else {
@@ -1330,7 +1330,7 @@ namespace lib {
       (*res)[ 0] = abs((*p0C)[ 0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
     } else {
@@ -1351,7 +1351,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
@@ -1368,7 +1368,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
@@ -1413,7 +1413,7 @@ namespace lib {
       (*res)[ 0] = abs((*res)[ 0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!parallelize) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
     } else {
@@ -1437,7 +1437,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult();
       else res = static_cast<DComplexGDL*> (p0);
       DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
@@ -1452,7 +1452,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
       else res = res = static_cast<DComplexDblGDL*> (p0);
       DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
@@ -1482,7 +1482,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
@@ -1495,7 +1495,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
@@ -1528,7 +1528,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
@@ -1541,7 +1541,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
       if (!parallelize) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
@@ -1669,7 +1669,7 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
           if (!parallelize) {
@@ -1717,7 +1717,7 @@ namespace lib {
           (*res)[ 0] = atan2((*p0F)[0], (*p1F)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
           if (!parallelize) {
@@ -1765,7 +1765,7 @@ namespace lib {
           (*res)[ 0] = atanC((*p0C)[0], (*p1C)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
           if (!parallelize) {
@@ -1813,7 +1813,7 @@ namespace lib {
           (*res)[ 0] = atanC((*p0DC)[0], (*p1DC)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
           if (!parallelize) {
@@ -1853,7 +1853,7 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nElMin)));
+        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
           if (!parallelize) {
@@ -1894,7 +1894,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
@@ -1910,7 +1910,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
@@ -1928,7 +1928,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           } else {
@@ -1944,7 +1944,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           } else {
@@ -1960,7 +1960,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
@@ -1976,7 +1976,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
@@ -1991,7 +1991,7 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl)));
+          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
           if (!parallelize) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           } else {
@@ -2120,7 +2120,7 @@ namespace lib {
     DInt n = (*nval)[0];
     SizeT nEx = xvals->N_Elements();
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEx)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEx)));
     if (!parallelize) {
       for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
     } else {
@@ -2139,7 +2139,7 @@ namespace lib {
       //GD: parallelizing this complicated loop cannot be done just like that.
       //I further doubt Laguerre is going to be used on large arrays.
       //      TRACEOMP(__FILE__,__LINE__)
-      //#pragma omp parallel for  (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= n))
+      //#pragma omp parallel for  (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))
       for (SizeT count = 0; count <= n; ++count) {
         double dcount = static_cast<double> (count);
         (*coefKW)[count] = ((count & 0x0001) ? -1.0 : 1.0) * gamma_kn1 /

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -58,11 +58,11 @@ namespace lib {
 
   template< typename srcT, typename destT>
   void FromToGSL(srcT* src, destT* dest, SizeT nEl) {
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
     }
   }
@@ -221,11 +221,11 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       }
       return res;
@@ -235,11 +235,11 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       }
 
@@ -267,11 +267,11 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
- #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+ #pragma omp parallel for num_threads(GDL_NTHREADS)
            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         }
         return res;
@@ -283,11 +283,11 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         }
         return res;
@@ -304,11 +304,11 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         }
         return res;
@@ -320,11 +320,11 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         }
         return res;
@@ -345,11 +345,11 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       }
       return res;
@@ -359,11 +359,11 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       }
 
@@ -389,11 +389,11 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         }
         return res;
@@ -405,11 +405,11 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         }
         return res;
@@ -426,11 +426,11 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         }
         return res;
@@ -442,11 +442,11 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         }
         return res;
@@ -467,11 +467,11 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       }
       return res;
@@ -481,11 +481,11 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       }
 
@@ -511,11 +511,11 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         }
         return res;
@@ -527,11 +527,11 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         }
         return res;
@@ -548,11 +548,11 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         }
         return res;
@@ -564,11 +564,11 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         }
         return res;
@@ -592,11 +592,11 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     }
     return res;
@@ -610,11 +610,11 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     }
     return p0;
@@ -638,11 +638,11 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       }
       return res;
@@ -660,11 +660,11 @@ namespace lib {
       (*res)[0] = sin((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
     }
     return res;
@@ -678,11 +678,11 @@ namespace lib {
       (*p0C)[0] = sin((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
     }
     return p0;
@@ -706,11 +706,11 @@ namespace lib {
       else return sin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       }
       return res;
@@ -728,11 +728,11 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     }
     return res;
@@ -746,11 +746,11 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     }
     return p0;
@@ -774,11 +774,11 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       }
       return res;
@@ -796,11 +796,11 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     }
     return res;
@@ -814,11 +814,11 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     }
     return p0;
@@ -842,11 +842,11 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       }
       return res;
@@ -864,11 +864,11 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     }
     return res;
@@ -882,11 +882,11 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     }
     return p0;
@@ -910,11 +910,11 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       }
       return res;
@@ -932,11 +932,11 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     }
     return res;
@@ -950,11 +950,11 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     }
     return p0;
@@ -978,11 +978,11 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       }
       return res;
@@ -1000,11 +1000,11 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     }
     return res;
@@ -1018,11 +1018,11 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     }
     return p0;
@@ -1046,11 +1046,11 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       }
       return res;
@@ -1066,11 +1066,11 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     }
     return res;
@@ -1084,11 +1084,11 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     }
     return p0;
@@ -1112,11 +1112,11 @@ namespace lib {
       else return asin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       }
       return res;
@@ -1132,11 +1132,11 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     }
     return res;
@@ -1150,11 +1150,11 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     }
     return p0;
@@ -1178,11 +1178,11 @@ namespace lib {
       else return acos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       }
       return res;
@@ -1200,11 +1200,11 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     }
     return res;
@@ -1218,11 +1218,11 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     }
     return p0;
@@ -1246,11 +1246,11 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       }
       return res;
@@ -1308,11 +1308,11 @@ namespace lib {
       (*res)[ 0] = abs((*p0C)[ 0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
     }
     return res;
@@ -1328,11 +1328,11 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       }
       return res;
@@ -1344,11 +1344,11 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       }
       return res;
@@ -1388,11 +1388,11 @@ namespace lib {
       (*res)[ 0] = abs((*res)[ 0]);
       return res;
     }
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
     }
     return res;
@@ -1411,11 +1411,11 @@ namespace lib {
       if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult();
       else res = static_cast<DComplexGDL*> (p0);
       DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       }
       return res;
@@ -1425,11 +1425,11 @@ namespace lib {
       if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
       else res = res = static_cast<DComplexDblGDL*> (p0);
       DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       }
       return res;
@@ -1454,11 +1454,11 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       }
       return res;
@@ -1466,11 +1466,11 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       }
       return res;
@@ -1498,11 +1498,11 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       }
       return res;
@@ -1510,11 +1510,11 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       }
       return res;
@@ -1639,29 +1639,29 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           }
           return res;
         case 1:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           }
           return res;
         case 2:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           }
           return res;
@@ -1686,29 +1686,29 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
           }
           return res;
         case 1:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
           }
           return res;
         case 2:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
           }
           return res;
@@ -1733,29 +1733,29 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
           }
           return res;
         case 1:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
           }
           return res;
         case 2:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
           }
           return res;
@@ -1780,29 +1780,29 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
           }
           return res;
         case 1:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
           }
           return res;
         case 2:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
           }
           return res;
@@ -1819,29 +1819,29 @@ namespace lib {
         }
         switch (cas) {
         case 0:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           }
           return res;
         case 1:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           }
           return res;
         case 2:
-          if (!parallelize( nElMin)) {
+          if (GDL_NTHREADS=parallelize( nElMin)==1) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           }
           return res;
@@ -1857,11 +1857,11 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           }
           return res;
@@ -1872,11 +1872,11 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           }
           return res;
@@ -1889,11 +1889,11 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           }
           return res;
@@ -1904,11 +1904,11 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           }
           return res;
@@ -1919,11 +1919,11 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           }
           return res;
@@ -1934,11 +1934,11 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           }
           return res;
@@ -1948,11 +1948,11 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
-          if (!parallelize( nEl)) {
+          if (GDL_NTHREADS=parallelize( nEl)==1) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
               for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           }
           return res;
@@ -2076,11 +2076,11 @@ namespace lib {
     DInt n = (*nval)[0];
     SizeT nEx = xvals->N_Elements();
 
-    if (!parallelize( nEx)) {
+    if (GDL_NTHREADS=parallelize( nEx)==1) {
       for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
     }
 
@@ -2093,8 +2093,6 @@ namespace lib {
 
       //GD: parallelizing this complicated loop cannot be done just like that.
       //I further doubt Laguerre is going to be used on large arrays.
-      //      TRACEOMP(__FILE__,__LINE__)
-      //#pragma omp parallel for  (n >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= n))
       for (SizeT count = 0; count <= n; ++count) {
         double dcount = static_cast<double> (count);
         (*coefKW)[count] = ((count & 0x0001) ? -1.0 : 1.0) * gamma_kn1 /

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -58,8 +58,7 @@ namespace lib {
 
   template< typename srcT, typename destT>
   void FromToGSL(srcT* src, destT* dest, SizeT nEl) {
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT d = 0; d < nEl; ++d) dest[ d] = src[ d];
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -215,7 +214,6 @@ namespace lib {
   round_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -223,7 +221,7 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -237,7 +235,7 @@ namespace lib {
         (*res)[ 0] = round((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -255,7 +253,6 @@ namespace lib {
     BaseGDL* p0 = e->GetParDefined(0); //, "ROUND");
 
     SizeT nEl = p0->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
 
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
@@ -270,7 +267,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -286,7 +283,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -307,7 +304,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -323,7 +320,7 @@ namespace lib {
           (*res)[ 0] = round((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = round((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -341,7 +338,6 @@ namespace lib {
   BaseGDL* ceil_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -349,7 +345,7 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -363,7 +359,7 @@ namespace lib {
         (*res)[ 0] = ceil((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -381,7 +377,6 @@ namespace lib {
 
     SizeT nEl = p0->N_Elements();
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
@@ -394,7 +389,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -410,7 +405,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -431,7 +426,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -447,7 +442,7 @@ namespace lib {
           (*res)[ 0] = ceil((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = ceil((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -465,7 +460,6 @@ namespace lib {
   BaseGDL* floor_fun_template(BaseGDL* p0, bool isKWSetL64) {
     T* p0C = static_cast<T*> (p0);
     SizeT nEl = p0->N_Elements();
-     bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     // L64 keyword support
     if (isKWSetL64) {
       DLong64GDL* res = new DLong64GDL(p0C->Dim(), BaseGDL::NOZERO);
@@ -473,7 +467,7 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -487,7 +481,7 @@ namespace lib {
         (*res)[ 0] = floor((*p0C)[ 0]);
         return res;
       }
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -505,7 +499,6 @@ namespace lib {
 
     SizeT nEl = p0->N_Elements();
     if (nEl == 0) e->Throw("Variable is undefined: " + e->GetParString(0));
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
     if (!(NumericType(p0->Type()))) e->Throw(p0->TypeStr() + " expression: not allowed in this context: " + e->GetParString(0));
 
     //L64 means it: output IS ALWAYS L64.
@@ -518,7 +511,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -534,7 +527,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -555,7 +548,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -571,7 +564,7 @@ namespace lib {
           (*res)[ 0] = floor((*p0C)[ 0].real());
           return res;
         }
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = floor((*p0C)[ i].real());
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -599,8 +592,7 @@ namespace lib {
       (*res)[0] = sqrt((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -618,8 +610,7 @@ namespace lib {
       (*p0C)[0] = sqrt((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sqrt((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -647,8 +638,7 @@ namespace lib {
       else return sqrt_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sqrt((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -670,8 +660,7 @@ namespace lib {
       (*res)[0] = sin((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -689,8 +678,7 @@ namespace lib {
       (*p0C)[0] = sin((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -718,8 +706,7 @@ namespace lib {
       else return sin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -741,8 +728,7 @@ namespace lib {
       (*res)[0] = cos((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -760,8 +746,7 @@ namespace lib {
       (*p0C)[0] = cos((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -789,8 +774,7 @@ namespace lib {
       else return cos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -812,8 +796,7 @@ namespace lib {
       (*res)[0] = tan((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -831,8 +814,7 @@ namespace lib {
       (*p0C)[0] = tan((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tan((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -860,8 +842,7 @@ namespace lib {
       else return tan_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tan((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -883,8 +864,7 @@ namespace lib {
       (*res)[0] = sinh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -902,8 +882,7 @@ namespace lib {
       (*p0C)[0] = sinh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = sinh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -931,8 +910,7 @@ namespace lib {
       else return sinh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = sinh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -954,8 +932,7 @@ namespace lib {
       (*res)[0] = cosh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -973,8 +950,7 @@ namespace lib {
       (*p0C)[0] = cosh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = cosh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1002,8 +978,7 @@ namespace lib {
       else return cosh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = cosh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1025,8 +1000,7 @@ namespace lib {
       (*res)[0] = tanh((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1044,8 +1018,7 @@ namespace lib {
       (*p0C)[0] = tanh((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = tanh((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1073,8 +1046,7 @@ namespace lib {
       else return tanh_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = tanh((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1094,8 +1066,7 @@ namespace lib {
       (*res)[0] = asin((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1113,8 +1084,7 @@ namespace lib {
       (*p0C)[0] = asin((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = asin((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1142,8 +1112,7 @@ namespace lib {
       else return asin_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = asin((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1163,8 +1132,7 @@ namespace lib {
       (*res)[0] = acos((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1182,8 +1150,7 @@ namespace lib {
       (*p0C)[0] = acos((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = acos((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1211,8 +1178,7 @@ namespace lib {
       else return acos_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = acos((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1234,8 +1200,7 @@ namespace lib {
       (*res)[0] = exp((*p0C)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1253,8 +1218,7 @@ namespace lib {
       (*p0C)[0] = exp((*p0C)[0]);
       return p0;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*p0C)[ i] = exp((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1282,8 +1246,7 @@ namespace lib {
       else return exp_fun_template_grab< DFloatGDL>(p0);
     else {
       DFloatGDL* res = static_cast<DFloatGDL*> (p0->Convert2(GDL_FLOAT, BaseGDL::COPY));
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i)(*res)[ i] = exp((*res)[ i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1345,8 +1308,7 @@ namespace lib {
       (*res)[ 0] = abs((*p0C)[ 0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1366,8 +1328,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1383,8 +1344,7 @@ namespace lib {
         (*res)[ 0] = abs((*p0C)[ 0]);
         return res;
       }
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*p0C)[ i]); //sqrt(Creal*Creal + Cimag*Cimag);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1428,8 +1388,7 @@ namespace lib {
       (*res)[ 0] = abs((*res)[ 0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = abs((*res)[ i]);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -1452,8 +1411,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexGDL*> (p0)->NewResult();
       else res = static_cast<DComplexGDL*> (p0);
       DComplexGDL* p0C = static_cast<DComplexGDL*> (p0);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1467,8 +1425,7 @@ namespace lib {
       if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
       else res = res = static_cast<DComplexDblGDL*> (p0);
       DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1497,8 +1454,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1510,8 +1466,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = imag((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1543,8 +1498,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEX) {
       DComplexGDL* c0 = static_cast<DComplexGDL*> (p0);
       DFloatGDL* res = new DFloatGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1556,8 +1510,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* c0 = static_cast<DComplexDblGDL*> (p0);
       DDoubleGDL* res = new DDoubleGDL(c0->Dim(), BaseGDL::NOZERO);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = real((*c0)[i]);
       } else {
         TRACEOMP(__FILE__, __LINE__)
@@ -1684,10 +1637,9 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1696,7 +1648,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1705,7 +1657,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1732,10 +1684,9 @@ namespace lib {
           (*res)[ 0] = atan2((*p0F)[0], (*p1F)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1744,7 +1695,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[i], (*p1F)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1753,7 +1704,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0F)[0], (*p1F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1780,10 +1731,9 @@ namespace lib {
           (*res)[ 0] = atanC((*p0C)[0], (*p1C)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1792,7 +1742,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[i], (*p1C)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1801,7 +1751,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0C)[0], (*p1C)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1828,10 +1778,9 @@ namespace lib {
           (*res)[ 0] = atanC((*p0DC)[0], (*p1DC)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1840,7 +1789,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[i], (*p1DC)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1849,7 +1798,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atanC((*p0DC)[0], (*p1DC)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1868,10 +1817,9 @@ namespace lib {
           (*res)[ 0] = atan2((*p0D)[0], (*p1D)[0]);
           return res;
         }
-        bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nElMin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nElMin)));
         switch (cas) {
         case 0:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1880,7 +1828,7 @@ namespace lib {
           }
           return res;
         case 1:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[i], (*p1D)[0]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1889,7 +1837,7 @@ namespace lib {
           }
           return res;
         case 2:
-          if (!parallelize) {
+          if (!parallelize( nElMin)) {
             for (SizeT i = 0; i < nElMin; ++i) (*res)[i] = atan2((*p0D)[0], (*p1D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1909,8 +1857,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1925,8 +1872,7 @@ namespace lib {
             (*res)[ 0] = atan2(((*p0C)[ 0]).imag(), ((*p0C)[ 0]).real());
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan2(((*p0C)[i]).imag(), ((*p0C)[i]).real());
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1943,8 +1889,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0D)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0D)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1959,8 +1904,7 @@ namespace lib {
             (*res)[ 0] = atan((*p0F)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*p0F)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1975,8 +1919,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -1991,8 +1934,7 @@ namespace lib {
             (*res)[ 0] = std::atan((*p0C)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = std::atan((*p0C)[ i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2006,8 +1948,7 @@ namespace lib {
             (*res)[ 0] = atan((*res)[ 0]);
             return res;
           }
-          bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-          if (!parallelize) {
+          if (!parallelize( nEl)) {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = atan((*res)[i]);
           } else {
             TRACEOMP(__FILE__, __LINE__)
@@ -2135,8 +2076,7 @@ namespace lib {
     DInt n = (*nval)[0];
     SizeT nEx = xvals->N_Elements();
 
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nEx >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEx)));
-    if (!parallelize) {
+    if (!parallelize( nEx)) {
       for (SizeT count = 0; count < nEx; ++count) (*res)[count] = gsl_sf_laguerre_n(n, k, (*xvals)[count]);
     } else {
       TRACEOMP(__FILE__, __LINE__)

--- a/src/math_fun.hpp
+++ b/src/math_fun.hpp
@@ -39,6 +39,7 @@ namespace lib {
 
   BaseGDL* alog_fun( BaseGDL* p0, bool isReference);//( EnvT* e);
   BaseGDL* alog10_fun( BaseGDL* p0, bool isReference);//( EnvT* e);
+  BaseGDL* alog2_fun( BaseGDL* p0, bool isReference);//( EnvT* e);
 
   BaseGDL* sqrt_fun( BaseGDL* p0, bool isReference);//( EnvT* e);
   BaseGDL* abs_fun( BaseGDL* p0, bool isReference);//( EnvT* e);

--- a/src/math_fun_ac.cpp
+++ b/src/math_fun_ac.cpp
@@ -539,6 +539,9 @@ namespace lib {
   // what does not work like IDL : warning messages when Inf/Nan or Zero/Negative X steps, X and Y not same size
 #define SPL_INIT_BIG double(1.0E30) 
   BaseGDL* spl_init_fun(EnvT* e) {
+    
+    e->NParam(2);
+
     static DInt doubleKWIx = e->KeywordIx("DOUBLE");
     bool isDouble = (e->GetParDefined(0)->Type() == GDL_DOUBLE || e->GetParDefined(1)->Type() == GDL_DOUBLE);
     if (e->KeywordSet(doubleKWIx)) isDouble = true;
@@ -709,6 +712,9 @@ namespace lib {
 
   BaseGDL* spl_interp_fun( EnvT* e)
   {
+    
+    e->NParam(4);
+
     static DInt doubleKWIx = e->KeywordIx("DOUBLE");
     bool isDouble = (e->GetParDefined(0)->Type() == GDL_DOUBLE || e->GetParDefined(1)->Type() == GDL_DOUBLE || 
         e->GetParDefined(2)->Type() == GDL_DOUBLE || e->GetParDefined(3)->Type() == GDL_DOUBLE);
@@ -1051,7 +1057,7 @@ namespace lib {
 
   BaseGDL* erode_fun( EnvT* e){
 
-    SizeT nParam = e->NParam(1);
+    SizeT nParam = e->NParam(2);
 
     DIntGDL* p0 = e->GetParAs<DIntGDL>(0);
     DIntGDL* p1 = e->GetParAs<DIntGDL>(1);
@@ -1213,7 +1219,7 @@ namespace lib {
 
   BaseGDL* dilate_fun( EnvT* e)
   {
-    SizeT nParam = e->NParam(1);
+    SizeT nParam = e->NParam(2);
 
     DIntGDL* p0 = e->GetParAs<DIntGDL>(0);
     DIntGDL* p1 = e->GetParAs<DIntGDL>(1);
@@ -1368,6 +1374,9 @@ namespace lib {
 
   BaseGDL* matrix_multiply( EnvT* e)
   {
+     
+    e->NParam(2);
+
     BaseGDL* a = e->GetParDefined(0);
     BaseGDL* b = e->GetParDefined(1);
 

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -199,27 +199,27 @@ namespace lib {
       SizeT nEl = src->N_Elements();
 
       if (kwNaN) {
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         }
       } else if (kwInfinity) {
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         }
       } else {
-        if (!parallelize( nEl)) {
+        if (GDL_NTHREADS=parallelize( nEl)==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
         }
       }
@@ -235,29 +235,29 @@ namespace lib {
        DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
        SizeT nEl = src->N_Elements();
        if (kwNaN){
-	 if (!parallelize( nEl)) {
+	 if (GDL_NTHREADS=parallelize( nEl)==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel  for num_threads(GDL_NTHREADS) 
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	   }
        }
        else if (kwInfinity){
-	 if (!parallelize( nEl)) {
+	 if (GDL_NTHREADS=parallelize( nEl)==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel  for num_threads(GDL_NTHREADS) 
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	   }
        }
        else{
-	 if (!parallelize( nEl)) {
+	 if (GDL_NTHREADS=parallelize( nEl)==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel  for num_threads(GDL_NTHREADS) 
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
 	   }
        }
@@ -285,25 +285,25 @@ namespace lib {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
               }
             } else {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -312,25 +312,25 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
               }
             } else {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -356,25 +356,25 @@ namespace lib {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
               }
             } else {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -383,25 +383,25 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
               }
             } else {
-              if (!parallelize( nEl)) {
+              if (GDL_NTHREADS=parallelize( nEl)==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
               } else {
                 TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+#pragma omp parallel for num_threads(GDL_NTHREADS) 
                   for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -423,7 +423,7 @@ namespace lib {
 //       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO);
 //       SizeT nEl = src->N_Elements();
 //       
-//		if (!parallelize( nEl)) {
+//		if (GDL_NTHREADS=parallelize( nEl)==1) {
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
 //	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
@@ -433,7 +433,7 @@ namespace lib {
 //	  }
 //		} else {
 //  TRACEOMP(__FILE__,__LINE__)
-// 	   #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+// 	   #pragma omp parallel for num_threads(GDL_NTHREADS) 
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
 //	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
@@ -916,17 +916,17 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -945,7 +945,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
         for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1016,17 +1016,17 @@ namespace lib {
 
 
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1098,7 +1098,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1214,17 +1214,17 @@ namespace lib {
 
 
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1281,7 +1281,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1362,17 +1362,17 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1393,7 +1393,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1474,17 +1474,17 @@ namespace lib {
 
 
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1556,7 +1556,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1680,17 +1680,17 @@ namespace lib {
 
 
     if (doMissing) {
-      if (!parallelize( nEl)) {
+      if (GDL_NTHREADS=parallelize( nEl)==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
-    if (!parallelize( nEl)) {
+    if (GDL_NTHREADS=parallelize( nEl)==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1747,7 +1747,7 @@ namespace lib {
       }
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for collapse(2) num_threads(GDL_NTHREADS)
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -199,15 +199,18 @@ namespace lib {
      SizeT nEl = src->N_Elements();
 
      if (kwNaN){
-      #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+       TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
        for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
      }
      else if (kwInfinity){
-      #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+       TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
        for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
      }
      else{
-      #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+       TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
        for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
      }
      return res;
@@ -222,17 +225,20 @@ namespace lib {
        DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
        SizeT nEl = src->N_Elements();
        if (kwNaN){
-	    #pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+	 TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
          for ( SizeT i=0; i<nEl; ++i) 
      	    (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	   }
        else if (kwInfinity){
-   	    #pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+	 TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
          for ( SizeT i=0; i<nEl; ++i)
            (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	   }
        else{
-	    #pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+	 TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
          for ( SizeT i=0; i<nEl; ++i)
            (*res)[ i] = isfinite((*src)[ i].real()) && 
                         isfinite((*src)[ i].imag());
@@ -262,12 +268,14 @@ namespace lib {
 	 {
 		if (kwInfinity) {
 			if (kwSign > 0) {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0)); 
 				}
 			} else {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					(*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0)) ; 
 				}
@@ -275,12 +283,14 @@ namespace lib {
 		}
 		if (kwNaN) {
 			if (kwSign > 0) {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0)); 
 				}
 			} else {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0)); 
 				}
@@ -306,12 +316,14 @@ namespace lib {
 	 {
 		if (kwInfinity) {
 			if (kwSign > 0) {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real())))||(isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag())))); 
 				}
 			} else {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real())))||(isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag())))); 
 				}
@@ -319,12 +331,14 @@ namespace lib {
 		}
 		if (kwNaN) {
 			if (kwSign > 0) {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real())))||(isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag())))); 
 				}
 			} else {
-				#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+			  TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 				for ( SizeT i=0; i<nEl; ++i) {
 					 (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real())))||(isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag())))); 
 				}
@@ -345,6 +359,7 @@ namespace lib {
 //       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO);
 //       SizeT nEl = src->N_Elements();
 //       
+//  TRACEOMP(__FILE__,__LINE__)
 // 	   #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
@@ -827,6 +842,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -835,6 +851,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)
@@ -908,6 +925,7 @@ namespace lib {
 
 
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -916,6 +934,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)
@@ -1034,6 +1053,7 @@ namespace lib {
 
 
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -1042,6 +1062,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)
@@ -1125,6 +1146,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -1133,6 +1155,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)
@@ -1216,6 +1239,7 @@ namespace lib {
 
 
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -1224,6 +1248,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)
@@ -1350,6 +1375,7 @@ namespace lib {
 
 
     if (doMissing) {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -1358,6 +1384,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for collapse(2)

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -1841,9 +1841,7 @@ namespace lib {
 
     // GD: POLY_2D IS 5 times slower that IDL's. TBC . I note that the loops contains a lot of 'ifs', so algorithm is not efficient.
     
-    SizeT nParam = e->NParam();
-    if (nParam < 3)
-      e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(3);
 
     BaseGDL* p0 = e->GetParDefined(0);
     

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -199,7 +199,7 @@ namespace lib {
       SizeT nEl = src->N_Elements();
 
       if (kwNaN) {
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -207,7 +207,7 @@ namespace lib {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         }
       } else if (kwInfinity) {
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -215,7 +215,7 @@ namespace lib {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         }
       } else {
-        if (GDL_NTHREADS=parallelize( nEl)==1) {
+        if ((GDL_NTHREADS=parallelize( nEl))==1) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -235,7 +235,7 @@ namespace lib {
        DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
        SizeT nEl = src->N_Elements();
        if (kwNaN){
-	 if (GDL_NTHREADS=parallelize( nEl)==1) {
+	 if ((GDL_NTHREADS=parallelize( nEl))==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -244,7 +244,7 @@ namespace lib {
 	   }
        }
        else if (kwInfinity){
-	 if (GDL_NTHREADS=parallelize( nEl)==1) {
+	 if ((GDL_NTHREADS=parallelize( nEl))==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -253,7 +253,7 @@ namespace lib {
 	   }
        }
        else{
-	 if (GDL_NTHREADS=parallelize( nEl)==1) {
+	 if ((GDL_NTHREADS=parallelize( nEl))==1) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -285,7 +285,7 @@ namespace lib {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
@@ -297,7 +297,7 @@ namespace lib {
                 }
               }
             } else {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -312,7 +312,7 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
@@ -324,7 +324,7 @@ namespace lib {
                 }
               }
             } else {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -356,7 +356,7 @@ namespace lib {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
@@ -368,7 +368,7 @@ namespace lib {
                 }
               }
             } else {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -383,7 +383,7 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
@@ -395,7 +395,7 @@ namespace lib {
                 }
               }
             } else {
-              if (GDL_NTHREADS=parallelize( nEl)==1) {
+              if ((GDL_NTHREADS=parallelize( nEl))==1) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -423,7 +423,7 @@ namespace lib {
 //       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO);
 //       SizeT nEl = src->N_Elements();
 //       
-//		if (GDL_NTHREADS=parallelize( nEl)==1) {
+//		if ((GDL_NTHREADS=parallelize( nEl))==1) {
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
 //	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
@@ -916,7 +916,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -926,7 +926,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1016,7 +1016,7 @@ namespace lib {
 
 
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1026,7 +1026,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1214,7 +1214,7 @@ namespace lib {
 
 
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1224,7 +1224,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1362,7 +1362,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1372,7 +1372,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1474,7 +1474,7 @@ namespace lib {
 
 
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1484,7 +1484,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1680,7 +1680,7 @@ namespace lib {
 
 
     if (doMissing) {
-      if (GDL_NTHREADS=parallelize( nEl)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1690,7 +1690,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    if (GDL_NTHREADS=parallelize( nEl)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -197,10 +197,9 @@ namespace lib {
     inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity) {
       DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::NOZERO);
       SizeT nEl = src->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
 
       if (kwNaN) {
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -208,7 +207,7 @@ namespace lib {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
         }
       } else if (kwInfinity) {
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -216,7 +215,7 @@ namespace lib {
             for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
         }
       } else {
-        if (!parallelize) {
+        if (!parallelize( nEl)) {
           for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
         } else {
           TRACEOMP(__FILE__, __LINE__)
@@ -235,9 +234,8 @@ namespace lib {
     {
        DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
        SizeT nEl = src->N_Elements();
-    	 bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
        if (kwNaN){
-	 if (!parallelize) {
+	 if (!parallelize( nEl)) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -246,7 +244,7 @@ namespace lib {
 	   }
        }
        else if (kwInfinity){
-	 if (!parallelize) {
+	 if (!parallelize( nEl)) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -255,7 +253,7 @@ namespace lib {
 	   }
        }
        else{
-	 if (!parallelize) {
+	 if (!parallelize( nEl)) {
          for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
 	 } else {
    TRACEOMP(__FILE__,__LINE__)
@@ -283,12 +281,11 @@ namespace lib {
 
       DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::ZERO); // ::ZERO is not working
       SizeT nEl = src->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (kwInfinity || kwNaN) {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
@@ -300,7 +297,7 @@ namespace lib {
                 }
               }
             } else {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -315,7 +312,7 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
                 }
@@ -327,7 +324,7 @@ namespace lib {
                 }
               }
             } else {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
                 }
@@ -355,12 +352,11 @@ namespace lib {
     inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity, DLong kwSign) {
       DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::ZERO);
       SizeT nEl = src->N_Elements();
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
       if (kwInfinity || kwNaN) {
         {
           if (kwInfinity) {
             if (kwSign > 0) {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
@@ -372,7 +368,7 @@ namespace lib {
                 }
               }
             } else {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -387,7 +383,7 @@ namespace lib {
           }
           if (kwNaN) {
             if (kwSign > 0) {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
                 }
@@ -399,7 +395,7 @@ namespace lib {
                 }
               }
             } else {
-              if (!parallelize) {
+              if (!parallelize( nEl)) {
                 for (SizeT i = 0; i < nEl; ++i) {
                   (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
                 }
@@ -427,8 +423,7 @@ namespace lib {
 //       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO);
 //       SizeT nEl = src->N_Elements();
 //       
-//		bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-//		if (!parallelize) {
+//		if (!parallelize( nEl)) {
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
 //	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
@@ -921,8 +916,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -932,8 +926,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1023,8 +1016,7 @@ namespace lib {
 
 
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1034,8 +1026,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1223,8 +1214,7 @@ namespace lib {
 
 
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1234,8 +1224,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
@@ -1373,8 +1362,7 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1384,8 +1372,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1487,8 +1474,7 @@ namespace lib {
 
 
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1498,8 +1484,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
@@ -1695,8 +1680,7 @@ namespace lib {
 
 
     if (doMissing) {
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-      if (!parallelize) {
+      if (!parallelize( nEl)) {
         for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       } else {
       TRACEOMP(__FILE__,__LINE__)
@@ -1706,8 +1690,7 @@ namespace lib {
     }
 
     /* Double loop on the output image  */
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
-    if (!parallelize) {
+    if (!parallelize( nEl)) {
       for (OMPInt j = 0; j < nRows; ++j) {
         for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.

--- a/src/math_fun_jmg.cpp
+++ b/src/math_fun_jmg.cpp
@@ -191,31 +191,42 @@ namespace lib {
   // slightly modified by Marc Schellens, m_schellens@users.sourceforge.net
 
   // general template
-   template< typename T, bool> struct finite_helper
-   {
-    inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity)
-    {
-     DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
-     SizeT nEl = src->N_Elements();
 
-     if (kwNaN){
-       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-       for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
-     }
-     else if (kwInfinity){
-       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-       for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
-     }
-     else{
-       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-       for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
-     }
-     return res;
+  template< typename T, bool> struct finite_helper {
+
+    inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity) {
+      DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::NOZERO);
+      SizeT nEl = src->N_Elements();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+
+      if (kwNaN) {
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isnan((*src)[ i]);
+        }
+      } else if (kwInfinity) {
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isinf((*src)[ i]);
+        }
+      } else {
+        if (!parallelize) {
+          for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
+        } else {
+          TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+            for (SizeT i = 0; i < nEl; ++i) (*res)[ i] = isfinite((*src)[ i]);
+        }
+      }
+      return res;
     }
-   };
+  };
 
    // partial specialization for GDL_COMPLEX, DCOMPLEX
    template< typename T> struct finite_helper<T, true>
@@ -224,25 +235,34 @@ namespace lib {
     {
        DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::NOZERO);
        SizeT nEl = src->N_Elements();
+    	 bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
        if (kwNaN){
-	 TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-         for ( SizeT i=0; i<nEl; ++i) 
-     	    (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
+	 if (!parallelize) {
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
+	 } else {
+   TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isnan((*src)[ i].real()) || isnan((*src)[ i].imag());
 	   }
+       }
        else if (kwInfinity){
-	 TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-         for ( SizeT i=0; i<nEl; ++i)
-           (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
+	 if (!parallelize) {
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
+	 } else {
+   TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isinf((*src)[ i].real()) || isinf((*src)[ i].imag());
 	   }
+       }
        else{
-	 TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel  for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-         for ( SizeT i=0; i<nEl; ++i)
-           (*res)[ i] = isfinite((*src)[ i].real()) && 
-                        isfinite((*src)[ i].imag());
+	 if (!parallelize) {
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
+	 } else {
+   TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel  for num_threads(CpuTPOOL_NTHREADS) 
+         for ( SizeT i=0; i<nEl; ++i) (*res)[ i] = isfinite((*src)[ i].real()) && isfinite((*src)[ i].imag());
 	   }
+       }
      return res;
     }
    };
@@ -254,103 +274,151 @@ namespace lib {
        do_it(static_cast<T*>(src), kwNaN, kwInfinity);
    };
 
-   //general signed template
-   template< typename T, bool> struct finite_helper_sign
-   {
-     inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity, DLong kwSign)
-     {
+  //general signed template
+
+  template< typename T, bool> struct finite_helper_sign {
+
+    inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity, DLong kwSign) {
 
 
-       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO); // ::ZERO is not working
-       SizeT nEl = src->N_Elements();
-	if (kwInfinity || kwNaN)
-	{
-	 {
-		if (kwInfinity) {
-			if (kwSign > 0) {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0)); 
-				}
-			} else {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					(*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0)) ; 
-				}
-			}
-		}
-		if (kwNaN) {
-			if (kwSign > 0) {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0)); 
-				}
-			} else {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0)); 
-				}
-			}
-		}
-	 }
-	 return res;
-	}
-		assert( false);
-        return NULL; //-Wreturn-type
-     }
-   };
+      DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::ZERO); // ::ZERO is not working
+      SizeT nEl = src->N_Elements();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+      if (kwInfinity || kwNaN) {
+        {
+          if (kwInfinity) {
+            if (kwSign > 0) {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) == 0));
+                }
+              }
+            } else {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isinf((*src)[ i]) && (signbit((*src)[ i]) != 0));
+                }
+              }
+            }
+          }
+          if (kwNaN) {
+            if (kwSign > 0) {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) == 0));
+                }
+              }
+            } else {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = (isnan((*src)[ i]) && (signbit((*src)[ i]) != 0));
+                }
+              }
+            }
+          }
+        }
+        return res;
+      }
+      assert(false);
+      return NULL; //-Wreturn-type
+    }
+  };
 
-   // partial specialization for GDL_COMPLEX, DCOMPLEX
-   template< typename T> struct finite_helper_sign<T, true>
-   {
-     inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity, DLong kwSign)
-     {
-       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO); 
-       SizeT nEl = src->N_Elements();
-	if (kwInfinity || kwNaN)
-	{
-	 {
-		if (kwInfinity) {
-			if (kwSign > 0) {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real())))||(isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag())))); 
-				}
-			} else {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real())))||(isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag())))); 
-				}
-			}
-		}
-		if (kwNaN) {
-			if (kwSign > 0) {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real())))||(isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag())))); 
-				}
-			} else {
-			  TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-				for ( SizeT i=0; i<nEl; ++i) {
-					 (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real())))||(isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag())))); 
-				}
-			}
-		}
-	 }
-	 return res;
-	}
-		assert( false);
-        return NULL; //-Wreturn-type
-     }
-   };
+  // partial specialization for GDL_COMPLEX, DCOMPLEX
+
+  template< typename T> struct finite_helper_sign<T, true> {
+
+    inline static BaseGDL* do_it(T* src, bool kwNaN, bool kwInfinity, DLong kwSign) {
+      DByteGDL* res = new DByteGDL(src->Dim(), BaseGDL::ZERO);
+      SizeT nEl = src->N_Elements();
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+      if (kwInfinity || kwNaN) {
+        {
+          if (kwInfinity) {
+            if (kwSign > 0) {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isinf((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
+                }
+              }
+            } else {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isinf((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isinf((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
+                }
+              }
+            }
+          }
+          if (kwNaN) {
+            if (kwSign > 0) {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isnan((*src)[ i].real()) && (!signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (!signbit((*src)[ i].imag()))));
+                }
+              }
+            } else {
+              if (!parallelize) {
+                for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
+                }
+              } else {
+                TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+                  for (SizeT i = 0; i < nEl; ++i) {
+                  (*res)[i] = ((isnan((*src)[ i].real()) && (signbit((*src)[ i].real()))) || (isnan((*src)[ i].imag()) && (signbit((*src)[ i].imag()))));
+                }
+              }
+            }
+          }
+        }
+        return res;
+      }
+      assert(false);
+      return NULL; //-Wreturn-type
+    }
+  };
 
 //   template< typename T> struct finite_helper_sign<T, true>
 //   {
@@ -359,8 +427,8 @@ namespace lib {
 //       DByteGDL* res = new DByteGDL( src->Dim(), BaseGDL::ZERO);
 //       SizeT nEl = src->N_Elements();
 //       
-//  TRACEOMP(__FILE__,__LINE__)
-// 	   #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+//		bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+//		if (!parallelize) {
 //       for ( SizeT i=0; i<nEl; ++i)
 //	  {
 //	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
@@ -368,6 +436,17 @@ namespace lib {
 //	   else if ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())!=0 && kwSign < 0) (*res)[i]=1;
 //	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())!=0 && kwSign < 0) (*res)[i]=1;	 
 //	  }
+//		} else {
+//  TRACEOMP(__FILE__,__LINE__)
+// 	   #pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) 
+//       for ( SizeT i=0; i<nEl; ++i)
+//	  {
+//	   if      ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())==0 && kwSign > 0) (*res)[i]=1;
+//	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())==0 && kwSign > 0) (*res)[i]=1;
+//	   else if ((kwInfinity && isinf((*src)[ i].real()) || kwNaN && isnan((*src)[ i].real())) && signbit((*src)[ i].real())!=0 && kwSign < 0) (*res)[i]=1;
+//	   else if ((kwInfinity && isinf((*src)[ i].imag()) || kwNaN && isnan((*src)[ i].imag())) && signbit((*src)[ i].imag())!=0 && kwSign < 0) (*res)[i]=1;	 
+//	  }
+//     }
 //     return res;
 //    } 
 //   };
@@ -842,21 +921,40 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
+          DLong px = (DLong) (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
+          DLong py = (DLong) (Q[0] + Q[1] * (DDouble) j + Q[2] * (DDouble) i);
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 0) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 0) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            res[i + j * nCols] = data[px + py * lx];
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
           DLong px = (DLong) (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
           DLong py = (DLong) (Q[0] + Q[1] * (DDouble) j + Q[2] * (DDouble) i);
@@ -925,21 +1023,93 @@ namespace lib {
 
 
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
+          DDouble x = (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
+          DLong px = (DLong) x;
+          DDouble y = (Q[0] + Q[1] * (DDouble) j + Q[2] * (DDouble) i);
+          DLong py = (DLong) y;
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 1) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 1) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            if ((px < 1) || (px > (lx - 3)) || (py < 1) || (py > (ly - 3))) res[i + j * nCols] = data[px + py * lx];
+            else {
+              DDouble cur;
+              DDouble neighbors[16];
+              DDouble rsc[8], sumrs;
+
+              // Feed the positions for the closest 16 neighbors
+              for (SizeT k = 0; k < 16; ++k) neighbors[k] = data[px + py * lx + leaps[k]];
+
+              DDouble dpx = (DDouble) px;
+              DDouble dpy = (DDouble) py;
+              // Which tabulated value index shall we use?
+              DLong tabx = (DLong) ((x - dpx) * (DDouble) (TABSPERPIX));
+              DLong taby = (DLong) ((y - dpy) * (DDouble) (TABSPERPIX));
+
+              /* Compute resampling coefficients  */
+              /* rsc[0..3] in x, rsc[4..7] in y   */
+
+              rsc[0] = kernel[TABSPERPIX + tabx];
+              rsc[1] = kernel[tabx];
+              rsc[2] = kernel[TABSPERPIX - tabx];
+              rsc[3] = kernel[2 * TABSPERPIX - tabx];
+              rsc[4] = kernel[TABSPERPIX + taby];
+              rsc[5] = kernel[taby];
+              rsc[6] = kernel[TABSPERPIX - taby];
+              rsc[7] = kernel[2 * TABSPERPIX - taby];
+
+              sumrs = (rsc[0] + rsc[1] + rsc[2] + rsc[3]) *
+                (rsc[4] + rsc[5] + rsc[6] + rsc[7]);
+
+              /* Compute interpolated pixel now   */
+              cur = rsc[4] * (rsc[0] * neighbors[0] +
+                rsc[1] * neighbors[1] +
+                rsc[2] * neighbors[2] +
+                rsc[3] * neighbors[3]) +
+                rsc[5] * (rsc[0] * neighbors[4] +
+                rsc[1] * neighbors[5] +
+                rsc[2] * neighbors[6] +
+                rsc[3] * neighbors[7]) +
+                rsc[6] * (rsc[0] * neighbors[8] +
+                rsc[1] * neighbors[9] +
+                rsc[2] * neighbors[10] +
+                rsc[3] * neighbors[11]) +
+                rsc[7] * (rsc[0] * neighbors[12] +
+                rsc[1] * neighbors[13] +
+                rsc[2] * neighbors[14] +
+                rsc[3] * neighbors[15]);
+
+              /* Affect the value to the output image */
+              res[i + j * nCols] = (cur / sumrs);
+              /* done ! */
+            }
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
           DDouble x = (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
           DLong px = (DLong) x;
@@ -1053,21 +1223,78 @@ namespace lib {
 
 
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
+          DDouble x = (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
+          DLong px = (DLong) x;
+          DDouble y = (Q[0] + Q[1] * (DDouble) j + Q[2] * (DDouble) i);
+          DLong py = (DLong) y;
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 1) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 1) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            if ((px < 1) || (px > (lx - 2)) || (py < 1) || (py > (ly - 2))) res[i + j * nCols] = data[px + py * lx];
+            else {
+              DDouble cur;
+              DDouble neighbors[9];
+              DDouble rsc[6], sumrs;
+
+              // Feed the positions for the closest 16 neighbors
+              for (SizeT k = 0; k < 9; ++k) neighbors[k] = data[px + py * lx + leaps[k]];
+
+              DDouble dpx = (DDouble) px;
+              DDouble dpy = (DDouble) py;
+              // Which tabulated value index shall we use?
+              DLong tabx = (DLong) ((x - dpx) * (DDouble) (TABSPERPIX));
+              DLong taby = (DLong) ((y - dpy) * (DDouble) (TABSPERPIX));
+
+              /* Compute resampling coefficients  */
+              /* rsc[0..3] in x, rsc[4..7] in y   */
+
+              rsc[0] = kernel[TABSPERPIX + tabx];
+              rsc[1] = kernel[tabx];
+              rsc[2] = kernel[TABSPERPIX - tabx];
+              rsc[3] = kernel[TABSPERPIX + taby];
+              rsc[4] = kernel[taby];
+              rsc[5] = kernel[TABSPERPIX - taby];
+
+              sumrs = (rsc[0] + rsc[1] + rsc[2]) *
+                (rsc[3] + rsc[4] + rsc[5]);
+
+              /* Compute interpolated pixel now   */
+              cur = rsc[3] * (rsc[0] * neighbors[0] + rsc[1] * neighbors[1] + rsc[2] * neighbors[2]) +
+                rsc[4] * (rsc[0] * neighbors[3] + rsc[1] * neighbors[4] + rsc[2] * neighbors[5]) +
+                rsc[5] * (rsc[0] * neighbors[6] + rsc[1] * neighbors[7] + rsc[2] * neighbors[8]);
+
+              /* Affect the value to the output image */
+              res[i + j * nCols] = (cur / sumrs);
+              /* done ! */
+            }
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i in P and Q definition of IDL doc.
           DDouble x = (P[0] + P[1] * (DDouble) j + P[2] * (DDouble) i);
           DLong px = (DLong) x;
@@ -1146,21 +1373,42 @@ namespace lib {
     T2* res = (T2*) res_->DataAddr();
     T2* data = (T2*) data_->DataAddr();
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i.
+          DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
+          DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
+          DLong px = (DLong) x;
+          DLong py = (DLong) y;
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 0) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 0) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            res[i + j * nCols] = data[px + py * lx];
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
           DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
           DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
@@ -1239,21 +1487,93 @@ namespace lib {
 
 
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i.
+          DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
+          DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
+          DLong px = (DLong) x;
+          DLong py = (DLong) y;
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 1) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 1) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            if ((px < 1) || (px > (lx - 3)) || (py < 1) || (py > (ly - 3))) res[i + j * nCols] = data[px + py * lx];
+            else {
+              DDouble cur;
+              DDouble neighbors[16];
+              DDouble rsc[8], sumrs;
+
+              // Feed the positions for the closest 16 neighbors
+              for (SizeT k = 0; k < 16; ++k) neighbors[k] = data[px + py * lx + leaps[k]];
+
+              DDouble dpx = (DDouble) px;
+              DDouble dpy = (DDouble) py;
+              // Which tabulated value index shall we use?
+              DLong tabx = (DLong) ((x - dpx) * (DDouble) (TABSPERPIX));
+              DLong taby = (DLong) ((y - dpy) * (DDouble) (TABSPERPIX));
+
+              /* Compute resampling coefficients  */
+              /* rsc[0..3] in x, rsc[4..7] in y   */
+
+              rsc[0] = kernel[TABSPERPIX + tabx];
+              rsc[1] = kernel[tabx];
+              rsc[2] = kernel[TABSPERPIX - tabx];
+              rsc[3] = kernel[2 * TABSPERPIX - tabx];
+              rsc[4] = kernel[TABSPERPIX + taby];
+              rsc[5] = kernel[taby];
+              rsc[6] = kernel[TABSPERPIX - taby];
+              rsc[7] = kernel[2 * TABSPERPIX - taby];
+
+              sumrs = (rsc[0] + rsc[1] + rsc[2] + rsc[3]) *
+                (rsc[4] + rsc[5] + rsc[6] + rsc[7]);
+
+              /* Compute interpolated pixel now   */
+              cur = rsc[4] * (rsc[0] * neighbors[0] +
+                rsc[1] * neighbors[1] +
+                rsc[2] * neighbors[2] +
+                rsc[3] * neighbors[3]) +
+                rsc[5] * (rsc[0] * neighbors[4] +
+                rsc[1] * neighbors[5] +
+                rsc[2] * neighbors[6] +
+                rsc[3] * neighbors[7]) +
+                rsc[6] * (rsc[0] * neighbors[8] +
+                rsc[1] * neighbors[9] +
+                rsc[2] * neighbors[10] +
+                rsc[3] * neighbors[11]) +
+                rsc[7] * (rsc[0] * neighbors[12] +
+                rsc[1] * neighbors[13] +
+                rsc[2] * neighbors[14] +
+                rsc[3] * neighbors[15]);
+
+              /* Affect the value to the output image */
+              res[i + j * nCols] = (cur / sumrs);
+              /* done ! */
+            }
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
           DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
           DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
@@ -1375,21 +1695,78 @@ namespace lib {
 
 
     if (doMissing) {
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+      if (!parallelize) {
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+      } else {
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-        for (DLong i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nCols * nRows; ++i) res[i] = initvalue;
       }
     }
 
     /* Double loop on the output image  */
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 &&  (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl)));
+    if (!parallelize) {
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
+          // Compute the original source for this pixel, note order of j and i.
+          DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
+          DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
+          DLong px = (DLong) x;
+          DLong py = (DLong) y;
+          if (doMissing && ((px < 0) || (px > (lx - 1)) || (py < 0) || (py > (ly - 1)))) {
+            continue; // already initialised to 'missing' value.
+          } else {
+            if (px < 1) px = 0;
+            if (px > (lx - 1)) px = (lx - 1);
+            if (py < 1) py = 0;
+            if (py > (ly - 1)) py = (ly - 1);
+            if ((px < 1) || (px > (lx - 2)) || (py < 1) || (py > (ly - 2))) res[i + j * nCols] = data[px + py * lx];
+            else {
+              DDouble cur;
+              DDouble neighbors[9];
+              DDouble rsc[6], sumrs;
+
+              // Feed the positions for the closest 16 neighbors
+              for (SizeT k = 0; k < 9; ++k) neighbors[k] = data[px + py * lx + leaps[k]];
+
+              DDouble dpx = (DDouble) px;
+              DDouble dpy = (DDouble) py;
+              // Which tabulated value index shall we use?
+              DLong tabx = (DLong) ((x - dpx) * (DDouble) (TABSPERPIX));
+              DLong taby = (DLong) ((y - dpy) * (DDouble) (TABSPERPIX));
+
+              /* Compute resampling coefficients  */
+              /* rsc[0..3] in x, rsc[4..7] in y   */
+
+              rsc[0] = kernel[TABSPERPIX + tabx];
+              rsc[1] = kernel[tabx];
+              rsc[2] = kernel[TABSPERPIX - tabx];
+              rsc[3] = kernel[TABSPERPIX + taby];
+              rsc[4] = kernel[taby];
+              rsc[5] = kernel[TABSPERPIX - taby];
+
+              sumrs = (rsc[0] + rsc[1] + rsc[2]) *
+                (rsc[3] + rsc[4] + rsc[5]);
+
+              /* Compute interpolated pixel now   */
+              cur = rsc[3] * (rsc[0] * neighbors[0] + rsc[1] * neighbors[1] + rsc[2] * neighbors[2]) +
+                rsc[4] * (rsc[0] * neighbors[3] + rsc[1] * neighbors[4] + rsc[2] * neighbors[5]) +
+                rsc[5] * (rsc[0] * neighbors[6] + rsc[1] * neighbors[7] + rsc[2] * neighbors[8]);
+
+              /* Affect the value to the output image */
+              res[i + j * nCols] = (cur / sumrs);
+              /* done ! */
+            }
+          }
+        }
+      }
+    } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for collapse(2)
-      for (DLong j = 0; j < nRows; ++j) {
-        for (DLong i = 0; i < nCols; ++i) {
+#pragma omp parallel for collapse(2) num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt j = 0; j < nRows; ++j) {
+        for (OMPInt i = 0; i < nCols; ++i) {
           // Compute the original source for this pixel, note order of j and i.
           DDouble x = poly2d_compute(poly_u, (DDouble) j, (DDouble) i);
           DDouble y = poly2d_compute(poly_v, (DDouble) j, (DDouble) i);
@@ -1462,6 +1839,8 @@ namespace lib {
     N. Devillard, "The eclipse software", The messenger No 87 - March 1997 http://www.eso.org/projects/aot/eclipse/
      */
 
+    // GD: POLY_2D IS 5 times slower that IDL's. TBC . I note that the loops contains a lot of 'ifs', so algorithm is not efficient.
+    
     SizeT nParam = e->NParam();
     if (nParam < 3)
       e->Throw("Incorrect number of arguments.");

--- a/src/medianfilter.cpp
+++ b/src/medianfilter.cpp
@@ -488,7 +488,8 @@ void median_filter_impl_2d(int x, int y, int hx, int hy, int b, const T* in, T* 
     }
     Dim dimx(b, x, hx);
     Dim dimy(b, y, hy);
-    #pragma omp parallel
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel
     {
         MedCalc2D<T> mc(b, dimx, dimy, in, out);
         #pragma omp for collapse(2)
@@ -507,7 +508,8 @@ void median_filter_impl_1d(int x, int hx, int b, const T* in, T* out) {
         throw std::invalid_argument("window too large for this block size");
     }
     Dim dimx(b, x, hx);
-    #pragma omp parallel
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel
     {
         MedCalc1D<T> mc(b, dimx, in, out);
         #pragma omp for

--- a/src/medianfilter.cpp
+++ b/src/medianfilter.cpp
@@ -489,7 +489,7 @@ void median_filter_impl_2d(int x, int y, int hx, int hy, int b, const T* in, T* 
     Dim dimx(b, x, hx);
     Dim dimy(b, y, hy);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
     {
         MedCalc2D<T> mc(b, dimx, dimy, in, out);
         #pragma omp for collapse(2)
@@ -509,7 +509,7 @@ void median_filter_impl_1d(int x, int hx, int b, const T* in, T* out) {
     }
     Dim dimx(b, x, hx);
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel
+#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
     {
         MedCalc1D<T> mc(b, dimx, in, out);
         #pragma omp for

--- a/src/medianfilter.cpp
+++ b/src/medianfilter.cpp
@@ -488,15 +488,10 @@ void median_filter_impl_2d(int x, int y, int hx, int hy, int b, const T* in, T* 
     }
     Dim dimx(b, x, hx);
     Dim dimy(b, y, hy);
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
-    {
-        MedCalc2D<T> mc(b, dimx, dimy, in, out);
-        #pragma omp for collapse(2)
-        for (int by = 0; by < dimy.count; ++by) {
-            for (int bx = 0; bx < dimx.count; ++bx) {
-                mc.run(bx, by);
-            }
+    MedCalc2D<T> mc(b, dimx, dimy, in, out);
+    for (int by = 0; by < dimy.count; ++by) {
+        for (int bx = 0; bx < dimx.count; ++bx) {
+            mc.run(bx, by);
         }
     }
 }
@@ -508,14 +503,9 @@ void median_filter_impl_1d(int x, int hx, int b, const T* in, T* out) {
         throw std::invalid_argument("window too large for this block size");
     }
     Dim dimx(b, x, hx);
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
-    {
-        MedCalc1D<T> mc(b, dimx, in, out);
-        #pragma omp for
-        for (int bx = 0; bx < dimx.count; ++bx) {
-            mc.run(bx);
-        }
+    MedCalc1D<T> mc(b, dimx, in, out);
+    for (int bx = 0; bx < dimx.count; ++bx) {
+        mc.run(bx);
     }
 }
 

--- a/src/minmax_include.cpp
+++ b/src/minmax_include.cpp
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-// for all variants of MinMax(), to be included from datatypes.cpp
+// for all variants of MinMax(), to be included from datatypes_minmax.cpp
 
   // default: start = 0, stop = 0, step = 1, valIx = -1
   if (stop == 0) stop = dd.size();
@@ -44,7 +44,8 @@
   
 
   SizeT nElem = (stop - start) / step;
-//trap existence of ABSFUNC and create something that stands cppchekck useage (needed by contiunous integration scripts!) 
+  GDL_NTHREADS=parallelize( nElem);
+  //trap existence of ABSFUNC and create something that stands cppchekck useage (needed by contiunous integration scripts!) 
 #ifndef ABSFUNC
 #define FUNCABS
   useAbs=false;
@@ -84,8 +85,7 @@
     DLong maxEl = start;
     Ty maxV = (*this)[maxEl];
 
-    if (nElem < CpuTPOOL_MIN_ELTS || nElem < CpuTPOOL_NTHREADS || CpuTPOOL_NTHREADS == 1)
-    {
+    if (GDL_NTHREADS==1) {
       if (!useAbs)
       {
         for (SizeT i = start+step ; i < stop; i += step) {
@@ -104,21 +104,21 @@
 #endif
     } else
     {
-      Ty* maxVArray= new Ty[CpuTPOOL_NTHREADS];
-      SizeT maxElArray[CpuTPOOL_NTHREADS];
+      Ty* maxVArray= new Ty[GDL_NTHREADS];
+      SizeT maxElArray[GDL_NTHREADS];
 //precaution:initialize to something realistic:
-      for (int i = 0; i < CpuTPOOL_NTHREADS; ++i) {maxVArray[i]=maxV;maxElArray[i]=maxEl;}
+      for (int i = 0; i < GDL_NTHREADS; ++i) {maxVArray[i]=maxV;maxElArray[i]=maxEl;}
 
-      SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
+      SizeT chunksize = nElem / (GDL_NTHREADS);
       if (!useAbs)
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -140,12 +140,12 @@
       else
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -169,7 +169,7 @@
 #ifdef ABSFUNC
       if (useAbs)
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) if (FUNCABS(maxVArray[i]) > FUNCABS(maxV))
+        for (int i = 1; i < GDL_NTHREADS; ++i) if (FUNCABS(maxVArray[i]) > FUNCABS(maxV))
           {
             maxV = maxVArray[i];
             maxEl = maxElArray[i];
@@ -178,7 +178,7 @@
       else
 #endif      
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) if (REAL_PART(maxVArray[i]) > REAL_PART(maxV))
+        for (int i = 1; i < GDL_NTHREADS; ++i) if (REAL_PART(maxVArray[i]) > REAL_PART(maxV))
           {
             maxV = maxVArray[i];
             maxEl = maxElArray[i];
@@ -199,8 +199,7 @@
     DLong minEl = start;
     Ty minV = (*this)[minEl];
 
-    if (nElem < CpuTPOOL_MIN_ELTS || nElem < CpuTPOOL_NTHREADS || CpuTPOOL_NTHREADS == 1)
-    {
+    if (GDL_NTHREADS==1) {
       if (!useAbs)
       {
         for (SizeT i = start+step; i < stop; i += step) {
@@ -219,21 +218,21 @@
 #endif
     } else
     {
-      Ty* minVArray=new Ty[CpuTPOOL_NTHREADS];
-      SizeT minElArray[CpuTPOOL_NTHREADS];
+      Ty* minVArray=new Ty[GDL_NTHREADS];
+      SizeT minElArray[GDL_NTHREADS];
 //precaution:initialize to something realistic:
-      for (int i = 0; i < CpuTPOOL_NTHREADS; ++i) {minVArray[i]=minV;minElArray[i]=minEl;}
+      for (int i = 0; i < GDL_NTHREADS; ++i) {minVArray[i]=minV;minElArray[i]=minEl;}
       
-      SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
+      SizeT chunksize = nElem / (GDL_NTHREADS);
       if (!useAbs)
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -255,12 +254,12 @@
       else
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -284,7 +283,7 @@
 #ifdef ABSFUNC
       if (useAbs)
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) if (FUNCABS(minVArray[i]) < FUNCABS(minV))
+        for (int i = 1; i < GDL_NTHREADS; ++i) if (FUNCABS(minVArray[i]) < FUNCABS(minV))
           {
             minV = minVArray[i];
             minEl = minElArray[i];
@@ -293,7 +292,7 @@
       else
 #endif
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) if (REAL_PART(minVArray[i]) < REAL_PART(minV))
+        for (int i = 1; i < GDL_NTHREADS; ++i) if (REAL_PART(minVArray[i]) < REAL_PART(minV))
           {
             minV = minVArray[i];
             minEl = minElArray[i];
@@ -317,8 +316,7 @@
     DLong maxEl = start;
     Ty maxV = (*this)[maxEl];
 
-    if (nElem < CpuTPOOL_MIN_ELTS || nElem < CpuTPOOL_NTHREADS || CpuTPOOL_NTHREADS == 1)
-    {
+    if (GDL_NTHREADS==1) {
       if (!useAbs)
       {
         for (SizeT i = start+step; i < stop; i += step) {
@@ -340,24 +338,24 @@
     } else
     {
 
-      Ty* maxVArray=new Ty[CpuTPOOL_NTHREADS];
-      SizeT maxElArray[CpuTPOOL_NTHREADS];
-      Ty* minVArray=new Ty[CpuTPOOL_NTHREADS];
-      SizeT minElArray[CpuTPOOL_NTHREADS];
+      Ty* maxVArray=new Ty[GDL_NTHREADS];
+      SizeT maxElArray[GDL_NTHREADS];
+      Ty* minVArray=new Ty[GDL_NTHREADS];
+      SizeT minElArray[GDL_NTHREADS];
 //precaution:initialize to something realistic:
-      for (int i = 0; i < CpuTPOOL_NTHREADS; ++i) {maxVArray[i]=maxV;maxElArray[i]=maxEl;}
-      for (int i = 0; i < CpuTPOOL_NTHREADS; ++i) {minVArray[i]=minV;minElArray[i]=minEl;}
+      for (int i = 0; i < GDL_NTHREADS; ++i) {maxVArray[i]=maxV;maxElArray[i]=maxEl;}
+      for (int i = 0; i < GDL_NTHREADS; ++i) {minVArray[i]=minV;minElArray[i]=minEl;}
       
-      SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
+      SizeT chunksize = nElem / (GDL_NTHREADS);
       if (!useAbs)
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -383,12 +381,12 @@
       else
       {
 	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel num_threads(GDL_NTHREADS)
         {
           int thread_id = MINMAX_THREAD_NUM;
           SizeT start_index, stop_index;
           start_index = start + thread_id * chunksize*step;
-          if (thread_id != (CpuTPOOL_NTHREADS - 1))
+          if (thread_id != (GDL_NTHREADS - 1))
           {
             stop_index = start_index + chunksize*step;
           } else
@@ -418,7 +416,7 @@
 #ifdef ABSFUNC
       if (useAbs)
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) {
+        for (int i = 1; i < GDL_NTHREADS; ++i) {
           if (FUNCABS(minVArray[i]) < FUNCABS(minV)) {
             minV = minVArray[i];
             minEl = minElArray[i];
@@ -432,7 +430,7 @@
       else
 #endif
       {
-        for (int i = 1; i < CpuTPOOL_NTHREADS; ++i) {
+        for (int i = 1; i < GDL_NTHREADS; ++i) {
           if (REAL_PART(minVArray[i]) < REAL_PART(minV)) {
             minV = minVArray[i];
             minEl = minElArray[i];

--- a/src/minmax_include.cpp
+++ b/src/minmax_include.cpp
@@ -112,6 +112,7 @@
       SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
       if (!useAbs)
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;
@@ -138,6 +139,7 @@
 #ifdef ABSFUNC
       else
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;
@@ -225,6 +227,7 @@
       SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
       if (!useAbs)
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;
@@ -251,6 +254,7 @@
 #ifdef ABSFUNC
       else
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;
@@ -347,6 +351,7 @@
       SizeT chunksize = nElem / (CpuTPOOL_NTHREADS);
       if (!useAbs)
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;
@@ -377,6 +382,7 @@
 #ifdef ABSFUNC
       else
       {
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(CpuTPOOL_NTHREADS) if (CpuTPOOL_NTHREADS > 1)
         {
           int thread_id = MINMAX_THREAD_NUM;

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -87,11 +87,10 @@ namespace structDesc {
   DStructDesc* IDLFFXMLSAX = NULL;
 }
 
-// for OpenMP
+//// for OpenMP
 DLong CpuTPOOL_NTHREADS;
 DLong64 CpuTPOOL_MIN_ELTS;
 DLong64 CpuTPOOL_MAX_ELTS;
-//const DULong64 CpuTPOOL_MAX_ELTS_max = numeric_limits<DLong64>::max();
 
 // instantiate own AST factory
 //_DNodeFactory DNodeFactory;

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -57,9 +57,11 @@ extern GDLFileListT  fileUnits;
 // for OpenMP
 const SizeT DefaultTPOOL_MIN_ELTS = 100000;
 const SizeT DefaultTPOOL_MAX_ELTS = 0;
-extern DLong CpuTPOOL_NTHREADS;
-extern DLong64 CpuTPOOL_MIN_ELTS;
-extern DLong64 CpuTPOOL_MAX_ELTS;
+
+//defined as extern in typedefs.hpp, which is 'seen' by all code
+//extern DLong CpuTPOOL_NTHREADS;
+//extern DLong64 CpuTPOOL_MIN_ELTS;
+//extern DLong64 CpuTPOOL_MAX_ELTS;
 
 //extern DeviceListT   deviceList;
 //extern Graphics*     actDevice;

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -113,7 +113,6 @@ bool IsRelaxed(); //tells if syntax is not strict (i.e. parenthesis for array in
 void SetStrict(bool value);
 
 bool BigEndian();
-
 int get_suggested_omp_num_threads();
 int currentNumberOfThreads();
 int currentThreadNumber();

--- a/src/otherdevices/gdlxstream.cpp
+++ b/src/otherdevices/gdlxstream.cpp
@@ -730,14 +730,6 @@ bool GDLXStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *pos
   XColor curcolor;
   curcolor = xwd->fgcolor; //default
   PLINT iclr1, ired, igrn, iblu;
-  // parallelize does not work when using XGet[Put]Pixel in the loop below, otherwise would be OK!
-  // please allow parallelization only after removing this problem ;^)
-  //#ifdef _OPENMP
-  //  SizeT nOp = kxLimit * kyLimit;
-  //#endif
-  //  #pragma omp parallel if (nOp >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nOp)) private(ired,igrn,iblu,kx,ky,iclr1,curcolor)
-  //  {
-  //  #pragma omp for
   for (ix = 0; ix < xmax; ++ix) {
     for (iy = 0; iy < ymax; ++iy) {
 
@@ -796,7 +788,6 @@ bool GDLXStream::PaintImage(unsigned char *idata, PLINT nx, PLINT ny, DLong *pos
       XPutPixel(ximg, ix, ymax-1-iy, curcolor.pixel); //ximg IS reversed allways.
     }
   }
-  //  } //end parallelize 
   if (dev->write_to_pixmap == 1)
     XPutImage(xwd->display, dev->pixmap, dev->gc, ximg, 0, 0,
     xoff, dev->height-yoff-ymax, xmax, ymax);

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -36,79 +36,77 @@
 
 using namespace std;
 
-std::string overloadOperatorNames[] = 
-{
+std::string overloadOperatorNames[] ={
   "_OVERLOADBRACKETSLEFTSIDE"
-, "_OVERLOADBRACKETSRIGHTSIDE" 
-, "_OVERLOADMINUSUNARY"
-, "_OVERLOADNOT"
-, "_OVERLOADTILDE" 
-, "_OVERLOADPLUS"
-, "_OVERLOADMINUS" 
-, "_OVERLOADASTERISK" 
-, "_OVERLOADSLASH" 
-, "_OVERLOADCARET" 
-, "_OVERLOADMOD" 
-, "_OVERLOADLESSTHAN" 
-, "_OVERLOADGREATERTHAN" 
-, "_OVERLOADAND"
-, "_OVERLOADOR"
-, "_OVERLOADXOR" 
-, "_OVERLOADEQ"
-, "_OVERLOADNE"
-, "_OVERLOADGE"
-, "_OVERLOADGT"
-, "_OVERLOADLE"
-, "_OVERLOADLT"
-, "_OVERLOADPOUND" 
-, "_OVERLOADPOUNDPOUND" 
-, "_OVERLOADISTRUE"
-, "_OVERLOADFOREACH"
-, "_OVERLOADHELP"
-, "_OVERLOADPRINT"
-, "_OVERLOADSIZE"
+  , "_OVERLOADBRACKETSRIGHTSIDE"
+  , "_OVERLOADMINUSUNARY"
+  , "_OVERLOADNOT"
+  , "_OVERLOADTILDE"
+  , "_OVERLOADPLUS"
+  , "_OVERLOADMINUS"
+  , "_OVERLOADASTERISK"
+  , "_OVERLOADSLASH"
+  , "_OVERLOADCARET"
+  , "_OVERLOADMOD"
+  , "_OVERLOADLESSTHAN"
+  , "_OVERLOADGREATERTHAN"
+  , "_OVERLOADAND"
+  , "_OVERLOADOR"
+  , "_OVERLOADXOR"
+  , "_OVERLOADEQ"
+  , "_OVERLOADNE"
+  , "_OVERLOADGE"
+  , "_OVERLOADGT"
+  , "_OVERLOADLE"
+  , "_OVERLOADLT"
+  , "_OVERLOADPOUND"
+  , "_OVERLOADPOUNDPOUND"
+  , "_OVERLOADISTRUE"
+  , "_OVERLOADFOREACH"
+  , "_OVERLOADHELP"
+  , "_OVERLOADPRINT"
+  , "_OVERLOADSIZE"
 };
 
 // except _OVERLOADBRACKETSLEFTSIDE all are functions
-int OverloadOperatorIndexFun( std::string subName)
-{
-  assert( !subName.empty());
-  if( subName[0] != '_') // optimization, true in most cases
+
+int OverloadOperatorIndexFun(std::string subName) {
+  assert(!subName.empty());
+  if (subName[0] != '_') // optimization, true in most cases
     return -1;
-  for( int i=1; i < NumberOfOverloadOperators; ++i)
-    if( subName == overloadOperatorNames[ i])
+  for (int i = 1; i < NumberOfOverloadOperators; ++i)
+    if (subName == overloadOperatorNames[ i])
       return i;
   return -1;
 }
-int OverloadOperatorIndexPro( std::string subName)
-{
-  if( subName == overloadOperatorNames[ 0])
+
+int OverloadOperatorIndexPro(std::string subName) {
+  if (subName == overloadOperatorNames[ 0])
     return 0;
   else return -1;
 }
 
 // for proper error reporting we need to unwind the stack
-void ThrowFromInternalUDSub( EnvUDT* e, const string& s)
-  {
-    ProgNodeP callingNode = e->CallingNode();
-    string objectName =e->GetPro()->ObjectName();
-    delete e;
-    GDLException::Interpreter()->CallStack().pop_back();
-    throw GDLException( callingNode, objectName+" (internal): " + s, false, false);
-  }
 
-BaseGDL* _GDL_OBJECT_OverloadIsTrue( EnvUDT* e)
-{
-// default behavior: Implict: Another object cannot be the null object
+void ThrowFromInternalUDSub(EnvUDT* e, const string& s) {
+  ProgNodeP callingNode = e->CallingNode();
+  string objectName = e->GetPro()->ObjectName();
+  delete e;
+  GDLException::Interpreter()->CallStack().pop_back();
+  throw GDLException(callingNode, objectName + " (internal): " + s, false, false);
+}
+
+BaseGDL* _GDL_OBJECT_OverloadIsTrue(EnvUDT* e) {
+  // default behavior: Implict: Another object cannot be the null object
   return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
 }
-BaseGDL* _GDL_OBJECT_Init( EnvUDT* e)
-{     
-//  std::cout << " gdl_OBJECT_Init!" << std::endl;
-    return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
+
+BaseGDL* _GDL_OBJECT_Init(EnvUDT* e) {
+  //  std::cout << " gdl_OBJECT_Init!" << std::endl;
+  return new DIntGDL(1); // if we reach here, defaul is to return 'TRUE'
 }
-void _GDL_OBJECT_OverloadBracketsLeftSide( EnvUDT* e)
-{
+
+void _GDL_OBJECT_OverloadBracketsLeftSide(EnvUDT* e) {
   //   // debug/check
   //   std::cout << "_GDL_OBJECT_OverloadBracketsLeftSide called" << std::endl;
 
@@ -116,828 +114,812 @@ void _GDL_OBJECT_OverloadBracketsLeftSide( EnvUDT* e)
   // IDL's default behavior is to just replace SELF (via OBJREF) by RVALUE
   // no index checking is done.
   SizeT nParam = e->NParam();
-  if( nParam < 3) // consider implicit SELF
+  if (nParam < 3) // consider implicit SELF
     return; // RVALUE not given -> ignore
 
-//  BaseGDL** objRef = e->GetKW(1);
-//  BaseGDL** objRefP = e->GetPtrTo( objRef);
-  if( !e->GlobalKW(1))
-  {
-    ThrowFromInternalUDSub( e, "Parameter 1 (OBJREF) must be a passed as reference in this context.");
+  //  BaseGDL** objRef = e->GetKW(1);
+  //  BaseGDL** objRefP = e->GetPtrTo( objRef);
+  if (!e->GlobalKW(1)) {
+    ThrowFromInternalUDSub(e, "Parameter 1 (OBJREF) must be a passed as reference in this context.");
   }
   BaseGDL** objRefP = &e->GetTheKW(1); //OK global KW tested above
   BaseGDL* objRef = *objRefP;
 
   BaseGDL* rValue = e->GetKW(2);
-  if( rValue == NULL)
-  {
-    ThrowFromInternalUDSub( e, "Parameter 2 (RVALUE) is undefined.");
+  if (rValue == NULL) {
+    ThrowFromInternalUDSub(e, "Parameter 2 (RVALUE) is undefined.");
   }
-  if( rValue->Type() != GDL_OBJ)
-  {
-    ThrowFromInternalUDSub( e, "Parameter 2 (RVALUE) must be an OBJECT in this context.");
+  if (rValue->Type() != GDL_OBJ) {
+    ThrowFromInternalUDSub(e, "Parameter 2 (RVALUE) must be an OBJECT in this context.");
   }
-  
-  GDLDelete( *objRefP);
+
+  GDLDelete(*objRefP);
   *objRefP = rValue->Dup();
 }
 
-
-BaseGDL* _GDL_OBJECT_OverloadBracketsRightSide( EnvUDT* e)
-{
-//   // debug/check
-//   std::cout << "_GDL_OBJECT_OverloadBracketsRightSide called" << std::endl;
+BaseGDL* _GDL_OBJECT_OverloadBracketsRightSide(EnvUDT* e) {
+  //   // debug/check
+  //   std::cout << "_GDL_OBJECT_OverloadBracketsRightSide called" << std::endl;
 
   SizeT nParam = e->NParam(); // number of parameters actually given
-//   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
-  if( nParam < 3) // consider implicit SELF
-    ThrowFromInternalUDSub( e, "At least 2 parameters are needed: ISRANGE, SUB1 [, ...].");
+  //   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
+  if (nParam < 3) // consider implicit SELF
+    ThrowFromInternalUDSub(e, "At least 2 parameters are needed: ISRANGE, SUB1 [, ...].");
 
   // default behavior: Exact like scalar indexing
   BaseGDL* isRange = e->GetKW(1);
-  if( isRange == NULL)
-    ThrowFromInternalUDSub( e, "Parameter 1 (ISRANGE) is undefined.");
-  if( isRange->Rank() == 0)
-    ThrowFromInternalUDSub( e, "Parameter 1 (ISRANGE) must be an array in this context: " + e->Caller()->GetString(e->GetTheKW(1)));
+  if (isRange == NULL)
+    ThrowFromInternalUDSub(e, "Parameter 1 (ISRANGE) is undefined.");
+  if (isRange->Rank() == 0)
+    ThrowFromInternalUDSub(e, "Parameter 1 (ISRANGE) must be an array in this context: " + e->Caller()->GetString(e->GetTheKW(1)));
   SizeT nIsRange = isRange->N_Elements();
-  if( nIsRange > (nParam - 2)) //- SELF and ISRANGE
-    ThrowFromInternalUDSub( e, "Parameter 1 (ISRANGE) must have "+i2s(nParam-2)+" elements.");
+  if (nIsRange > (nParam - 2)) //- SELF and ISRANGE
+    ThrowFromInternalUDSub(e, "Parameter 1 (ISRANGE) must have " + i2s(nParam - 2) + " elements.");
   Guard<DLongGDL> isRangeLongGuard;
   DLongGDL* isRangeLong;
-  if( isRange->Type() == GDL_LONG)
-    isRangeLong = static_cast<DLongGDL*>( isRange);
-  else  {
-    try{
-      isRangeLong = static_cast<DLongGDL*>( isRange->Convert2( GDL_LONG, BaseGDL::COPY));
+  if (isRange->Type() == GDL_LONG)
+    isRangeLong = static_cast<DLongGDL*> (isRange);
+  else {
+    try {
+      isRangeLong = static_cast<DLongGDL*> (isRange->Convert2(GDL_LONG, BaseGDL::COPY));
+    } catch (GDLException& ex) {
+      ThrowFromInternalUDSub(e, ex.ANTLRException::getMessage());
     }
-        catch( GDLException& ex) {
-      ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-    }
-    isRangeLongGuard.Reset( isRangeLong);
+    isRangeLongGuard.Reset(isRangeLong);
   }
 
   ArrayIndexVectorT ixList;
-//   IxExprListT exprList;
+  //   IxExprListT exprList;
   try {
-    for( int p=0; p<nIsRange; ++p)
-    {
-      BaseGDL* parX = e->GetKW( p + 2); // implicit SELF, ISRANGE, par1..par8
-      if( parX == NULL)
-            ThrowFromInternalUDSub( e,
-             "Parameter is undefined: "  + e->Caller()->GetString(e->GetTheKW( p + 2)));
+    for (int p = 0; p < nIsRange; ++p) {
+      BaseGDL* parX = e->GetKW(p + 2); // implicit SELF, ISRANGE, par1..par8
+      if (parX == NULL)
+        ThrowFromInternalUDSub(e,
+        "Parameter is undefined: " + e->Caller()->GetString(e->GetTheKW(p + 2)));
       DLong isRangeX = (*isRangeLong)[p];
-      if( isRangeX != 0 && isRangeX != 1)
-            ThrowFromInternalUDSub( e,
-             "Value of parameter 1 (ISRANGE["+i2s(p)+"]) is out of allowed range.");
-      if( isRangeX == 1)
+      if (isRangeX != 0 && isRangeX != 1)
+        ThrowFromInternalUDSub(e,
+        "Value of parameter 1 (ISRANGE[" + i2s(p) + "]) is out of allowed range.");
+      if (isRangeX == 1) {
+        if (parX->N_Elements() != 3)
+          ThrowFromInternalUDSub(e, "Range vector must have 3 elements: " +
+          e->Caller()->GetString(e->GetTheKW(p + 2)));
+        Guard<DLongGDL> parXLongGuard;
+        DLongGDL* parXLong;
+        if (parX->Type() == GDL_LONG)
+          parXLong = static_cast<DLongGDL*> (parX);
+        else {
+          try {
+            parXLong = static_cast<DLongGDL*> (parX->Convert2(GDL_LONG, BaseGDL::COPY));
+          } catch (GDLException& ex) {
+            ThrowFromInternalUDSub(e, ex.ANTLRException::getMessage());
+          }
+          parXLongGuard.Reset(parXLong);
+        }
+        // negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
+        ixList.push_back(new CArrayIndexRangeS((*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
+      } else // non-range
       {
-    if( parX->N_Elements() != 3)
-            ThrowFromInternalUDSub( e, "Range vector must have 3 elements: " +
-                            e->Caller()->GetString(e->GetTheKW( p + 2)));
-    Guard<DLongGDL> parXLongGuard;
-    DLongGDL* parXLong;
-          if( parX->Type() == GDL_LONG)
-            parXLong = static_cast<DLongGDL*>( parX);
-          else  {
-      try{
-        parXLong = static_cast<DLongGDL*>( parX->Convert2( GDL_LONG, BaseGDL::COPY));
-      }
-                catch( GDLException& ex) {
-        ThrowFromInternalUDSub( e, ex.ANTLRException::getMessage());
-      }
-            parXLongGuard.Reset( parXLong);
-    }
-    // negative end ix is fine -> CArrayIndexRangeS can handle [b:*:s] ([b,-1,s])
-    ixList.push_back(new CArrayIndexRangeS( (*parXLong)[0], (*parXLong)[1], (*parXLong)[2]));
-      }
-      else // non-range
-      {
-    // ATTENTION: These two grab c1 (all others don't)
-    // a bit unclean, but for maximum efficiency
-    if( parX->Rank() == 0)
-      ixList.push_back( new CArrayIndexScalar( parX->Dup()));
-    else
-      ixList.push_back( new CArrayIndexIndexed( parX->Dup()));
+        // ATTENTION: These two grab c1 (all others don't)
+        // a bit unclean, but for maximum efficiency
+        if (parX->Rank() == 0)
+          ixList.push_back(new CArrayIndexScalar(parX->Dup()));
+        else
+          ixList.push_back(new CArrayIndexIndexed(parX->Dup()));
       }
     } // for
-  }
-  catch( GDLException& ex)
-  {
+  }  catch (GDLException& ex) {
     ixList.Destruct(); // ixList is not valid afterwards, but as we throw this is ok
     throw ex;
   }
-  
+
   ArrayIndexListT* aL;
-  MakeArrayIndex( &ixList, &aL, NULL); // important to get the non-NoAssoc ArrayIndexListT
+  MakeArrayIndex(&ixList, &aL, NULL); // important to get the non-NoAssoc ArrayIndexListT
   // because only they clean up ixList on destruction
-  Guard< ArrayIndexListT> aLGuard( aL);
+  Guard< ArrayIndexListT> aLGuard(aL);
 
   IxExprListT ixL;
-  return aL->Index( e->GetTheKW( 0), ixL); // index SELF
+  return aL->Index(e->GetTheKW(0), ixL); // index SELF
 }
 
-BaseGDL* _GDL_OBJECT_OverloadEQOp( EnvUDT* e)
-{
+BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
   SizeT nParam = e->NParam(); // number of parameters actually given
-//   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
-  if( nParam < 2) // consider implicit SELF
-    ThrowFromInternalUDSub( e, "2 parameters are needed: LEFT, RIGHT.");
+  //   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
+  if (nParam < 2) // consider implicit SELF
+    ThrowFromInternalUDSub(e, "2 parameters are needed: LEFT, RIGHT.");
 
   // default behavior: Exact like scalar indexing
   BaseGDL* l = e->GetKW(1);
-  if( l->Type() != GDL_OBJ)
-    ThrowFromInternalUDSub( e, "Unable to convert parameter #1 to type object reference.");
+  if (l->Type() != GDL_OBJ)
+    ThrowFromInternalUDSub(e, "Unable to convert parameter #1 to type object reference.");
 
   BaseGDL* r = e->GetKW(2);
-  if( r->Type() != GDL_OBJ)
-    ThrowFromInternalUDSub( e, "Unable to convert parameter #2 to type object reference.");
-  
-  DObjGDL* left = static_cast<DObjGDL*>(l);
-  DObjGDL* right = static_cast<DObjGDL*>(r);
-  
-  ULong rEl=right->N_Elements();
-  ULong nEl=left->N_Elements();
+  if (r->Type() != GDL_OBJ)
+    ThrowFromInternalUDSub(e, "Unable to convert parameter #2 to type object reference.");
+
+  DObjGDL* left = static_cast<DObjGDL*> (l);
+  DObjGDL* right = static_cast<DObjGDL*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = left->N_Elements();
   //   if( nEl == 0)
   //     nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  assert(rEl);
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
 
   Data_<SpDByte>* res;
 
   DObj s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
-      if( nEl == 1)
-    {
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(left->Dim(), BaseGDL::NOZERO);
+    if (nEl == 1) {
       (*res)[0] = (s == (*left)[0]);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-        (*res)[i] = ((*left)[i] == s);
-    }    }
-  else if( left->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
-      if( rEl == 1)
-    {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
+    }
+  } else if (left->StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
+    if (rEl == 1) {
       (*res)[0] = ((*right)[0] == s);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < rEl; ++i)
-        (*res)[i] = ((*right)[i] == s);
-    }    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < rEl; ++i)
-        (*res)[i] = ((*right)[i] == (*left)[i]);
-    }    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
-      if( rEl == 1)
-    {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(left->Dim(), BaseGDL::NOZERO);
+    if (rEl == 1) {
       (*res)[0] = ((*right)[0] == (*left)[0]);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-        (*res)[i] = ((*right)[i] == (*left)[i]);
-    }    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
+    }
+  }
   return res;
 }
 
-BaseGDL* _GDL_OBJECT_OverloadNEOp( EnvUDT* e)
-{
+BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
   SizeT nParam = e->NParam(); // number of parameters actually given
-//   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
-  if( nParam < 3) // consider implicit SELF
-    ThrowFromInternalUDSub( e, "Two parameters are needed: LEFT, RIGHT.");
+  //   int envSize = e->EnvSize(); // number of parameters + keywords 'e' (pro) has defined
+  if (nParam < 3) // consider implicit SELF
+    ThrowFromInternalUDSub(e, "Two parameters are needed: LEFT, RIGHT.");
 
   // default behavior: Exact like scalar indexing
   BaseGDL* l = e->GetKW(1);
-  if( l->Type() != GDL_OBJ)
-    ThrowFromInternalUDSub( e, "Unable to convert parameter #1 to type object reference.");
+  if (l->Type() != GDL_OBJ)
+    ThrowFromInternalUDSub(e, "Unable to convert parameter #1 to type object reference.");
 
   BaseGDL* r = e->GetKW(2);
-  if( r->Type() != GDL_OBJ)
-    ThrowFromInternalUDSub( e, "Unable to convert parameter #2 to type object reference.");
-  
-  DObjGDL* left = static_cast<DObjGDL*>(l);
-  DObjGDL* right = static_cast<DObjGDL*>(r);
-  
-  ULong rEl=right->N_Elements();
-  ULong nEl=left->N_Elements();
+  if (r->Type() != GDL_OBJ)
+    ThrowFromInternalUDSub(e, "Unable to convert parameter #2 to type object reference.");
+
+  DObjGDL* left = static_cast<DObjGDL*> (l);
+  DObjGDL* right = static_cast<DObjGDL*> (r);
+
+  ULong rEl = right->N_Elements();
+  ULong nEl = left->N_Elements();
   //   if( nEl == 0)
   //     nEl=N_Elements();
-  assert( rEl);
-  assert( nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");  
+  assert(rEl);
+  assert(nEl);
+  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
 
   Data_<SpDByte>* res;
 
   DObj s;
-  if( right->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
-      if( nEl == 1)
-    {
+  if (right->StrictScalar(s)) {
+    res = new Data_<SpDByte>(left->Dim(), BaseGDL::NOZERO);
+    if (nEl == 1) {
       (*res)[0] = (s != (*left)[0]);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-        (*res)[i] = ((*left)[i] != s);
-    }    }
-  else if( left->StrictScalar(s)) 
-    {
-      res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
-      if( rEl == 1)
-    {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
+       for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
+   } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
+    }
+  } else if (left->StrictScalar(s)) {
+    res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
+    if (rEl == 1) {
       (*res)[0] = ((*right)[0] != s);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < rEl; ++i)
-        (*res)[i] = ((*right)[i] != s);
-    }    }
-  else if( rEl < nEl) 
-    {
-      res= new Data_<SpDByte>( right->Dim(), BaseGDL::NOZERO);
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= rEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < rEl; ++i)
-        (*res)[i] = ((*right)[i] != (*left)[i]);
-    }    }
-  else // ( rEl >= nEl)
-    {
-      res= new Data_<SpDByte>( left->Dim(), BaseGDL::NOZERO);
-      if( rEl == 1)
-    {
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
+    }
+  } else if (rEl < nEl) {
+    res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
+    }
+  } else // ( rEl >= nEl)
+  {
+    res = new Data_<SpDByte>(left->Dim(), BaseGDL::NOZERO);
+    if (rEl == 1) {
       (*res)[0] = ((*right)[0] != (*left)[0]);
       return res;
     }
-      TRACEOMP( __FILE__, __LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-      for( OMPInt i=0; i < nEl; ++i)
-        (*res)[i] = ((*right)[i] != (*left)[i]);
-    }    }
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
+    } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
+    }
+  }
   return res;
 }
 
 // for GDL_OBJECT all other overloads are illegal operations as default
 // however, they need to be accessible for (nonsense) parent method calls.
 // But we can use just this one function for all of them
-BaseGDL* _GDL_OBJECT_OverloadReportIllegalOperation( EnvUDT* e)
-{
-  ThrowFromInternalUDSub( e, "Operation illegal with object reference types.");
+
+BaseGDL* _GDL_OBJECT_OverloadReportIllegalOperation(EnvUDT* e) {
+  ThrowFromInternalUDSub(e, "Operation illegal with object reference types.");
   return 0;
 }
 
 // set up the _overload... subroutines for GDL_OBJECT
-void SetupOverloadSubroutines()
-{
-//   // The call
-//   BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
-//   in call_fun eventually (in GDLInterpreter::statement) tree->Run() is called
+
+void SetupOverloadSubroutines() {
+  //   // The call
+  //   BaseGDL* res=interpreter->call_fun(static_cast<DSubUD*>(newEnv->GetPro())->GetTree());
+  //   in call_fun eventually (in GDLInterpreter::statement) tree->Run() is called
   DStructDesc* gdlObjectDesc = FindInStructList(structList, GDL_OBJECT_NAME);
-  assert( gdlObjectDesc != NULL);
+  assert(gdlObjectDesc != NULL);
   DStructDesc* gdlContainerDesc = FindInStructList(structList, "GDL_CONTAINER");
-  assert( gdlObjectDesc != NULL);
+  assert(gdlObjectDesc != NULL);
   DStructDesc* listDesc = FindInStructList(structList, "LIST");
-  assert( listDesc != NULL);
+  assert(listDesc != NULL);
   DStructDesc* hashDesc = FindInStructList(structList, "HASH");
-  assert( hashDesc != NULL);
+  assert(hashDesc != NULL);
 
 #ifdef USE_SHAPELIB
   DStructDesc* GDLffShapeDesc = FindInStructList(structList, "IDLFFSHAPE");
-  assert( GDLffShapeDesc != NULL);
+  assert(GDLffShapeDesc != NULL);
 #endif
 
-#ifdef USE_EXPAT  
+#ifdef USE_EXPAT
   DStructDesc* GDLffXmlSaxDesc = FindInStructList(structList, "IDLFFXMLSAX");
-  assert( GDLffXmlSaxDesc != NULL);  
+  assert(GDLffXmlSaxDesc != NULL);
 #endif
-  
+
   WRAPPED_FUNNode *treeFun;
   WRAPPED_PRONode *treePro;
-  
+
   // automatically adds "SELF" parameter (object name is != "")
-  DFun *_overloadIsTrue = new DFun("_OVERLOADISTRUE",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  DFun *_overloadIsTrue = new DFun("_OVERLOADISTRUE", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadIsTrue);
-  _overloadIsTrue->SetTree( treeFun);
-// we are NOT setting the operator to have (faster) default behavior
-// the functions must be there nevertheless for expicit callingNode
-// that's why we add them to the functions list  
+  _overloadIsTrue->SetTree(treeFun);
+  // we are NOT setting the operator to have (faster) default behavior
+  // the functions must be there nevertheless for expicit callingNode
+  // that's why we add them to the functions list
   gdlObjectDesc->FunList().push_back(_overloadIsTrue);
-//   gdlObjectDesc->SetOperator(OOIsTrue,_overloadIsTrue);
-// GDL_OBJECT:: [
-  DPro *_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OOIsTrue,_overloadIsTrue);
+  // GDL_OBJECT:: [
+  DPro *_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadBracketsLeftSide->AddPar("OBJREF")->AddPar("RVALUE")->AddPar("ISRANGE");
   _overloadBracketsLeftSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   _overloadBracketsLeftSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
   treePro = new WRAPPED_PRONode(_GDL_OBJECT_OverloadBracketsLeftSide);
-  _overloadBracketsLeftSide->SetTree( treePro); 
+  _overloadBracketsLeftSide->SetTree(treePro);
   gdlObjectDesc->ProList().push_back(_overloadBracketsLeftSide);
-//   gdlObjectDesc->SetOperator(OOBracketsLeftSide,_overloadBracketsLeftSide);
-// GDL_OBJECT::INIT()
-  DFun *_init = new DFun("INIT",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OOBracketsLeftSide,_overloadBracketsLeftSide);
+  // GDL_OBJECT::INIT()
+  DFun *_init = new DFun("INIT", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_Init);
-  _init->SetTree( treeFun);
+  _init->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_init);
-// GDL_OBJECT:: ]
-  DFun *_overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  // GDL_OBJECT:: ]
+  DFun *_overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadBracketsRightSide->AddPar("ISRANGE");
   _overloadBracketsRightSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   _overloadBracketsRightSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadBracketsRightSide);
-  _overloadBracketsRightSide->SetTree( treeFun);
+  _overloadBracketsRightSide->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_overloadBracketsRightSide);
-//   gdlObjectDesc->SetOperator(OOBracketsRightSide,_overloadBracketsRightSide);
-// GDL_OBJECT:: =
-   DFun *_overloadEQ = new DFun("_OVERLOADEQ",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OOBracketsRightSide,_overloadBracketsRightSide);
+  // GDL_OBJECT:: =
+  DFun *_overloadEQ = new DFun("_OVERLOADEQ", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadEQ->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadEQOp);
-  _overloadEQ->SetTree( treeFun);
+  _overloadEQ->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_overloadEQ);
-//   gdlObjectDesc->SetOperator(OOEQ,_overloadEQ);
-// GDL_OBJECT:: !=
-  DFun *_overloadNE = new DFun("_OVERLOADNE",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OOEQ,_overloadEQ);
+  // GDL_OBJECT:: !=
+  DFun *_overloadNE = new DFun("_OVERLOADNE", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadNE->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadNEOp);
-  _overloadNE->SetTree( treeFun);
+  _overloadNE->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_overloadNE);
-//   gdlObjectDesc->SetOperator(OONE,_overloadNE);
-// GDL_OBJECT:: +
-  DFun *_overloadPlus = new DFun("_OVERLOADPLUS",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OONE,_overloadNE);
+  // GDL_OBJECT:: +
+  DFun *_overloadPlus = new DFun("_OVERLOADPLUS", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadPlus->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadReportIllegalOperation);
-  _overloadPlus->SetTree( treeFun);
+  _overloadPlus->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_overloadPlus);
-//   gdlObjectDesc->SetOperator(OOPlus,_overloadPlus);
-// GDL_OBJECT:: -
-  DFun *_overloadMinus = new DFun("_OVERLOADMINUS",GDL_OBJECT_NAME,INTERNAL_LIBRARY_STR);
+  //   gdlObjectDesc->SetOperator(OOPlus,_overloadPlus);
+  // GDL_OBJECT:: -
+  DFun *_overloadMinus = new DFun("_OVERLOADMINUS", GDL_OBJECT_NAME, INTERNAL_LIBRARY_STR);
   _overloadMinus->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(_GDL_OBJECT_OverloadReportIllegalOperation);
-  _overloadMinus->SetTree( treeFun);
+  _overloadMinus->SetTree(treeFun);
   gdlObjectDesc->FunList().push_back(_overloadMinus);
-//   gdlObjectDesc->SetOperator(OOMINUS,_overloadMinus);
+  //   gdlObjectDesc->SetOperator(OOMINUS,_overloadMinus);
 
-// LIST:: ]  
-  DFun *DFunLIST__overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE","LIST",INTERNAL_LIBRARY_STR);
+  // LIST:: ]
+  DFun *DFunLIST__overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE", "LIST", INTERNAL_LIBRARY_STR);
   DFunLIST__overloadBracketsRightSide->AddPar("ISRANGE");
   DFunLIST__overloadBracketsRightSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   DFunLIST__overloadBracketsRightSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
-  treeFun = new WRAPPED_FUNNode( lib::LIST___OverloadBracketsRightSide);
-  DFunLIST__overloadBracketsRightSide->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::LIST___OverloadBracketsRightSide);
+  DFunLIST__overloadBracketsRightSide->SetTree(treeFun);
   listDesc->FunList().push_back(DFunLIST__overloadBracketsRightSide);
-  listDesc->SetOperator(OOBracketsRightSide,DFunLIST__overloadBracketsRightSide);
-// LIST:: [
-  DPro *DFunPro_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE","LIST",INTERNAL_LIBRARY_STR);
+  listDesc->SetOperator(OOBracketsRightSide, DFunLIST__overloadBracketsRightSide);
+  // LIST:: [
+  DPro *DFunPro_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE", "LIST", INTERNAL_LIBRARY_STR);
   DFunPro_overloadBracketsLeftSide->AddPar("OBJREF")->AddPar("RVALUE")->AddPar("ISRANGE");
   DFunPro_overloadBracketsLeftSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   DFunPro_overloadBracketsLeftSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
   treePro = new WRAPPED_PRONode(lib::LIST___OverloadBracketsLeftSide);
-  DFunPro_overloadBracketsLeftSide->SetTree( treePro); 
+  DFunPro_overloadBracketsLeftSide->SetTree(treePro);
   listDesc->ProList().push_back(DFunPro_overloadBracketsLeftSide);
-  listDesc->SetOperator(OOBracketsLeftSide,DFunPro_overloadBracketsLeftSide);
-// LIST:: +
-  DFun *LIST_overloadPlus = new DFun("_OVERLOADPLUS","LIST",INTERNAL_LIBRARY_STR);
+  listDesc->SetOperator(OOBracketsLeftSide, DFunPro_overloadBracketsLeftSide);
+  // LIST:: +
+  DFun *LIST_overloadPlus = new DFun("_OVERLOADPLUS", "LIST", INTERNAL_LIBRARY_STR);
   LIST_overloadPlus->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::LIST___OverloadPlus);
-  LIST_overloadPlus->SetTree( treeFun);
+  LIST_overloadPlus->SetTree(treeFun);
   listDesc->FunList().push_back(LIST_overloadPlus);
-  listDesc->SetOperator(OOPlus,LIST_overloadPlus);
-// LIST:: =
-  DFun *LIST_overloadEQ = new DFun("_OVERLOADEQ","LIST",INTERNAL_LIBRARY_STR);
+  listDesc->SetOperator(OOPlus, LIST_overloadPlus);
+  // LIST:: =
+  DFun *LIST_overloadEQ = new DFun("_OVERLOADEQ", "LIST", INTERNAL_LIBRARY_STR);
   LIST_overloadEQ->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::LIST___OverloadEQOp);
-  LIST_overloadEQ->SetTree( treeFun);
+  LIST_overloadEQ->SetTree(treeFun);
   listDesc->FunList().push_back(LIST_overloadEQ);
-  listDesc->SetOperator(OOEQ,LIST_overloadEQ);
-// LIST:: !=
-  DFun *LIST_overloadNE = new DFun("_OVERLOADNE","LIST",INTERNAL_LIBRARY_STR);
+  listDesc->SetOperator(OOEQ, LIST_overloadEQ);
+  // LIST:: !=
+  DFun *LIST_overloadNE = new DFun("_OVERLOADNE", "LIST", INTERNAL_LIBRARY_STR);
   LIST_overloadNE->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::LIST___OverloadNEOp);
-  LIST_overloadNE->SetTree( treeFun);
+  LIST_overloadNE->SetTree(treeFun);
   listDesc->FunList().push_back(LIST_overloadNE);
-  listDesc->SetOperator(OONE,LIST_overloadNE);
-// LIST::
-  DFun *LIST_overloadIsTrue = new DFun("_OVERLOADISTRUE","LIST",INTERNAL_LIBRARY_STR);
+  listDesc->SetOperator(OONE, LIST_overloadNE);
+  // LIST::
+  DFun *LIST_overloadIsTrue = new DFun("_OVERLOADISTRUE", "LIST", INTERNAL_LIBRARY_STR);
   treeFun = new WRAPPED_FUNNode(lib::LIST___OverloadIsTrue);
-  LIST_overloadIsTrue->SetTree( treeFun);
+  LIST_overloadIsTrue->SetTree(treeFun);
   listDesc->FunList().push_back(LIST_overloadIsTrue);
-  listDesc->SetOperator(OOIsTrue,LIST_overloadIsTrue);
- 
-// LIST::ADD
-  DPro *DProLIST__ADD = new DPro("ADD","LIST",INTERNAL_LIBRARY_STR);
-  DProLIST__ADD->AddKey("EXTRACT","EXTRACT")->AddKey("NO_COPY","NO_COPY");
-  DProLIST__ADD->AddKey("POSITION","POSITION");
-  DProLIST__ADD->AddPar("VALUE")->AddPar("INDEX");
-  treePro = new WRAPPED_PRONode( lib::list__add);
-  DProLIST__ADD->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__ADD);
-// LIST::REMOVE()
-  DFun *DFunLIST__REMOVE = new DFun("REMOVE","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__REMOVE->AddKey("ALL","ALL");
-  DFunLIST__REMOVE->AddPar("INDEX");
-  treeFun = new WRAPPED_FUNNode( lib::list__remove_fun);
-  DFunLIST__REMOVE->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__REMOVE);
-// LIST::REMOVE PRO
-  DPro *DProLIST__REMOVE = new DPro("REMOVE","LIST",INTERNAL_LIBRARY_STR);
-  DProLIST__REMOVE->AddKey("ALL","ALL");
-  DProLIST__REMOVE->AddPar("INDEX");
-  treePro = new WRAPPED_PRONode( lib::list__remove_pro);
-  DProLIST__REMOVE->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__REMOVE);
-// LIST::REVERSE PRO
-  DPro *DProLIST__REVERSE = new DPro("REVERSE","LIST",INTERNAL_LIBRARY_STR);
-  treePro = new WRAPPED_PRONode( lib::list__reverse);
-  DProLIST__REVERSE->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__REVERSE);
-// LIST::ToArray()
-  DFun *DFunLIST__TOARRAY = new DFun("TOARRAY","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__TOARRAY->AddKey("TYPE","TYPE")->AddKey("MISSING","MISSING");
-  DFunLIST__TOARRAY->AddKey("DIMENSION","DIMENSION")->AddKey("NO_COPY","NO_COPY");
-  DFunLIST__TOARRAY->AddKey("PROMOTE_TYPE","PROMOTE_TYPE")->AddKey("TRANSPOSE","TRANSPOSE");
-  
-  treeFun = new WRAPPED_FUNNode( lib::list__toarray);
-  DFunLIST__TOARRAY->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__TOARRAY);
-  #if 0
-// LIST::HELP()
-  DFun *DFunLIST__HELP = new DFun("HELP","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__TOHELP->AddKey("MAXITEM","MAXITEM");
-  treeFun = new WRAPPED_FUNNode( lib::list__help);
-  DFunLIST__TOHELP->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__TOHELP);
-  #endif
-  #if 0
-// LIST::HELP
-  DPro *DProLIST__HELP = new DPro("HELP","LIST",INTERNAL_LIBRARY_STR);
-  DProLIST__HELP->AddKey("MAXITEM","MAXITEM");
-  treePro = new WRAPPED_PRONode( lib::list__help);
-  DProLIST__HELP->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__HELP);
-  #endif
-// LIST::CLEANUP
-  DPro *DProLIST__CLEANUP = new DPro("CLEANUP","LIST",INTERNAL_LIBRARY_STR);
-  treePro = new WRAPPED_PRONode( lib::list__cleanup);
-  DProLIST__CLEANUP->SetTree( treePro);
-      listDesc->ProList().push_back(DProLIST__CLEANUP);
-// LIST::MOVE
-  DPro *DProLIST__MOVE = new DPro("MOVE","LIST",INTERNAL_LIBRARY_STR);
-  DProLIST__MOVE->AddPar("SOURCE")->AddPar("DESTINATION");
-  treePro = new WRAPPED_PRONode( lib::list__move);
-  DProLIST__MOVE->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__MOVE);
-// LIST::SWAP
-  DPro *DProLIST__SWAP = new DPro("SWAP","LIST",INTERNAL_LIBRARY_STR);
-  DProLIST__SWAP->AddPar("INDEX1")->AddPar("INDEX2");
-  treePro = new WRAPPED_PRONode( lib::list__swap);
-  DProLIST__SWAP->SetTree( treePro);
-  listDesc->ProList().push_back(DProLIST__SWAP);
-// LIST::COUNT()
-  DFun *DFunLIST__COUNT = new DFun("COUNT","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__COUNT->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::list__count);
-  DFunLIST__COUNT->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__COUNT);
-// LIST::ISEMPTY()
-  DFun *DFunLIST__ISEMPTY = new DFun("ISEMPTY","LIST",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::list__isempty);
-  DFunLIST__ISEMPTY->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__ISEMPTY);
-// LIST::WHERE()
-  DFun *DFunLIST__WHERE = new DFun("WHERE","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__WHERE->AddKey("COMPLEMENT","COMPLEMENT");
-  DFunLIST__WHERE->AddKey("COUNT","COUNT");
-  DFunLIST__WHERE->AddKey("NCOMPLEMENT","NCOMPLEMENT");
-  DFunLIST__WHERE->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::list__where);
-  DFunLIST__WHERE->SetTree( treeFun);
-  listDesc->FunList().push_back(DFunLIST__WHERE);
-// LIST::GET()  // here to make up for IDL_CONTAINER lack.
-  // res=List.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
-  DFun *DFunLIST__GET = new DFun("GET","LIST",INTERNAL_LIBRARY_STR);
-  DFunLIST__GET->AddKey("ALL","ALL")->AddKey("ISA","ISA")->AddKey("NULL","NULL");
-  DFunLIST__GET->AddKey("COUNT","COUNT");
-  DFunLIST__GET->AddKey("POSITION","POSITION");
+  listDesc->SetOperator(OOIsTrue, LIST_overloadIsTrue);
 
-  treeFun = new WRAPPED_FUNNode( lib::list__get);
-  DFunLIST__GET->SetTree( treeFun);
+  // LIST::ADD
+  DPro *DProLIST__ADD = new DPro("ADD", "LIST", INTERNAL_LIBRARY_STR);
+  DProLIST__ADD->AddKey("EXTRACT", "EXTRACT")->AddKey("NO_COPY", "NO_COPY");
+  DProLIST__ADD->AddKey("POSITION", "POSITION");
+  DProLIST__ADD->AddPar("VALUE")->AddPar("INDEX");
+  treePro = new WRAPPED_PRONode(lib::list__add);
+  DProLIST__ADD->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__ADD);
+  // LIST::REMOVE()
+  DFun *DFunLIST__REMOVE = new DFun("REMOVE", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__REMOVE->AddKey("ALL", "ALL");
+  DFunLIST__REMOVE->AddPar("INDEX");
+  treeFun = new WRAPPED_FUNNode(lib::list__remove_fun);
+  DFunLIST__REMOVE->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__REMOVE);
+  // LIST::REMOVE PRO
+  DPro *DProLIST__REMOVE = new DPro("REMOVE", "LIST", INTERNAL_LIBRARY_STR);
+  DProLIST__REMOVE->AddKey("ALL", "ALL");
+  DProLIST__REMOVE->AddPar("INDEX");
+  treePro = new WRAPPED_PRONode(lib::list__remove_pro);
+  DProLIST__REMOVE->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__REMOVE);
+  // LIST::REVERSE PRO
+  DPro *DProLIST__REVERSE = new DPro("REVERSE", "LIST", INTERNAL_LIBRARY_STR);
+  treePro = new WRAPPED_PRONode(lib::list__reverse);
+  DProLIST__REVERSE->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__REVERSE);
+  // LIST::ToArray()
+  DFun *DFunLIST__TOARRAY = new DFun("TOARRAY", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__TOARRAY->AddKey("TYPE", "TYPE")->AddKey("MISSING", "MISSING");
+  DFunLIST__TOARRAY->AddKey("DIMENSION", "DIMENSION")->AddKey("NO_COPY", "NO_COPY");
+  DFunLIST__TOARRAY->AddKey("PROMOTE_TYPE", "PROMOTE_TYPE")->AddKey("TRANSPOSE", "TRANSPOSE");
+
+  treeFun = new WRAPPED_FUNNode(lib::list__toarray);
+  DFunLIST__TOARRAY->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__TOARRAY);
+#if 0
+  // LIST::HELP()
+  DFun *DFunLIST__HELP = new DFun("HELP", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__TOHELP->AddKey("MAXITEM", "MAXITEM");
+  treeFun = new WRAPPED_FUNNode(lib::list__help);
+  DFunLIST__TOHELP->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__TOHELP);
+#endif
+#if 0
+  // LIST::HELP
+  DPro *DProLIST__HELP = new DPro("HELP", "LIST", INTERNAL_LIBRARY_STR);
+  DProLIST__HELP->AddKey("MAXITEM", "MAXITEM");
+  treePro = new WRAPPED_PRONode(lib::list__help);
+  DProLIST__HELP->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__HELP);
+#endif
+  // LIST::CLEANUP
+  DPro *DProLIST__CLEANUP = new DPro("CLEANUP", "LIST", INTERNAL_LIBRARY_STR);
+  treePro = new WRAPPED_PRONode(lib::list__cleanup);
+  DProLIST__CLEANUP->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__CLEANUP);
+  // LIST::MOVE
+  DPro *DProLIST__MOVE = new DPro("MOVE", "LIST", INTERNAL_LIBRARY_STR);
+  DProLIST__MOVE->AddPar("SOURCE")->AddPar("DESTINATION");
+  treePro = new WRAPPED_PRONode(lib::list__move);
+  DProLIST__MOVE->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__MOVE);
+  // LIST::SWAP
+  DPro *DProLIST__SWAP = new DPro("SWAP", "LIST", INTERNAL_LIBRARY_STR);
+  DProLIST__SWAP->AddPar("INDEX1")->AddPar("INDEX2");
+  treePro = new WRAPPED_PRONode(lib::list__swap);
+  DProLIST__SWAP->SetTree(treePro);
+  listDesc->ProList().push_back(DProLIST__SWAP);
+  // LIST::COUNT()
+  DFun *DFunLIST__COUNT = new DFun("COUNT", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__COUNT->AddPar("VALUE");
+  treeFun = new WRAPPED_FUNNode(lib::list__count);
+  DFunLIST__COUNT->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__COUNT);
+  // LIST::ISEMPTY()
+  DFun *DFunLIST__ISEMPTY = new DFun("ISEMPTY", "LIST", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::list__isempty);
+  DFunLIST__ISEMPTY->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__ISEMPTY);
+  // LIST::WHERE()
+  DFun *DFunLIST__WHERE = new DFun("WHERE", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__WHERE->AddKey("COMPLEMENT", "COMPLEMENT");
+  DFunLIST__WHERE->AddKey("COUNT", "COUNT");
+  DFunLIST__WHERE->AddKey("NCOMPLEMENT", "NCOMPLEMENT");
+  DFunLIST__WHERE->AddPar("VALUE");
+  treeFun = new WRAPPED_FUNNode(lib::list__where);
+  DFunLIST__WHERE->SetTree(treeFun);
+  listDesc->FunList().push_back(DFunLIST__WHERE);
+  // LIST::GET()  // here to make up for IDL_CONTAINER lack.
+  // res=List.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
+  DFun *DFunLIST__GET = new DFun("GET", "LIST", INTERNAL_LIBRARY_STR);
+  DFunLIST__GET->AddKey("ALL", "ALL")->AddKey("ISA", "ISA")->AddKey("NULL", "NULL");
+  DFunLIST__GET->AddKey("COUNT", "COUNT");
+  DFunLIST__GET->AddKey("POSITION", "POSITION");
+
+  treeFun = new WRAPPED_FUNNode(lib::list__get);
+  DFunLIST__GET->SetTree(treeFun);
   listDesc->FunList().push_back(DFunLIST__GET);
 
-// LIST::INIT()  // here to make up for IDL_CONTAINER lack.
+  // LIST::INIT()  // here to make up for IDL_CONTAINER lack.
   // list is parented by GDL_OBJECT which can handled INIT:
- // DFun *DFunLIST__INIT = new DFun("INIT","LIST",INTERNAL_LIBRARY_STR);
- // treeFun = new WRAPPED_FUNNode( lib::list__init);
- // DFunLIST__INIT->SetTree( treeFun);
- // listDesc->FunList().push_back(DFunLIST__INIT);
-  
-  
-// HASH  
-  DFun *DFunHASH__overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE","HASH",INTERNAL_LIBRARY_STR);
+  // DFun *DFunLIST__INIT = new DFun("INIT","LIST",INTERNAL_LIBRARY_STR);
+  // treeFun = new WRAPPED_FUNNode( lib::list__init);
+  // DFunLIST__INIT->SetTree( treeFun);
+  // listDesc->FunList().push_back(DFunLIST__INIT);
+
+
+  // HASH
+  DFun *DFunHASH__overloadBracketsRightSide = new DFun("_OVERLOADBRACKETSRIGHTSIDE", "HASH", INTERNAL_LIBRARY_STR);
   DFunHASH__overloadBracketsRightSide->AddPar("ISRANGE");
   DFunHASH__overloadBracketsRightSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   DFunHASH__overloadBracketsRightSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
-  treeFun = new WRAPPED_FUNNode( lib::HASH___OverloadBracketsRightSide);
-  DFunHASH__overloadBracketsRightSide->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::HASH___OverloadBracketsRightSide);
+  DFunHASH__overloadBracketsRightSide->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__overloadBracketsRightSide);
-  hashDesc->SetOperator(OOBracketsRightSide,DFunHASH__overloadBracketsRightSide);
+  hashDesc->SetOperator(OOBracketsRightSide, DFunHASH__overloadBracketsRightSide);
 
-  DPro *DProHASH_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE","HASH",INTERNAL_LIBRARY_STR);
+  DPro *DProHASH_overloadBracketsLeftSide = new DPro("_OVERLOADBRACKETSLEFTSIDE", "HASH", INTERNAL_LIBRARY_STR);
   DProHASH_overloadBracketsLeftSide->AddPar("OBJREF")->AddPar("RVALUE")->AddPar("ISRANGE");
   DProHASH_overloadBracketsLeftSide->AddPar("SUB1")->AddPar("SUB2")->AddPar("SUB3")->AddPar("SUB4");
   DProHASH_overloadBracketsLeftSide->AddPar("SUB5")->AddPar("SUB6")->AddPar("SUB7")->AddPar("SUB8");
   treePro = new WRAPPED_PRONode(lib::HASH___OverloadBracketsLeftSide);
-  DProHASH_overloadBracketsLeftSide->SetTree( treePro); 
+  DProHASH_overloadBracketsLeftSide->SetTree(treePro);
   hashDesc->ProList().push_back(DProHASH_overloadBracketsLeftSide);
-  hashDesc->SetOperator(OOBracketsLeftSide,DProHASH_overloadBracketsLeftSide);
+  hashDesc->SetOperator(OOBracketsLeftSide, DProHASH_overloadBracketsLeftSide);
 
-  DFun *HASH_overloadPlus = new DFun("_OVERLOADPLUS","HASH",INTERNAL_LIBRARY_STR);
+  DFun *HASH_overloadPlus = new DFun("_OVERLOADPLUS", "HASH", INTERNAL_LIBRARY_STR);
   HASH_overloadPlus->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::HASH___OverloadPlus);
-  HASH_overloadPlus->SetTree( treeFun);
+  HASH_overloadPlus->SetTree(treeFun);
   hashDesc->FunList().push_back(HASH_overloadPlus);
-  hashDesc->SetOperator(OOPlus,HASH_overloadPlus);
- 
-  DFun *HASH_overloadEQ = new DFun("_OVERLOADEQ","HASH",INTERNAL_LIBRARY_STR);
+  hashDesc->SetOperator(OOPlus, HASH_overloadPlus);
+
+  DFun *HASH_overloadEQ = new DFun("_OVERLOADEQ", "HASH", INTERNAL_LIBRARY_STR);
   HASH_overloadEQ->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::HASH___OverloadEQOp);
-  HASH_overloadEQ->SetTree( treeFun);
+  HASH_overloadEQ->SetTree(treeFun);
   hashDesc->FunList().push_back(HASH_overloadEQ);
-  hashDesc->SetOperator(OOEQ,HASH_overloadEQ);
+  hashDesc->SetOperator(OOEQ, HASH_overloadEQ);
 
-  DFun *HASH_overloadNE = new DFun("_OVERLOADNE","HASH",INTERNAL_LIBRARY_STR);
+  DFun *HASH_overloadNE = new DFun("_OVERLOADNE", "HASH", INTERNAL_LIBRARY_STR);
   HASH_overloadNE->AddPar("LEFT")->AddPar("RIGHT");
   treeFun = new WRAPPED_FUNNode(lib::HASH___OverloadNEOp);
-  HASH_overloadNE->SetTree( treeFun);
+  HASH_overloadNE->SetTree(treeFun);
   hashDesc->FunList().push_back(HASH_overloadNE);
-  hashDesc->SetOperator(OONE,HASH_overloadNE);
- 
-  DFun *HASH_overloadIsTrue = new DFun("_OVERLOADISTRUE","HASH",INTERNAL_LIBRARY_STR);
+  hashDesc->SetOperator(OONE, HASH_overloadNE);
+
+  DFun *HASH_overloadIsTrue = new DFun("_OVERLOADISTRUE", "HASH", INTERNAL_LIBRARY_STR);
   treeFun = new WRAPPED_FUNNode(lib::HASH___OverloadIsTrue);
-  HASH_overloadIsTrue->SetTree( treeFun);
+  HASH_overloadIsTrue->SetTree(treeFun);
   hashDesc->FunList().push_back(HASH_overloadIsTrue);
-  hashDesc->SetOperator(OOIsTrue,HASH_overloadIsTrue);
- 
-// HASH::REMOVE()
-  DFun *DFunHASH__REMOVE = new DFun("REMOVE","HASH",INTERNAL_LIBRARY_STR);
-  DFunHASH__REMOVE->AddKey("ALL","ALL");
+  hashDesc->SetOperator(OOIsTrue, HASH_overloadIsTrue);
+
+  // HASH::REMOVE()
+  DFun *DFunHASH__REMOVE = new DFun("REMOVE", "HASH", INTERNAL_LIBRARY_STR);
+  DFunHASH__REMOVE->AddKey("ALL", "ALL");
   DFunHASH__REMOVE->AddPar("INDEX");
-  treeFun = new WRAPPED_FUNNode( lib::hash__remove_fun);
-  DFunHASH__REMOVE->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::hash__remove_fun);
+  DFunHASH__REMOVE->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__REMOVE);
-// HASH::REMOVE PRO
-  DPro *DProHASH__REMOVE = new DPro("REMOVE","HASH",INTERNAL_LIBRARY_STR);
-  DProHASH__REMOVE->AddKey("ALL","ALL");
+  // HASH::REMOVE PRO
+  DPro *DProHASH__REMOVE = new DPro("REMOVE", "HASH", INTERNAL_LIBRARY_STR);
+  DProHASH__REMOVE->AddKey("ALL", "ALL");
   DProHASH__REMOVE->AddPar("INDEX");
-  treePro = new WRAPPED_PRONode( lib::hash__remove_pro);
-  DProHASH__REMOVE->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::hash__remove_pro);
+  DProHASH__REMOVE->SetTree(treePro);
   hashDesc->ProList().push_back(DProHASH__REMOVE);
-// HASH::HASKEY()
-  DFun *DFunHASH__HASKEY = new DFun("HASKEY","HASH",INTERNAL_LIBRARY_STR);
+  // HASH::HASKEY()
+  DFun *DFunHASH__HASKEY = new DFun("HASKEY", "HASH", INTERNAL_LIBRARY_STR);
   DFunHASH__HASKEY->AddPar("KEYLIST");
-  treeFun = new WRAPPED_FUNNode( lib::hash__haskey);
-  DFunHASH__HASKEY->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::hash__haskey);
+  DFunHASH__HASKEY->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__HASKEY);
-// HASH::KEYS()
-  DFun *DFunHASH__KEYS = new DFun("KEYS","HASH",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::hash__keys);
-  DFunHASH__KEYS->SetTree( treeFun);
+  // HASH::KEYS()
+  DFun *DFunHASH__KEYS = new DFun("KEYS", "HASH", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::hash__keys);
+  DFunHASH__KEYS->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__KEYS);
-// HASH::VALUES()
-  DFun *DFunHASH__VALUES = new DFun("VALUES","HASH",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::hash__values);
-  DFunHASH__VALUES->SetTree( treeFun);
+  // HASH::VALUES()
+  DFun *DFunHASH__VALUES = new DFun("VALUES", "HASH", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::hash__values);
+  DFunHASH__VALUES->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__VALUES);
-// HASH::TOSTRUCT()
-  DFun *DFunHASH__TOSTRUCT = new DFun("TOSTRUCT","HASH",INTERNAL_LIBRARY_STR);
+  // HASH::TOSTRUCT()
+  DFun *DFunHASH__TOSTRUCT = new DFun("TOSTRUCT", "HASH", INTERNAL_LIBRARY_STR);
 
-  DFunHASH__TOSTRUCT->AddKey("SKIPPED","SKIPPED")->AddKey("MISSING","MISSING");
-  DFunHASH__TOSTRUCT->AddKey("NO_COPY","NO_COPY")->AddKey("RECURSIVE","RECURSIVE");
+  DFunHASH__TOSTRUCT->AddKey("SKIPPED", "SKIPPED")->AddKey("MISSING", "MISSING");
+  DFunHASH__TOSTRUCT->AddKey("NO_COPY", "NO_COPY")->AddKey("RECURSIVE", "RECURSIVE");
 
-  treeFun = new WRAPPED_FUNNode( lib::hash__tostruct);
-  DFunHASH__TOSTRUCT->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::hash__tostruct);
+  DFunHASH__TOSTRUCT->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__TOSTRUCT);
-// HASH::COUNT()
-  DFun *DFunHASH__COUNT = new DFun("COUNT","HASH",INTERNAL_LIBRARY_STR);
+  // HASH::COUNT()
+  DFun *DFunHASH__COUNT = new DFun("COUNT", "HASH", INTERNAL_LIBRARY_STR);
   DFunHASH__COUNT->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::hash__count);
-  DFunHASH__COUNT->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::hash__count);
+  DFunHASH__COUNT->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__COUNT);
-// HASH::ISEMPTY()
-  DFun *DFunHASH__ISEMPTY = new DFun("ISEMPTY","HASH",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::hash__isempty);
-  DFunHASH__ISEMPTY->SetTree( treeFun);
+  // HASH::ISEMPTY()
+  DFun *DFunHASH__ISEMPTY = new DFun("ISEMPTY", "HASH", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::hash__isempty);
+  DFunHASH__ISEMPTY->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__ISEMPTY);
-// HASH::ISORDERED()
-  DFun *DFunHASH__ISORDERED = new DFun("ISORDERED","HASH",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::hash__isordered);
-  DFunHASH__ISORDERED->SetTree( treeFun);
+  // HASH::ISORDERED()
+  DFun *DFunHASH__ISORDERED = new DFun("ISORDERED", "HASH", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::hash__isordered);
+  DFunHASH__ISORDERED->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__ISORDERED);
-// HASH::ISFOLDCASE()
-  DFun *DFunHASH__ISFOLDCASE = new DFun("ISFOLDCASE","HASH",INTERNAL_LIBRARY_STR);
-  treeFun = new WRAPPED_FUNNode( lib::hash__isfoldcase);
-  DFunHASH__ISFOLDCASE->SetTree( treeFun);
+  // HASH::ISFOLDCASE()
+  DFun *DFunHASH__ISFOLDCASE = new DFun("ISFOLDCASE", "HASH", INTERNAL_LIBRARY_STR);
+  treeFun = new WRAPPED_FUNNode(lib::hash__isfoldcase);
+  DFunHASH__ISFOLDCASE->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__ISFOLDCASE);
-// HASH::WHERE()
-  DFun *DFunHASH__WHERE = new DFun("WHERE","HASH",INTERNAL_LIBRARY_STR);
-  DFunHASH__WHERE->AddKey("COMPLEMENT","COMPLEMENT");
-  DFunHASH__WHERE->AddKey("COUNT","COUNT");
-  DFunHASH__WHERE->AddKey("NCOMPLEMENT","NCOMPLEMENT");
+  // HASH::WHERE()
+  DFun *DFunHASH__WHERE = new DFun("WHERE", "HASH", INTERNAL_LIBRARY_STR);
+  DFunHASH__WHERE->AddKey("COMPLEMENT", "COMPLEMENT");
+  DFunHASH__WHERE->AddKey("COUNT", "COUNT");
+  DFunHASH__WHERE->AddKey("NCOMPLEMENT", "NCOMPLEMENT");
   DFunHASH__WHERE->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::hash__where);
-  DFunHASH__WHERE->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::hash__where);
+  DFunHASH__WHERE->SetTree(treeFun);
   hashDesc->FunList().push_back(DFunHASH__WHERE);
- 
- // GDL_CONTAINER - references list procedures because, we can.
-// res=GDL_CONTAINER.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
-  DFun* DFunlist = new DFun("GET","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  DFunlist->AddKey("ALL","ALL")->AddKey("ISA","ISA")->AddKey("NULL","NULL");
-  DFunlist->AddKey("COUNT","COUNT");
-  DFunlist->AddKey("POSITION","POSITION");
 
-  treeFun = new WRAPPED_FUNNode( lib::list__get);
-  DFunlist->SetTree( treeFun);
+  // GDL_CONTAINER - references list procedures because, we can.
+  // res=GDL_CONTAINER.get([/all] [, isa=(names)] [. position=index] [, count=variable] [/null][)
+  DFun* DFunlist = new DFun("GET", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  DFunlist->AddKey("ALL", "ALL")->AddKey("ISA", "ISA")->AddKey("NULL", "NULL");
+  DFunlist->AddKey("COUNT", "COUNT");
+  DFunlist->AddKey("POSITION", "POSITION");
+
+  treeFun = new WRAPPED_FUNNode(lib::list__get);
+  DFunlist->SetTree(treeFun);
   gdlContainerDesc->FunList().push_back(DFunlist);
 
-// GDL_CONTAINER::INIT()
-//  DFunlist = new DFun("INIT","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-//  treeFun = new WRAPPED_FUNNode( lib::list__init);
-//  DFunlist->SetTree( treeFun);
-//  gdlContainerDesc->FunList().push_back(DFunlist);
-  
-// GDL_CONTAINER::COUNT()
-  DFunlist = new DFun("COUNT","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
+  // GDL_CONTAINER::INIT()
+  //  DFunlist = new DFun("INIT","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
+  //  treeFun = new WRAPPED_FUNNode( lib::list__init);
+  //  DFunlist->SetTree( treeFun);
+  //  gdlContainerDesc->FunList().push_back(DFunlist);
+
+  // GDL_CONTAINER::COUNT()
+  DFunlist = new DFun("COUNT", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::list__count);
-  DFunlist->SetTree( treeFun);
+  treeFun = new WRAPPED_FUNNode(lib::list__count);
+  DFunlist->SetTree(treeFun);
   gdlContainerDesc->FunList().push_back(DFunlist);
-// GDL_CONTAINER::ADD
-  DPro* DProlist = new DPro("ADD","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("EXTRACT","EXTRACT")->AddKey("NO_COPY","NO_COPY");
-  DProlist->AddKey("POSITION","POSITION");
+  // GDL_CONTAINER::ADD
+  DPro* DProlist = new DPro("ADD", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("EXTRACT", "EXTRACT")->AddKey("NO_COPY", "NO_COPY");
+  DProlist->AddKey("POSITION", "POSITION");
   DProlist->AddPar("VALUE")->AddPar("INDEX");
-  treePro = new WRAPPED_PRONode( lib::list__add);
-  DProlist->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::list__add);
+  DProlist->SetTree(treePro);
   gdlContainerDesc->ProList().push_back(DProlist);
-  #if 0
-// GDL_CONTAINER::HELP
-  DProlist = new DPro("HELP","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("MAXITEM","MAXITEM");
-  treePro = new WRAPPED_PRONode( lib::list__help);
-  DProlist->SetTree( treePro);
+#if 0
+  // GDL_CONTAINER::HELP
+  DProlist = new DPro("HELP", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("MAXITEM", "MAXITEM");
+  treePro = new WRAPPED_PRONode(lib::list__help);
+  DProlist->SetTree(treePro);
   gdlContainerDesc->ProList().push_back(DProlist);
-  #endif
-// GDL_CONTAINER::CLEANUP
-  DProlist = new DPro("CLEANUP","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  treePro = new WRAPPED_PRONode( lib::container__cleanup);
-  DProlist->SetTree( treePro);
-  gdlContainerDesc->ProList().push_back(DProlist);//*/
-// GDL_CONTAINER::MOVE
-  DProlist = new DPro("MOVE","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
+#endif
+  // GDL_CONTAINER::CLEANUP
+  DProlist = new DPro("CLEANUP", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  treePro = new WRAPPED_PRONode(lib::container__cleanup);
+  DProlist->SetTree(treePro);
+  gdlContainerDesc->ProList().push_back(DProlist); //*/
+  // GDL_CONTAINER::MOVE
+  DProlist = new DPro("MOVE", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
   DProlist->AddPar("SOURCE")->AddPar("DESTINATION");
-  treePro = new WRAPPED_PRONode( lib::list__move);
-  DProlist->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::list__move);
+  DProlist->SetTree(treePro);
   gdlContainerDesc->ProList().push_back(DProlist);
-// GDL_CONTAINER::REMOVE()
-  DProlist = new DPro("REMOVE","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("ALL","ALL");
-  DProlist->AddKey("POSITION","POSITION");
+  // GDL_CONTAINER::REMOVE()
+  DProlist = new DPro("REMOVE", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("ALL", "ALL");
+  DProlist->AddKey("POSITION", "POSITION");
   DProlist->AddPar("HEAPVAR");
-  treePro = new WRAPPED_PRONode( lib::container__remove);
-  DProlist->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::container__remove);
+  DProlist->SetTree(treePro);
   gdlContainerDesc->ProList().push_back(DProlist);
-// GDL_CONTAINER::EQUALS()
-  DFunlist = new DFun("EQUALS","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
+  // GDL_CONTAINER::EQUALS()
+  DFunlist = new DFun("EQUALS", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::container__equals);
-  DFunlist->SetTree( treeFun);
-  gdlContainerDesc->FunList().push_back( DFunlist);
-// GDL_CONTAINER::ISCONTAINED()
-  DFunlist = new DFun("ISCONTAINED","GDL_CONTAINER",INTERNAL_LIBRARY_STR);
-  DFunlist->AddKey("POSITION","POSITION");
+  treeFun = new WRAPPED_FUNNode(lib::container__equals);
+  DFunlist->SetTree(treeFun);
+  gdlContainerDesc->FunList().push_back(DFunlist);
+  // GDL_CONTAINER::ISCONTAINED()
+  DFunlist = new DFun("ISCONTAINED", "GDL_CONTAINER", INTERNAL_LIBRARY_STR);
+  DFunlist->AddKey("POSITION", "POSITION");
   DFunlist->AddPar("VALUE");
-  treeFun = new WRAPPED_FUNNode( lib::container__iscontained);
-  DFunlist->SetTree( treeFun);
-  gdlContainerDesc->FunList().push_back( DFunlist);
-#ifdef USE_SHAPELIB  
+  treeFun = new WRAPPED_FUNNode(lib::container__iscontained);
+  DFunlist->SetTree(treeFun);
+  gdlContainerDesc->FunList().push_back(DFunlist);
+#ifdef USE_SHAPELIB
   //=============GDLffShape========================
-//IDLFFSHAPE::GETATTRIBUTES
-  DFunlist = new DFun("GETATTRIBUTES","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::GETATTRIBUTES
+  DFunlist = new DFun("GETATTRIBUTES", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("INDEX");
-  DFunlist->AddKey("ATTRIBUTE_STRUCTURE","ATTRIBUTE_STRUCTURE");
-  DFunlist->AddKey("ALL","ALL"); 
-  treeFun = new WRAPPED_FUNNode( lib::GDLffShape___GetAttributes);
-  DFunlist->SetTree( treeFun);
+  DFunlist->AddKey("ATTRIBUTE_STRUCTURE", "ATTRIBUTE_STRUCTURE");
+  DFunlist->AddKey("ALL", "ALL");
+  treeFun = new WRAPPED_FUNNode(lib::GDLffShape___GetAttributes);
+  DFunlist->SetTree(treeFun);
   GDLffShapeDesc->FunList().push_back(DFunlist);
-//IDLFFSHAPE::GETENTITY
-  DFunlist = new DFun("GETENTITY","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::GETENTITY
+  DFunlist = new DFun("GETENTITY", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("INDEX");
-  DFunlist->AddKey("ATTRIBUTES","ATTRIBUTES");
-  DFunlist->AddKey("ALL","ALL"); 
-  treeFun = new WRAPPED_FUNNode( lib::GDLffShape___GetEntity);
-  DFunlist->SetTree( treeFun);
+  DFunlist->AddKey("ATTRIBUTES", "ATTRIBUTES");
+  DFunlist->AddKey("ALL", "ALL");
+  treeFun = new WRAPPED_FUNNode(lib::GDLffShape___GetEntity);
+  DFunlist->SetTree(treeFun);
   GDLffShapeDesc->FunList().push_back(DFunlist);
-//IDLFFSHAPE::INIT
-  DFunlist = new DFun("INIT","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::INIT
+  DFunlist = new DFun("INIT", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("FILENAME");
-  DFunlist->AddKey("DBF_ONLY","DBF_ONLY");
-  DFunlist->AddKey("ENTITY_TYPE","ENTITY_TYPE");
-  DFunlist->AddKey("UPDATE","UPDATE");
-  treeFun = new WRAPPED_FUNNode( lib::GDLffShape___Init);
-  DFunlist->SetTree( treeFun);
+  DFunlist->AddKey("DBF_ONLY", "DBF_ONLY");
+  DFunlist->AddKey("ENTITY_TYPE", "ENTITY_TYPE");
+  DFunlist->AddKey("UPDATE", "UPDATE");
+  treeFun = new WRAPPED_FUNNode(lib::GDLffShape___Init);
+  DFunlist->SetTree(treeFun);
   GDLffShapeDesc->FunList().push_back(DFunlist);
   //IDLFFSHAPE::OPEN
-  DFunlist = new DFun("OPEN","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  DFunlist = new DFun("OPEN", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DFunlist->AddPar("FILENAME");
-  DFunlist->AddKey("DBF_ONLY","DBF_ONLY");
-  DFunlist->AddKey("ENTITY_TYPE","ENTITY_TYPE"); 
-  DFunlist->AddKey("UPDATE","UPDATE"); 
-  treeFun = new WRAPPED_FUNNode( lib::GDLffShape___Open);
-  DFunlist->SetTree( treeFun);
+  DFunlist->AddKey("DBF_ONLY", "DBF_ONLY");
+  DFunlist->AddKey("ENTITY_TYPE", "ENTITY_TYPE");
+  DFunlist->AddKey("UPDATE", "UPDATE");
+  treeFun = new WRAPPED_FUNNode(lib::GDLffShape___Open);
+  DFunlist->SetTree(treeFun);
   GDLffShapeDesc->FunList().push_back(DFunlist);
- //IDLFFSHAPE::ADDATTRIBUTE
-  DProlist = new DPro("ADDATTRIBUTE","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::ADDATTRIBUTE
+  DProlist = new DPro("ADDATTRIBUTE", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DProlist->AddPar("NAME");
   DProlist->AddPar("TYPE");
   DProlist->AddPar("WIDTH");
-  DProlist->AddKey("PRECISION","PRECISION");
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___AddAttribute);
-  DProlist->SetTree( treePro);
+  DProlist->AddKey("PRECISION", "PRECISION");
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___AddAttribute);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::CLEANUP
-  DProlist = new DPro("CLEANUP","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___Cleanup);
-  DProlist->SetTree( treePro);
+  //IDLFFSHAPE::CLEANUP
+  DProlist = new DPro("CLEANUP", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___Cleanup);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::CLOSE
-  DProlist = new DPro("CLOSE","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___Close);
-  DProlist->SetTree( treePro);
+  //IDLFFSHAPE::CLOSE
+  DProlist = new DPro("CLOSE", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___Close);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::DESTROYENTITY
-  DProlist = new DPro("DESTROYENTITY","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::DESTROYENTITY
+  DProlist = new DPro("DESTROYENTITY", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DProlist->AddPar("Entity");
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___DestroyEntity);
-  DProlist->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___DestroyEntity);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::GETPROPERTY
-  DProlist = new DPro("GETPROPERTY","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("ATTRIBUTE_INFO","ATTRIBUTE_INFO");
-  DProlist->AddKey("ATTRIBUTE_NAMES","ATTRIBUTE_NAMES");
-  DProlist->AddKey("ENTITY_TYPE","ENTITY_TYPE");
-  DProlist->AddKey("FILENAME","FILENAME");
-  DProlist->AddKey("IS_OPEN","IS_OPEN");
-  DProlist->AddKey("N_ATTRIBUTES","N_ATTRIBUTES");
-  DProlist->AddKey("N_ENTITIES","N_ENTITIES");
-  DProlist->AddKey("N_RECORDS","N_RECORDS");
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___GetProperty);
-  DProlist->SetTree( treePro);
+  //IDLFFSHAPE::GETPROPERTY
+  DProlist = new DPro("GETPROPERTY", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("ATTRIBUTE_INFO", "ATTRIBUTE_INFO");
+  DProlist->AddKey("ATTRIBUTE_NAMES", "ATTRIBUTE_NAMES");
+  DProlist->AddKey("ENTITY_TYPE", "ENTITY_TYPE");
+  DProlist->AddKey("FILENAME", "FILENAME");
+  DProlist->AddKey("IS_OPEN", "IS_OPEN");
+  DProlist->AddKey("N_ATTRIBUTES", "N_ATTRIBUTES");
+  DProlist->AddKey("N_ENTITIES", "N_ENTITIES");
+  DProlist->AddKey("N_RECORDS", "N_RECORDS");
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___GetProperty);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::PUTENTITY
-  DProlist = new DPro("PUTENTITY","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::PUTENTITY
+  DProlist = new DPro("PUTENTITY", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DProlist->AddPar("DATA");
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___PutEntity);
-  DProlist->SetTree( treePro);
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___PutEntity);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
- //IDLFFSHAPE::SETATTRIBUTES
-  DProlist = new DPro("SETATTRIBUTES","IDLFFSHAPE",INTERNAL_LIBRARY_STR);
+  //IDLFFSHAPE::SETATTRIBUTES
+  DProlist = new DPro("SETATTRIBUTES", "IDLFFSHAPE", INTERNAL_LIBRARY_STR);
   DProlist->AddPar("INDEX");
   DProlist->AddPar("ATTRIBUTES_NUM");
-  DProlist->AddPar("Value"); 
-  treePro = new WRAPPED_PRONode( lib::GDLffShape___SetAttributes);
-  DProlist->SetTree( treePro);
+  DProlist->AddPar("Value");
+  treePro = new WRAPPED_PRONode(lib::GDLffShape___SetAttributes);
+  DProlist->SetTree(treePro);
   GDLffShapeDesc->ProList().push_back(DProlist);
 #endif
 
@@ -1156,26 +1138,26 @@ void SetupOverloadSubroutines()
   DProlist->SetTree(treePro);
   GDLffXmlSaxDesc->ProList().push_back(DProlist);
 
-  DProlist = new DPro("GETPROPERTY","IDLFFXMLSAX",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("VALIDATION_MODE","VALIDATION_MODE"); //6
-  DProlist->AddKey("SCHEMA_CHECKING","SCHEMA_CHECKING"); //5
-  DProlist->AddKey("PARSER_URI","PARSER_URI"); //4
-  DProlist->AddKey("PARSER_PUBLICID","PARSER_PUBLICID"); //3
-  DProlist->AddKey("PARSER_LOCATION","PARSER_LOCATION"); //2
-  DProlist->AddKey("NAMESPACE_PREFIXES","NAMESPACE_PREFIXES"); //1
-  DProlist->AddKey("FILENAME","FILENAME"); //0
-  treePro = new WRAPPED_PRONode( lib::GDLffXmlSax__GetProperty);
-  DProlist->SetTree( treePro);
-  GDLffXmlSaxDesc->ProList().push_back(DProlist);
-  
-  DProlist = new DPro("SETPROPERTY","IDLFFXMLSAX",INTERNAL_LIBRARY_STR);
-  DProlist->AddKey("NAMESPACE_PREFIXES","NAMESPACE_PREFIXES");
-  DProlist->AddKey("SCHEMA_CHECKING","SCHEMA_CHECKING");
-  DProlist->AddKey("VALIDATION_MODE","VALIDATION_MODE");
-  treePro = new WRAPPED_PRONode( lib::GDLffXmlSax__SetProperty);
-  DProlist->SetTree( treePro);
+  DProlist = new DPro("GETPROPERTY", "IDLFFXMLSAX", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("VALIDATION_MODE", "VALIDATION_MODE"); //6
+  DProlist->AddKey("SCHEMA_CHECKING", "SCHEMA_CHECKING"); //5
+  DProlist->AddKey("PARSER_URI", "PARSER_URI"); //4
+  DProlist->AddKey("PARSER_PUBLICID", "PARSER_PUBLICID"); //3
+  DProlist->AddKey("PARSER_LOCATION", "PARSER_LOCATION"); //2
+  DProlist->AddKey("NAMESPACE_PREFIXES", "NAMESPACE_PREFIXES"); //1
+  DProlist->AddKey("FILENAME", "FILENAME"); //0
+  treePro = new WRAPPED_PRONode(lib::GDLffXmlSax__GetProperty);
+  DProlist->SetTree(treePro);
   GDLffXmlSaxDesc->ProList().push_back(DProlist);
 
-  
+  DProlist = new DPro("SETPROPERTY", "IDLFFXMLSAX", INTERNAL_LIBRARY_STR);
+  DProlist->AddKey("NAMESPACE_PREFIXES", "NAMESPACE_PREFIXES");
+  DProlist->AddKey("SCHEMA_CHECKING", "SCHEMA_CHECKING");
+  DProlist->AddKey("VALIDATION_MODE", "VALIDATION_MODE");
+  treePro = new WRAPPED_PRONode(lib::GDLffXmlSax__SetProperty);
+  DProlist->SetTree(treePro);
+  GDLffXmlSaxDesc->ProList().push_back(DProlist);
+
+
 #endif
 }

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -257,8 +257,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = (s == (*left)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -271,8 +270,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == s);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -281,8 +279,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -296,8 +293,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == (*left)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -343,8 +339,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = (s != (*left)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
        for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
    } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -357,8 +352,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != s);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -367,8 +361,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && rEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= rEl));
-    if (!parallelize) {
+    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -382,8 +375,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != (*left)[0]);
       return res;
     }
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -257,7 +257,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = (s == (*left)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
@@ -270,7 +270,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == s);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -279,7 +279,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -293,7 +293,7 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == (*left)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -339,7 +339,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = (s != (*left)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
        for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
    } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -352,7 +352,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != s);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -361,7 +361,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
@@ -375,7 +375,7 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != (*left)[0]);
       return res;
     }
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -257,11 +257,11 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = (s == (*left)[0]);
       return res;
     }
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*left)[i] == s);
     }
   } else if (left->StrictScalar(s)) {
@@ -270,20 +270,20 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == s);
       return res;
     }
-    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < rEl; ++i)  (*res)[i] = ((*right)[i] == s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     }
   } else // ( rEl >= nEl)
@@ -293,11 +293,11 @@ BaseGDL* _GDL_OBJECT_OverloadEQOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] == (*left)[0]);
       return res;
     }
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] == (*left)[i]);
     }
   }
@@ -339,11 +339,11 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = (s != (*left)[0]);
       return res;
     }
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
        for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
    } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] = ((*left)[i] != s);
     }
   } else if (left->StrictScalar(s)) {
@@ -352,20 +352,20 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != s);
       return res;
     }
-    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != s);
     }
   } else if (rEl < nEl) {
     res = new Data_<SpDByte>(right->Dim(), BaseGDL::NOZERO);
-    if (!parallelize( rEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( rEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < rEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     }
   } else // ( rEl >= nEl)
@@ -375,11 +375,11 @@ BaseGDL* _GDL_OBJECT_OverloadNEOp(EnvUDT* e) {
       (*res)[0] = ((*right)[0] != (*left)[0]);
       return res;
     }
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     } else {
     TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
       for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = ((*right)[i] != (*left)[i]);
     }
   }

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -445,14 +445,14 @@ namespace lib
 
     if ( xML+xMR>=1.0 )
     {
-      Message("XMARGIN to large (adjusted).");
+//      Message("XMARGIN to large (adjusted).");
       PLFLT xMMult=xML+xMR;
       xML/=xMMult*1.5;
       xMR/=xMMult*1.5;
     }
     if ( yMB+yMT>=1.0 )
     {
-      Message("YMARGIN to large (adjusted).");
+//      Message("YMARGIN to large (adjusted).");
       PLFLT yMMult=yMB+yMT;
       yMB/=yMMult*1.5;
       yMT/=yMMult*1.5;

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1641,8 +1641,7 @@ namespace lib
     DFloat thethick;
     DLong thecolor;
     DFloat *x, *y;
-    SizeT nParam=e->NParam();
-    if (nParam==0) e->Throw("Incorrect number of arguments.");
+    SizeT nParam=e->NParam(1);
     if ( nParam==1 )
     {
       BaseGDL* p0=e->GetNumericArrayParDefined(0)->Transpose(NULL); //hence [49,2]

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1730,14 +1730,14 @@ void GDLgrProjectedPolygonPlot( GDLGStream * a, PROJTYPE ref, DStructGDL* map,
     DLongGDL *gons, *lines;
     if (!isRadians) {
     SizeT nin = lons->N_Elements( );
-    if (!parallelize( nin, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nin, TP_MEMORY_ACCESS)==1) {
         for (OMPInt in = 0; in < nin; in++) { //pass in radians for gdlProjForward
           (*lons)[in] *= DEG_TO_RAD;
           (*lats)[in] *= DEG_TO_RAD;
         }      
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for ( OMPInt in = 0; in < nin; in++ ) { //pass in radians for gdlProjForward
           (*lons)[in] *= DEG_TO_RAD;
           (*lats)[in] *= DEG_TO_RAD;

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1730,8 +1730,7 @@ void GDLgrProjectedPolygonPlot( GDLGStream * a, PROJTYPE ref, DStructGDL* map,
     DLongGDL *gons, *lines;
     if (!isRadians) {
     SizeT nin = lons->N_Elements( );
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nin));
-    if (!parallelize) {
+    if (!parallelize( nin, TP_MEMORY_ACCESS)) {
         for (OMPInt in = 0; in < nin; in++) { //pass in radians for gdlProjForward
           (*lons)[in] *= DEG_TO_RAD;
           (*lats)[in] *= DEG_TO_RAD;

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1731,6 +1731,7 @@ void GDLgrProjectedPolygonPlot( GDLGStream * a, PROJTYPE ref, DStructGDL* map,
     DLongGDL *gons, *lines;
     if (!isRadians) {
     SizeT nin = lons->N_Elements( );
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nin >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nin))
       {
 #pragma omp for

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1730,7 +1730,7 @@ void GDLgrProjectedPolygonPlot( GDLGStream * a, PROJTYPE ref, DStructGDL* map,
     DLongGDL *gons, *lines;
     if (!isRadians) {
     SizeT nin = lons->N_Elements( );
-    if (GDL_NTHREADS=parallelize( nin, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nin, TP_MEMORY_ACCESS))==1) {
         for (OMPInt in = 0; in < nin; in++) { //pass in radians for gdlProjForward
           (*lons)[in] *= DEG_TO_RAD;
           (*lats)[in] *= DEG_TO_RAD;

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -28,55 +28,58 @@ namespace lib {
 
   using namespace std;
 
-  static DDouble cubeCorners[32]=
-      {
-   0,1,0,1,0,1,0,1,0,0,1,1,0,0,1,1,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1
+  static DDouble cubeCorners[32] ={
+    0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
   };
 
   DDoubleGDL* convert_coord_double(EnvT* e, DDoubleGDL* xVal, DDoubleGDL* yVal, DDoubleGDL* zVal) {
 
-    typedef enum
-    {
-      DATA=0,
+    typedef enum {
+      DATA = 0,
       NORMAL,
       DEVICE
-    } COORDSYS; 
-    
-    COORDSYS icoordinateSystem=DATA, ocoordinateSystem=DATA ;
+    } COORDSYS;
+
+    COORDSYS icoordinateSystem = DATA, ocoordinateSystem = DATA;
     //check presence of DATA,DEVICE and NORMAL options
-    static int DATAIx=e->KeywordIx("DATA");
-    static int DEVICEIx=e->KeywordIx("DEVICE");
-    static int NORMALIx=e->KeywordIx("NORMAL");
-    static int TO_DATAIx=e->KeywordIx("TO_DATA");
-    static int TO_DEVICEIx=e->KeywordIx("TO_DEVICE");
-    static int TO_NORMALIx=e->KeywordIx("TO_NORMAL");
-    
-    if ( e->KeywordSet(DATAIx) ) icoordinateSystem=DATA;
-    if ( e->KeywordSet(DEVICEIx) ) icoordinateSystem=DEVICE;
-    if ( e->KeywordSet(NORMALIx) ) icoordinateSystem=NORMAL;
-    if ( e->KeywordSet(TO_DATAIx) ) ocoordinateSystem=DATA;
-    if ( e->KeywordSet(TO_DEVICEIx) ) ocoordinateSystem=DEVICE;
-    if ( e->KeywordSet(TO_NORMALIx) ) ocoordinateSystem=NORMAL;
-    static int t3dIx = e->KeywordIx( "T3D");
-    bool doT3d=(e->KeywordSet(t3dIx) || T3Denabled());   
+    static int DATAIx = e->KeywordIx("DATA");
+    static int DEVICEIx = e->KeywordIx("DEVICE");
+    static int NORMALIx = e->KeywordIx("NORMAL");
+    static int TO_DATAIx = e->KeywordIx("TO_DATA");
+    static int TO_DEVICEIx = e->KeywordIx("TO_DEVICE");
+    static int TO_NORMALIx = e->KeywordIx("TO_NORMAL");
+
+    if (e->KeywordSet(DATAIx)) icoordinateSystem = DATA;
+    if (e->KeywordSet(DEVICEIx)) icoordinateSystem = DEVICE;
+    if (e->KeywordSet(NORMALIx)) icoordinateSystem = NORMAL;
+    if (e->KeywordSet(TO_DATAIx)) ocoordinateSystem = DATA;
+    if (e->KeywordSet(TO_DEVICEIx)) ocoordinateSystem = DEVICE;
+    if (e->KeywordSet(TO_NORMALIx)) ocoordinateSystem = NORMAL;
+    static int t3dIx = e->KeywordIx("T3D");
+    bool doT3d = (e->KeywordSet(t3dIx) || T3Denabled());
     DLong dims[2] = {3, 0};
 
     DDoubleGDL* res;
     SizeT nrows;
 
     nrows = xVal->Dim(0);
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows)));
     dims[1] = nrows;
     dimension dim((DLong *) dims, 2);
     res = new DDoubleGDL(dim, BaseGDL::NOZERO);
 
     //eliminate simplest case here:
-    if (ocoordinateSystem==icoordinateSystem)
-    {
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
+    if (ocoordinateSystem == icoordinateSystem) {
+      if (!parallelize) {
         for (OMPInt i = 0; i < nrows; ++i) {
+          (*res)[i * 3 + 0] = (*xVal)[i];
+          (*res)[i * 3 + 1] = (*yVal)[i];
+          (*res)[i * 3 + 2] = (*zVal)[i];
+        }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nrows; ++i) {
           (*res)[i * 3 + 0] = (*xVal)[i];
           (*res)[i * 3 + 1] = (*yVal)[i];
           (*res)[i * 3 + 2] = (*zVal)[i];
@@ -87,176 +90,177 @@ namespace lib {
 
     DDouble *sx, *sy, *sz;
     GetSFromPlotStructs(&sx, &sy, &sz);
-    
+
     bool xLog, yLog, zLog;
     gdlGetAxisType(XAXIS, xLog);
     gdlGetAxisType(YAXIS, yLog);
     gdlGetAxisType(ZAXIS, zLog);
-        
+
     int xSize, ySize;
     //give default values
     DStructGDL* dStruct = SysVar::D();
-    unsigned xsizeTag = dStruct->Desc()->TagIndex( "X_SIZE");
-    unsigned ysizeTag = dStruct->Desc()->TagIndex( "Y_SIZE");
-    xSize = (*static_cast<DLongGDL*>( dStruct->GetTag( xsizeTag, 0)))[0];
-    ySize = (*static_cast<DLongGDL*>( dStruct->GetTag( ysizeTag, 0)))[0];
+    unsigned xsizeTag = dStruct->Desc()->TagIndex("X_SIZE");
+    unsigned ysizeTag = dStruct->Desc()->TagIndex("Y_SIZE");
+    xSize = (*static_cast<DLongGDL*> (dStruct->GetTag(xsizeTag, 0)))[0];
+    ySize = (*static_cast<DLongGDL*> (dStruct->GetTag(ysizeTag, 0)))[0];
     // Use Size in lieu of VSize
     GraphicsDevice* actDevice = GraphicsDevice::GetDevice();
     DLong wIx = actDevice->ActWin();
-    if( wIx != -1) bool success = actDevice->WSize(wIx, &xSize, &ySize); //on failure, sizes are ot changed by WSize.
-    
+    if (wIx != -1) bool success = actDevice->WSize(wIx, &xSize, &ySize); //on failure, sizes are ot changed by WSize.
+
     //projection?
-      bool mapSet=false;
+    bool mapSet = false;
 #ifdef USE_LIBPROJ
-      static LPTYPE idata;
-      static XYTYPE odata;
-      get_mapset ( mapSet );
-      if ( mapSet )
-      {
-        ref=map_init ();
-        if ( ref==NULL ) e->Throw ( "Projection initialization failed." );
+    static LPTYPE idata;
+    static XYTYPE odata;
+    get_mapset(mapSet);
+    if (mapSet) {
+      ref = map_init();
+      if (ref == NULL) e->Throw("Projection initialization failed.");
+    }
+#endif
+
+    //convert input (we can overwrite X Y and Z) to normalized
+    switch (icoordinateSystem) {
+    case DATA:
+      // to u,v
+#ifdef USE_LIBPROJ
+      if (mapSet) {
+          for (SizeT i = 0; i < nrows; i++) {
+#if LIBPROJ_MAJOR_VERSION >= 5
+            idata.lam = (*xVal)[i] * DEG_TO_RAD;
+            idata.phi = (*yVal)[i] * DEG_TO_RAD;
+            odata = protect_proj_fwd_lp(idata, ref);
+            (*xVal)[i] = odata.x;
+            (*yVal)[i] = odata.y;
+#else
+            idata.u = (*xVal)[i] * DEG_TO_RAD;
+            idata.v = (*yVal)[i] * DEG_TO_RAD;
+            odata = PJ_FWD(idata, ref);
+            (*xVal)[i] = odata.u;
+            (*yVal)[i] = odata.v;
+#endif
+          }
       }
 #endif
-      
-    //convert input (we can overwrite X Y and Z) to normalized 
-    switch(icoordinateSystem)
-    {
-      case DATA:
-        // to u,v
-#ifdef USE_LIBPROJ
-      if ( mapSet )
-      {
-#ifdef PROJ_IS_THREADSAFE
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-        {
-#pragma omp for private(idata,odata)
-#endif
-            for (SizeT i = 0; i < nrows; i++) {
-#if LIBPROJ_MAJOR_VERSION >= 5
-              idata.lam = (*xVal)[i] * DEG_TO_RAD;
-              idata.phi = (*yVal)[i] * DEG_TO_RAD;
-              odata = protect_proj_fwd_lp(idata, ref);
-              (*xVal)[i] = odata.x;
-              (*yVal)[i] = odata.y;
-#else
-              idata.u = (*xVal)[i] * DEG_TO_RAD;
-              idata.v = (*yVal)[i] * DEG_TO_RAD;
-              odata = PJ_FWD(idata, ref);
-              (*xVal)[i] = odata.u;
-              (*yVal)[i] = odata.v;
-#endif
-            }
-#ifdef PROJ_IS_THREADSAFE
-          }
-#endif
-        }
-#endif
-        // to norm:
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
+      // to norm:
+      if (!parallelize) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
           TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
           TONORMCOORDZ((*zVal)[i], (*zVal)[i], zLog, doT3d);
         }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nrows; ++i) {
+          TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
+          TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
+          TONORMCOORDZ((*zVal)[i], (*zVal)[i], zLog, doT3d);
+        }
       }
-        break;
-      case DEVICE:
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
+      break;
+    case DEVICE:
+      if (!parallelize) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] /= xSize;
           (*yVal)[i] /= ySize;
           // (zSize is 1)
         }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nrows; ++i) {
+          (*xVal)[i] /= xSize;
+          (*yVal)[i] /= ySize;
+          // (zSize is 1)
+        }
       }
-      default:
-        break;
+    default:
+      break;
     }
 
-    //convert to output from normalized 
-    switch(ocoordinateSystem)
-    {
-      case DATA:
-        // from norm:
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
+    //convert to output from normalized
+    switch (ocoordinateSystem) {
+    case DATA:
+      // from norm:
+      if (!parallelize) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
           TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
           TODATACOORDZ((*zVal)[i], (*zVal)[i], zLog, doT3d);
         }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nrows; ++i) {
+          TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
+          TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
+          TODATACOORDZ((*zVal)[i], (*zVal)[i], zLog, doT3d);
+        }
       }
-      
+
       // from u,v
 #ifdef USE_LIBPROJ
-      if ( mapSet )
-      {
-#ifdef PROJ_IS_THREADSAFE
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-        {
-#pragma omp for private(idata,odata)
-#endif
-            for (SizeT i = 0; i < nrows; i++) {
+      if (mapSet) {
+          for (SizeT i = 0; i < nrows; i++) {
 #if LIBPROJ_MAJOR_VERSION >= 5
-              odata.x = (*xVal)[i];
-              odata.y = (*yVal)[i];
-              idata = protect_proj_inv_xy(odata, ref);
-              (*xVal)[i] = idata.lam * RAD_TO_DEG;
-              (*yVal)[i] = idata.phi * RAD_TO_DEG;
+            odata.x = (*xVal)[i];
+            odata.y = (*yVal)[i];
+            idata = protect_proj_inv_xy(odata, ref);
+            (*xVal)[i] = idata.lam * RAD_TO_DEG;
+            (*yVal)[i] = idata.phi * RAD_TO_DEG;
 #else
-              odata.u = (*xVal)[i];
-              odata.v = (*yVal)[i];
-              idata = PJ_INV(odata, ref);
-              (*xVal)[i] = idata.u * RAD_TO_DEG;
-              (*yVal)[i] = idata.v * RAD_TO_DEG;
+            odata.u = (*xVal)[i];
+            odata.v = (*yVal)[i];
+            idata = PJ_INV(odata, ref);
+            (*xVal)[i] = idata.u * RAD_TO_DEG;
+            (*yVal)[i] = idata.v * RAD_TO_DEG;
 #endif
-            }
-#ifdef PROJ_IS_THREADSAFE
           }
-#endif
         }
 #endif
 
-        break;
-      case DEVICE:
-	TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
+      break;
+    case DEVICE:
+      if (!parallelize) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] *= xSize;
           (*yVal)[i] *= ySize;
           //(zSize is 1)
         }
-      }
-      default:
-        break;
-    }
-    
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
-      {
-#pragma omp for
-        for (OMPInt i = 0; i < nrows; ++i) {
-          (*res)[i * 3 + 0] = (*xVal)[i];
-          (*res)[i * 3 + 1] = (*yVal)[i];
-          (*res)[i * 3 + 2] = (*zVal)[i];
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nrows; ++i) {
+          (*xVal)[i] *= xSize;
+          (*yVal)[i] *= ySize;
+          //(zSize is 1)
         }
       }
+    default:
+      break;
+    }
+
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nrows; ++i) {
+        (*res)[i * 3 + 0] = (*xVal)[i];
+        (*res)[i * 3 + 1] = (*yVal)[i];
+        (*res)[i * 3 + 2] = (*zVal)[i];
+      }
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nrows; ++i) {
+        (*res)[i * 3 + 0] = (*xVal)[i];
+        (*res)[i * 3 + 1] = (*yVal)[i];
+        (*res)[i * 3 + 2] = (*zVal)[i];
+      }
+    }
     return res;
   }
 
-  BaseGDL* convert_coord( EnvT* e)
-  {
+  BaseGDL* convert_coord(EnvT* e) {
     DDoubleGDL* xVal, *yVal, *zVal;
     Guard<DDoubleGDL> xval_guard, yval_guard, zval_guard;
     SizeT xEl, yEl, zEl, minEl, xDim, yDim, zDim;
@@ -266,761 +270,772 @@ namespace lib {
     //minimum set of dimensions of arrays. singletons expanded to dimension,
 
     //T3D
-    static int t3dIx = e->KeywordIx( "T3D");
-    bool doT3d=(e->KeywordSet(t3dIx) || T3Denabled());
+    static int t3dIx = e->KeywordIx("T3D");
+    bool doT3d = (e->KeywordSet(t3dIx) || T3Denabled());
     DDoubleGDL *xValou;
     DDoubleGDL *yValou;
     Guard<BaseGDL> xvalou_guard, yvalou_guard;
-    
-    SizeT nParam=e->NParam();
-    if( nParam < 1)
-      e->Throw( "Incorrect number of arguments.");
+
+    SizeT nParam = e->NParam();
+    if (nParam < 1)
+      e->Throw("Incorrect number of arguments.");
 
     BaseGDL* p0;
     BaseGDL* p1;
     BaseGDL* p2;
-    
-    DType type=GDL_FLOAT;
-    static int doubleIx = e->KeywordIx( "DOUBLE");
-    if (e->KeywordSet(doubleIx)) type=GDL_DOUBLE;
 
-    p0 = e->GetParDefined( 0);
-    if (p0->Type() == GDL_DOUBLE) type=GDL_DOUBLE;
+    DType type = GDL_FLOAT;
+    static int doubleIx = e->KeywordIx("DOUBLE");
+    if (e->KeywordSet(doubleIx)) type = GDL_DOUBLE;
 
-    if( e->NParam() == 1) {
-      if (p0->Dim(0) == 0) e->Throw( "Expression must be an array in this context: "+e->GetParString(0));
-      if (p0->Dim(0) != 2 && p0->Dim(0) != 3) e->Throw( "When only 1 param, dims must be (2,n) or (3,n)"); //with n=0 also!!!
-      SizeT dim0=p0->Dim(0);
-      minEl=p0->Dim(1);
-      if (minEl==0) minEl=1; // aka in convert_coord([44,22])-->n_dim=1,dim=2
-      xVal=new DDoubleGDL(dimension(minEl), BaseGDL::NOZERO);
+    p0 = e->GetParDefined(0);
+    if (p0->Type() == GDL_DOUBLE) type = GDL_DOUBLE;
+
+    if (e->NParam() == 1) {
+      if (p0->Dim(0) == 0) e->Throw("Expression must be an array in this context: " + e->GetParString(0));
+      if (p0->Dim(0) != 2 && p0->Dim(0) != 3) e->Throw("When only 1 param, dims must be (2,n) or (3,n)"); //with n=0 also!!!
+      SizeT dim0 = p0->Dim(0);
+      minEl = p0->Dim(1);
+      if (minEl == 0) minEl = 1; // aka in convert_coord([44,22])-->n_dim=1,dim=2
+      xVal = new DDoubleGDL(dimension(minEl), BaseGDL::NOZERO);
       xval_guard.Reset(xVal); // delete upon exit
-      DDoubleGDL* tmpVal=e->GetParAs< DDoubleGDL>(0);
-      for (SizeT i=0; i< minEl ; ++i) (*xVal)[i]=(*tmpVal)[i*dim0+0];
-      yVal=new DDoubleGDL(dimension(minEl), BaseGDL::NOZERO);
+      DDoubleGDL* tmpVal = e->GetParAs< DDoubleGDL>(0);
+      for (SizeT i = 0; i < minEl; ++i) (*xVal)[i] = (*tmpVal)[i * dim0 + 0];
+      yVal = new DDoubleGDL(dimension(minEl), BaseGDL::NOZERO);
       yval_guard.Reset(yVal); // delete upon exit
-      for (SizeT i=0; i< minEl ; ++i) (*yVal)[i]=(*tmpVal)[i*dim0+1];
-      zVal=new DDoubleGDL(dimension(minEl), BaseGDL::ZERO);
+      for (SizeT i = 0; i < minEl; ++i) (*yVal)[i] = (*tmpVal)[i * dim0 + 1];
+      zVal = new DDoubleGDL(dimension(minEl), BaseGDL::ZERO);
       zval_guard.Reset(zVal); // delete upon exit
-      if (dim0==3) for (SizeT i=0; i< minEl ; ++i) (*zVal)[i]=(*tmpVal)[i*dim0+2];
+      if (dim0 == 3) for (SizeT i = 0; i < minEl; ++i) (*zVal)[i] = (*tmpVal)[i * dim0 + 2];
     }
 
     if (nParam >= 2) {
-      p1 = e->GetParDefined( 1);
-      if (p1->Type() == GDL_DOUBLE) type=GDL_DOUBLE;
-      xVal=e->GetParAs< DDoubleGDL>(0);
-      xEl=xVal->N_Elements();
-      xDim=xVal->Dim(0);
-      yVal=e->GetParAs< DDoubleGDL>(1);
-      yEl=yVal->N_Elements();
-      yDim=yVal->Dim(0);
+      p1 = e->GetParDefined(1);
+      if (p1->Type() == GDL_DOUBLE) type = GDL_DOUBLE;
+      xVal = e->GetParAs< DDoubleGDL>(0);
+      xEl = xVal->N_Elements();
+      xDim = xVal->Dim(0);
+      yVal = e->GetParAs< DDoubleGDL>(1);
+      yEl = yVal->N_Elements();
+      yDim = yVal->Dim(0);
       //minEl:
-      minEl=-1;
-      minEl=(minEl>xEl&&xDim)?xEl:minEl;
-      minEl=(minEl>yEl&&yDim)?yEl:minEl;
-      
-      if (minEl==-1){
-        minEl=1;
+      minEl = -1;
+      minEl = (minEl > xEl && xDim) ? xEl : minEl;
+      minEl = (minEl > yEl && yDim) ? yEl : minEl;
+
+      if (minEl == -1) {
+        minEl = 1;
       } else {
-        minEl=(minEl>xEl&&xDim)?xEl:minEl;
-        minEl=(minEl>yEl&&yDim)?yEl:minEl;
+        minEl = (minEl > xEl && xDim) ? xEl : minEl;
+        minEl = (minEl > yEl && yDim) ? yEl : minEl;
       }
-      DDoubleGDL* tmpxVal=e->GetParAs< DDoubleGDL>(0);
-      xVal=new DDoubleGDL(minEl, BaseGDL::NOZERO); 
+      DDoubleGDL* tmpxVal = e->GetParAs< DDoubleGDL>(0);
+      xVal = new DDoubleGDL(minEl, BaseGDL::NOZERO);
       xval_guard.Reset(xVal); // delete upon exit
-      if (xDim) for (SizeT i=0; i< minEl ; ++i) (*xVal)[i]=(*tmpxVal)[i]; else for (SizeT i=0; i< minEl ; ++i) (*xVal)[i]=(*tmpxVal)[0];
-      DDoubleGDL* tmpyVal=e->GetParAs< DDoubleGDL>(1);
-      yVal=new DDoubleGDL(minEl, BaseGDL::NOZERO); 
+      if (xDim) for (SizeT i = 0; i < minEl; ++i) (*xVal)[i] = (*tmpxVal)[i];
+      else for (SizeT i = 0; i < minEl; ++i) (*xVal)[i] = (*tmpxVal)[0];
+      DDoubleGDL* tmpyVal = e->GetParAs< DDoubleGDL>(1);
+      yVal = new DDoubleGDL(minEl, BaseGDL::NOZERO);
       yval_guard.Reset(yVal); // delete upon exit
-      if (yDim) for (SizeT i=0; i< minEl ; ++i) (*yVal)[i]=(*tmpyVal)[i]; else for (SizeT i=0; i< minEl ; ++i) (*yVal)[i]=(*tmpyVal)[0];
-      zVal=new DDoubleGDL(minEl, BaseGDL::ZERO); 
+      if (yDim) for (SizeT i = 0; i < minEl; ++i) (*yVal)[i] = (*tmpyVal)[i];
+      else for (SizeT i = 0; i < minEl; ++i) (*yVal)[i] = (*tmpyVal)[0];
+      zVal = new DDoubleGDL(minEl, BaseGDL::ZERO);
       zval_guard.Reset(zVal); // delete upon exit
     }
 
     if (nParam == 3) {
-      p2 = e->GetParDefined( 2);
-      if (p2->Type() == GDL_DOUBLE) type=GDL_DOUBLE;
-      xVal=e->GetParAs< DDoubleGDL>(0);
-      xEl=xVal->N_Elements();
-      xDim=xVal->Dim(0);
-      yVal=e->GetParAs< DDoubleGDL>(1);
-      yEl=yVal->N_Elements();
-      yDim=yVal->Dim(0);
-      zVal=e->GetParAs<DDoubleGDL>(2);
-      zEl=zVal->N_Elements();
-      zDim=zVal->Dim(0);
+      p2 = e->GetParDefined(2);
+      if (p2->Type() == GDL_DOUBLE) type = GDL_DOUBLE;
+      xVal = e->GetParAs< DDoubleGDL>(0);
+      xEl = xVal->N_Elements();
+      xDim = xVal->Dim(0);
+      yVal = e->GetParAs< DDoubleGDL>(1);
+      yEl = yVal->N_Elements();
+      yDim = yVal->Dim(0);
+      zVal = e->GetParAs<DDoubleGDL>(2);
+      zEl = zVal->N_Elements();
+      zDim = zVal->Dim(0);
       //minEl:
-      minEl=-1;
-      minEl=(minEl>xEl&&xDim)?xEl:minEl;
-      minEl=(minEl>yEl&&yDim)?yEl:minEl;
-      minEl=(minEl>zEl&&zDim)?zEl:minEl;
-      
-      if (minEl==-1){
-        minEl=1;
+      minEl = -1;
+      minEl = (minEl > xEl && xDim) ? xEl : minEl;
+      minEl = (minEl > yEl && yDim) ? yEl : minEl;
+      minEl = (minEl > zEl && zDim) ? zEl : minEl;
+
+      if (minEl == -1) {
+        minEl = 1;
       } else {
-        minEl=(minEl>xEl&&xDim)?xEl:minEl;
-        minEl=(minEl>yEl&&yDim)?yEl:minEl;
-        minEl=(minEl>zEl&&zDim)?zEl:minEl;
+        minEl = (minEl > xEl && xDim) ? xEl : minEl;
+        minEl = (minEl > yEl && yDim) ? yEl : minEl;
+        minEl = (minEl > zEl && zDim) ? zEl : minEl;
       }
-      DDoubleGDL* tmpxVal=e->GetParAs< DDoubleGDL>(0);
-      xVal=new DDoubleGDL(minEl, BaseGDL::NOZERO); 
+      DDoubleGDL* tmpxVal = e->GetParAs< DDoubleGDL>(0);
+      xVal = new DDoubleGDL(minEl, BaseGDL::NOZERO);
       xval_guard.Reset(xVal); // delete upon exit
-      if (xDim) for (SizeT i=0; i< minEl ; ++i) (*xVal)[i]=(*tmpxVal)[i]; else for (SizeT i=0; i< minEl ; ++i) (*xVal)[i]=(*tmpxVal)[0];
-      DDoubleGDL* tmpyVal=e->GetParAs< DDoubleGDL>(1);
-      yVal=new DDoubleGDL(minEl, BaseGDL::NOZERO); 
+      if (xDim) for (SizeT i = 0; i < minEl; ++i) (*xVal)[i] = (*tmpxVal)[i];
+      else for (SizeT i = 0; i < minEl; ++i) (*xVal)[i] = (*tmpxVal)[0];
+      DDoubleGDL* tmpyVal = e->GetParAs< DDoubleGDL>(1);
+      yVal = new DDoubleGDL(minEl, BaseGDL::NOZERO);
       yval_guard.Reset(yVal); // delete upon exit
-      if (yDim) for (SizeT i=0; i< minEl ; ++i) (*yVal)[i]=(*tmpyVal)[i]; else for (SizeT i=0; i< minEl ; ++i) (*yVal)[i]=(*tmpyVal)[0];
-      DDoubleGDL* tmpzVal=e->GetParAs< DDoubleGDL>(2);
-      zVal=new DDoubleGDL(minEl, BaseGDL::NOZERO);
+      if (yDim) for (SizeT i = 0; i < minEl; ++i) (*yVal)[i] = (*tmpyVal)[i];
+      else for (SizeT i = 0; i < minEl; ++i) (*yVal)[i] = (*tmpyVal)[0];
+      DDoubleGDL* tmpzVal = e->GetParAs< DDoubleGDL>(2);
+      zVal = new DDoubleGDL(minEl, BaseGDL::NOZERO);
       zval_guard.Reset(zVal); // delete upon exit
-      if (zDim) for (SizeT i=0; i< minEl ; ++i) (*zVal)[i]=(*tmpzVal)[i]; else for (SizeT i=0; i< minEl ; ++i) (*zVal)[i]=(*tmpzVal)[0];       
+      if (zDim) for (SizeT i = 0; i < minEl; ++i) (*zVal)[i] = (*tmpzVal)[i];
+      else for (SizeT i = 0; i < minEl; ++i) (*zVal)[i] = (*tmpzVal)[0];
     }
 
-    if ( doT3d ) //convert X,Y,Z in X',Y' as per T3D perspective.
+    if (doT3d) //convert X,Y,Z in X',Y' as per T3D perspective.
     {
       DDoubleGDL* t3dMatrix;
       Guard<BaseGDL> t3dMatrix_guard;
-      t3dMatrix=gdlGetT3DMatrix(); //the original one
+      t3dMatrix = gdlGetT3DMatrix(); //the original one
       t3dMatrix_guard.Reset(t3dMatrix);
       DDouble *sx, *sy, *sz;
       GetSFromPlotStructs(&sx, &sy, &sz);
-      xValou=new DDoubleGDL(dimension(minEl));
-      yValou=new DDoubleGDL(dimension(minEl));
+      xValou = new DDoubleGDL(dimension(minEl));
+      yValou = new DDoubleGDL(dimension(minEl));
       Guard<BaseGDL> xval_guard, yval_guard;
       xval_guard.reset(xValou);
       yval_guard.reset(yValou);
       gdlProject3dCoordinatesIn2d(t3dMatrix, xVal, sx, yVal, sy, zVal, sz, xValou, yValou);
-      xVal=xValou;
-      yVal=yValou;
+      xVal = xValou;
+      yVal = yValou;
     }
-    
-    DDoubleGDL* res=convert_coord_double( e, xVal, yVal, zVal);
+
+    DDoubleGDL* res = convert_coord_double(e, xVal, yVal, zVal);
 
     if (type == GDL_DOUBLE) {
       return res;
     }
     //else return something...
-    DFloatGDL* res1 = static_cast<DFloatGDL*>(res->Convert2(GDL_FLOAT, BaseGDL::COPY));
+    DFloatGDL* res1 = static_cast<DFloatGDL*> (res->Convert2(GDL_FLOAT, BaseGDL::COPY));
     delete res;
     return res1;
   }
 
   //THE FOLLOWING ARE POSSIBLY THE WORST WAY TO DO THE JOB. At least they are to be used *only*
   //for [4,4] generalized 3D matrices
-  void SelfTranspose3d(DDoubleGDL* me)
-  {
+
+  void SelfTranspose3d(DDoubleGDL* me) {
     //crude quick hack to have the same behaviour as the other functions.
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim1,dim0),BaseGDL::NOZERO));
-    for (int j=0; j < dim0; ++j) for (int i=0; i < dim1; ++i)(*mat)[i*dim1+j]=(*me)[j*dim0 + i];
-    memcpy(me->DataAddr(),mat->DataAddr(),dim0*dim1*sizeof(double));
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim1, dim0), BaseGDL::NOZERO));
+    for (int j = 0; j < dim0; ++j) for (int i = 0; i < dim1; ++i)(*mat)[i * dim1 + j] = (*me)[j * dim0 + i];
+    memcpy(me->DataAddr(), mat->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(mat);
   }
-  void SelfReset3d(DDoubleGDL* me)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* Identity=(new DDoubleGDL(dimension(dim0,dim1)));
-    for(SizeT i=0; i<dim1; ++i) {(*Identity)[i*dim1+i]=(double)1.0;}
-    memcpy(me->DataAddr(),Identity->DataAddr(),dim0*dim1*sizeof(double));
+
+  void SelfReset3d(DDoubleGDL* me) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* Identity = (new DDoubleGDL(dimension(dim0, dim1)));
+    for (SizeT i = 0; i < dim1; ++i) {
+      (*Identity)[i * dim1 + i] = (double) 1.0;
+    }
+    memcpy(me->DataAddr(), Identity->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(Identity);
   }
-  DDoubleGDL* Translate3d(DDoubleGDL* me, DDouble* trans)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
+
+  DDoubleGDL* Translate3d(DDoubleGDL* me, DDouble* trans) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
     Guard<BaseGDL> mat_guard;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
     mat_guard.Reset(mat);
     SelfReset3d(mat); //identity Matrix
-    for(SizeT i=0; i<3; ++i) {(*mat)[3*dim1+i]=trans[i];}
-    return mat->MatrixOp(me,false,false);
+    for (SizeT i = 0; i < 3; ++i) {
+      (*mat)[3 * dim1 + i] = trans[i];
+    }
+    return mat->MatrixOp(me, false, false);
   }
-  void SelfTranslate3d(DDoubleGDL* me, DDouble* trans)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
+
+  void SelfTranslate3d(DDoubleGDL* me, DDouble* trans) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
     SelfReset3d(mat); //identity Matrix
-    for(SizeT i=0; i<3; ++i) {(*mat)[3*dim1+i]=trans[i];}
-    DDoubleGDL* intermediary=mat->MatrixOp(me,false,false);
-    memcpy(me->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
+    for (SizeT i = 0; i < 3; ++i) {
+      (*mat)[3 * dim1 + i] = trans[i];
+    }
+    DDoubleGDL* intermediary = mat->MatrixOp(me, false, false);
+    memcpy(me->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(intermediary);
     GDLDelete(mat);
   }
-  DDoubleGDL* Scale3d(DDoubleGDL* me, DDouble *scale)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
+
+  DDoubleGDL* Scale3d(DDoubleGDL* me, DDouble *scale) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
     Guard<BaseGDL> mat_guard;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
     mat_guard.Reset(mat);
     SelfReset3d(mat); //identity Matrix
-    for(SizeT i=0; i<3; ++i) {(*mat)[i*dim1+i]=scale[i];}
-    return mat->MatrixOp(me,false,false);
+    for (SizeT i = 0; i < 3; ++i) {
+      (*mat)[i * dim1 + i] = scale[i];
+    }
+    return mat->MatrixOp(me, false, false);
   }
-  void SelfScale3d(DDoubleGDL* me, DDouble *scale)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
+
+  void SelfScale3d(DDoubleGDL* me, DDouble *scale) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
     SelfReset3d(mat); //identity Matrix
-    for(SizeT i=0; i<3; ++i) {(*mat)[i*dim1+i]=scale[i];}
-    DDoubleGDL* intermediary=mat->MatrixOp(me,false,false);
-    memcpy(me->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
+    for (SizeT i = 0; i < 3; ++i) {
+      (*mat)[i * dim1 + i] = scale[i];
+    }
+    DDoubleGDL* intermediary = mat->MatrixOp(me, false, false);
+    memcpy(me->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(intermediary);
     GDLDelete(mat);
-}
+  }
 #define DPI (double)(4*atan(1.0))
 #define DEGTORAD (DPI/180.0)
 #define RADTODEG (180.0/DPI)
-  void SelfRotate3d(DDoubleGDL* me, DDouble *rot)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(4,4)));
-    SelfReset3d(mat);
-    DDoubleGDL* maty=(new DDoubleGDL(dimension(4,4)));
-    SelfReset3d(maty);
-    DDoubleGDL* matz=(new DDoubleGDL(dimension(4,4)));
-    SelfReset3d(matz);
-    SizeT ncols=4;
-    double c,s;
-    for(SizeT j=0; j<3; ++j)
-    {
-        c=cos(rot[j]*DEGTORAD);
-        s=sin(rot[j]*DEGTORAD);
-        switch(j)
-        {
-          case 0:
-          {
-            (*mat)[1 * ncols + 1] = c;
-            (*mat)[1 * ncols + 2] = s;
-            (*mat)[2 * ncols + 1] = -s;
-            (*mat)[2 * ncols + 2] = c;
-            break;
-          }
-          case 1:
-          {
-            (*maty)[0 * ncols + 0] = c;
-            (*maty)[0 * ncols + 2] = -s;
-            (*maty)[2 * ncols + 0] = s;
-            (*maty)[2 * ncols + 2] = c;
-            DDoubleGDL* intermediary=maty->MatrixOp(mat,false,false);
-            memcpy(mat->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
-            GDLDelete(intermediary);
-            break;
-          }
-          case 2:
-          {
-            (*matz)[0 * ncols + 0] = c;
-            (*matz)[0 * ncols + 1] = s;
-            (*matz)[1 * ncols + 0] = -s;
-            (*matz)[1 * ncols + 1] = c;
-            DDoubleGDL* intermediary=matz->MatrixOp(mat,false,false);
-            memcpy(mat->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
-            GDLDelete(intermediary);
-          }
-        }
-      }
 
-    DDoubleGDL* intermediary=mat->MatrixOp(me,false,false);
-    memcpy(me->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
+  void SelfRotate3d(DDoubleGDL* me, DDouble *rot) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(4, 4)));
+    SelfReset3d(mat);
+    DDoubleGDL* maty = (new DDoubleGDL(dimension(4, 4)));
+    SelfReset3d(maty);
+    DDoubleGDL* matz = (new DDoubleGDL(dimension(4, 4)));
+    SelfReset3d(matz);
+    SizeT ncols = 4;
+    double c, s;
+    for (SizeT j = 0; j < 3; ++j) {
+      c = cos(rot[j] * DEGTORAD);
+      s = sin(rot[j] * DEGTORAD);
+      switch (j) {
+      case 0:
+      {
+        (*mat)[1 * ncols + 1] = c;
+        (*mat)[1 * ncols + 2] = s;
+        (*mat)[2 * ncols + 1] = -s;
+        (*mat)[2 * ncols + 2] = c;
+        break;
+      }
+      case 1:
+      {
+        (*maty)[0 * ncols + 0] = c;
+        (*maty)[0 * ncols + 2] = -s;
+        (*maty)[2 * ncols + 0] = s;
+        (*maty)[2 * ncols + 2] = c;
+        DDoubleGDL* intermediary = maty->MatrixOp(mat, false, false);
+        memcpy(mat->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
+        GDLDelete(intermediary);
+        break;
+      }
+      case 2:
+      {
+        (*matz)[0 * ncols + 0] = c;
+        (*matz)[0 * ncols + 1] = s;
+        (*matz)[1 * ncols + 0] = -s;
+        (*matz)[1 * ncols + 1] = c;
+        DDoubleGDL* intermediary = matz->MatrixOp(mat, false, false);
+        memcpy(mat->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
+        GDLDelete(intermediary);
+      }
+      }
+    }
+
+    DDoubleGDL* intermediary = mat->MatrixOp(me, false, false);
+    memcpy(me->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(intermediary);
     GDLDelete(matz);
     GDLDelete(maty);
     GDLDelete(mat);
   }
-  void SelfPerspective3d(DDoubleGDL* me, DDouble zdist)
-  {
+
+  void SelfPerspective3d(DDoubleGDL* me, DDouble zdist) {
     if (!isfinite(zdist)) return; //Nan
-    if (zdist==0.0) return;
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
+    if (zdist == 0.0) return;
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
     SelfReset3d(mat); //identity Matrix
-    (*mat)[2*dim1+3]=-1.0/zdist;
-    DDoubleGDL* intermediary=mat->MatrixOp(me,false,false);
-    memcpy(me->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
-    GDLDelete(intermediary);
-    GDLDelete(mat);
- }
-  void SelfOblique3d(DDoubleGDL* me, DDouble dist, DDouble angle)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(dim0,dim1)));
-    SelfReset3d(mat); //identity Matrix
-    (*mat)[2*dim1+2]=0.0;
-    (*mat)[2*dim1+0]=dist*cos(angle*DEGTORAD);
-    (*mat)[2*dim1+1]=dist*sin(angle*DEGTORAD);
-    DDoubleGDL* intermediary=mat->MatrixOp(me,false,false);
-    memcpy(me->DataAddr(),intermediary->DataAddr(),dim0*dim1*sizeof(double));
+    (*mat)[2 * dim1 + 3] = -1.0 / zdist;
+    DDoubleGDL* intermediary = mat->MatrixOp(me, false, false);
+    memcpy(me->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
     GDLDelete(intermediary);
     GDLDelete(mat);
   }
-  void SelfExch3d(DDoubleGDL* me, DLong code)
-  {
-    SizeT dim0=me->Dim(0);
-    SizeT dim1=me->Dim(1);
-    if (dim0 !=4 && dim1 !=4) return;
-    DDoubleGDL* mat=me->Dup();
-    switch(code)
-    {
-      case 1: //exchange 0 and 1
-        for(SizeT i=0; i<dim0; ++i)
-        {
-          (*me)[0*dim1+i]=(*mat)[1*dim1+i];
-          (*me)[1*dim1+i]=(*mat)[0*dim1+i];
-        }
-        break;
-      case 2: //exchange 0 and 2
-        for(SizeT i=0; i<dim0; ++i)
-        {
-          (*me)[0*dim1+i]=(*mat)[2*dim1+i];
-          (*me)[2*dim1+i]=(*mat)[0*dim1+i];
-        }
-        break;
-      case 12: //exchange 1 and 2
-        for(SizeT i=0; i<dim0; ++i)
-        {
-          (*me)[1*dim1+i]=(*mat)[2*dim1+i];
-          (*me)[2*dim1+i]=(*mat)[1*dim1+i];
-        }
+
+  void SelfOblique3d(DDoubleGDL* me, DDouble dist, DDouble angle) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(dim0, dim1)));
+    SelfReset3d(mat); //identity Matrix
+    (*mat)[2 * dim1 + 2] = 0.0;
+    (*mat)[2 * dim1 + 0] = dist * cos(angle * DEGTORAD);
+    (*mat)[2 * dim1 + 1] = dist * sin(angle * DEGTORAD);
+    DDoubleGDL* intermediary = mat->MatrixOp(me, false, false);
+    memcpy(me->DataAddr(), intermediary->DataAddr(), dim0 * dim1 * sizeof (double));
+    GDLDelete(intermediary);
+    GDLDelete(mat);
+  }
+
+  void SelfExch3d(DDoubleGDL* me, DLong code) {
+    SizeT dim0 = me->Dim(0);
+    SizeT dim1 = me->Dim(1);
+    if (dim0 != 4 && dim1 != 4) return;
+    DDoubleGDL* mat = me->Dup();
+    switch (code) {
+    case 1: //exchange 0 and 1
+      for (SizeT i = 0; i < dim0; ++i) {
+        (*me)[0 * dim1 + i] = (*mat)[1 * dim1 + i];
+        (*me)[1 * dim1 + i] = (*mat)[0 * dim1 + i];
+      }
+      break;
+    case 2: //exchange 0 and 2
+      for (SizeT i = 0; i < dim0; ++i) {
+        (*me)[0 * dim1 + i] = (*mat)[2 * dim1 + i];
+        (*me)[2 * dim1 + i] = (*mat)[0 * dim1 + i];
+      }
+      break;
+    case 12: //exchange 1 and 2
+      for (SizeT i = 0; i < dim0; ++i) {
+        (*me)[1 * dim1 + i] = (*mat)[2 * dim1 + i];
+        (*me)[2 * dim1 + i] = (*mat)[1 * dim1 + i];
+      }
     }
     GDLDelete(mat);
   }
- DDoubleGDL* gdlComputePlplotRotationMatrix(DDouble az, DDouble alt, DDouble zValue, DDouble scale)
-  {
+
+  DDoubleGDL* gdlComputePlplotRotationMatrix(DDouble az, DDouble alt, DDouble zValue, DDouble scale) {
     //scale should not be used and must be 1 until scale is introduced everywhre.
-    DDoubleGDL* plplot3d=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
+    DDoubleGDL* plplot3d = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
     SelfReset3d(plplot3d);
-    static DDouble mytrans[3]={-0.5, -0.5, -zValue};
-    SelfTranslate3d(plplot3d,mytrans);
-    static DDouble myscale[3]={scale, scale, scale};
-    SelfScale3d(plplot3d,myscale);
-    DDouble rot1[3]={-90.0, az, 0.0};
-    DDouble rot2[3]={alt, 0.0, 0.0};
-    SelfRotate3d(plplot3d,rot1);
-    SelfRotate3d(plplot3d,rot2);
-//    static DDouble mytrans2[3]={0.5, 0.5, zValue};
-//    SelfTranslate3d(plplot3d,mytrans2);
+    static DDouble mytrans[3] = {-0.5, -0.5, -zValue};
+    SelfTranslate3d(plplot3d, mytrans);
+    static DDouble myscale[3] = {scale, scale, scale};
+    SelfScale3d(plplot3d, myscale);
+    DDouble rot1[3] = {-90.0, az, 0.0};
+    DDouble rot2[3] = {alt, 0.0, 0.0};
+    SelfRotate3d(plplot3d, rot1);
+    SelfRotate3d(plplot3d, rot2);
+    //    static DDouble mytrans2[3]={0.5, 0.5, zValue};
+    //    SelfTranslate3d(plplot3d,mytrans2);
     return plplot3d; //this matrix converts 3D xyz in plplot's 2d
- }
+  }
 
- void gdl3dTo2dTransform(PLFLT x, PLFLT y, PLFLT *xt, PLFLT *yt, PLPointer data)
- {
-   struct GDL_3DTRANSFORMDATA *ptr = (GDL_3DTRANSFORMDATA* )data;
-   DDoubleGDL* xyzw=new DDoubleGDL(dimension(4));
-   (*xyzw)[3]=1.0;
-   (*xyzw)[ptr->code[0]]=(x+ptr->x0)*ptr->xs;
-   (*xyzw)[ptr->code[1]]=(y+ptr->y0)*ptr->ys;;
-   (*xyzw)[ptr->code[2]]=ptr->zValue;
-   DDoubleGDL* trans=xyzw->MatrixOp(ptr->Matrix,false,true);
-   *xt=(*trans)[0];
-   *yt=(*trans)[1];
-   GDLDelete(trans);
-   GDLDelete(xyzw);
- }
-//Special for Contour (not special for the moment in fact):
- void gdl3dTo2dTransformContour(PLFLT x, PLFLT y, PLFLT *xt, PLFLT *yt, PLPointer data)
- {
-   struct GDL_3DTRANSFORMDATA *ptr = (GDL_3DTRANSFORMDATA* )data;
-   DDoubleGDL* xyzw=new DDoubleGDL(dimension(4));
-   (*xyzw)[3]=1.0;
-   (*xyzw)[ptr->code[0]]=(x+ptr->x0)*ptr->xs;
-   (*xyzw)[ptr->code[1]]=(y+ptr->y0)*ptr->ys;;
-   (*xyzw)[ptr->code[2]]=ptr->zValue;
-   DDoubleGDL* trans=xyzw->MatrixOp(ptr->Matrix,false,true);
-   *xt=(*trans)[0];
-   *yt=(*trans)[1];
-   GDLDelete(trans);
-   GDLDelete(xyzw);
- }
+  void gdl3dTo2dTransform(PLFLT x, PLFLT y, PLFLT *xt, PLFLT *yt, PLPointer data) {
+    struct GDL_3DTRANSFORMDATA *ptr = (GDL_3DTRANSFORMDATA*) data;
+    DDoubleGDL* xyzw = new DDoubleGDL(dimension(4));
+    (*xyzw)[3] = 1.0;
+    (*xyzw)[ptr->code[0]] = (x + ptr->x0) * ptr->xs;
+    (*xyzw)[ptr->code[1]] = (y + ptr->y0) * ptr->ys;
+    ;
+    (*xyzw)[ptr->code[2]] = ptr->zValue;
+    DDoubleGDL* trans = xyzw->MatrixOp(ptr->Matrix, false, true);
+    *xt = (*trans)[0];
+    *yt = (*trans)[1];
+    GDLDelete(trans);
+    GDLDelete(xyzw);
+  }
+  //Special for Contour (not special for the moment in fact):
 
- //retrieve !P.T,
- DDoubleGDL* gdlGetT3DMatrix()
- {
-    DDoubleGDL* t3dMatrix=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
-    DStructGDL* pStruct=SysVar::P();   //MUST NOT BE STATIC, due to .reset 
-    static unsigned tTag=pStruct->Desc()->TagIndex("T");
-    for (int i=0; i<t3dMatrix->N_Elements(); ++i )(*t3dMatrix)[i]=(*static_cast<DDoubleGDL*>(pStruct->GetTag(tTag, 0)))[i];
+  void gdl3dTo2dTransformContour(PLFLT x, PLFLT y, PLFLT *xt, PLFLT *yt, PLPointer data) {
+    struct GDL_3DTRANSFORMDATA *ptr = (GDL_3DTRANSFORMDATA*) data;
+    DDoubleGDL* xyzw = new DDoubleGDL(dimension(4));
+    (*xyzw)[3] = 1.0;
+    (*xyzw)[ptr->code[0]] = (x + ptr->x0) * ptr->xs;
+    (*xyzw)[ptr->code[1]] = (y + ptr->y0) * ptr->ys;
+    ;
+    (*xyzw)[ptr->code[2]] = ptr->zValue;
+    DDoubleGDL* trans = xyzw->MatrixOp(ptr->Matrix, false, true);
+    *xt = (*trans)[0];
+    *yt = (*trans)[1];
+    GDLDelete(trans);
+    GDLDelete(xyzw);
+  }
+
+  //retrieve !P.T,
+
+  DDoubleGDL* gdlGetT3DMatrix() {
+    DDoubleGDL* t3dMatrix = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
+    DStructGDL* pStruct = SysVar::P(); //MUST NOT BE STATIC, due to .reset
+    static unsigned tTag = pStruct->Desc()->TagIndex("T");
+    for (int i = 0; i < t3dMatrix->N_Elements(); ++i)(*t3dMatrix)[i] = (*static_cast<DDoubleGDL*> (pStruct->GetTag(tTag, 0)))[i];
     SelfTranspose3d(t3dMatrix);
     return t3dMatrix;
- }
- // retrieve !P.T, (or use passed matrix)
- // scale to current X.S Y.S and Z.S, returns a matrix that can be applied directly to
- // XYZ data to get projected X' Y' *normalized* coordinates values
- DDoubleGDL* gdlGetScaledNormalizedT3DMatrix(DDoubleGDL* passedMatrix)
- {
-    DDoubleGDL* t3dMatrix;
-    if (passedMatrix==NULL) t3dMatrix=gdlGetT3DMatrix(); else t3dMatrix=passedMatrix;
-    DDouble *sx, *sy, *sz;
-    GetSFromPlotStructs(&sx, &sy, &sz);
-    DDoubleGDL* toScaled=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
-    SelfReset3d(toScaled);
-    DDouble depla[3]={sx[0],sy[0],sz[0]};
-    DDouble scale[3]={sx[1],sy[1],sz[1]};
-    SelfScale3d(toScaled, scale);  //pay attention to order for matrices!
-    SelfTranslate3d(toScaled,depla);
-    DDoubleGDL* returnMatrix=t3dMatrix->MatrixOp(toScaled,false,false);
-    GDLDelete(toScaled);
-    if (passedMatrix==NULL) GDLDelete(t3dMatrix);
-    return returnMatrix;
- }
+  }
+  // retrieve !P.T, (or use passed matrix)
+  // scale to current X.S Y.S and Z.S, returns a matrix that can be applied directly to
+  // XYZ data to get projected X' Y' *normalized* coordinates values
 
- void gdlNormed3dToWorld3d(DDoubleGDL *xValin, DDoubleGDL *yValin, DDoubleGDL* zValin,
-                           DDoubleGDL *xValou, DDoubleGDL *yValou, DDoubleGDL* zValou)
- {
+  DDoubleGDL* gdlGetScaledNormalizedT3DMatrix(DDoubleGDL* passedMatrix) {
+    DDoubleGDL* t3dMatrix;
+    if (passedMatrix == NULL) t3dMatrix = gdlGetT3DMatrix();
+    else t3dMatrix = passedMatrix;
     DDouble *sx, *sy, *sz;
     GetSFromPlotStructs(&sx, &sy, &sz);
-    DDoubleGDL* toWorld=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
+    DDoubleGDL* toScaled = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
+    SelfReset3d(toScaled);
+    DDouble depla[3] = {sx[0], sy[0], sz[0]};
+    DDouble scale[3] = {sx[1], sy[1], sz[1]};
+    SelfScale3d(toScaled, scale); //pay attention to order for matrices!
+    SelfTranslate3d(toScaled, depla);
+    DDoubleGDL* returnMatrix = t3dMatrix->MatrixOp(toScaled, false, false);
+    GDLDelete(toScaled);
+    if (passedMatrix == NULL) GDLDelete(t3dMatrix);
+    return returnMatrix;
+  }
+
+  void gdlNormed3dToWorld3d(DDoubleGDL *xValin, DDoubleGDL *yValin, DDoubleGDL* zValin,
+    DDoubleGDL *xValou, DDoubleGDL *yValou, DDoubleGDL* zValou) {
+    DDouble *sx, *sy, *sz;
+    GetSFromPlotStructs(&sx, &sy, &sz);
+    DDoubleGDL* toWorld = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
     SelfReset3d(toWorld);
-    DDouble depla[3]={-sx[0],-sy[0],-sz[0]};
-    DDouble scale[3]={1/sx[1],1/sy[1],1/sz[1]};
-    SelfTranslate3d(toWorld,depla);  //pay attention to order for matrices!
+    DDouble depla[3] = {-sx[0], -sy[0], -sz[0]};
+    DDouble scale[3] = {1 / sx[1], 1 / sy[1], 1 / sz[1]};
+    SelfTranslate3d(toWorld, depla); //pay attention to order for matrices!
     SelfScale3d(toWorld, scale);
     //populate a 4D matrix with reduced coordinates through sx,sy,sz:
-    SizeT nEl=xValin->N_Elements();
-    DDoubleGDL* xyzw=new DDoubleGDL(dimension(nEl,4));
-    memcpy(&((*xyzw)[0]),xValin->DataAddr(),nEl*sizeof(double));
-    memcpy(&((*xyzw)[nEl]),yValin->DataAddr(),nEl*sizeof(double));
-    if (zValin != NULL) memcpy(&((*xyzw)[2*nEl]),zValin->DataAddr(),nEl*sizeof(double));
-    else for (int index=0; index< nEl; ++index){ (*xyzw)[2*nEl+index]=1.0;}
-    for (int index=0; index< nEl; ++index){ (*xyzw)[3*nEl+index]=1.0;}
-    DDoubleGDL* trans=xyzw->MatrixOp(toWorld,false,true);
-    memcpy(xValou->DataAddr(), trans->DataAddr(),nEl*sizeof(double));
-    memcpy(yValou->DataAddr(), &(*trans)[nEl],nEl*sizeof(double));
-    if (zValou != NULL) memcpy(zValou->DataAddr(), &(*trans)[2*nEl],nEl*sizeof(double));
+    SizeT nEl = xValin->N_Elements();
+    DDoubleGDL* xyzw = new DDoubleGDL(dimension(nEl, 4));
+    memcpy(&((*xyzw)[0]), xValin->DataAddr(), nEl * sizeof (double));
+    memcpy(&((*xyzw)[nEl]), yValin->DataAddr(), nEl * sizeof (double));
+    if (zValin != NULL) memcpy(&((*xyzw)[2 * nEl]), zValin->DataAddr(), nEl * sizeof (double));
+    else for (int index = 0; index < nEl; ++index) {
+        (*xyzw)[2 * nEl + index] = 1.0;
+      }
+    for (int index = 0; index < nEl; ++index) {
+      (*xyzw)[3 * nEl + index] = 1.0;
+    }
+    DDoubleGDL* trans = xyzw->MatrixOp(toWorld, false, true);
+    memcpy(xValou->DataAddr(), trans->DataAddr(), nEl * sizeof (double));
+    memcpy(yValou->DataAddr(), &(*trans)[nEl], nEl * sizeof (double));
+    if (zValou != NULL) memcpy(zValou->DataAddr(), &(*trans)[2 * nEl], nEl * sizeof (double));
     GDLDelete(trans);
     GDLDelete(xyzw);
     GDLDelete(toWorld);
- }
- void gdl3dto2dProjectDDouble(DDoubleGDL* t3dMatrix, DDoubleGDL *xVal, DDoubleGDL *yVal, DDoubleGDL* zVal,
-                              DDoubleGDL *xValou, DDoubleGDL *yValou, int* code)
- {
-      DDoubleGDL *decodedAxis[3]={xVal,yVal,zVal};
-      int *localCode=code;
-      if (localCode == NULL) localCode=code012;
-      //populate a 4D matrix with reduced coordinates through sx,sy,sz:
-      SizeT nEl=xVal->N_Elements();
-      DDoubleGDL* xyzw=new DDoubleGDL(dimension(nEl,4));
-      memcpy(&((*xyzw)[0]),decodedAxis[localCode[0]]->DataAddr(),nEl*sizeof(double));
-      memcpy(&((*xyzw)[nEl]),decodedAxis[localCode[1]]->DataAddr(),nEl*sizeof(double));
-      memcpy(&((*xyzw)[2*nEl]),decodedAxis[localCode[2]]->DataAddr(),nEl*sizeof(double));
-      for (int index=0; index< nEl; ++index){ (*xyzw)[3*nEl+index]=1.0;}
-      DDoubleGDL* trans=xyzw->MatrixOp(t3dMatrix,false,true);
-      memcpy(xValou->DataAddr(), trans->DataAddr(),nEl*sizeof(double));
-      memcpy(yValou->DataAddr(), &(*trans)[nEl],nEl*sizeof(double));
-      GDLDelete(trans);
-      GDLDelete(xyzw);
- }
+  }
+
+  void gdl3dto2dProjectDDouble(DDoubleGDL* t3dMatrix, DDoubleGDL *xVal, DDoubleGDL *yVal, DDoubleGDL* zVal,
+    DDoubleGDL *xValou, DDoubleGDL *yValou, int* code) {
+    DDoubleGDL * decodedAxis[3] = {xVal, yVal, zVal};
+    int *localCode = code;
+    if (localCode == NULL) localCode = code012;
+    //populate a 4D matrix with reduced coordinates through sx,sy,sz:
+    SizeT nEl = xVal->N_Elements();
+    DDoubleGDL* xyzw = new DDoubleGDL(dimension(nEl, 4));
+    memcpy(&((*xyzw)[0]), decodedAxis[localCode[0]]->DataAddr(), nEl * sizeof (double));
+    memcpy(&((*xyzw)[nEl]), decodedAxis[localCode[1]]->DataAddr(), nEl * sizeof (double));
+    memcpy(&((*xyzw)[2 * nEl]), decodedAxis[localCode[2]]->DataAddr(), nEl * sizeof (double));
+    for (int index = 0; index < nEl; ++index) {
+      (*xyzw)[3 * nEl + index] = 1.0;
+    }
+    DDoubleGDL* trans = xyzw->MatrixOp(t3dMatrix, false, true);
+    memcpy(xValou->DataAddr(), trans->DataAddr(), nEl * sizeof (double));
+    memcpy(yValou->DataAddr(), &(*trans)[nEl], nEl * sizeof (double));
+    GDLDelete(trans);
+    GDLDelete(xyzw);
+  }
 
   void gdlProject3dCoordinatesIn2d(DDoubleGDL* Matrix, DDoubleGDL *xVal, DDouble* sx,
-      DDoubleGDL *yVal, DDouble *sy, DDoubleGDL* zVal, DDouble *sz , DDoubleGDL *xValou, DDoubleGDL *yValou)
- {
-      DDoubleGDL* toScaled=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
-      SelfReset3d(toScaled);
-      DDouble depla[3]={sx[0],sy[0],sz[0]};
-      DDouble scale[3]={sx[1],sy[1],sz[1]};
-      SelfScale3d(toScaled, scale);
-      SelfTranslate3d(toScaled,depla);
-      //populate a 4D matrix with reduced coordinates through sx,sy,sz:
-      SizeT nEl=xVal->N_Elements();
-      DDoubleGDL* xyzw=new DDoubleGDL(dimension(nEl,4));
-      memcpy(&((*xyzw)[0]),xVal->DataAddr(),nEl*sizeof(double));
-      memcpy(&((*xyzw)[nEl]),yVal->DataAddr(),nEl*sizeof(double));
-      memcpy(&((*xyzw)[2*nEl]),zVal->DataAddr(),nEl*sizeof(double));
-      for (int index=0; index< nEl; ++index){ (*xyzw)[3*nEl+index]=1.0;}
-      DDoubleGDL* temp=Matrix->MatrixOp(toScaled,false,false);
-      DDoubleGDL* trans=xyzw->MatrixOp(temp,false,true);
-      memcpy(xValou->DataAddr(), trans->DataAddr(),nEl*sizeof(double));
-      memcpy(yValou->DataAddr(), &(*trans)[nEl],nEl*sizeof(double));
-      GDLDelete(trans);
-      GDLDelete(xyzw);
-      GDLDelete(temp);
- }
+    DDoubleGDL *yVal, DDouble *sy, DDoubleGDL* zVal, DDouble *sz, DDoubleGDL *xValou, DDoubleGDL *yValou) {
+    DDoubleGDL* toScaled = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
+    SelfReset3d(toScaled);
+    DDouble depla[3] = {sx[0], sy[0], sz[0]};
+    DDouble scale[3] = {sx[1], sy[1], sz[1]};
+    SelfScale3d(toScaled, scale);
+    SelfTranslate3d(toScaled, depla);
+    //populate a 4D matrix with reduced coordinates through sx,sy,sz:
+    SizeT nEl = xVal->N_Elements();
+    DDoubleGDL* xyzw = new DDoubleGDL(dimension(nEl, 4));
+    memcpy(&((*xyzw)[0]), xVal->DataAddr(), nEl * sizeof (double));
+    memcpy(&((*xyzw)[nEl]), yVal->DataAddr(), nEl * sizeof (double));
+    memcpy(&((*xyzw)[2 * nEl]), zVal->DataAddr(), nEl * sizeof (double));
+    for (int index = 0; index < nEl; ++index) {
+      (*xyzw)[3 * nEl + index] = 1.0;
+    }
+    DDoubleGDL* temp = Matrix->MatrixOp(toScaled, false, false);
+    DDoubleGDL* trans = xyzw->MatrixOp(temp, false, true);
+    memcpy(xValou->DataAddr(), trans->DataAddr(), nEl * sizeof (double));
+    memcpy(yValou->DataAddr(), &(*trans)[nEl], nEl * sizeof (double));
+    GDLDelete(trans);
+    GDLDelete(xyzw);
+    GDLDelete(temp);
+  }
 
-  bool isMatrixRotation(DDoubleGDL* Matrix,DDouble &rx, DDouble &ry, DDouble &rz, DDouble &scale)
-  {
-    DDoubleGDL* t3dMatrix=Matrix->Dup();
+  bool isMatrixRotation(DDoubleGDL* Matrix, DDouble &rx, DDouble &ry, DDouble &rz, DDouble &scale) {
+    DDoubleGDL* t3dMatrix = Matrix->Dup();
     // !P.T=rt#cs#9r#Ry#Rx(#Rz?)#tr !Ry contains az!
     // r9#sc#tr# rt#cs#9r#Ry#Rx(#Rz?)#tr #rt =  r9#sc#tr#!P.T#rt = Ry#Rx(#Rz?)
     //
     // a= r9#sc#tr#!P.T#rt
     //construct derotator of Matrix=!P.T . We can find sc if not stretch.
     //substract translation rt
-    static DDouble rt[3]={-0.5, -0.5, -0.5};
-    SelfTranslate3d(t3dMatrix,rt); //!P.T#rt
+    static DDouble rt[3] = {-0.5, -0.5, -0.5};
+    SelfTranslate3d(t3dMatrix, rt); //!P.T#rt
     //on the other end compute the good invert translation-rotation t3dMatrix
-    DDoubleGDL* test=(new DDoubleGDL(dimension(4,4)));
+    DDoubleGDL* test = (new DDoubleGDL(dimension(4, 4)));
     SelfReset3d(test);
-    static DDouble r9[3]={90.0, 0.0, 0.0};
-    SelfRotate3d(test,r9);
-    static DDouble tr[3]={0.5, 0.5, 0.5};
-    SelfTranslate3d(test,tr);
+    static DDouble r9[3] = {90.0, 0.0, 0.0};
+    SelfRotate3d(test, r9);
+    static DDouble tr[3] = {0.5, 0.5, 0.5};
+    SelfTranslate3d(test, tr);
     // product of the two should be a pure scaled rotx,roty(rotz)(scale) matrix, hence:
-    DDoubleGDL* xz=(t3dMatrix->MatrixOp(test,false,false));
-    rx=atan2((*xz)[1*4+2],(*xz)[1*4+1])*RADTODEG;
-    ry=atan2((*xz)[2*4+0],sqrt(pow((*xz)[2*4+1],2.0)+pow((*xz)[2*4+2],2.0)))*RADTODEG;
-    rz=atan2((*xz)[1*4+0],(*xz)[0*4+0])*RADTODEG;
+    DDoubleGDL* xz = (t3dMatrix->MatrixOp(test, false, false));
+    rx = atan2((*xz)[1 * 4 + 2], (*xz)[1 * 4 + 1]) * RADTODEG;
+    ry = atan2((*xz)[2 * 4 + 0], sqrt(pow((*xz)[2 * 4 + 1], 2.0) + pow((*xz)[2 * 4 + 2], 2.0))) * RADTODEG;
+    rz = atan2((*xz)[1 * 4 + 0], (*xz)[0 * 4 + 0]) * RADTODEG;
     //test by rotation inverse
     static DDouble Rot[3];
-    memset(Rot,'\0',3*sizeof(DDouble)); Rot[2]=-rz; SelfRotate3d(xz,Rot); //#zR
-    memset(Rot,'\0',3*sizeof(DDouble)); Rot[0]=-rx; SelfRotate3d(xz,Rot); //#xR
-    memset(Rot,'\0',3*sizeof(DDouble)); Rot[1]=-ry; SelfRotate3d(xz,Rot); //#yR
-    scale=(*xz)[0];
-    DDouble sum=(*xz)[0]+(*xz)[5]+(*xz)[10];
-    sum/=scale; //sum of scaled Rotation matrix diagonal
-    if (abs(sum-3.0)<1E-4) return true; else return false;
+    memset(Rot, '\0', 3 * sizeof (DDouble));
+    Rot[2] = -rz;
+    SelfRotate3d(xz, Rot); //#zR
+    memset(Rot, '\0', 3 * sizeof (DDouble));
+    Rot[0] = -rx;
+    SelfRotate3d(xz, Rot); //#xR
+    memset(Rot, '\0', 3 * sizeof (DDouble));
+    Rot[1] = -ry;
+    SelfRotate3d(xz, Rot); //#yR
+    scale = (*xz)[0];
+    DDouble sum = (*xz)[0]+(*xz)[5]+(*xz)[10];
+    sum /= scale; //sum of scaled Rotation matrix diagonal
+    if (abs(sum - 3.0) < 1E-4) return true;
+    else return false;
   }
-  DDoubleGDL* gdlConvertT3DMatrixToPlplotRotationMatrix( DDouble zValue, DDouble &az,
-      DDouble &alt,  DDouble &ay, DDouble &scale, ORIENTATION3D &code)
-  {
+
+  DDoubleGDL* gdlConvertT3DMatrixToPlplotRotationMatrix(DDouble zValue, DDouble &az,
+    DDouble &alt, DDouble &ay, DDouble &scale, ORIENTATION3D &code) {
     //returns NULL if error!
-    DDoubleGDL* t3dMatrix=(new DDoubleGDL(dimension(4,4)));
+    DDoubleGDL* t3dMatrix = (new DDoubleGDL(dimension(4, 4)));
     //retrieve !P.T and find az, alt, inversions, and (possibly) scale and roty
-    DStructGDL* pStruct=SysVar::P();   //MUST NOT BE STATIC, due to .reset 
-    static unsigned tTag=pStruct->Desc()->TagIndex("T");
-    for (int i=0; i<t3dMatrix->N_Elements(); ++i )(*t3dMatrix)[i]=(*static_cast<DDoubleGDL*>(pStruct->GetTag(tTag, 0)))[i];
+    DStructGDL* pStruct = SysVar::P(); //MUST NOT BE STATIC, due to .reset
+    static unsigned tTag = pStruct->Desc()->TagIndex("T");
+    for (int i = 0; i < t3dMatrix->N_Elements(); ++i)(*t3dMatrix)[i] = (*static_cast<DDoubleGDL*> (pStruct->GetTag(tTag, 0)))[i];
     SelfTranspose3d(t3dMatrix);
     //check repeatedly rotations & translations
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=NORMAL3D;   goto done; // 0
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = NORMAL3D;
+      goto done; // 0
     }
-    SelfExch3d(t3dMatrix,01); //XY, 1
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=XY;   goto done;
+    SelfExch3d(t3dMatrix, 01); //XY, 1
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = XY;
+      goto done;
     }
-    SelfExch3d(t3dMatrix,01); //-XY
-    SelfExch3d(t3dMatrix,02); //+XZ 2
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=XZ;   goto done;
+    SelfExch3d(t3dMatrix, 01); //-XY
+    SelfExch3d(t3dMatrix, 02); //+XZ 2
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = XZ;
+      goto done;
     }
-    SelfExch3d(t3dMatrix,02); //-XZ
-    SelfExch3d(t3dMatrix,12); //+YZ 3
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=YZ;   goto done;
+    SelfExch3d(t3dMatrix, 02); //-XZ
+    SelfExch3d(t3dMatrix, 12); //+YZ 3
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = YZ;
+      goto done;
     }
-    SelfExch3d(t3dMatrix,12); //-YZ
+    SelfExch3d(t3dMatrix, 12); //-YZ
 
-    SelfExch3d(t3dMatrix,01); //XY first
+    SelfExch3d(t3dMatrix, 01); //XY first
 
-    SelfExch3d(t3dMatrix,02); //+XZ 5
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=XZXY;   goto done;
+    SelfExch3d(t3dMatrix, 02); //+XZ 5
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = XZXY;
+      goto done;
     }
-    SelfExch3d(t3dMatrix,02); //-XZ
-    SelfExch3d(t3dMatrix,12); //+YZ 4
-    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-    {
-      code=XZYZ;   goto done;
+    SelfExch3d(t3dMatrix, 02); //-XZ
+    SelfExch3d(t3dMatrix, 12); //+YZ 4
+    if (isMatrixRotation(t3dMatrix, alt, az, ay, scale)) {
+      code = XZYZ;
+      goto done;
     }
-    SelfExch3d(t3dMatrix,12); //-YZ
-    SelfExch3d(t3dMatrix,01); //-XY
-//redundant
-//    SelfExch3d(t3dMatrix,12); // YZ first
-//
-//    SelfExch3d(t3dMatrix,01); //XY 5
-//    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-//    {
-//      code=YZXY;   goto done;
-//    }
-//    SelfExch3d(t3dMatrix,01); //-XY
-//    SelfExch3d(t3dMatrix,02); //+XZ 4
-//    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-//    {
-//      code=YZXZ;   goto done;
-//    }
-//    SelfExch3d(t3dMatrix,02); //-XZ
-//    SelfExch3d(t3dMatrix,12); //-YZ
-//
-//    SelfExch3d(t3dMatrix,02); // XZ first
-//
-//    SelfExch3d(t3dMatrix,01); //XY 4
-//    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-//    {
-//      code=XZXY;   goto done;
-//    }
-//    SelfExch3d(t3dMatrix,01); //-XY
-//    SelfExch3d(t3dMatrix,12); //+YZ 4
-//    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
-//    {
-//      code=XZYZ;   goto done;
-//    }
-    return (DDoubleGDL*)(NULL); //ERROR!
-done:
-    if (alt > 90.0 || alt <-1.E-3) return (DDoubleGDL*)(NULL);
-    if (alt<0.0) alt=0.0; //prevents plplot complain for epsilon not being strictly positive.
+    SelfExch3d(t3dMatrix, 12); //-YZ
+    SelfExch3d(t3dMatrix, 01); //-XY
+    //redundant
+    //    SelfExch3d(t3dMatrix,12); // YZ first
+    //
+    //    SelfExch3d(t3dMatrix,01); //XY 5
+    //    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
+    //    {
+    //      code=YZXY;   goto done;
+    //    }
+    //    SelfExch3d(t3dMatrix,01); //-XY
+    //    SelfExch3d(t3dMatrix,02); //+XZ 4
+    //    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
+    //    {
+    //      code=YZXZ;   goto done;
+    //    }
+    //    SelfExch3d(t3dMatrix,02); //-XZ
+    //    SelfExch3d(t3dMatrix,12); //-YZ
+    //
+    //    SelfExch3d(t3dMatrix,02); // XZ first
+    //
+    //    SelfExch3d(t3dMatrix,01); //XY 4
+    //    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
+    //    {
+    //      code=XZXY;   goto done;
+    //    }
+    //    SelfExch3d(t3dMatrix,01); //-XY
+    //    SelfExch3d(t3dMatrix,12); //+YZ 4
+    //    if (isMatrixRotation(t3dMatrix,alt,az,ay,scale))
+    //    {
+    //      code=XZYZ;   goto done;
+    //    }
+    return (DDoubleGDL*) (NULL); //ERROR!
+  done:
+    if (alt > 90.0 || alt <-1.E-3) return (DDoubleGDL*) (NULL);
+    if (alt < 0.0) alt = 0.0; //prevents plplot complain for epsilon not being strictly positive.
 
     //recompute transformation matrix with plplot conventions:
-    DDoubleGDL* plplot3d=gdlComputePlplotRotationMatrix(az, alt, zValue, scale);
+    DDoubleGDL* plplot3d = gdlComputePlplotRotationMatrix(az, alt, zValue, scale);
     return plplot3d;
   }
-  void scale3_pro(EnvT* e)
-  {
-    static unsigned tTag=SysVar::P()->Desc()->TagIndex("T");
-    const double invsqrt3=1.0/sqrt(3.0);
+
+  void scale3_pro(EnvT* e) {
+    static unsigned tTag = SysVar::P()->Desc()->TagIndex("T");
+    const double invsqrt3 = 1.0 / sqrt(3.0);
     //AX
-    DDouble ax=30.0;
-    static int AX=e->KeywordIx("AX");
+    DDouble ax = 30.0;
+    static int AX = e->KeywordIx("AX");
     e->AssureDoubleScalarKWIfPresent(AX, ax);
     //AZ
-    DDouble az=30.0;
-    static int AZ=e->KeywordIx("AZ");
+    DDouble az = 30.0;
+    static int AZ = e->KeywordIx("AZ");
     e->AssureDoubleScalarKWIfPresent(AZ, az);
-    DDoubleGDL* mat=(new DDoubleGDL(dimension(4,4),BaseGDL::NOZERO));
+    DDoubleGDL* mat = (new DDoubleGDL(dimension(4, 4), BaseGDL::NOZERO));
     SelfReset3d(mat);
-    static DDouble mytrans[3]={-0.5, -0.5, -0.5};
-    SelfTranslate3d(mat,mytrans);
-    static DDouble myscale[3]={invsqrt3, invsqrt3, invsqrt3};
-    SelfScale3d(mat,myscale);
-    DDouble rot1[3]={-90.0, az, 0.0};
-    DDouble rot2[3]={ax, 0.0, 0.0};
-    SelfRotate3d(mat,rot1);
-    SelfRotate3d(mat,rot2);
-    static DDouble mytrans2[3]={0.5, 0.5, 0.5};
-    SelfTranslate3d(mat,mytrans2);
-    SelfTranspose3d(mat); 
-    for (int i=0; i<mat->N_Elements(); ++i )(*static_cast<DDoubleGDL*>(SysVar::P()->GetTag(tTag, 0)))[i]=(*mat)[i];
+    static DDouble mytrans[3] = {-0.5, -0.5, -0.5};
+    SelfTranslate3d(mat, mytrans);
+    static DDouble myscale[3] = {invsqrt3, invsqrt3, invsqrt3};
+    SelfScale3d(mat, myscale);
+    DDouble rot1[3] = {-90.0, az, 0.0};
+    DDouble rot2[3] = {ax, 0.0, 0.0};
+    SelfRotate3d(mat, rot1);
+    SelfRotate3d(mat, rot2);
+    static DDouble mytrans2[3] = {0.5, 0.5, 0.5};
+    SelfTranslate3d(mat, mytrans2);
+    SelfTranspose3d(mat);
+    for (int i = 0; i < mat->N_Elements(); ++i)(*static_cast<DDoubleGDL*> (SysVar::P()->GetTag(tTag, 0)))[i] = (*mat)[i];
 
     DDouble size;
     //XRANGE
-    static int xrangeIx = e->KeywordIx( "XRANGE");
-    DDoubleGDL* xrange = e->IfDefGetKWAs<DDoubleGDL>( xrangeIx);
-    if (xrange != NULL){
-        if (xrange->N_Elements()<2) e->Throw("XRANGE needs at least a 2-elements vector");
-        static unsigned sTag=SysVar::X()->Desc()->TagIndex("S");
-        size=((*xrange)[1]-(*xrange)[0]);
-        (*static_cast<DDoubleGDL*>(SysVar::X()->GetTag(sTag, 0)))[0]=-(*xrange)[0]/size;
-        (*static_cast<DDoubleGDL*>(SysVar::X()->GetTag(sTag, 0)))[1]=1.0/size;
-      }
+    static int xrangeIx = e->KeywordIx("XRANGE");
+    DDoubleGDL* xrange = e->IfDefGetKWAs<DDoubleGDL>(xrangeIx);
+    if (xrange != NULL) {
+      if (xrange->N_Elements() < 2) e->Throw("XRANGE needs at least a 2-elements vector");
+      static unsigned sTag = SysVar::X()->Desc()->TagIndex("S");
+      size = ((*xrange)[1]-(*xrange)[0]);
+      (*static_cast<DDoubleGDL*> (SysVar::X()->GetTag(sTag, 0)))[0] = -(*xrange)[0] / size;
+      (*static_cast<DDoubleGDL*> (SysVar::X()->GetTag(sTag, 0)))[1] = 1.0 / size;
+    }
     //YRANGE
-    static int yrangeIx = e->KeywordIx( "YRANGE");
-    DDoubleGDL* yrange = e->IfDefGetKWAs<DDoubleGDL>( yrangeIx);
-    if (yrange != NULL){
-        if (yrange->N_Elements()<2) e->Throw("YRANGE needs at least a 2-elements vector");
-        static unsigned sTag=SysVar::Y()->Desc()->TagIndex("S");
-        size=((*yrange)[1]-(*yrange)[0]);
-        (*static_cast<DDoubleGDL*>(SysVar::Y()->GetTag(sTag, 0)))[0]=-(*yrange)[0]/size;
-        (*static_cast<DDoubleGDL*>(SysVar::Y()->GetTag(sTag, 0)))[1]=1.0/size;
-      }
+    static int yrangeIx = e->KeywordIx("YRANGE");
+    DDoubleGDL* yrange = e->IfDefGetKWAs<DDoubleGDL>(yrangeIx);
+    if (yrange != NULL) {
+      if (yrange->N_Elements() < 2) e->Throw("YRANGE needs at least a 2-elements vector");
+      static unsigned sTag = SysVar::Y()->Desc()->TagIndex("S");
+      size = ((*yrange)[1]-(*yrange)[0]);
+      (*static_cast<DDoubleGDL*> (SysVar::Y()->GetTag(sTag, 0)))[0] = -(*yrange)[0] / size;
+      (*static_cast<DDoubleGDL*> (SysVar::Y()->GetTag(sTag, 0)))[1] = 1.0 / size;
+    }
     //ZRANGE
-    static int zrangeIx = e->KeywordIx( "ZRANGE");
-    DDoubleGDL* zrange = e->IfDefGetKWAs<DDoubleGDL>( zrangeIx);
-    if (zrange != NULL){
-      if (zrange->N_Elements()<2) e->Throw("ZRANGE needs at least a 2-elements vector");
-        static unsigned sTag=SysVar::Z()->Desc()->TagIndex("S");
-        size=((*zrange)[1]-(*zrange)[0]);
-        (*static_cast<DDoubleGDL*>(SysVar::Z()->GetTag(sTag, 0)))[0]=-(*zrange)[0]/size;
-        (*static_cast<DDoubleGDL*>(SysVar::Z()->GetTag(sTag, 0)))[1]=1.0/size;
-      }
+    static int zrangeIx = e->KeywordIx("ZRANGE");
+    DDoubleGDL* zrange = e->IfDefGetKWAs<DDoubleGDL>(zrangeIx);
+    if (zrange != NULL) {
+      if (zrange->N_Elements() < 2) e->Throw("ZRANGE needs at least a 2-elements vector");
+      static unsigned sTag = SysVar::Z()->Desc()->TagIndex("S");
+      size = ((*zrange)[1]-(*zrange)[0]);
+      (*static_cast<DDoubleGDL*> (SysVar::Z()->GetTag(sTag, 0)))[0] = -(*zrange)[0] / size;
+      (*static_cast<DDoubleGDL*> (SysVar::Z()->GetTag(sTag, 0)))[1] = 1.0 / size;
+    }
   }
-  void t3d_pro( EnvT* e)
-  {
-    static unsigned tTag=SysVar::P()->Desc()->TagIndex("T");
-    DDoubleGDL *mat=NULL;
-    DDoubleGDL *matin=NULL;
-    // MATRIX keyword (read, write)
-    static int matrixIx=e->KeywordIx("MATRIX");
-    bool externalarray=e->KeywordPresent(matrixIx);
 
-    static int resetIx = e->KeywordIx( "RESET");
-    bool reset=e->KeywordSet(resetIx);
-    if (e->NParam() > 1)
-    {
-        e->Throw("Accepts only one (optional) 4x4 array");
-    }
-    else  if (e->NParam() == 1 && !reset)
-    {
-      matin=e->GetParAs< DDoubleGDL > (0);
-      if (matin->Rank() != 2)  e->Throw(e->GetParString(0)+"must be a 2d array.");
-      if (matin->Dim(0) != 4 || matin->Dim(1) != 4) e->Throw(e->GetParString(0)+"must be a [4,4] array.");
-      mat=matin->Dup();
-    }
-    else
-    {
-      mat=(new DDoubleGDL(dimension(4,4)));
-      for (int i=0; i<mat->N_Elements(); ++i )(*mat)[i]=(*static_cast<DDoubleGDL*>(SysVar::P()->GetTag(tTag, 0)))[i];
+  void t3d_pro(EnvT* e) {
+    static unsigned tTag = SysVar::P()->Desc()->TagIndex("T");
+    DDoubleGDL *mat = NULL;
+    DDoubleGDL *matin = NULL;
+    // MATRIX keyword (read, write)
+    static int matrixIx = e->KeywordIx("MATRIX");
+    bool externalarray = e->KeywordPresent(matrixIx);
+
+    static int resetIx = e->KeywordIx("RESET");
+    bool reset = e->KeywordSet(resetIx);
+    if (e->NParam() > 1) {
+      e->Throw("Accepts only one (optional) 4x4 array");
+    } else if (e->NParam() == 1 && !reset) {
+      matin = e->GetParAs< DDoubleGDL > (0);
+      if (matin->Rank() != 2) e->Throw(e->GetParString(0) + "must be a 2d array.");
+      if (matin->Dim(0) != 4 || matin->Dim(1) != 4) e->Throw(e->GetParString(0) + "must be a [4,4] array.");
+      mat = matin->Dup();
+    } else {
+      mat = (new DDoubleGDL(dimension(4, 4)));
+      for (int i = 0; i < mat->N_Elements(); ++i)(*mat)[i] = (*static_cast<DDoubleGDL*> (SysVar::P()->GetTag(tTag, 0)))[i];
     }
     SelfTranspose3d(mat); //for c matrix handling
     if (reset) SelfReset3d(mat);
     //TRANSLATE
-    static int translateIx = e->KeywordIx( "TRANSLATE");
-    DDoubleGDL* translate = e->IfDefGetKWAs<DDoubleGDL>( translateIx);
-    if (translate != NULL)
-    {
+    static int translateIx = e->KeywordIx("TRANSLATE");
+    DDoubleGDL* translate = e->IfDefGetKWAs<DDoubleGDL>(translateIx);
+    if (translate != NULL) {
       if (translate->N_Elements() != 3) e->Throw("TRANSLATE parameter must be a [3] array.");
-      SelfTranslate3d(mat, (DDouble*)translate->DataAddr());
+      SelfTranslate3d(mat, (DDouble*) translate->DataAddr());
     }
     //SCALE
-    static int scaleIx = e->KeywordIx( "SCALE");
-    DDoubleGDL* scale = e->IfDefGetKWAs<DDoubleGDL>( scaleIx);
-    if (scale != NULL)
-    {
+    static int scaleIx = e->KeywordIx("SCALE");
+    DDoubleGDL* scale = e->IfDefGetKWAs<DDoubleGDL>(scaleIx);
+    if (scale != NULL) {
       if (scale->N_Elements() != 3) e->Throw("SCALE parameter must be a [3] array.");
-      SelfScale3d(mat, (DDouble*)scale->DataAddr());
+      SelfScale3d(mat, (DDouble*) scale->DataAddr());
     }
     //ROTATE
-    static int rotateIx = e->KeywordIx( "ROTATE");
-    DDoubleGDL* rotate = e->IfDefGetKWAs<DDoubleGDL>( rotateIx);
-    if (rotate != NULL)
-    {
+    static int rotateIx = e->KeywordIx("ROTATE");
+    DDoubleGDL* rotate = e->IfDefGetKWAs<DDoubleGDL>(rotateIx);
+    if (rotate != NULL) {
       if (rotate->N_Elements() != 3) e->Throw("ROTATE parameter must be a [3] array.");
-      SelfRotate3d(mat, (DDouble*)rotate->DataAddr());
+      SelfRotate3d(mat, (DDouble*) rotate->DataAddr());
     }
     //PERSPECTIVE
     static int perspIx = e->KeywordIx("PERSPECTIVE");
-    BaseGDL* perspective=e->GetKW(perspIx);
-    if (perspective != NULL) 
-    { DDoubleGDL* persp= static_cast<DDoubleGDL*>(perspective->Convert2( GDL_DOUBLE, BaseGDL::COPY));
+    BaseGDL* perspective = e->GetKW(perspIx);
+    if (perspective != NULL) {
+      DDoubleGDL* persp = static_cast<DDoubleGDL*> (perspective->Convert2(GDL_DOUBLE, BaseGDL::COPY));
       SelfPerspective3d(mat, (*persp)[0]);
     }
     //OBLIQUE
-    static int obliqueIx = e->KeywordIx( "OBLIQUE");
-    DDoubleGDL* oblique = e->IfDefGetKWAs<DDoubleGDL>( obliqueIx);
-    if (oblique != NULL)
-    {
+    static int obliqueIx = e->KeywordIx("OBLIQUE");
+    DDoubleGDL* oblique = e->IfDefGetKWAs<DDoubleGDL>(obliqueIx);
+    if (oblique != NULL) {
       if (oblique->N_Elements() != 2) e->Throw("OBLIQUE parameter must be a [2] array.");
-      SelfOblique3d(mat, (*oblique)[0],(*oblique)[1]);
+      SelfOblique3d(mat, (*oblique)[0], (*oblique)[1]);
     }
     DLong code;
     //XYEXCH
-    static int exchxyIx = e->KeywordIx( "XYEXCH");
-    bool exchxy=e->KeywordSet(exchxyIx);
-    if (exchxy) code=01;
+    static int exchxyIx = e->KeywordIx("XYEXCH");
+    bool exchxy = e->KeywordSet(exchxyIx);
+    if (exchxy) code = 01;
     //XZEXCH
-    static int exchxzIx = e->KeywordIx( "XZEXCH");
-    bool exchxz=e->KeywordSet(exchxzIx);
-    if (exchxz) code=02;
+    static int exchxzIx = e->KeywordIx("XZEXCH");
+    bool exchxz = e->KeywordSet(exchxzIx);
+    if (exchxz) code = 02;
     //YYEXCH
-    static int exchyzIx = e->KeywordIx( "YZEXCH");
-    bool exchyz=e->KeywordSet(exchyzIx);
-    if (exchyz) code=12;
+    static int exchyzIx = e->KeywordIx("YZEXCH");
+    bool exchyz = e->KeywordSet(exchyzIx);
+    if (exchyz) code = 12;
 
-    if (exchxy||exchxz||exchyz) SelfExch3d(mat, code );
+    if (exchxy || exchxz || exchyz) SelfExch3d(mat, code);
 
     SelfTranspose3d(mat); //prior to give back.
-    if ( externalarray )
-    {
-       e->SetKW(matrixIx, mat);
-    }
-    else
-    {
-      for (int i=0; i<mat->N_Elements(); ++i )(*static_cast<DDoubleGDL*>(SysVar::P()->GetTag(tTag, 0)))[i]=(*mat)[i];
+    if (externalarray) {
+      e->SetKW(matrixIx, mat);
+    } else {
+      for (int i = 0; i < mat->N_Elements(); ++i)(*static_cast<DDoubleGDL*> (SysVar::P()->GetTag(tTag, 0)))[i] = (*mat)[i];
       GDLDelete(mat);
     }
   }

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -69,7 +69,7 @@ namespace lib {
 
     //eliminate simplest case here:
     if (ocoordinateSystem == icoordinateSystem) {
-      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*res)[i * 3 + 0] = (*xVal)[i];
           (*res)[i * 3 + 1] = (*yVal)[i];
@@ -77,7 +77,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nrows; ++i) {
           (*res)[i * 3 + 0] = (*xVal)[i];
           (*res)[i * 3 + 1] = (*yVal)[i];
@@ -143,7 +143,7 @@ namespace lib {
       }
 #endif
       // to norm:
-      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
           TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -151,7 +151,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nrows; ++i) {
           TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
           TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -160,7 +160,7 @@ namespace lib {
       }
       break;
     case DEVICE:
-      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] /= xSize;
           (*yVal)[i] /= ySize;
@@ -168,7 +168,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] /= xSize;
           (*yVal)[i] /= ySize;
@@ -183,7 +183,7 @@ namespace lib {
     switch (ocoordinateSystem) {
     case DATA:
       // from norm:
-      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
           TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -191,7 +191,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nrows; ++i) {
           TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
           TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -222,7 +222,7 @@ namespace lib {
 
       break;
     case DEVICE:
-      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] *= xSize;
           (*yVal)[i] *= ySize;
@@ -230,7 +230,7 @@ namespace lib {
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] *= xSize;
           (*yVal)[i] *= ySize;
@@ -241,7 +241,7 @@ namespace lib {
       break;
     }
 
-    if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nrows; ++i) {
         (*res)[i * 3 + 0] = (*xVal)[i];
         (*res)[i * 3 + 1] = (*yVal)[i];
@@ -249,7 +249,7 @@ namespace lib {
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nrows; ++i) {
         (*res)[i * 3 + 0] = (*xVal)[i];
         (*res)[i * 3 + 1] = (*yVal)[i];

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -63,14 +63,13 @@ namespace lib {
     SizeT nrows;
 
     nrows = xVal->Dim(0);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nrows)));
     dims[1] = nrows;
     dimension dim((DLong *) dims, 2);
     res = new DDoubleGDL(dim, BaseGDL::NOZERO);
 
     //eliminate simplest case here:
     if (ocoordinateSystem == icoordinateSystem) {
-      if (!parallelize) {
+      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*res)[i * 3 + 0] = (*xVal)[i];
           (*res)[i * 3 + 1] = (*yVal)[i];
@@ -144,7 +143,7 @@ namespace lib {
       }
 #endif
       // to norm:
-      if (!parallelize) {
+      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
           TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -161,7 +160,7 @@ namespace lib {
       }
       break;
     case DEVICE:
-      if (!parallelize) {
+      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] /= xSize;
           (*yVal)[i] /= ySize;
@@ -184,7 +183,7 @@ namespace lib {
     switch (ocoordinateSystem) {
     case DATA:
       // from norm:
-      if (!parallelize) {
+      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
           TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -223,7 +222,7 @@ namespace lib {
 
       break;
     case DEVICE:
-      if (!parallelize) {
+      if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] *= xSize;
           (*yVal)[i] *= ySize;
@@ -242,7 +241,7 @@ namespace lib {
       break;
     }
 
-    if (!parallelize) {
+    if (!parallelize( nrows, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nrows; ++i) {
         (*res)[i * 3 + 0] = (*xVal)[i];
         (*res)[i * 3 + 1] = (*yVal)[i];

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -63,7 +63,7 @@ namespace lib {
     SizeT nrows;
 
     nrows = xVal->Dim(0);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows)));
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nrows)));
     dims[1] = nrows;
     dimension dim((DLong *) dims, 2);
     res = new DDoubleGDL(dim, BaseGDL::NOZERO);

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -72,6 +72,7 @@ namespace lib {
     //eliminate simplest case here:
     if (ocoordinateSystem==icoordinateSystem)
     {
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for
@@ -126,6 +127,7 @@ namespace lib {
       if ( mapSet )
       {
 #ifdef PROJ_IS_THREADSAFE
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
         {
 #pragma omp for private(idata,odata)
@@ -151,6 +153,7 @@ namespace lib {
         }
 #endif
         // to norm:
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for
@@ -162,6 +165,7 @@ namespace lib {
       }
         break;
       case DEVICE:
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for
@@ -180,6 +184,7 @@ namespace lib {
     {
       case DATA:
         // from norm:
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for
@@ -195,6 +200,7 @@ namespace lib {
       if ( mapSet )
       {
 #ifdef PROJ_IS_THREADSAFE
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
         {
 #pragma omp for private(idata,odata)
@@ -222,6 +228,7 @@ namespace lib {
 
         break;
       case DEVICE:
+	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for
@@ -235,6 +242,7 @@ namespace lib {
         break;
     }
     
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nrows >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nrows))
       {
 #pragma omp for

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -69,7 +69,7 @@ namespace lib {
 
     //eliminate simplest case here:
     if (ocoordinateSystem == icoordinateSystem) {
-      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*res)[i * 3 + 0] = (*xVal)[i];
           (*res)[i * 3 + 1] = (*yVal)[i];
@@ -143,7 +143,7 @@ namespace lib {
       }
 #endif
       // to norm:
-      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TONORMCOORDX((*xVal)[i], (*xVal)[i], xLog);
           TONORMCOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -160,7 +160,7 @@ namespace lib {
       }
       break;
     case DEVICE:
-      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] /= xSize;
           (*yVal)[i] /= ySize;
@@ -183,7 +183,7 @@ namespace lib {
     switch (ocoordinateSystem) {
     case DATA:
       // from norm:
-      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           TODATACOORDX((*xVal)[i], (*xVal)[i], xLog);
           TODATACOORDY((*yVal)[i], (*yVal)[i], yLog);
@@ -222,7 +222,7 @@ namespace lib {
 
       break;
     case DEVICE:
-      if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nrows; ++i) {
           (*xVal)[i] *= xSize;
           (*yVal)[i] *= ySize;
@@ -241,7 +241,7 @@ namespace lib {
       break;
     }
 
-    if (GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nrows, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nrows; ++i) {
         (*res)[i * 3 + 0] = (*xVal)[i];
         (*res)[i * 3 + 1] = (*yVal)[i];

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -276,9 +276,7 @@ namespace lib {
     DDoubleGDL *yValou;
     Guard<BaseGDL> xvalou_guard, yvalou_guard;
 
-    SizeT nParam = e->NParam();
-    if (nParam < 1)
-      e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(1);
 
     BaseGDL* p0;
     BaseGDL* p1;

--- a/src/pro/tvscl.pro
+++ b/src/pro/tvscl.pro
@@ -49,7 +49,7 @@
 ; (at your option) any later version.                                   
 ; 
 ;-
-pro TVSCL, image, x, y, NaN=NaN, top=top, _extra = _extra
+pro TVSCL, image, x, y, NaN=NaN, top=top, TPOOL_MAX_ELTS=TPOOL_MAX_ELTS, TPOOL_MIN_ELTS=TPOOL_MIN_ELTS, TPOOL_NOTHREAD=TPOOL_NOTHREAD, extra = _extra
 
 ; silent:
 compile_opt idl2, hidden

--- a/src/pro/utilities/gdl_implied_print.pro
+++ b/src/pro/utilities/gdl_implied_print.pro
@@ -160,7 +160,19 @@ endif
 
 w=where(type eq types, count)
 if (count gt 0) then begin
-  print, value
+  ret=size(value)
+  ndim=ret[0]
+  type=ret[ndim+1]
+  n=n_elements(value)
+  if (n eq 1) then begin
+    case type of
+    4: print,value,format='(G16.8)'
+    5: print,value,format='(G25.17)'
+    6: print,value,format='("(",G16.8,",",G16.8,")")'
+    9: print,value,format='("(",G25.17,",",G25.17,")")'
+    ELSE: print,value
+    endcase
+  endif else print,value
   return
 endif
 

--- a/src/pro/utilities/gdl_implied_print.pro
+++ b/src/pro/utilities/gdl_implied_print.pro
@@ -160,20 +160,7 @@ endif
 
 w=where(type eq types, count)
 if (count gt 0) then begin
-  ret=size(value)
-  ndim=ret[0]
-  type=ret[ndim+1]
-  n=n_elements(value)
-  case type of
-  7: BEGIN
-    for i=0,n-1 do print,value[i]
-  END
-  4: print,value,format='(G16.8)'
-  5: print,value,format='(G25.17)'
-  6: print,value,format='("(",G16.8,",",G16.8,")")'
-  9: print,value,format='("(",G25.17,",",G25.17,")")'
-  ELSE: print,value
-  endcase
+  print, value
   return
 endif
 

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -109,8 +109,7 @@ namespace lib {
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
 
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
           (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
@@ -135,8 +134,7 @@ namespace lib {
       lonGuard.Reset(lon);
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
-      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-      if (!parallelize) {
+      if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
           (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
@@ -1541,8 +1539,7 @@ namespace lib {
 
 
     SizeT nEl = lonsIn->N_Elements();
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nEl; ++i) {
         lons[i] *= DEG_TO_RAD;
         lats[i] *= DEG_TO_RAD;
@@ -2065,8 +2062,7 @@ namespace lib {
     odims[1] = nEl;
     dimension dim(odims, 2);
     DDoubleGDL *res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
-    if (!parallelize) {
+    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[2 * i] = (*lons)[i];
         (*res)[2 * i + 1] = (*lats)[i];

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -109,7 +109,7 @@ namespace lib {
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
 
-      if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
           (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
@@ -134,7 +134,7 @@ namespace lib {
       lonGuard.Reset(lon);
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
-      if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+      if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
           (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
@@ -1539,7 +1539,7 @@ namespace lib {
 
 
     SizeT nEl = lonsIn->N_Elements();
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         lons[i] *= DEG_TO_RAD;
         lats[i] *= DEG_TO_RAD;
@@ -2062,7 +2062,7 @@ namespace lib {
     odims[1] = nEl;
     dimension dim(odims, 2);
     DDoubleGDL *res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
+    if ((GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS))==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[2 * i] = (*lons)[i];
         (*res)[2 * i + 1] = (*lats)[i];

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -131,6 +131,7 @@ namespace lib {
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
 
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -211,6 +212,7 @@ namespace lib {
       
       SizeT nEl = p0->N_Elements() / 2;
 #ifdef PROJ_IS_THREADSAFE
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for
@@ -258,6 +260,7 @@ namespace lib {
         return res; //e->Throw("The PROJ library version you use unfortunately defines no inverse for this projection!");
       }
 #ifdef PROJ_IS_THREADSAFE
+      TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
 #pragma omp for 
@@ -1466,6 +1469,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     
     //convert all lons lats, next tag NaN those outside CUTS
 #ifdef PROJ_IS_THREADSAFE
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for
@@ -1571,6 +1575,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     
 
     SizeT nEl = lonsIn->N_Elements();
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     for (OMPInt i = 0; i < nEl; ++i) {
        lons[i]*=DEG_TO_RAD;
@@ -2086,6 +2091,7 @@ done:             aliasList->remove_if(isInvalid);
     odims[1] = nEl;
     dimension dim(odims, 2);
     DDoubleGDL *res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
     {
 #pragma omp for

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -27,8 +27,8 @@ namespace lib {
   static DDouble sRot, cRot;
 
   //OLD?-> Must be static and in plotting.hpp if one changes the position of "MAP_STRUCTURE".
-  DStructGDL *GetMapAsMapStructureKeyword(EnvT *e, bool &externalmap)
-  {
+
+  DStructGDL *GetMapAsMapStructureKeyword(EnvT *e, bool &externalmap) {
     externalmap = e->KeywordSet(0); //MAP_STRUCTURE
     DStructGDL* map = NULL;
 
@@ -46,9 +46,8 @@ namespace lib {
     }
     return map;
   }
-  
-  BaseGDL* map_proj_forward_fun(EnvT* e)
-  {
+
+  BaseGDL* map_proj_forward_fun(EnvT* e) {
 #ifdef USE_LIBPROJ
     BaseGDL* p0;
     BaseGDL* p1;
@@ -110,10 +109,16 @@ namespace lib {
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
 
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+      if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) {
+          (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
+          (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
+        }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
           (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
         }
@@ -130,12 +135,16 @@ namespace lib {
       lonGuard.Reset(lon);
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
-
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
+      bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+      if (!parallelize) {
         for (OMPInt i = 0; i < nEl; ++i) {
+          (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
+          (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
+        }
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+          for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
           (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
         }
@@ -146,7 +155,7 @@ namespace lib {
       res = gdlProjForward(ref, map, lon, lat, connectivity, doConn, gons, doGons, lines, doLines, doFill);
       if (doGons) e->SetKW(gonsIx, gons);
       else e->SetKW(linesIx, lines);
-    } else res=gdlApplyFullProjection(ref, map, lon, lat);
+    } else res = gdlApplyFullProjection(ref, map, lon, lat);
     return res;
 #else
     e->Throw("GDL was compiled without support for map projections");
@@ -154,8 +163,7 @@ namespace lib {
 #endif
   }
 
-  BaseGDL* map_proj_inverse_fun(EnvT* e)
-  {
+  BaseGDL* map_proj_inverse_fun(EnvT* e) {
 #ifdef USE_LIBPROJ
     // xy -> lonlat
     SizeT nParam = e->NParam();
@@ -189,7 +197,7 @@ namespace lib {
     if (nParam == 1) {
       p0 = e->GetParDefined(0);
       DDoubleGDL* xy = static_cast<DDoubleGDL*>
-          (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
+        (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
 
       dims[0] = 2;
       if (p0->Rank() == 2) { //[2,dim1]->N_elements=2*Dim1
@@ -201,41 +209,31 @@ namespace lib {
         dimension dim((DLong *) dims, 2);
         res = new DDoubleGDL(dim, BaseGDL::NOZERO);
       }
-      
+
       //protect against projections that have no inverse in PROJ (and inverse in libproj) (silly, is'nt it?) (I guess I'll copy all
       //this code one day and make our own certified version!
       if (noInv) {
         //return Nans --- hoping it is sufficient 
-        for (OMPInt i = 0; i < p0->N_Elements() ; ++i) (*res)[i]=std::numeric_limits<double>::quiet_NaN();
+        for (OMPInt i = 0; i < p0->N_Elements(); ++i) (*res)[i] = std::numeric_limits<double>::quiet_NaN();
         return res; //e->Throw("The PROJ library version you use unfortunately defines no inverse for this projection!");
       }
-      
-      SizeT nEl = p0->N_Elements() / 2;
-#ifdef PROJ_IS_THREADSAFE
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for
-#endif
-        for (OMPInt i = 0; i < nEl; ++i) {
-#if LIBPROJ_MAJOR_VERSION >= 5
-          idata.x = (*xy)[2 * i];
-          idata.y = (*xy)[2 * i + 1];
-          odata = protect_proj_inv_xy(idata, ref);
-          (*res)[2 * i] = odata.lam * ((radians) ? 1.0 : RAD_TO_DEG);
-          (*res)[2 * i + 1] = odata.phi * ((radians) ? 1.0 : RAD_TO_DEG);
-#else
-          idata.u = (*xy)[2 * i];
-          idata.v = (*xy)[2 * i + 1];
-          odata = PJ_INV(idata, ref);
-          (*res)[2 * i] = odata.u * ((radians) ? 1.0 : RAD_TO_DEG);
-          (*res)[2 * i + 1] = odata.v * ((radians) ? 1.0 : RAD_TO_DEG);
-#endif
-        }
-#ifdef PROJ_IS_THREADSAFE
-      }
-#endif
 
+      SizeT nEl = p0->N_Elements() / 2;
+      for (OMPInt i = 0; i < nEl; ++i) {
+#if LIBPROJ_MAJOR_VERSION >= 5
+        idata.x = (*xy)[2 * i];
+        idata.y = (*xy)[2 * i + 1];
+        odata = protect_proj_inv_xy(idata, ref);
+        (*res)[2 * i] = odata.lam * ((radians) ? 1.0 : RAD_TO_DEG);
+        (*res)[2 * i + 1] = odata.phi * ((radians) ? 1.0 : RAD_TO_DEG);
+#else
+        idata.u = (*xy)[2 * i];
+        idata.v = (*xy)[2 * i + 1];
+        odata = PJ_INV(idata, ref);
+        (*res)[2 * i] = odata.u * ((radians) ? 1.0 : RAD_TO_DEG);
+        (*res)[2 * i + 1] = odata.v * ((radians) ? 1.0 : RAD_TO_DEG);
+#endif
+      }
       return res;
 
     } else if (nParam == 2) {
@@ -244,9 +242,9 @@ namespace lib {
       p1 = e->GetParDefined(1);
       if (p1->N_Elements() != nEl) e->Throw("X & Y arrays must have same number of points.");
       DDoubleGDL* x = static_cast<DDoubleGDL*>
-          (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
+        (p0->Convert2(GDL_DOUBLE, BaseGDL::COPY));
       DDoubleGDL* y = static_cast<DDoubleGDL*>
-          (p1->Convert2(GDL_DOUBLE, BaseGDL::COPY));
+        (p1->Convert2(GDL_DOUBLE, BaseGDL::COPY));
 
       dims[0] = 2;
       dims[1] = nEl;
@@ -256,34 +254,24 @@ namespace lib {
       //this code one day and make our own certified version!
       if (noInv) {
         //return Nans --- hoping it is sufficient 
-        for (OMPInt i = 0; i < p0->N_Elements() ; ++i) (*res)[i]=std::numeric_limits<double>::quiet_NaN();
+        for (OMPInt i = 0; i < p0->N_Elements(); ++i) (*res)[i] = std::numeric_limits<double>::quiet_NaN();
         return res; //e->Throw("The PROJ library version you use unfortunately defines no inverse for this projection!");
       }
-#ifdef PROJ_IS_THREADSAFE
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-      {
-#pragma omp for 
-#endif
-        for (OMPInt i = 0; i < nEl; ++i) {
+      for (OMPInt i = 0; i < nEl; ++i) {
 #if LIBPROJ_MAJOR_VERSION >= 5
-          idata.x = (*x)[i];
-          idata.y = (*y)[i];
-          odata = protect_proj_inv_xy(idata, ref);
-          (*res)[2 * i] = odata.lam * ((radians) ? 1.0 : RAD_TO_DEG);
-          (*res)[2 * i + 1] = odata.phi * ((radians) ? 1.0 : RAD_TO_DEG);
+        idata.x = (*x)[i];
+        idata.y = (*y)[i];
+        odata = protect_proj_inv_xy(idata, ref);
+        (*res)[2 * i] = odata.lam * ((radians) ? 1.0 : RAD_TO_DEG);
+        (*res)[2 * i + 1] = odata.phi * ((radians) ? 1.0 : RAD_TO_DEG);
 #else
-          idata.u = (*x)[i];
-          idata.v = (*y)[i];
-          odata = PJ_INV(idata, ref);
-          (*res)[2 * i] = odata.u * ((radians) ? 1.0 : RAD_TO_DEG);
-          (*res)[2 * i + 1] = odata.v * ((radians) ? 1.0 : RAD_TO_DEG);
+        idata.u = (*x)[i];
+        idata.v = (*y)[i];
+        odata = PJ_INV(idata, ref);
+        (*res)[2 * i] = odata.u * ((radians) ? 1.0 : RAD_TO_DEG);
+        (*res)[2 * i + 1] = odata.v * ((radians) ? 1.0 : RAD_TO_DEG);
 #endif
-        }
-#ifdef PROJ_IS_THREADSAFE
       }
-#endif
-
       return res;
     }
     e->Throw("More than 2 parameters not handled."); //impossible to reach!
@@ -295,303 +283,301 @@ namespace lib {
   }
 
 #ifdef USE_LIBPROJ
-    //enum all the projections
+  //enum all the projections
 
-    enum {
-      Invalid = 0,
-      Stereographic,
-      Orthographic,
-      LambertConic,
-      LambertAzimuthal,
-      Gnomic,
-      AzimuthalEquidistant,
-      Satellite,
-      Cylindrical,
-      Mercator,
-      Mollweide,
-      Sinusoidal,
-      Aitoff,
-      HammerAitoff,
-      AlbersEqualAreaConic,
-      TransverseMercator,
-      MillerCylindrical,
-      Robinson,
-      LambertEllipsoidConic,
-      GoodesHomolosine,
-      Geographic,
-      GCTP_UTM,
-      GCTP_StatePlane,
-      GCTP_AlbersEqualArea,
-      GCTP_LambertConformalConic,
-      GCTP_Mercator,
-      GCTP_PolarStereographic,
-      GCTP_Polyconic,
-      GCTP_EquidistantConic,
-      GCTP_TransverseMercator,
-      GCTP_Stereographic,
-      GCTP_LambertAzimutha,
-      GCTP_Azimuthal,
-      GCTP_Gnomonic,
-      GCTP_Orthographic,
-      GCTP_NearSidePerspective,
-      GCTP_Sinusoidal,
-      GCTP_Equirectangular,
-      GCTP_MillerCylindrical,
-      GCTP_VanderGrinten,
-      GCTP_HotineObliqueMercator,
-      GCTP_Robinson,
-      GCTP_SpaceObliqueMercator,
-      GCTP_AlaskaConformal,
-      GCTP_InterruptedGoode,
-      GCTP_Mollweide,
-      GCTP_InterruptedMollweide,
-      GCTP_Hammer,
-      GCTP_WagnerIV,
-      GCTP_WagnerVII,
-      GCTP_OblatedEqualArea,
-      GCTP_IntegerizedSinusoidal,
-      GCTP_CylindricalEqualArea
-    } Projection = Stereographic;
+  enum {
+    Invalid = 0,
+    Stereographic,
+    Orthographic,
+    LambertConic,
+    LambertAzimuthal,
+    Gnomic,
+    AzimuthalEquidistant,
+    Satellite,
+    Cylindrical,
+    Mercator,
+    Mollweide,
+    Sinusoidal,
+    Aitoff,
+    HammerAitoff,
+    AlbersEqualAreaConic,
+    TransverseMercator,
+    MillerCylindrical,
+    Robinson,
+    LambertEllipsoidConic,
+    GoodesHomolosine,
+    Geographic,
+    GCTP_UTM,
+    GCTP_StatePlane,
+    GCTP_AlbersEqualArea,
+    GCTP_LambertConformalConic,
+    GCTP_Mercator,
+    GCTP_PolarStereographic,
+    GCTP_Polyconic,
+    GCTP_EquidistantConic,
+    GCTP_TransverseMercator,
+    GCTP_Stereographic,
+    GCTP_LambertAzimutha,
+    GCTP_Azimuthal,
+    GCTP_Gnomonic,
+    GCTP_Orthographic,
+    GCTP_NearSidePerspective,
+    GCTP_Sinusoidal,
+    GCTP_Equirectangular,
+    GCTP_MillerCylindrical,
+    GCTP_VanderGrinten,
+    GCTP_HotineObliqueMercator,
+    GCTP_Robinson,
+    GCTP_SpaceObliqueMercator,
+    GCTP_AlaskaConformal,
+    GCTP_InterruptedGoode,
+    GCTP_Mollweide,
+    GCTP_InterruptedMollweide,
+    GCTP_Hammer,
+    GCTP_WagnerIV,
+    GCTP_WagnerVII,
+    GCTP_OblatedEqualArea,
+    GCTP_IntegerizedSinusoidal,
+    GCTP_CylindricalEqualArea
+  } Projection = Stereographic;
 
-    enum { //see projElement below
-      NONE = 0,
-      SPHERE_RADIUS,           //+R
-      CENTER_LONGITUDE,        //+lon_0
-      CENTER_LATITUDE,         //+lat_0
-      STANDARD_PAR1,           //+lat_1
-      STANDARD_PAR2,           //+lat_2
-      HEIGHT,                  //+h
-      SAT_TILT,                //+tilt 
-      CENTER_AZIMUTH,          //+alpha
-      SEMIMAJOR_AXIS,          //+a
-      SEMIMINOR_AXIS,          //+b
-      MERCATOR_SCALE,          //+k0
-      ZONE,                    //+zone
-      FALSE_EASTING,           //+x_0
-      FALSE_NORTHING,          //+y_0
-      TRUE_SCALE_LATITUDE,     //+lat_ts
-      STANDARD_PARALLEL,       //+lat_1
-      HOM_LONGITUDE1,          //+lon_1
-      HOM_LONGITUDE2,          //+lon_2
-      HOM_AZIM_LONGITUDE,      //+lonc
-      SOM_LANDSAT_NUMBER,      //+lsat
-      SOM_LANDSAT_PATH,        //+path
-      OEA_SHAPEM,              //+m
-      OEA_SHAPEN,              //+n
-      IS_ZONES,                // +n=4 +m=  zone num see https://modis-land.gsfc.nasa.gov/MODLAND_grid.html
-      IS_JUSTIFY,              //see above
-      HOM_AZIM_ANGLE,          //+alpha
-      HOM_LATITUDE1,           //+lat_1
-      HOM_LATITUDE2,           //+lat_2
-      OEA_ANGLE,               //+theta
-//      SOM_INCLINATION,         // unknown with PROJ
-//      SOM_LONGITUDE,           //
-//      SOM_PERIOD,              //
-//      SOM_RATIO,               //
-//      SOM_FLAG,                //
-      ROTATION                 //done elsewhere?
-    } projElementIndex;
-    
-    static int isAngle[] = {-100, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,1,1,1};
-    static string projElement[] = {//same order that projElementIndex, please!
-      "Null", " +R=", " +lon_0=", " +lat_0=", " +lat_1=", " +lat_2=",
-      " +h=", " +tilt=", " +alpha=", " +a=", " +b=", " +k0=", " +zone=", " +x_0=",
-      " +y_0=", " +lat_ts=", " +lat_1=", " +lon_1=", " +lon_2=", " +lonc=",
-      " +lsat=", " +path=", " +m=", " +n=", " +n=4 +m=", " ", " +alpha=", " +lat_1=", " +lat_2=", " +theta="
-    };
-    static string obliqueProjElement[] = {//same order that projElementIndex, please!
-      "Null", " +R=", " +o_lon_p=", " +o_lat_p=", " +lat_1=", " +lat_2=",
-      " +h=", " +tilt=", " +alpha=", " +a=", " +b=", " +k0=", " +zone=", " +x_0=",
-      " +y_0=", " +lat_ts=", " +lat_1=", " +lon_1=", " +lon_2=", " +lonc=",
-      " +lsat=", " +path=", " +m=", " +n=", " +n=4 +m=", " ", " +alpha=", " +lat_1=", " +lat_2=",  " +theta="
-    };
+  enum { //see projElement below
+    NONE = 0,
+    SPHERE_RADIUS, //+R
+    CENTER_LONGITUDE, //+lon_0
+    CENTER_LATITUDE, //+lat_0
+    STANDARD_PAR1, //+lat_1
+    STANDARD_PAR2, //+lat_2
+    HEIGHT, //+h
+    SAT_TILT, //+tilt 
+    CENTER_AZIMUTH, //+alpha
+    SEMIMAJOR_AXIS, //+a
+    SEMIMINOR_AXIS, //+b
+    MERCATOR_SCALE, //+k0
+    ZONE, //+zone
+    FALSE_EASTING, //+x_0
+    FALSE_NORTHING, //+y_0
+    TRUE_SCALE_LATITUDE, //+lat_ts
+    STANDARD_PARALLEL, //+lat_1
+    HOM_LONGITUDE1, //+lon_1
+    HOM_LONGITUDE2, //+lon_2
+    HOM_AZIM_LONGITUDE, //+lonc
+    SOM_LANDSAT_NUMBER, //+lsat
+    SOM_LANDSAT_PATH, //+path
+    OEA_SHAPEM, //+m
+    OEA_SHAPEN, //+n
+    IS_ZONES, // +n=4 +m=  zone num see https://modis-land.gsfc.nasa.gov/MODLAND_grid.html
+    IS_JUSTIFY, //see above
+    HOM_AZIM_ANGLE, //+alpha
+    HOM_LATITUDE1, //+lat_1
+    HOM_LATITUDE2, //+lat_2
+    OEA_ANGLE, //+theta
+    //      SOM_INCLINATION,         // unknown with PROJ
+    //      SOM_LONGITUDE,           //
+    //      SOM_PERIOD,              //
+    //      SOM_RATIO,               //
+    //      SOM_FLAG,                //
+    ROTATION //done elsewhere?
+  } projElementIndex;
 
-    typedef struct {
-      int pidx;
-      int pnum;
-      int ptyp;
-      string pnam;
-      string p4nam;
-      int nopt;
-      int code[16];
-      int vcode[16];
-    } projCoding;
+  static int isAngle[] = {-100, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1};
+  static string projElement[] = {//same order that projElementIndex, please!
+    "Null", " +R=", " +lon_0=", " +lat_0=", " +lat_1=", " +lat_2=",
+    " +h=", " +tilt=", " +alpha=", " +a=", " +b=", " +k0=", " +zone=", " +x_0=",
+    " +y_0=", " +lat_ts=", " +lat_1=", " +lon_1=", " +lon_2=", " +lonc=",
+    " +lsat=", " +path=", " +m=", " +n=", " +n=4 +m=", " ", " +alpha=", " +lat_1=", " +lat_2=", " +theta="
+  };
+  static string obliqueProjElement[] = {//same order that projElementIndex, please!
+    "Null", " +R=", " +o_lon_p=", " +o_lat_p=", " +lat_1=", " +lat_2=",
+    " +h=", " +tilt=", " +alpha=", " +a=", " +b=", " +k0=", " +zone=", " +x_0=",
+    " +y_0=", " +lat_ts=", " +lat_1=", " +lon_1=", " +lon_2=", " +lonc=",
+    " +lsat=", " +path=", " +m=", " +n=", " +n=4 +m=", " ", " +alpha=", " +lat_1=", " +lat_2=", " +theta="
+  };
 
-    static projCoding projectionOptions[] = {
-      // pidx, proj. Number as in doc, Name, PROJ litle name, number of projElements to read, 
-      // Values as index in projElements (options for PROJ), idem for variant.
-      //pidx|pnum|ptyp|pnam                          |p4nam         |nopt|                     code                           |vcode
-      { 0, 0, 0, "Invalid Projection", "none", 0,
-        {0},
-        {0}},
-      { 1, 1, 0, "Stereographic", "stere", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 2, 2, 0, "Orthographic", "ortho", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 3, 3, 1, "LambertConic", "lcc", 6,
-        {SPHERE_RADIUS, 0, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 4, 4, 0, "LambertAzimuthal", "laea", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 5, 5, 0, "Gnomonic", "gnom", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 6, 6, 0, "AzimuthalEquidistant", "aeqd", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 7, 7, 0, "Satellite", "tpers", 6,
-        {SPHERE_RADIUS, 0, HEIGHT, SAT_TILT, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 8, 8, 2, "Cylindrical", "eqc", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 9, 9, 2, "Mercator", "merc", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 10, 10, 4, "Mollweide", "moll", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 11, 11, 4, "Sinusoidal", "sinu", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 12, 12, 3, "Aitoff", "aitoff", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 13, 13, 3, "HammerAitoff", "hammer", 6,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 14, 14, 1, "AlbersEqualAreaConic", "aea", 6,
-        {SPHERE_RADIUS, 0, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 15, 15, 2, "TransverseMercator", "tmerc", 6,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 16, 16, 2, "MillerCylindrical", "mill", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 17, 17, 4, "Robinson", "robin", 6,
-        {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 18, 18, 1, "LambertConicEllipsoid", "lcc", 6,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
-        {0}},
-      { 19, 19, 4, "GoodesHomolosine",
-        "igh"
-        , 5,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, 0},
-        {0}},
-      {20, 100, 5, "Geographic", "eqc", 1,
-        {CENTER_LONGITUDE, 0, 0, 0, 0, 0, 0},
-        {0}},
-      {21, 101, 5, "GCTP_UTM", "utm", 6,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, ZONE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0, 0},
-        {0}}, //may use "+south"
-      {22, 102, 2, "GCTP_StatePlane", "utm", 3,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, ZONE, 0, 0, 0, 0, 0},
-        {0}}, //may use "+south"
-      {23, 103, 1, "GCTP_AlbersEqualArea", "aea", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {24, 104, 1, "GCTP_LambertConformalConic", "lcc", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {25, 105, 2, "GCTP_Mercator", "merc", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {26, 106, 0, "GCTP_PolarStereographic", "ups", 10,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING, CENTER_LATITUDE,0},
-        {0}}, //may use "+south"
-      {27, 107, 1, "GCTP_Polyconic", "poly", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {28, 108, 1, "GCTP_EquidistantConic", "eqdc", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PARALLEL, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,1}},
-      {29, 109, 2, "GCTP_TransverseMercator", "tmerc", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {30, 110, 0, "GCTP_Stereographic", "stere", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {31, 111, 0, "GCTP_LambertAzimutha", "laea", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {32, 112, 0, "GCTP_Azimuthal", "aeqd", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {33, 113, 0, "GCTP_Gnomonic", "gnom", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {34, 114, 0, "GCTP_Orthographic", "ortho", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {35, 115, 0, "GCTP_NearSidePerspective", "nsper", 9,
-        {SPHERE_RADIUS, 0, HEIGHT, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {36, 116, 4, "GCTP_Sinusoidal", "sinu", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {37, 117, 2, "GCTP_Equirectangular", "eqc", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {38, 118, 2, "GCTP_MillerCylindrical", "mill", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {39, 119, 3, "GCTP_VanderGrinten", "vandg", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {40, 120, 1, "GCTP_HotineObliqueMercator", "omerc", 13,// Two point method; variant is Central point and azimuth method
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0             , 0                 , CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, HOM_LONGITUDE1, HOM_LATITUDE1, HOM_LONGITUDE2, HOM_LATITUDE2,0},
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, HOM_AZIM_ANGLE, HOM_AZIM_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0             , 0            , 0             , 0            ,1}},
-      {41, 121, 4, "GCTP_Robinson", "robin", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {42, 122, 2, "GCTP_SpaceObliqueMercator", "lsat", 13,  //only variant implemented in PROJ.
-        //{SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, SOM_INCLINATION, SOM_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, SOM_PERIOD, SOM_RATIO, SOM_FLAG},
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, SOM_LANDSAT_NUMBER, SOM_LANDSAT_PATH, 0, 0, FALSE_EASTING, FALSE_NORTHING, 0, 0, 0, 0, 0},
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, SOM_LANDSAT_NUMBER, SOM_LANDSAT_PATH, 0, 0, FALSE_EASTING, FALSE_NORTHING, 0, 0, 0, 0, 1}},
-      {43, 123, 0, "GCTP_AlaskaConformal", "alsk", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, 0, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {44, 124, 4, "GCTP_InterruptedGoode", "igh", 2,
-        {SPHERE_RADIUS,0},
-        {0}},
-      {45, 125, 4, "GCTP_Mollweide", "moll", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {46, 126, 4, "GCTP_InterruptedMollweide", "moll", 2,
-        {SPHERE_RADIUS,0},
-        {0}},
-      {47, 127, 4, "GCTP_Hammer", "hammer", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {48, 128, 4, "GCTP_WagnerIV", "wag4", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {49, 129, 3, "GCTP_WagnerVII", "wag7", 9,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {50, 130, 3, "GCTP_OblatedEqualArea", "oea", 9,
-        {SPHERE_RADIUS, 0, OEA_SHAPEM, OEA_SHAPEN, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}},
-      {51, 131, 9, "GCTP_IntegerizedSinusoidal", "sinu", 12,
-        {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, IS_ZONES, 0, IS_JUSTIFY,0},
-        {0}},
-      {52, 132, 2, "GCTP_CylindricalEqualArea", "cea", 9,
-        {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PARALLEL, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING,0},
-        {0}}
-    };
+  typedef struct {
+    int pidx;
+    int pnum;
+    int ptyp;
+    string pnam;
+    string p4nam;
+    int nopt;
+    int code[16];
+    int vcode[16];
+  } projCoding;
 
-    //epsilon is the size of the "trouble ahead" region around splits. Mostly due to projection numerical errors?
+  static projCoding projectionOptions[] = {
+    // pidx, proj. Number as in doc, Name, PROJ litle name, number of projElements to read, 
+    // Values as index in projElements (options for PROJ), idem for variant.
+    //pidx|pnum|ptyp|pnam                          |p4nam         |nopt|                     code                           |vcode
+    { 0, 0, 0, "Invalid Projection", "none", 0,
+      {0},
+      {0}},
+    { 1, 1, 0, "Stereographic", "stere", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 2, 2, 0, "Orthographic", "ortho", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 3, 3, 1, "LambertConic", "lcc", 6,
+      {SPHERE_RADIUS, 0, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 4, 4, 0, "LambertAzimuthal", "laea", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 5, 5, 0, "Gnomonic", "gnom", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 6, 6, 0, "AzimuthalEquidistant", "aeqd", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 7, 7, 0, "Satellite", "tpers", 6,
+      {SPHERE_RADIUS, 0, HEIGHT, SAT_TILT, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 8, 8, 2, "Cylindrical", "eqc", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 9, 9, 2, "Mercator", "merc", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 10, 10, 4, "Mollweide", "moll", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 11, 11, 4, "Sinusoidal", "sinu", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 12, 12, 3, "Aitoff", "aitoff", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 13, 13, 3, "HammerAitoff", "hammer", 6,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 14, 14, 1, "AlbersEqualAreaConic", "aea", 6,
+      {SPHERE_RADIUS, 0, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 15, 15, 2, "TransverseMercator", "tmerc", 6,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 16, 16, 2, "MillerCylindrical", "mill", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 17, 17, 4, "Robinson", "robin", 6,
+      {SPHERE_RADIUS, 0, 0, CENTER_AZIMUTH, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 18, 18, 1, "LambertConicEllipsoid", "lcc", 6,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, 0},
+      {0}},
+    { 19, 19, 4, "GoodesHomolosine",
+      "igh"
+      , 5,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, 0},
+      {0}},
+    {20, 100, 5, "Geographic", "eqc", 1,
+      {CENTER_LONGITUDE, 0, 0, 0, 0, 0, 0},
+      {0}},
+    {21, 101, 5, "GCTP_UTM", "utm", 6,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, ZONE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, 0, 0},
+      {0}}, //may use "+south"
+    {22, 102, 2, "GCTP_StatePlane", "utm", 3,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, ZONE, 0, 0, 0, 0, 0},
+      {0}}, //may use "+south"
+    {23, 103, 1, "GCTP_AlbersEqualArea", "aea", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {24, 104, 1, "GCTP_LambertConformalConic", "lcc", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {25, 105, 2, "GCTP_Mercator", "merc", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {26, 106, 0, "GCTP_PolarStereographic", "ups", 10,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING, CENTER_LATITUDE, 0},
+      {0}}, //may use "+south"
+    {27, 107, 1, "GCTP_Polyconic", "poly", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {28, 108, 1, "GCTP_EquidistantConic", "eqdc", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PARALLEL, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PAR1, STANDARD_PAR2, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 1}},
+    {29, 109, 2, "GCTP_TransverseMercator", "tmerc", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {30, 110, 0, "GCTP_Stereographic", "stere", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {31, 111, 0, "GCTP_LambertAzimutha", "laea", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {32, 112, 0, "GCTP_Azimuthal", "aeqd", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {33, 113, 0, "GCTP_Gnomonic", "gnom", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {34, 114, 0, "GCTP_Orthographic", "ortho", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {35, 115, 0, "GCTP_NearSidePerspective", "nsper", 9,
+      {SPHERE_RADIUS, 0, HEIGHT, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {36, 116, 4, "GCTP_Sinusoidal", "sinu", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {37, 117, 2, "GCTP_Equirectangular", "eqc", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, TRUE_SCALE_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {38, 118, 2, "GCTP_MillerCylindrical", "mill", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {39, 119, 3, "GCTP_VanderGrinten", "vandg", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {40, 120, 1, "GCTP_HotineObliqueMercator", "omerc", 13, // Two point method; variant is Central point and azimuth method
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, 0, 0, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, HOM_LONGITUDE1, HOM_LATITUDE1, HOM_LONGITUDE2, HOM_LATITUDE2, 0},
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, MERCATOR_SCALE, HOM_AZIM_ANGLE, HOM_AZIM_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0, 0, 0, 0, 1}},
+    {41, 121, 4, "GCTP_Robinson", "robin", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {42, 122, 2, "GCTP_SpaceObliqueMercator", "lsat", 13, //only variant implemented in PROJ.
+      //{SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, SOM_INCLINATION, SOM_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, SOM_PERIOD, SOM_RATIO, SOM_FLAG},
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, SOM_LANDSAT_NUMBER, SOM_LANDSAT_PATH, 0, 0, FALSE_EASTING, FALSE_NORTHING, 0, 0, 0, 0, 0},
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, SOM_LANDSAT_NUMBER, SOM_LANDSAT_PATH, 0, 0, FALSE_EASTING, FALSE_NORTHING, 0, 0, 0, 0, 1}},
+    {43, 123, 0, "GCTP_AlaskaConformal", "alsk", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, 0, 0, 0, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {44, 124, 4, "GCTP_InterruptedGoode", "igh", 2,
+      {SPHERE_RADIUS, 0},
+      {0}},
+    {45, 125, 4, "GCTP_Mollweide", "moll", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {46, 126, 4, "GCTP_InterruptedMollweide", "moll", 2,
+      {SPHERE_RADIUS, 0},
+      {0}},
+    {47, 127, 4, "GCTP_Hammer", "hammer", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {48, 128, 4, "GCTP_WagnerIV", "wag4", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {49, 129, 3, "GCTP_WagnerVII", "wag7", 9,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {50, 130, 3, "GCTP_OblatedEqualArea", "oea", 9,
+      {SPHERE_RADIUS, 0, OEA_SHAPEM, OEA_SHAPEN, CENTER_LONGITUDE, CENTER_LATITUDE, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}},
+    {51, 131, 9, "GCTP_IntegerizedSinusoidal", "sinu", 12,
+      {SPHERE_RADIUS, 0, 0, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, IS_ZONES, 0, IS_JUSTIFY, 0},
+      {0}},
+    {52, 132, 2, "GCTP_CylindricalEqualArea", "cea", 9,
+      {SEMIMAJOR_AXIS, SEMIMINOR_AXIS, STANDARD_PARALLEL, 0, CENTER_LONGITUDE, 0, FALSE_EASTING, FALSE_NORTHING, 0},
+      {0}}
+  };
+
+  //epsilon is the size of the "trouble ahead" region around splits. Mostly due to projection numerical errors?
   //if set to a smaller value, the splits of the Goode projections are not OK (? some goode's projection computation in float instead of double?)
-static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7 
+  static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7 
 
-
-  PROJTYPE map_init(DStructGDL * map)
-  {
+  PROJTYPE map_init(DStructGDL * map) {
 
 
 
@@ -608,13 +594,13 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     unsigned projNameTag = map->Desc()->TagIndex("UP_NAME");
 
     DDouble map_rot = (*static_cast<DDoubleGDL*> (map->GetTag(rTag, 0)))[0];
-    
+
     if (map_rot != 0.0) {
       isRot = true;
       sRot = sin(map_rot * DEG_TO_RAD);
       cRot = cos(map_rot * DEG_TO_RAD);
     } else isRot = false;
-    
+
     DLong map_projection = (*static_cast<DLongGDL*> (map->GetTag(projectionTag, 0)))[0];
 
     if (map_projection < 1) return NULL;
@@ -630,11 +616,12 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     DDouble map_lat1 = (*static_cast<DDoubleGDL*> (map->GetTag(pTag, 0)))[3];
     DDouble map_lat2 = (*static_cast<DDoubleGDL*> (map->GetTag(pTag, 0)))[4];
     DString projName = (*static_cast<DStringGDL*> (map->GetTag(projNameTag, 0)))[0];
-    
- // test: use value (if non-zero) in map.up_flags to define epsilon (actually, 1/epsilon)
+
+    // test: use value (if non-zero) in map.up_flags to define epsilon (actually, 1/epsilon)
     unsigned epsilonTag = map->Desc()->TagIndex("UP_FLAGS");
     DLong epsilonvalue = (*static_cast<DLongGDL*> (map->GetTag(epsilonTag, 0)))[0];
-    if (epsilonvalue != 0) epsilon=1.0/double(epsilonvalue); else epsilon=std::numeric_limits<float>::epsilon();
+    if (epsilonvalue != 0) epsilon = 1.0 / double(epsilonvalue);
+    else epsilon = std::numeric_limits<float>::epsilon();
     //Trick for using ALL the PROJ projections.
     if (map_projection == 999) { //our special code
 #if LIBPROJ_MAJOR_VERSION >= 5
@@ -644,24 +631,24 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
 #endif
       if (!prev_ref) {
 #if LIBPROJ_MAJOR_VERSION >= 5
-        ThrowGDLException("PROJ returned error message: "+std::string(proj_errno_string(proj_context_errno(PJ_DEFAULT_CTX))));
+        ThrowGDLException("PROJ returned error message: " + std::string(proj_errno_string(proj_context_errno(PJ_DEFAULT_CTX))));
 #else
-        ThrowGDLException("PROJ returned error message: "+std::string(pj_strerrno(pj_errno)));
+        ThrowGDLException("PROJ returned error message: " + std::string(pj_strerrno(pj_errno)));
 #endif
       }
-      noInv=false ; //((void*)(static_cast<PJ*>(prev_ref)->inv) == NULL);
+      noInv = false; //((void*)(static_cast<PJ*>(prev_ref)->inv) == NULL);
       return prev_ref;
-    }    
-    
+    }
+
     static char *parms[32]; //parameters for LIBPROj.4, old style
 
 
-    DLong noptions=0;
+    DLong noptions = 0;
     //GCTP support
     if (map_projection == 20) {
       map_projection = (*static_cast<DLongGDL*> (map->GetTag(simpleTag, 0)))[0] + GoodesHomolosine + 1;
-      noptions=projectionOptions[map_projection].nopt-1; //-1 as the last is not an option but variant;
-      variant=(map_p[noptions]>0);
+      noptions = projectionOptions[map_projection].nopt - 1; //-1 as the last is not an option but variant;
+      variant = (map_p[noptions] > 0);
     }
 
     char proj[64];
@@ -698,15 +685,15 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     bool trans = false;
 
     bool redo = (map_projection != last_proj ||
-        map_p0lon != last_p0lon ||
-        map_p0lat != last_p0lat ||
-        map_a != last_a ||
-        map_e2 != last_e2 ||
-        map_lat1 != last_lat1 ||
-        map_lat2 != last_lat2 ||
-        map_rot != last_rot ||
-        projName != last_projName
-        );
+      map_p0lon != last_p0lon ||
+      map_p0lat != last_p0lat ||
+      map_a != last_a ||
+      map_e2 != last_e2 ||
+      map_lat1 != last_lat1 ||
+      map_lat2 != last_lat2 ||
+      map_rot != last_rot ||
+      projName != last_projName
+      );
     for (SizeT i = 0; i < 16; ++i) if (last_p[i] != map_p[i]) redo = true;
 
     if (redo) {
@@ -740,9 +727,9 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
           if (projectionOptions[map_projection].code[i] != 0) {
             val = map_p[i];
             if (
-                ((map_projection == GCTP_UTM || map_projection == GCTP_StatePlane) && i == 2) ||
-                (map_projection == GCTP_PolarStereographic && i == 8)
-                ) {
+              ((map_projection == GCTP_UTM || map_projection == GCTP_StatePlane) && i == 2) ||
+              (map_projection == GCTP_PolarStereographic && i == 8)
+              ) {
               if (val < 0) { //negative Zone is South!
                 val *= -1.0;
                 projCommand += " +south";
@@ -757,15 +744,16 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
       // for projections above 100 in map_proj_init, things are finished here:
       if (map_projection > GoodesHomolosine) { //use projComand automatically defined above
         //some special treatments:
-      switch (map_projection) {
+        switch (map_projection) {
         case Geographic:
-          projCommand +=" +R="; projCommand +=i2s(RAD_TO_DEG);
+          projCommand += " +R=";
+          projCommand += i2s(RAD_TO_DEG);
           break;
         case GCTP_StatePlane:
-         ThrowGDLException("GCTP StatePlane projection unsupported (FIXME!).");
-         break;
+          ThrowGDLException("GCTP StatePlane projection unsupported (FIXME!).");
+          break;
         }
-//      cout<<projCommand<<endl;
+        //      cout<<projCommand<<endl;
 #if LIBPROJ_MAJOR_VERSION >= 5
         prev_ref = proj_create(PJ_DEFAULT_CTX, projCommand.c_str());
 #else
@@ -808,13 +796,13 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
       if (map_e2 != 0.0) parms[nparms++] = &e2[0];
 
       if (trans //CHECK THIS FOR GCTP projections!
-          //      && map_projection != Satellite
-          && map_projection != GCTP_WagnerVII //no invert in old and new PROJ.
-          //      && map_projection != Mercator  //crashes with map_grid!!!
-          && map_projection != TransverseMercator //idem!!
-          //      && map_projection != Orthographic //idem!!
-          //      && map_projection != Aitoff //idem!!
-          ) {
+        //      && map_projection != Satellite
+        && map_projection != GCTP_WagnerVII //no invert in old and new PROJ.
+        //      && map_projection != Mercator  //crashes with map_grid!!!
+        && map_projection != TransverseMercator //idem!!
+        //      && map_projection != Orthographic //idem!!
+        //      && map_projection != Aitoff //idem!!
+        ) {
         strcpy(ob_proj, "proj=ob_tran");
         parms[nparms++] = &ob_proj[0];
         sprintf(proj, "o_proj=%s", projectionOptions[map_projection].p4nam.c_str());
@@ -860,9 +848,9 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
         break;
       }
 
-//      fprintf(stderr, "nparms=%d:", nparms);
-//      for (SizeT i = 0; i < nparms; ++i) fprintf(stderr, "+%s ", parms[i]);
-//      fprintf(stderr, "\n");
+      //      fprintf(stderr, "nparms=%d:", nparms);
+      //      for (SizeT i = 0; i < nparms; ++i) fprintf(stderr, "+%s ", parms[i]);
+      //      fprintf(stderr, "\n");
 #if PROJ_VERSION_MAJOR >= 5
       prev_ref = proj_create_argv(PJ_DEFAULT_CTX, nparms, parms);
 #else
@@ -880,8 +868,8 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
   }
 
 #if LIBPROJ_MAJOR_VERSION >= 5
-  PJ_XY protect_proj_fwd_lp(PJ_LP idata, PJ *proj)
-  {
+
+  PJ_XY protect_proj_fwd_lp(PJ_LP idata, PJ *proj) {
     PJ_COORD c, c_out;
     DDouble x, y;
     if (isfinite((idata.lam)*(idata.phi))) {
@@ -900,8 +888,7 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return badProjXY;
   }
 
-  PJ_XY protect_proj_fwd_xy(PJ_XY idata, PJ *proj)
-  {
+  PJ_XY protect_proj_fwd_xy(PJ_XY idata, PJ *proj) {
     PJ_COORD c, c_out;
     DDouble x, y;
     if (isfinite((idata.x)*(idata.y))) {
@@ -920,8 +907,7 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return badProjXY;
   }
 
-  PJ_LP protect_proj_inv_xy(PJ_XY idata, PJ *proj)
-  {
+  PJ_LP protect_proj_inv_xy(PJ_XY idata, PJ *proj) {
     if (noInv) return badProjLP;
     //  throw GDLException("The PROJ library version you use unfortunately defines no inverse for this projection!");
     PJ_COORD c, c_out;
@@ -939,8 +925,8 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return badProjLP;
   }
 #else
-  PROJDATA protect_proj_fwd(PROJDATA idata, PROJTYPE proj)
-  {
+
+  PROJDATA protect_proj_fwd(PROJDATA idata, PROJTYPE proj) {
     XYTYPE odata;
     DDouble u, v;
     if (isfinite((idata.u)*(idata.v))) {
@@ -958,8 +944,7 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return badProj;
   }
 
-  PROJDATA protect_proj_inv(PROJDATA idata, PROJTYPE proj)
-  {
+  PROJDATA protect_proj_inv(PROJDATA idata, PROJTYPE proj) {
     if (noInv) return badProj;
     //  throw GDLException("The PROJ library version you use unfortunately defines no inverse for this projection!");
     LPTYPE odata;
@@ -980,24 +965,21 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
 
   //dummy functions for compatibility support of GCTP projections. Should define map_pipeline values. 
 
-  void map_proj_gctp_forinit(EnvT* e)
-  {
-  };
+  void map_proj_gctp_forinit(EnvT* e) { };
 
-  void map_proj_gctp_revinit(EnvT* e)
-  {
-  };
+  void map_proj_gctp_revinit(EnvT* e) { };
 
-//our implementation of sincos(), test if generic sincos() is faster than compiler optimzation of sin() and cos()
-  inline void gdl_sincos(DDouble angle, DDouble *s, DDouble *c){
-//    sincos(angle,s,c); //apparently compilers are clever, time is identical. No use to call an unsupported feature on clang for example.
-    *s=sin(angle);
-    *c=cos(angle);
+  //our implementation of sincos(), test if generic sincos() is faster than compiler optimzation of sin() and cos()
+
+  inline void gdl_sincos(DDouble angle, DDouble *s, DDouble *c) {
+    //    sincos(angle,s,c); //apparently compilers are clever, time is identical. No use to call an unsupported feature on clang for example.
+    *s = sin(angle);
+    *c = cos(angle);
   }
-  
+
 #define GDL_PI     double(3.1415926535897932384626433832795)
 #define GDL_HALFPI 0.5*GDL_PI  
-  
+
 
 #define DELTA  (double)(0.5*DEG_TO_RAD) //0.5 degree for increment between stitch vertexes.
 
@@ -1020,8 +1002,7 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     DDouble z;
   };
 
-  Point3d* toPoint3d(DDouble x, DDouble y, DDouble z)
-  {
+  Point3d* toPoint3d(DDouble x, DDouble y, DDouble z) {
     Point3d* p = new Point3d;
     DDouble norm = sqrt(x * x + y * y + z * z);
     p->x = x / norm;
@@ -1030,18 +1011,17 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return p;
   }
 
-  void rotate3d(Point3d &p1, const Point3d &a, DDouble theta)
-  {
-    DDouble st,ct;
-    gdl_sincos(theta,&st,&ct);
+  void rotate3d(Point3d &p1, const Point3d &a, DDouble theta) {
+    DDouble st, ct;
+    gdl_sincos(theta, &st, &ct);
     // quaternion-derived rotation matrix
     DDouble matrix[3][3] = {
       { a.x * a.x * (1 - ct) + ct, a.x * a.y * (1 - ct) - a.z*st, a.x * a.z * (1 - ct) + a.y * st},
       { a.y * a.x * (1 - ct) + a.z*st, a.y * a.y * (1 - ct) + ct, a.y * a.z * (1 - ct) - a.x * st},
-    { a.z * a.x * (1 - ct) - a.y*st, a.z * a.y * (1 - ct) + a.x*st, a.z * a.z * (1 - ct) + ct },
-     };
+      { a.z * a.x * (1 - ct) - a.y*st, a.z * a.y * (1 - ct) + a.x*st, a.z * a.z * (1 - ct) + ct},
+    };
     // multiply matrix vector
-    DDouble vector[3]={p1.x, p1.y, p1.z};
+    DDouble vector[3] = {p1.x, p1.y, p1.z};
     DDouble rotated[3] = {0, 0, 0};
     for (int i = 0; i < 3; i++) {
       for (int j = 0; j < 3; j++) {
@@ -1049,20 +1029,19 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
       }
     }
     //normalize (useful?)
-    DDouble norm=sqrt(rotated[0]*rotated[0]+rotated[1]*rotated[1]+rotated[2]*rotated[2]);
+    DDouble norm = sqrt(rotated[0] * rotated[0] + rotated[1] * rotated[1] + rotated[2] * rotated[2]);
 
-    p1.x=rotated[0]/norm;
-    p1.y=rotated[1]/norm; 
-    p1.z=rotated[2]/norm;
+    p1.x = rotated[0] / norm;
+    p1.y = rotated[1] / norm;
+    p1.z = rotated[2] / norm;
   }
-    
-    void printVertex(Vertex v){
-      std::cerr.precision(10);
-      std::cerr<<"("<<v.lon/DEG_TO_RAD<<","<<v.lat/DEG_TO_RAD<<")";
-    }
 
-  Point3d* normedCrossP(const Point3d* p1, const Point3d *p2)
-  {
+  void printVertex(Vertex v) {
+    std::cerr.precision(10);
+    std::cerr << "(" << v.lon / DEG_TO_RAD << "," << v.lat / DEG_TO_RAD << ")";
+  }
+
+  Point3d* normedCrossP(const Point3d* p1, const Point3d *p2) {
     Point3d* p = new Point3d;
     p->x = (p1->y * p2->z - p1->z * p2->y);
     p->y = (p1->z * p2->x - p1->x * p2->z);
@@ -1074,90 +1053,89 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return p;
   }
 
-  inline DDouble dotP(const Point3d* p1, const Point3d *p2)
-  {
+  inline DDouble dotP(const Point3d* p1, const Point3d *p2) {
     return p1->x * p2->x + p1->y * p2->y + p1->z * p2->z;
   }
 
   //arc distance from a (split) pole and a position
 
-//  inline DDouble DistanceFromSplitPole(DDouble x, DDouble y, DDouble z, DDouble px, DDouble py, DDouble pz)
-//  {
-//    DDouble dotp = x * px + y * py + z*pz;
-//    DDouble crossp = sqrt((y * pz - z * py)*(y * pz - z * py) + (z * px - x * pz)*(z * px - x * pz) + (x * py - y * px)*(x * py - y * px));
-//    return atan2(crossp, dotp);
-//  }
-  
+  //  inline DDouble DistanceFromSplitPole(DDouble x, DDouble y, DDouble z, DDouble px, DDouble py, DDouble pz)
+  //  {
+  //    DDouble dotp = x * px + y * py + z*pz;
+  //    DDouble crossp = sqrt((y * pz - z * py)*(y * pz - z * py) + (z * px - x * pz)*(z * px - x * pz) + (x * py - y * px)*(x * py - y * px));
+  //    return atan2(crossp, dotp);
+  //  }
+
 
   //angular distance between 2 points on sphere.
-  inline DDouble DistanceOnSphere(Vertex v1, Vertex v2, DDouble px, DDouble py, DDouble pz)
-  {
-    DDouble clon,slon,clat,slat;
+
+  inline DDouble DistanceOnSphere(Vertex v1, Vertex v2, DDouble px, DDouble py, DDouble pz) {
+    DDouble clon, slon, clat, slat;
 
     //the 2 points are on the split
     DDouble x1, y1, z1;
-    gdl_sincos(v1.lon,&slon,&clon);
-    gdl_sincos(v1.lat,&slat,&clat);
+    gdl_sincos(v1.lon, &slon, &clon);
+    gdl_sincos(v1.lat, &slat, &clat);
     x1 = clon * clat;
     y1 = slon * clat;
     z1 = slat;
-    
+
     DDouble x2, y2, z2;
-    gdl_sincos(v2.lon,&slon,&clon);
-    gdl_sincos(v2.lat,&slat,&clat);
+    gdl_sincos(v2.lon, &slon, &clon);
+    gdl_sincos(v2.lat, &slat, &clat);
     x2 = clon * clat;
     y2 = slon * clat;
     z2 = slat;
-    
+
     DDouble dotp = x1 * x2 + y1 * y2 + z1 * z2;
 
     //cross-product vector
-    DDouble xx,yy,zz;
-    xx= (y1 * z2 - z1 * y2);
-    yy= (z1 * x2 - x1 * z2);
-    zz= (x1 * y2 - y1 * x2);
-    DDouble crossp = sqrt(xx*xx+yy*yy+zz*zz);
-    DDouble projpole=(xx * px + yy * py + zz * pz);
-    if (projpole <0) crossp*=-1;
+    DDouble xx, yy, zz;
+    xx = (y1 * z2 - z1 * y2);
+    yy = (z1 * x2 - x1 * z2);
+    zz = (x1 * y2 - y1 * x2);
+    DDouble crossp = sqrt(xx * xx + yy * yy + zz * zz);
+    DDouble projpole = (xx * px + yy * py + zz * pz);
+    if (projpole < 0) crossp *= -1;
     return atan2(crossp, dotp);
   }
-  
-//    void dumpPolygonVertexes(std::list<Polygon> PolygonList)
-//    {
-//      int i=0;
-//      for (std::list<Polygon>::iterator p = PolygonList.begin(); p != PolygonList.end(); ++p) {
-//        i++;
-//        if (p->VertexList.size()) {
-//        std::cerr<<"Polygon "<<i<<":"<<std::endl;
-//        std::cerr<<"Inside "<<p->inside<<":"<<std::endl;
-//        std::cerr<<"Outside "<<p->outside<<":"<<std::endl;
-//        std::cerr<<"Type "<<p->type<<":"<<std::endl;
-//        std::list<Vertex>::iterator v;
-//        std::cerr << "[";
-//        for (v = p->VertexList.begin(); v != p->VertexList.end(); ++v) {
-//          std::cerr << v->lon / DEG_TO_RAD << "d,";
-//        }
-//        std::cerr << "\b],[";
-//        for (v = p->VertexList.begin(); v != p->VertexList.end(); ++v) {
-//          std::cerr << v->lat / DEG_TO_RAD << "d,";
-//        }
-//        std::cerr << "\b]" << std::endl;
-//        } else {
-//         std::cerr<<"Polygon "<<i<<": EMPTY"<<std::endl;
-//        }
-//      }
-//    }  
 
-  inline void correct(DDouble &x, DDouble &y, DDouble &z){
+  //    void dumpPolygonVertexes(std::list<Polygon> PolygonList)
+  //    {
+  //      int i=0;
+  //      for (std::list<Polygon>::iterator p = PolygonList.begin(); p != PolygonList.end(); ++p) {
+  //        i++;
+  //        if (p->VertexList.size()) {
+  //        std::cerr<<"Polygon "<<i<<":"<<std::endl;
+  //        std::cerr<<"Inside "<<p->inside<<":"<<std::endl;
+  //        std::cerr<<"Outside "<<p->outside<<":"<<std::endl;
+  //        std::cerr<<"Type "<<p->type<<":"<<std::endl;
+  //        std::list<Vertex>::iterator v;
+  //        std::cerr << "[";
+  //        for (v = p->VertexList.begin(); v != p->VertexList.end(); ++v) {
+  //          std::cerr << v->lon / DEG_TO_RAD << "d,";
+  //        }
+  //        std::cerr << "\b],[";
+  //        for (v = p->VertexList.begin(); v != p->VertexList.end(); ++v) {
+  //          std::cerr << v->lat / DEG_TO_RAD << "d,";
+  //        }
+  //        std::cerr << "\b]" << std::endl;
+  //        } else {
+  //         std::cerr<<"Polygon "<<i<<": EMPTY"<<std::endl;
+  //        }
+  //      }
+  //    }  
+
+  inline void correct(DDouble &x, DDouble &y, DDouble &z) {
     DDouble mag = sqrt(x * x + y * y + z * z);
     x /= mag;
     y /= mag;
     z /= mag;
     DDouble lon = atan2(y, x);
     DDouble lat = atan2(z, sqrt(x * x + y * y));
-    DDouble clon,slon,clat,slat;
-    gdl_sincos(lon,&slon,&clon);
-    gdl_sincos(lat,&slat,&clat);
+    DDouble clon, slon, clat, slat;
+    gdl_sincos(lon, &slon, &clon);
+    gdl_sincos(lat, &slat, &clat);
     x = clon * clat;
     y = slon * clat;
     z = slat;
@@ -1166,19 +1144,17 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
 
   // are we on the cut pole side or not?
 
-  inline int getSign(DDouble distanceToPlane)
-  {
+  inline int getSign(DDouble distanceToPlane) {
     if (distanceToPlane >= 0) return 1;
     else return -1;
   }
 
   // push values on a split/clip plane on one or the other side by 'epsilon'.
 
-  inline bool avoid(DDouble &x, DDouble &y, DDouble &z, DDouble a, DDouble b, DDouble c, DDouble d, int sideCode)
-  {
+  inline bool avoid(DDouble &x, DDouble &y, DDouble &z, DDouble a, DDouble b, DDouble c, DDouble d, int sideCode) {
     DDouble distanceToPlane = a * x + b * y + c * z + d;
     int i = 0;
-    assert (sideCode == 1 || sideCode == -1);
+    assert(sideCode == 1 || sideCode == -1);
     while (abs(distanceToPlane) < epsilon) { //just displace a bit on the same "side" but at a larger distance.
       x += sideCode * epsilon * a;
       y += sideCode * epsilon * b;
@@ -1193,9 +1169,8 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
   //returns the point on the clip plane located between two vertexes.
 
   inline void OnSphereVectorPlaneIntersection(DDouble x1, DDouble y1, DDouble z1, DDouble x2, DDouble y2,
-      DDouble z2, DDouble a, DDouble b, DDouble c, DDouble d,
-      DDouble &xb, DDouble &yb, DDouble &zb, DDouble &xe, DDouble &ye, DDouble &ze, int sideCode)
-  {
+    DDouble z2, DDouble a, DDouble b, DDouble c, DDouble d,
+    DDouble &xb, DDouble &yb, DDouble &zb, DDouble &xe, DDouble &ye, DDouble &ze, int sideCode) {
     //intersection of line between points 1 and 2 (parametrized line equation with paramteter t) with plane height d
     DDouble dx = x2 - x1;
     DDouble dy = y2 - y1;
@@ -1217,9 +1192,9 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     DDouble y = dy * t + y1;
     DDouble z = dz * t + z1;
     DDouble distanceToPlane = a * x + b * y + c * z + d;
-    int i=0;
+    int i = 0;
     while (abs(distanceToPlane) > epsilon && i < 10) {
-      int sign=getSign(distanceToPlane);
+      int sign = getSign(distanceToPlane);
       dx = x - x1;
       dy = y - y1;
       dz = z - z1;
@@ -1235,7 +1210,7 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     xb = xe = x;
     yb = ye = y;
     zb = ze = z; //already normed etc.
-    bool ret= avoid(xb, yb, zb, a, b, c, d, sideCode);
+    bool ret = avoid(xb, yb, zb, a, b, c, d, sideCode);
     ret = avoid(xe, ye, ze, a, b, c, d, -sideCode);
     return;
   }
@@ -1243,12 +1218,11 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
   // will insure that no point falls exactly on a split, since the projection errors may send the value on either side of it 
   // if we do no avoid the splits by a (rather large) margin.
 
-  inline bool avoidSplits(std::list<Vertex>::iterator vertex, DDouble a, DDouble b, DDouble c, DDouble d, int sideCode)
-  {
+  inline bool avoidSplits(std::list<Vertex>::iterator vertex, DDouble a, DDouble b, DDouble c, DDouble d, int sideCode) {
     DDouble x, y, z;
-    DDouble clon,slon,clat,slat;
-    gdl_sincos(vertex->lon,&slon,&clon);
-    gdl_sincos(vertex->lat,&slat,&clat);
+    DDouble clon, slon, clat, slat;
+    gdl_sincos(vertex->lon, &slon, &clon);
+    gdl_sincos(vertex->lat, &slat, &clat);
     x = clon * clat;
     y = slon * clat;
     z = slat;
@@ -1262,22 +1236,21 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
 
   //find the 'sign' of the initial cut. Used to force stitch values to stay on this side, for example.
 
-  int findSign(Polygon p, DDouble a, DDouble b, DDouble c, DDouble d)
-  {
+  int findSign(Polygon p, DDouble a, DDouble b, DDouble c, DDouble d) {
     DDouble x, y, z;
-    DDouble clon,slon,clat,slat;
+    DDouble clon, slon, clat, slat;
 
     std::list<Vertex>::iterator vertex = p.VertexList.begin();
-    gdl_sincos(vertex->lon,&slon,&clon);
-    gdl_sincos(vertex->lat,&slat,&clat);
+    gdl_sincos(vertex->lon, &slon, &clon);
+    gdl_sincos(vertex->lat, &slat, &clat);
     x = clon * clat;
     y = slon * clat;
     z = slat;
-    DDouble distanceToPlane = a * x + b * y + c * z + d; 
+    DDouble distanceToPlane = a * x + b * y + c * z + d;
     ++vertex;
     while (abs(distanceToPlane) < epsilon && vertex != p.VertexList.end()) {
-      gdl_sincos(vertex->lon,&slon,&clon);
-      gdl_sincos(vertex->lat,&slat,&clat);
+      gdl_sincos(vertex->lon, &slon, &clon);
+      gdl_sincos(vertex->lat, &slat, &clat);
       x = clon * clat;
       y = slon * clat;
       z = slat;
@@ -1287,64 +1260,63 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     return getSign(distanceToPlane);
   }
 
-//  //returns the point on the split plane (defined by u,v,w) located between two 3d points.
-//
-//  Point3d* CutPosition(const Point3d* p1, const Point3d* p2, DDouble a, DDouble b, DDouble c)
-//  {
-//    // p1 p2 define a plane--> perpendicular vector
-//    Point3d* p1p2 = normedCrossP(p1, p2);
-//    // u,v,w define the 2nd vector
-//    Point3d* cutplane = toPoint3d(a, b, c);
-//    // intersection of the 2 planes give two opposite points on sphere. We must choose.
-//    Point3d* cut1 = normedCrossP(p1p2, cutplane);
-//    Point3d* cut2 = normedCrossP(cutplane, p1p2);
-//    //general case: cut must be between p1 and p2
-//    delete p1p2;
-//    delete cutplane;
-//    if (dotP(p1, cut1) < 0) {
-//      delete cut1;
-//      return cut2;
-//    } else {
-//      delete cut2;
-//      return cut1;
-//    }
-//  }
+  //  //returns the point on the split plane (defined by u,v,w) located between two 3d points.
+  //
+  //  Point3d* CutPosition(const Point3d* p1, const Point3d* p2, DDouble a, DDouble b, DDouble c)
+  //  {
+  //    // p1 p2 define a plane--> perpendicular vector
+  //    Point3d* p1p2 = normedCrossP(p1, p2);
+  //    // u,v,w define the 2nd vector
+  //    Point3d* cutplane = toPoint3d(a, b, c);
+  //    // intersection of the 2 planes give two opposite points on sphere. We must choose.
+  //    Point3d* cut1 = normedCrossP(p1p2, cutplane);
+  //    Point3d* cut2 = normedCrossP(cutplane, p1p2);
+  //    //general case: cut must be between p1 and p2
+  //    delete p1p2;
+  //    delete cutplane;
+  //    if (dotP(p1, cut1) < 0) {
+  //      delete cut1;
+  //      return cut2;
+  //    } else {
+  //      delete cut2;
+  //      return cut1;
+  //    }
+  //  }
 
-//  //returns the point on the split plane located between two vertexes.
-//  //this is a plane-vector intersection. Problem is: we cannot afford (x1,y1,z1) or (x2,y2,z2) to be exactly on the plane.
-//  //in this case, the result, within the numerical error, can be on the "wrong" side. Hence the 'avoid' trick.
-//
-//  inline void OnSphereVectorSplitPlaneIntersection(DDouble xs, DDouble ys, DDouble zs, DDouble xe, DDouble ye,
-//      DDouble ze, DDouble a, DDouble b, DDouble c, DDouble d,
-//      DDouble &xb, DDouble &yb, DDouble &zb,
-//      DDouble &xa, DDouble &ya, DDouble &za, int sideCode)
-//  {
-//    //compute exact point of crossing the plane, following a great circle (3d vectors=> we follow great circles.)
-//    Point3d* p1 = toPoint3d(xs, ys, zs);
-//    Point3d* p2 = toPoint3d(xe, ye, ze);
-//    Point3d* cut = CutPosition(p1, p2, a, b, c);
-//    xb = xa = cut->x;
-//    yb = ya = cut->y;
-//    zb = za = cut->z;
-//    avoid(xb, yb, zb, a, b, c, d, sideCode);
-//    avoid(xa, ya, za, a, b, c, d, -sideCode);
-//    delete p1;
-//    delete p2;
-//    delete cut;
-//    return;
-//  }
+  //  //returns the point on the split plane located between two vertexes.
+  //  //this is a plane-vector intersection. Problem is: we cannot afford (x1,y1,z1) or (x2,y2,z2) to be exactly on the plane.
+  //  //in this case, the result, within the numerical error, can be on the "wrong" side. Hence the 'avoid' trick.
+  //
+  //  inline void OnSphereVectorSplitPlaneIntersection(DDouble xs, DDouble ys, DDouble zs, DDouble xe, DDouble ye,
+  //      DDouble ze, DDouble a, DDouble b, DDouble c, DDouble d,
+  //      DDouble &xb, DDouble &yb, DDouble &zb,
+  //      DDouble &xa, DDouble &ya, DDouble &za, int sideCode)
+  //  {
+  //    //compute exact point of crossing the plane, following a great circle (3d vectors=> we follow great circles.)
+  //    Point3d* p1 = toPoint3d(xs, ys, zs);
+  //    Point3d* p2 = toPoint3d(xe, ye, ze);
+  //    Point3d* cut = CutPosition(p1, p2, a, b, c);
+  //    xb = xa = cut->x;
+  //    yb = ya = cut->y;
+  //    zb = za = cut->z;
+  //    avoid(xb, yb, zb, a, b, c, d, sideCode);
+  //    avoid(xa, ya, za, a, b, c, d, -sideCode);
+  //    delete p1;
+  //    delete p2;
+  //    delete cut;
+  //    return;
+  //  }
 
   // returns the distance between end of first and start of second
-  inline DDouble proximityEvaluator(const Polygon * outside, const Polygon * inside, DDouble px, DDouble py, DDouble pz)
-  {
+
+  inline DDouble proximityEvaluator(const Polygon * outside, const Polygon * inside, DDouble px, DDouble py, DDouble pz) {
     Vertex endout = (outside->VertexList.back());
     Vertex startin = (inside->VertexList.front());
-    DDouble ret= DistanceOnSphere(endout, startin, px, py, pz);
+    DDouble ret = DistanceOnSphere(endout, startin, px, py, pz);
     return ret;
   }
-  
-  bool IsPolygonInside(const Polygon * outside, const Polygon * inside, DDouble px, DDouble py, DDouble pz, DDouble pt=0)
-  { //is second inside first?
+
+  bool IsPolygonInside(const Polygon * outside, const Polygon * inside, DDouble px, DDouble py, DDouble pz, DDouble pt = 0) { //is second inside first?
     //second inside first means that second's start and end points are inside first's start and end points, and that they are "return" polygons.
     //I.e. when closing the "outside" polygon, on encounters first the start of the inside polygon, then its end.
     //polygons that go in the other direction are not related with the current polygon.
@@ -1359,38 +1331,38 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
     DDouble endout2startin = DistanceOnSphere(endout, startin, px, py, pz);
     DDouble endout2endin = DistanceOnSphere(endout, endin, px, py, pz);
     //we go in the direction of "outside".
-    bool ret = ( (outRange > 0 && endout2startin > 0 && endout2endin > 0 ) || (outRange < 0 && endout2startin <0 && endout2endin <0 ));
-    if (ret) { 
-     if (outRange > 0) ret = (endout2endin < outRange && endout2startin < outRange && endout2startin < endout2endin ); 
-     else              ret = (outRange < endout2endin && outRange < endout2startin && endout2endin < endout2startin );
+    bool ret = ((outRange > 0 && endout2startin > 0 && endout2endin > 0) || (outRange < 0 && endout2startin < 0 && endout2endin < 0));
+    if (ret) {
+      if (outRange > 0) ret = (endout2endin < outRange && endout2startin < outRange && endout2startin < endout2endin);
+      else ret = (outRange < endout2endin && outRange < endout2startin && endout2endin < endout2startin);
     }
-//    std::cerr<<inside<<" in "<<outside<<"? [0, "<<endout2startin<<","<<endout2endin<<","<<outRange<<"] ? "<<ret<<std::endl;
+    //    std::cerr<<inside<<" in "<<outside<<"? [0, "<<endout2startin<<","<<endout2endin<<","<<outRange<<"] ? "<<ret<<std::endl;
     return ret;
   }
-  
+
   //rotates repeatedly vector end of p toward start of q...
-  void StitchTwoPolygons(Polygon *p, Polygon *q, DDouble a, DDouble b, DDouble c,DDouble d=0)
-  {
+
+  void StitchTwoPolygons(Polygon *p, Polygon *q, DDouble a, DDouble b, DDouble c, DDouble d = 0) {
     //stitch end of p to start of q
     Vertex endOfP = p->VertexList.back();
     Vertex startOfQ = q->VertexList.front();
-    DDouble dist = DistanceOnSphere(endOfP,startOfQ,a,b,c); //is an angle.
+    DDouble dist = DistanceOnSphere(endOfP, startOfQ, a, b, c); //is an angle.
     DDouble dintervals = dist / DELTA;
     //add vertexes to end of p until start of q is reached
     if (abs(dintervals) > 1) {
       //rotate xs around vector [a,b,c] by dist/nintervals
-      Point3d axis={a,b,c};
+      Point3d axis = {a, b, c};
       Point3d v;
-      DDouble clon,slon,clat,slat;
+      DDouble clon, slon, clat, slat;
 
-      gdl_sincos(endOfP.lon,&slon,&clon);
-      gdl_sincos(endOfP.lat,&slat,&clat);
+      gdl_sincos(endOfP.lon, &slon, &clon);
+      gdl_sincos(endOfP.lat, &slat, &clat);
       v.x = clon * clat;
       v.y = slon * clat;
       v.z = slat;
       int nintervals = abs(dintervals);
       for (int k = 0; k < nintervals; k++) {
-        rotate3d(v,axis,dist/nintervals);
+        rotate3d(v, axis, dist / nintervals);
         Vertex stitch;
         stitch.lon = atan2(v.y, v.x);
         stitch.lat = atan2(v.z, sqrt(v.x * v.x + v.y * v.y));
@@ -1403,18 +1375,21 @@ static double epsilon = std::numeric_limits<float>::epsilon(); //say, 5e-7
       p->VertexList.splice(p->VertexList.end(), q->VertexList);
     }
   }
-  
-//  bool intersectsLonLatBox(DDouble minlon, DDouble maxlon, DDouble minlat, DDouble maxlat, const DDouble* llbox){
-//    return !( ( (maxlon < llbox[1]) || (minlon > llbox[3]) ) && ( ( maxlat < llbox[0] ) || ( minlat > llbox[2]) ) );
-//  }
-  
-// a predicate implemented as a function:
-bool isInvalid (const Polygon& pol) { return (!pol.valid); }
 
-//special version of gdlProJForward that works on non-polygon data and takes care of current projection limits and CLIPS.
-  DDoubleGDL* gdlApplyFullProjection(PROJTYPE ref, DStructGDL* map, DDoubleGDL *lonsIn, DDoubleGDL *latsIn)
-  {
-    if (map==NULL) map = SysVar::Map();
+  //  bool intersectsLonLatBox(DDouble minlon, DDouble maxlon, DDouble minlat, DDouble maxlat, const DDouble* llbox){
+  //    return !( ( (maxlon < llbox[1]) || (minlon > llbox[3]) ) && ( ( maxlat < llbox[0] ) || ( minlat > llbox[2]) ) );
+  //  }
+
+  // a predicate implemented as a function:
+
+  bool isInvalid(const Polygon& pol) {
+    return (!pol.valid);
+  }
+
+  //special version of gdlProJForward that works on non-polygon data and takes care of current projection limits and CLIPS.
+
+  DDoubleGDL* gdlApplyFullProjection(PROJTYPE ref, DStructGDL* map, DDoubleGDL *lonsIn, DDoubleGDL *latsIn) {
+    if (map == NULL) map = SysVar::Map();
     //DATA MUST BE IN RADIANS
     unsigned pTag = map->Desc()->TagIndex("PIPELINE");
     DDoubleGDL* pipeline = (static_cast<DDoubleGDL*> (map->GetTag(pTag, 0))->Dup());
@@ -1425,7 +1400,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     Guard<BaseGDL> llboxGuard(llbox);
 
     // convert to radians
-    for (int i=0; i<4; ++i) (*llbox)[i]*=DEG_TO_RAD;
+    for (int i = 0; i < 4; ++i) (*llbox)[i] *= DEG_TO_RAD;
 
     DLong pipedims[2];
 
@@ -1452,10 +1427,10 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     DDouble px = (*pipeline)[pipedims[0] * line + 5]; //pole x,y,z
     DDouble py = (*pipeline)[pipedims[0] * line + 6];
     DDouble pz = (*pipeline)[pipedims[0] * line + 7];
-    DDouble clon,slon,clat,slat;
-    DDouble x,y,z;
-    DDouble* lons=static_cast<DDouble*>(&(*lonsIn)[0]);
-    DDouble* lats=static_cast<DDouble*>(&(*latsIn)[0]);
+    DDouble clon, slon, clat, slat;
+    DDouble x, y, z;
+    DDouble* lons = static_cast<DDouble*> (&(*lonsIn)[0]);
+    DDouble* lats = static_cast<DDouble*> (&(*latsIn)[0]);
     bool isHidden;
 
     SizeT nEl = lonsIn->N_Elements();
@@ -1466,32 +1441,23 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     dims[1] = nEl;
     dimension dim(dims, 2);
     DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-    
+
     //convert all lons lats, next tag NaN those outside CUTS
-#ifdef PROJ_IS_THREADSAFE
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
-#endif
-      for (OMPInt i = 0; i < nEl; ++i) {
+    for (OMPInt i = 0; i < nEl; ++i) {
 #if LIBPROJ_MAJOR_VERSION >= 5
-        idata.lam = lons[i];
-        idata.phi = lats[i];
-        odata = protect_proj_fwd_lp(idata, ref);
-        (*res)[2 * i] = odata.x;
-        (*res)[2 * i + 1] = odata.y;
+      idata.lam = lons[i];
+      idata.phi = lats[i];
+      odata = protect_proj_fwd_lp(idata, ref);
+      (*res)[2 * i] = odata.x;
+      (*res)[2 * i + 1] = odata.y;
 #else
-        idata.u = lons[i];
-        idata.v = lats[i];
-        odata = PJ_FWD(idata, ref);
-        (*res)[2 * i] = odata.u;
-        (*res)[2 * i + 1] = odata.v;
+      idata.u = lons[i];
+      idata.v = lats[i];
+      odata = PJ_FWD(idata, ref);
+      (*res)[2 * i] = odata.u;
+      (*res)[2 * i + 1] = odata.v;
 #endif
-      }
-#ifdef PROJ_IS_THREADSAFE
     }
-#endif
     while (icode > 0 && line < 12) {
       switch (icode) {
       case CLIP_PLANE:
@@ -1525,10 +1491,10 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     return res;
   }
 
-//special version of gdlProJForward that updates X and Y and generalizes PJ_FWD by enabling clipping to NaNs
-  void gdlFullProjectionTransformation(PROJTYPE ref, DStructGDL* map, DDoubleGDL *lonsIn, DDoubleGDL *latsIn)
-  {
-    if (map==NULL) map = SysVar::Map();
+  //special version of gdlProJForward that updates X and Y and generalizes PJ_FWD by enabling clipping to NaNs
+
+  void gdlFullProjectionTransformation(PROJTYPE ref, DStructGDL* map, DDoubleGDL *lonsIn, DDoubleGDL *latsIn) {
+    if (map == NULL) map = SysVar::Map();
     //DATA MUST BE IN RADIANS
     unsigned pTag = map->Desc()->TagIndex("PIPELINE");
     DDoubleGDL* pipeline = (static_cast<DDoubleGDL*> (map->GetTag(pTag, 0))->Dup());
@@ -1539,7 +1505,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     Guard<BaseGDL> llboxGuard(llbox);
 
     // convert to radians
-    for (int i=0; i<4; ++i) (*llbox)[i]*=DEG_TO_RAD;
+    for (int i = 0; i < 4; ++i) (*llbox)[i] *= DEG_TO_RAD;
 
     DLong pipedims[2];
 
@@ -1566,20 +1532,28 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     DDouble px = (*pipeline)[pipedims[0] * line + 5]; //pole x,y,z
     DDouble py = (*pipeline)[pipedims[0] * line + 6];
     DDouble pz = (*pipeline)[pipedims[0] * line + 7];
-    DDouble clon,slon,clat,slat;
-    DDouble x,y,z;
-    DDouble* lons=static_cast<DDouble*>(&(*lonsIn)[0]);
-    DDouble* lats=static_cast<DDouble*>(&(*latsIn)[0]);
+    DDouble clon, slon, clat, slat;
+    DDouble x, y, z;
+    DDouble* lons = static_cast<DDouble*> (&(*lonsIn)[0]);
+    DDouble* lats = static_cast<DDouble*> (&(*latsIn)[0]);
     bool isHidden;
     // convert to radians
-    
+
 
     SizeT nEl = lonsIn->N_Elements();
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    for (OMPInt i = 0; i < nEl; ++i) {
-       lons[i]*=DEG_TO_RAD;
-       lats[i]*=DEG_TO_RAD;
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
+      for (OMPInt i = 0; i < nEl; ++i) {
+        lons[i] *= DEG_TO_RAD;
+        lats[i] *= DEG_TO_RAD;
+      }
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) {
+        lons[i] *= DEG_TO_RAD;
+        lats[i] *= DEG_TO_RAD;
+      }
     }
 
     LPTYPE idata;
@@ -1636,8 +1610,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
   }
 
   DDoubleGDL* gdlProjForward(PROJTYPE ref, DStructGDL* map, DDoubleGDL *lonsIn, DDoubleGDL *latsIn, DLongGDL *connIn,
-      bool doConn, DLongGDL *&gonsOut, bool doGons, DLongGDL *&linesOut, bool doLines, bool const doFill)
-  {
+    bool doConn, DLongGDL *&gonsOut, bool doGons, DLongGDL *&linesOut, bool doLines, bool const doFill) {
 
     //DATA MUST BE IN RADIANS
 #ifdef USE_LIBPROJ
@@ -1654,10 +1627,10 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     Guard<BaseGDL> llboxGuard(llbox);
     //test if we can eliminate some polygons as they are probably (this is the use of ll_box) not going to be seen at the end.
     //this has problems as ll_box is very crude and false for some projetions (satellite)
-//    bool llsubset=!((*llbox)[0] <= -90.0 && (*llbox)[2] >= 90.0 && (*llbox)[1] <= -180.0 && (*llbox)[3] >= 180.0);
-    
+    //    bool llsubset=!((*llbox)[0] <= -90.0 && (*llbox)[2] >= 90.0 && (*llbox)[1] <= -180.0 && (*llbox)[3] >= 180.0);
+
     // convert to radians
-    for (int i=0; i<4; ++i) (*llbox)[i]*=DEG_TO_RAD;
+    for (int i = 0; i < 4; ++i) (*llbox)[i] *= DEG_TO_RAD;
 
     DLong dims[2];
 
@@ -1691,10 +1664,10 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     DDoubleGDL *lats;
     DLongGDL *currentConn;
 
-    DDouble clon,slon,clat,slat;
-    DDouble minlon,maxlon,minlat,maxlat;
+    DDouble clon, slon, clat, slat;
+    DDouble minlon, maxlon, minlat, maxlat;
 
-      //interpolations for GONS on cuts is every 2.5 degrees.
+    //interpolations for GONS on cuts is every 2.5 degrees.
     //Gons takes precedence on Lines
 
     SizeT nEl = lonsIn->N_Elements();
@@ -1733,23 +1706,23 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
     SizeT num = 0;
     while (index < currentConn->N_Elements()) {
       size = (*currentConn)[index];
-      if (size > ( (fill) ? 2 : 1) ) { //two or 3 points I hope.
+      if (size > ((fill) ? 2 : 1)) { //two or 3 points I hope.
         start = index + 1; //start new chunk...
         num++;
         currentVertexList.clear();
-         
+
         k = (*currentConn)[start + 0];
-        minlon=maxlon=currstart.lon = (*lons)[k];
-        minlat=maxlat=currstart.lat = (*lats)[k];
+        minlon = maxlon = currstart.lon = (*lons)[k];
+        minlat = maxlat = currstart.lat = (*lats)[k];
         currentVertexList.push_back(currstart);
         for (in = 1; in < size; in++) {
           k = (*currentConn)[start + in]; //conn is a list of indexes...
           curr.lon = (*lons)[k];
           curr.lat = (*lats)[k];
-          minlon=min(minlon,curr.lon);
-          minlat=min(minlat,curr.lat);
-          maxlon=max(maxlon,curr.lon);
-          maxlat=max(maxlat,curr.lat);
+          minlon = min(minlon, curr.lon);
+          minlat = min(minlat, curr.lat);
+          maxlon = max(maxlon, curr.lon);
+          maxlat = max(maxlat, curr.lat);
           currentVertexList.push_back(curr);
         }
         if (fill) {
@@ -1761,22 +1734,22 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
             currentVertexList.push_back(curr);
           }
         }
-//        if (llsubset) {
-//          bool keep=intersectsLonLatBox(minlon,maxlon,minlat,maxlat,&((*llbox)[0]));
-//          if (keep) 
-//          {
-//            currentPol.VertexList = currentVertexList;
-//            currentPol.type = 1; //before cut
-//            PolygonList.push_back(currentPol);
-//          } else {
-////            cerr<<"removed "<<minlon*RAD_TO_DEG<<","<<maxlon*RAD_TO_DEG<<","<<minlat*RAD_TO_DEG<<","<<maxlat*RAD_TO_DEG<<endl;
-//            currentVertexList.clear();
-//          }
-//        } else {
-            currentPol.VertexList = currentVertexList;
-            currentPol.type = 1; //before cut
-            PolygonList.push_back(currentPol);
-//        }
+        //        if (llsubset) {
+        //          bool keep=intersectsLonLatBox(minlon,maxlon,minlat,maxlat,&((*llbox)[0]));
+        //          if (keep) 
+        //          {
+        //            currentPol.VertexList = currentVertexList;
+        //            currentPol.type = 1; //before cut
+        //            PolygonList.push_back(currentPol);
+        //          } else {
+        ////            cerr<<"removed "<<minlon*RAD_TO_DEG<<","<<maxlon*RAD_TO_DEG<<","<<minlat*RAD_TO_DEG<<","<<maxlat*RAD_TO_DEG<<endl;
+        //            currentVertexList.clear();
+        //          }
+        //        } else {
+        currentPol.VertexList = currentVertexList;
+        currentPol.type = 1; //before cut
+        PolygonList.push_back(currentPol);
+        //        }
       } else break;
       index += (size + 1);
     }
@@ -1786,13 +1759,13 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
 
     std::list<Polygon> newPolygonList;
     std::list<Polygon> tmpPolygonList;
-    
+
     int sideCode = 0; //side Code: +1: on the pole side if the clip/split plane = visible (for CLIP) -1 on the other side.
     while (icode > 0 && line < 12) {
-      bool doClip=false; //say we clip plane, not split along poles.
+      bool doClip = false; //say we clip plane, not split along poles.
       switch (icode) {
       case CLIP_PLANE:
-        doClip=true;
+        doClip = true;
       case SPLIT:
         if (PolygonList.empty()) break;
         for (std::list<Polygon>::iterator p = PolygonList.begin(); p != PolygonList.end(); ++p) {
@@ -1802,8 +1775,8 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
           Vertex curr;
 
           std::list<Vertex>::iterator v = p->VertexList.begin();
-          gdl_sincos(v->lon,&slon,&clon);
-          gdl_sincos(v->lat,&slat,&clat);
+          gdl_sincos(v->lon, &slon, &clon);
+          gdl_sincos(v->lat, &slat, &clat);
           xs = clon * clat;
           ys = slon * clat;
           zs = slat;
@@ -1812,13 +1785,13 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
           // all the previous points towards it. This is the reason of the "sideCode" parameter in avoidSplits(), based on positivity of the
           // distance to the plane. If every vertexes are on the split (MAP_GRID values for example), sideCode is 0 and the result
           // is "somewhere" but consistent. In summary: once "sideCode" is defined and followed, nothing should go wrong.
- 
+
           if (abs(before) < epsilon) sideCode = findSign((*p), a, b, c, d); //if we start too close to the plane, 
           else sideCode = getSign(before);
           avoidSplits(v, a, b, c, d, sideCode);
           // xs etc may have changed due to avoidSplits(), recompute.
-          gdl_sincos(v->lon,&slon,&clon);
-          gdl_sincos(v->lat,&slat,&clat);
+          gdl_sincos(v->lon, &slon, &clon);
+          gdl_sincos(v->lat, &slat, &clat);
           xs = clon * clat;
           ys = slon * clat;
           zs = slat;
@@ -1826,15 +1799,15 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
           before = a * xs + b * ys + c * zs + d;
 
           currentPol.type = sideCode;
-          currentPol.valid = (doClip && currentPol.type ==-1)?false:true;
+          currentPol.valid = (doClip && currentPol.type == -1) ? false : true;
           curr.lon = v->lon;
           curr.lat = v->lat;
           currentVertexList.push_back(curr);
           for (++v; v != p->VertexList.end(); ++v) {
 
             avoidSplits(v, a, b, c, d, sideCode);
-            gdl_sincos(v->lon,&slon,&clon);
-            gdl_sincos(v->lat,&slat,&clat);
+            gdl_sincos(v->lon, &slon, &clon);
+            gdl_sincos(v->lat, &slat, &clat);
             xe = clon * clat;
             ye = slon * clat;
             ze = slat;
@@ -1843,7 +1816,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
             if (before * after < 0) {
               //cut and start a new polygon
               //find intersection. 
-                OnSphereVectorPlaneIntersection(xs, ys, zs, xe, ye, ze, a, b, c, d, xcutb, ycutb, zcutb, xcuta, ycuta, zcuta, sideCode);
+              OnSphereVectorPlaneIntersection(xs, ys, zs, xe, ye, ze, a, b, c, d, xcutb, ycutb, zcutb, xcuta, ycuta, zcuta, sideCode);
 
               //double dist = DistanceFromSplitPole(xcutb, ycutb, zcutb, px, py, pz);
               //SPLIT is made to cut on the opposite side of the sphere, not on all the split plane.
@@ -1860,8 +1833,8 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
                 tmpPolygonList.push_back(currentPol);
                 sideCode = -sideCode; //as we are on the other side
                 //create a new polygon list
-                currentPol.type = sideCode; 
-                currentPol.valid = (doClip && currentPol.type ==-1)?false:true;
+                currentPol.type = sideCode;
+                currentPol.valid = (doClip && currentPol.type == -1) ? false : true;
                 x = xcuta;
                 y = ycuta;
                 z = zcuta;
@@ -1895,7 +1868,7 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
           if (doClip) { //eliminate invalid (cached) polygons.
             tmpPolygonList.remove_if(isInvalid);
           }
-          
+
           if (fill && tmpPolygonList.size() > 1) {
             // produce 2 lists: before and after cut
             std::list<Polygon> beforePolygonList;
@@ -1920,8 +1893,9 @@ bool isInvalid (const Polygon& pol) { return (!pol.valid); }
               maxloop = 0;
               do {
                 //establish the complexity of each polygon: contains or/and is contained:
-done:             aliasList->remove_if(isInvalid);
-                  for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
+              done:
+                aliasList->remove_if(isInvalid);
+                for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
                   Polygon * container = &(*q);
                   // (re)establish cur's complexity number: either the polygon does not contain others, nor it is contained, and we stitch it alone
                   // or it is contained and we pass,
@@ -1931,54 +1905,54 @@ done:             aliasList->remove_if(isInvalid);
                   container->outside = 0;
                   for (std::list<Polygon>::iterator p = aliasList->begin(); p != aliasList->end(); ++p) {
                     Polygon * test = &(*p);
-                    if (!(test == container)) { 
-                      if (IsPolygonInside(container, test,a,b,c)) container->inside += 1;
-                      if (IsPolygonInside(test, container,a,b,c)) container->outside += 1;
+                    if (!(test == container)) {
+                      if (IsPolygonInside(container, test, a, b, c)) container->inside += 1;
+                      if (IsPolygonInside(test, container, a, b, c)) container->outside += 1;
                     }
                   }
                 }
-//                for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
-//                  Polygon * container = &(*q);
-//                    std::cerr << "polygon " << container << "inside: "<<container->inside <<", outside "<<container->outside <<endl;
-//                }                
+                //                for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
+                //                  Polygon * container = &(*q);
+                //                    std::cerr << "polygon " << container << "inside: "<<container->inside <<", outside "<<container->outside <<endl;
+                //                }                
                 //find all non-contained non-container polygons, close and remove them
-                int needsUpdate=0;  
+                int needsUpdate = 0;
                 for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
                   Polygon * container = &(*q);
                   if (container->inside == 0 && container->outside == 0) { //if the polygon is alone, stitch it and pop it
-//                    cerr<<" closing on itself "<<container<<endl;
-                      StitchTwoPolygons(container, container, a, b, c);
-                      //add closed polygon to end of newPolygonList
-                      newPolygonList.push_back(*container);
-                      container->valid = false;
-                      needsUpdate++;
-                    }
+                    //                    cerr<<" closing on itself "<<container<<endl;
+                    StitchTwoPolygons(container, container, a, b, c);
+                    //add closed polygon to end of newPolygonList
+                    newPolygonList.push_back(*container);
+                    container->valid = false;
+                    needsUpdate++;
                   }
+                }
                 if (needsUpdate) goto done;
                 //find all containers that are not contained, they contain at least one polygon. remove the nearest inside polygon by stitching
                 for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
                   Polygon * container = &(*q);
                   if (container->inside > 0 && container->outside == 0) { //not contained
-//                      std::cerr<<"closing container-only polygon "<<container<<endl;
-                      std::list<Polygon>::iterator toStitch = aliasList->end();
-                      DDouble distref = proximityEvaluator(container,container,a,b,c);
-                      DDouble dist;
-                      for (std::list<Polygon>::iterator p = aliasList->begin(); p != aliasList->end(); ++p) {
-                        Polygon * inside = &(*p);
-                        if (!(inside == container) && IsPolygonInside(container, inside,a,b,c)) {
-                          dist = proximityEvaluator(container,inside,a,b,c);
-                          if (dist/distref > 0 && dist/distref < 1) {
-                            distref = dist;
-                            toStitch = p;
-                          }
+                    //                      std::cerr<<"closing container-only polygon "<<container<<endl;
+                    std::list<Polygon>::iterator toStitch = aliasList->end();
+                    DDouble distref = proximityEvaluator(container, container, a, b, c);
+                    DDouble dist;
+                    for (std::list<Polygon>::iterator p = aliasList->begin(); p != aliasList->end(); ++p) {
+                      Polygon * inside = &(*p);
+                      if (!(inside == container) && IsPolygonInside(container, inside, a, b, c)) {
+                        dist = proximityEvaluator(container, inside, a, b, c);
+                        if (dist / distref > 0 && dist / distref < 1) {
+                          distref = dist;
+                          toStitch = p;
                         }
                       }
-//                      cerr<<" stitching "<<container<<" to " <<&(*toStitch)<< endl;
-                      StitchTwoPolygons(container, &(*toStitch), a, b, c);
-                      toStitch->valid = false; 
-                      goto done;
                     }
+                    //                      cerr<<" stitching "<<container<<" to " <<&(*toStitch)<< endl;
+                    StitchTwoPolygons(container, &(*toStitch), a, b, c);
+                    toStitch->valid = false;
+                    goto done;
                   }
+                }
                 //will break on empty list
                 int erase_all = 1;
                 for (std::list<Polygon>::iterator q = aliasList->begin(); q != aliasList->end(); ++q) {
@@ -2032,7 +2006,7 @@ done:             aliasList->remove_if(isInvalid);
         break;
       case CLIP_UV:
         //TO BE DONE (really useful?)
-//        if (PolygonList.empty()) break;
+        //        if (PolygonList.empty()) break;
         break;
       default:
         continue;
@@ -2091,11 +2065,16 @@ done:             aliasList->remove_if(isInvalid);
     odims[1] = nEl;
     dimension dim(odims, 2);
     DDoubleGDL *res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-    TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-    {
-#pragma omp for
+    bool parallelize = (CpuTPOOL_NTHREADS > 1 && nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl));
+    if (!parallelize) {
       for (OMPInt i = 0; i < nEl; ++i) {
+        (*res)[2 * i] = (*lons)[i];
+        (*res)[2 * i + 1] = (*lats)[i];
+      }
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[2 * i] = (*lons)[i];
         (*res)[2 * i + 1] = (*lats)[i];
       }

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -109,14 +109,14 @@ namespace lib {
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
 
-      if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
           (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*ll)[2 * i] * ((radians) ? 1.0 : DEG_TO_RAD);
           (*lat)[i] = (*ll)[2 * i + 1] * ((radians) ? 1.0 : DEG_TO_RAD);
@@ -134,14 +134,14 @@ namespace lib {
       lonGuard.Reset(lon);
       lat = new DDoubleGDL(dimension(nEl), BaseGDL::NOZERO);
       latGuard.Reset(lat);
-      if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+      if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
         for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
           (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
         }
       } else {
         TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
           for (OMPInt i = 0; i < nEl; ++i) {
           (*lon)[i] = (*tmplon)[i] * ((radians) ? 1 : DEG_TO_RAD);
           (*lat)[i] = (*tmplat)[i] * ((radians) ? 1 : DEG_TO_RAD);
@@ -1539,14 +1539,14 @@ namespace lib {
 
 
     SizeT nEl = lonsIn->N_Elements();
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         lons[i] *= DEG_TO_RAD;
         lats[i] *= DEG_TO_RAD;
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         lons[i] *= DEG_TO_RAD;
         lats[i] *= DEG_TO_RAD;
@@ -2062,14 +2062,14 @@ namespace lib {
     odims[1] = nEl;
     dimension dim(odims, 2);
     DDoubleGDL *res = new DDoubleGDL(dim, BaseGDL::NOZERO);
-    if (!parallelize( nEl, TP_MEMORY_ACCESS)) {
+    if (GDL_NTHREADS=parallelize( nEl, TP_MEMORY_ACCESS)==1) {
       for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[2 * i] = (*lons)[i];
         (*res)[2 * i + 1] = (*lats)[i];
       }
     } else {
       TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
         for (OMPInt i = 0; i < nEl; ++i) {
         (*res)[2 * i] = (*lons)[i];
         (*res)[2 * i + 1] = (*lats)[i];

--- a/src/randomgenerators.cpp
+++ b/src/randomgenerators.cpp
@@ -98,6 +98,7 @@ namespace lib {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
@@ -120,6 +121,7 @@ namespace lib {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
 
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
@@ -205,7 +207,8 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -226,7 +229,8 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -468,6 +472,7 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
@@ -489,6 +494,7 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
@@ -513,7 +519,8 @@ namespace lib {
     DDouble p = (DDouble) (*binomialKey)[1];
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -537,7 +544,8 @@ namespace lib {
     DDouble p = (DDouble) (*binomialKey)[1];
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -559,7 +567,8 @@ namespace lib {
     DDouble mu = (DDouble) (*poissonKey)[0];
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -581,7 +590,8 @@ namespace lib {
     DDouble mu = (DDouble) (*poissonKey)[0];
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -602,7 +612,8 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;
@@ -623,7 +634,8 @@ namespace lib {
   {
     DEFINE_NCHUNK_FOR_dSFMT
     SizeT chunksize = nEl / nchunk;
-    #pragma omp parallel num_threads(nchunk) if (nchunk > 1)
+    TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) if (nchunk > 1)
     {
       int thread_id = currentThreadNumber();
       SizeT start_index, stop_index;

--- a/src/smooth2d.hpp
+++ b/src/smooth2d.hpp
@@ -22,7 +22,6 @@ SizeT w2 = width[1] / 2;
 SizeT nEl = dimx*dimy;
 SMOOTH_Ty* tmp=(SMOOTH_Ty*)malloc(nEl*sizeof(SMOOTH_Ty));
 //parallelizing all that stuff is more complicated than a single pragma...
-//#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 {
  for (SizeT j = 0; j < dimy; ++j) {
   DDouble z;

--- a/src/smooth2dnans.hpp
+++ b/src/smooth2dnans.hpp
@@ -23,7 +23,6 @@ SizeT w2 = width[1] / 2;
 SizeT nEl = dimx*dimy;
 SMOOTH_Ty* tmp=(SMOOTH_Ty*)malloc(nEl*sizeof(SMOOTH_Ty));
 //parallelizing all that stuff is more complicated than a single pragma...
-//#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
 {
  for (SizeT j = 0; j < dimy; ++j) {
   DDouble z;

--- a/src/smoothPolyD.hpp
+++ b/src/smoothPolyD.hpp
@@ -50,18 +50,8 @@ for (int r = 0; r < rank; ++r) {
  SizeT dimy = nEl / dimx;
  SizeT w = width[r] / 2;
  if (w == 0) {//fast transpose
-   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  {
-#pragma omp for nowait
    for (SizeT i = 0; i < nEl; ++i) dest[transposed1Index(i, srcDim, destStride, rank)] = src[i];
-  }
  } else { //smooth & transpose
-   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  {
-#pragma omp for nowait
-
    for (SizeT j = 0; j < dimy; ++j) {
     //initiate mean of Width first values:
     DDouble z;
@@ -73,7 +63,6 @@ for (int r = 0; r < rank; ++r) {
      z = 1. / n;
      mean = (1. - z) * mean + z * v;
     }
-
 #if defined(USE_EDGE)  
     //start: use mean1
     DDouble mean1 = mean;
@@ -133,7 +122,6 @@ for (int r = 0; r < rank; ++r) {
 #endif   
    }
   }
- }
  //pseudo-dim of src is now rotated by 1
  SizeT tempSize[MAXRANK];
  for (int i = 0; i < rank; ++i) tempSize[i] = srcDim[i];

--- a/src/smoothPolyD.hpp
+++ b/src/smoothPolyD.hpp
@@ -50,12 +50,14 @@ for (int r = 0; r < rank; ++r) {
  SizeT dimy = nEl / dimx;
  SizeT w = width[r] / 2;
  if (w == 0) {//fast transpose
+   TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
   {
 #pragma omp for nowait
    for (SizeT i = 0; i < nEl; ++i) dest[transposed1Index(i, srcDim, destStride, rank)] = src[i];
   }
  } else { //smooth & transpose
+   TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
   {
 #pragma omp for nowait

--- a/src/smoothPolyDnans.hpp
+++ b/src/smoothPolyDnans.hpp
@@ -50,18 +50,8 @@ for (int r = 0; r < rank; ++r) {
  SizeT dimy = nEl / dimx;
  SizeT w = width[r] / 2;
  if (w == 0) {//fast transpose
-   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  {
-#pragma omp for nowait
    for (SizeT i = 0; i < nEl; ++i) dest[transposed1Index(i, srcDim, destStride, rank)] = src[i];
-  }
  } else { //smooth & transpose
-   TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
-  {
-#pragma omp for nowait
-
    for (SizeT j = 0; j < dimy; ++j) {
     //initiate mean of Width first values:
     DDouble z;
@@ -179,7 +169,6 @@ for (int r = 0; r < rank; ++r) {
 #endif   
    }
   }
- }
  //pseudo-dim of src is now rotated by 1
  SizeT tempSize[MAXRANK];
  for (int i = 0; i < rank; ++i) tempSize[i] = srcDim[i];

--- a/src/smoothPolyDnans.hpp
+++ b/src/smoothPolyDnans.hpp
@@ -50,12 +50,14 @@ for (int r = 0; r < rank; ++r) {
  SizeT dimy = nEl / dimx;
  SizeT w = width[r] / 2;
  if (w == 0) {//fast transpose
+   TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
   {
 #pragma omp for nowait
    for (SizeT i = 0; i < nEl; ++i) dest[transposed1Index(i, srcDim, destStride, rank)] = src[i];
   }
  } else { //smooth & transpose
+   TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
   {
 #pragma omp for nowait

--- a/src/snippets/interpolate_1d_cubic.incpp
+++ b/src/snippets/interpolate_1d_cubic.incpp
@@ -1,0 +1,45 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      vres = &(res[ncontiguous * j]);
+      x = xx[j];
+     if (x < 0) {
+        v0 = &(array[0]);
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
+      } else if (x  < n1-1 ) { 
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0]=ix-1; xi[1]=ix; xi[2]=ix+1; xi[3]=ix+2;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        if (xi[2]<0) xi[2]=0; else if (xi[2]>n1-1) xi[2]=n1-1; 
+        if (xi[3]<0) xi[3]=0; else if (xi[3]>n1-1) xi[3]=n1-1; 
+        v0 = &(array[ncontiguous * xi[0]]);
+        v1 = &(array[ncontiguous * xi[1]]);
+        v2 = &(array[ncontiguous * xi[2]]);
+        v3 = &(array[ncontiguous * xi[3]]);
+        dx = (x - xi[1]);
+        double d2 = dx*dx;
+        double d3 = d2*dx;
+        double omd = 1 - dx;
+        double omd2 = omd*omd;
+        double omd3 = omd2*omd;
+        double opd = 1 + dx;
+        double opd2 = opd*opd;
+        double opd3 = opd2*opd;
+        double dmd = 2 - dx;
+        double dmd2 = dmd*dmd;
+        double dmd3 = dmd2*dmd;
+        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
+        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
+        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
+        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
+
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = c1 * v1[i] + c2 * v2[i] + c0 * v0[i] + c3 * v3[i];
+        }
+      } else {
+        v0 = &(array[ncontiguous * (n1-1)]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = v0[i];
+        }
+      }
+    }

--- a/src/snippets/interpolate_1d_cubic_single.incpp
+++ b/src/snippets/interpolate_1d_cubic_single.incpp
@@ -1,0 +1,36 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      x = xx[j];
+      if (x < 0) {
+        res[j] = array[0];
+      } else if (x < n1 - 1) {
+        ix = floor(x);  if (x<0)x=0; if(x>n1-1)x=n1-1; //floor  ix is [0 .. n1[
+        xi[0] = ix - 1;
+        xi[1] = ix;
+        xi[2] = ix + 1;
+        xi[3] = ix + 2;
+        //make in range
+        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
+        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
+        dx = (x - xi[1]);
+        double d2 = dx*dx;
+        double d3 = d2*dx;
+        double omd = 1 - dx;
+        double omd2 = omd*omd;
+        double omd3 = omd2*omd;
+        double opd = 1 + dx;
+        double opd2 = opd*opd;
+        double opd3 = opd2*opd;
+        double dmd = 2 - dx;
+        double dmd2 = dmd*dmd;
+        double dmd3 = dmd2*dmd;
+        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
+        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
+        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
+        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
+        res[j] = c1 * array[xi[1]] + c2 * array[xi[2]] + c0 * array[xi[0]] + c3 * array[xi[3]];
+      } else {
+        res[j] = array[n1-1];
+      }
+    }

--- a/src/snippets/interpolate_1d_cubic_use_missing.incpp
+++ b/src/snippets/interpolate_1d_cubic_use_missing.incpp
@@ -1,0 +1,46 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      vres = &(res[ncontiguous * j]);
+      x = xx[j];
+     if (x < 0) {
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+      } else if (x  < n1-1 ) { 
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0]=ix-1; xi[1]=ix; xi[2]=ix+1; xi[3]=ix+2;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        if (xi[2]<0) xi[2]=0; else if (xi[2]>n1-1) xi[2]=n1-1; 
+        if (xi[3]<0) xi[3]=0; else if (xi[3]>n1-1) xi[3]=n1-1; 
+        v0 = &(array[ncontiguous * xi[0]]);
+        v1 = &(array[ncontiguous * xi[1]]);
+        v2 = &(array[ncontiguous * xi[2]]);
+        v3 = &(array[ncontiguous * xi[3]]);
+        dx = (x - xi[1]);
+        double d2 = dx*dx;
+        double d3 = d2*dx;
+        double omd = 1 - dx;
+        double omd2 = omd*omd;
+        double omd3 = omd2*omd;
+        double opd = 1 + dx;
+        double opd2 = opd*opd;
+        double opd3 = opd2*opd;
+        double dmd = 2 - dx;
+        double dmd2 = dmd*dmd;
+        double dmd3 = dmd2*dmd;
+        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
+        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
+        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
+        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
+
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = c1 * v1[i] + c2 * v2[i] + c0 * v0[i] + c3 * v3[i];
+        }
+      } else if (x < n1) {
+        v0 = &(array[ncontiguous * (n1-1)]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = v0[i];
+        }
+      } else {
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+      }
+    }

--- a/src/snippets/interpolate_1d_cubic_use_missing_single.incpp
+++ b/src/snippets/interpolate_1d_cubic_use_missing_single.incpp
@@ -1,0 +1,38 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      x = xx[j];
+      if (x < 0) {
+        res[j] = missing;
+      } else if (x < n1 - 1) {
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0] = ix - 1;
+        xi[1] = ix;
+        xi[2] = ix + 1;
+        xi[3] = ix + 2;
+        //make in range
+        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
+        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
+        dx = (x - xi[1]);
+        double d2 = dx*dx;
+        double d3 = d2*dx;
+        double omd = 1 - dx;
+        double omd2 = omd*omd;
+        double omd3 = omd2*omd;
+        double opd = 1 + dx;
+        double opd2 = opd*opd;
+        double opd3 = opd2*opd;
+        double dmd = 2 - dx;
+        double dmd2 = dmd*dmd;
+        double dmd3 = dmd2*dmd;
+        double c1 = ((g + 2) * d3 - (g + 3) * d2 + 1);
+        double c2 = ((g + 2) * omd3 - (g + 3) * omd2 + 1);
+        double c0 = (g * opd3 - 5 * g * opd2 + 8 * g * opd - 4 * g);
+        double c3 = (g * dmd3 - 5 * g * dmd2 + 8 * g * dmd - 4 * g);
+        res[j] = c1 * array[xi[1]] + c2 * array[xi[2]] + c0 * array[xi[0]] + c3 * array[xi[3]];
+      } else if (x < n1) {
+        res[j] = array[n1 - 1];
+      } else {
+        res[j] = missing;
+      }
+    }

--- a/src/snippets/interpolate_1d_linear.incpp
+++ b/src/snippets/interpolate_1d_linear.incpp
@@ -1,0 +1,23 @@
+    for (SizeT j = 0; j < nx; ++j) {
+      vres = &(res[ncontiguous * j]);
+      x = xx[j];
+      if (x < 0) {
+        v0 = &(array[0]);
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
+      } else if (x < n1 - 1) {
+        ix = floor(x);
+        xi[0]=ix; xi[1]=ix+1;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        dx = (x - xi[0]);
+        v0 = &(array[ncontiguous * xi[0]]);
+        v1 = &(array[ncontiguous * xi[1]]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = (1. - dx) * v0[i] + dx * v1[i];
+        }
+      } else {
+        v0 = &(array[ncontiguous * (n1 - 1)]);
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
+      }
+    }

--- a/src/snippets/interpolate_1d_linear_single.incpp
+++ b/src/snippets/interpolate_1d_linear_single.incpp
@@ -1,0 +1,16 @@
+    for (SizeT j = 0; j < nx; ++j) {
+      x = xx[j];
+      if (x < 0) {
+        res[j] = array[0];
+      } else if (x < n1) {
+        ix = floor(x);
+        xi[0]=ix; xi[1]=ix+1;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        dx = (x - xi[0]);
+        res[j] = (1. - dx) * array[xi[0]] + dx * array[xi[1]];
+      } else {
+        res[j] = array[n1-1];
+      }
+    }

--- a/src/snippets/interpolate_1d_linear_use_missing.incpp
+++ b/src/snippets/interpolate_1d_linear_use_missing.incpp
@@ -1,0 +1,21 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      vres = &(res[ncontiguous * j]);
+      x = xx[j];
+      if (x < 0) {
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+      } else if (x < n1) {
+        ix = floor(x);
+        xi[0]=ix; xi[1]=ix+1;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        dx = (x - xi[0]);
+        v0 = &(array[ncontiguous * xi[0]]);
+        v1 = &(array[ncontiguous * xi[1]]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          vres[i] = (1. - dx) * v0[i] + dx * v1[i];
+        }
+      } else {
+        for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+      }
+    }

--- a/src/snippets/interpolate_1d_linear_use_missing_single.incpp
+++ b/src/snippets/interpolate_1d_linear_use_missing_single.incpp
@@ -1,0 +1,17 @@
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      x = xx[j];
+      if (x < 0) {
+        res[j] = missing;
+      }
+      else if (x < n1) {
+        ix = floor(x);
+        xi[0]=ix; xi[1]=ix+1;
+      //make in range
+        if (xi[0]<0) xi[0]=0; else if (xi[0]>n1-1) xi[0]=n1-1;
+        if (xi[1]<0) xi[1]=0; else if (xi[1]>n1-1) xi[1]=n1-1; 
+        dx = (x - xi[0]);
+        res[j] = (1. - dx) * array[xi[0]] + dx * array[xi[1]];
+      } else {
+        res[j] = missing;
+      }
+    }

--- a/src/snippets/interpolate_1d_nearest.incpp
+++ b/src/snippets/interpolate_1d_nearest.incpp
@@ -1,0 +1,13 @@
+    for (SizeT j = 0; j < nx; ++j) {
+      vres = &(res[ncontiguous * j]);
+      x = xx[j];
+      if (x < 0) {
+        v0 = &(array[0]);
+      } else if (x < n1 - 1) {
+        ix = floor(x); //floor  ix is [0 .. n1[
+        v0 = &(array[ncontiguous * ix]);
+      } else {
+        v0 = &(array[ncontiguous * (n1 - 1)]);
+      }
+      for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = v0[i];
+    }

--- a/src/snippets/interpolate_1d_nearest_single.incpp
+++ b/src/snippets/interpolate_1d_nearest_single.incpp
@@ -1,0 +1,11 @@
+    for (SizeT j = 0; j < nx; ++j) {
+      x = xx[j];
+      if (x < 0) {
+        res[j] = array[0];
+      } else if (x < n1 - 1) {
+        ix = floor(x); //floor  ix is [0 .. n1[
+        res[j] = array[ix];
+      } else {
+        res[j] = array[n1 - 1];
+      }
+    }

--- a/src/snippets/interpolate_2d_cubic.incpp
+++ b/src/snippets/interpolate_2d_cubic.incpp
@@ -1,0 +1,86 @@
+    for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j ]);
+        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0] = ix - 1;
+        xi[1] = ix;
+        xi[2] = ix + 1;
+        xi[3] = ix + 2;
+        //make in range
+        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
+        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
+        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
+        dx = (x - xi[1]);
+        double dx2 = dx*dx;
+        double dx3 = dx2*dx;
+        double omdx = 1 - dx;
+        double omdx2 = omdx*omdx;
+        double omdx3 = omdx2*omdx;
+        double opdx = 1 + dx;
+        double opdx2 = opdx*opdx;
+        double opdx3 = opdx2*opdx;
+        double dmdx = 2 - dx;
+        double dmdx2 = dmdx*dmdx;
+        double dmdx3 = dmdx2*dmdx;
+        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+        y = yy[j]; if (y<0)y=0; if(y>n2-1)y=n2-1;
+        iy = floor(y);
+        yi[0] = iy - 1;
+        yi[1] = iy;
+        yi[2] = iy + 1;
+        yi[3] = iy + 2;
+        //make in range
+        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
+        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
+        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
+        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
+        dy = (y - yi[1]);
+        double dy2 = dy*dy;
+        double dy3 = dy2*dy;
+        double omdy = 1 - dy;
+        double omdy2 = omdy*omdy;
+        double omdy3 = omdy2*omdy;
+        double opdy = 1 + dy;
+        double opdy2 = opdy*opdy;
+        double opdy3 = opdy2*opdy;
+        double dmdy = 2 - dy;
+        double dmdy2 = dmdy*dmdy;
+        double dmdy3 = dmdy2*dmdy;
+        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+
+        vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+        vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+        vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
+        vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
+
+        vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+        vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+        vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
+        vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
+
+        vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
+        vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
+        vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
+        vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
+
+        vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
+        vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
+        vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
+        vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
+
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          double r0 = cx1 * vx1y0[i] + cx2 * vx2y0[i] + cx0 * vx0y0[i] + cx3 * vx3y0[i];
+          double r1 = cx1 * vx1y1[i] + cx2 * vx2y1[i] + cx0 * vx0y1[i] + cx3 * vx3y1[i];
+          double r2 = cx1 * vx1y2[i] + cx2 * vx2y2[i] + cx0 * vx0y2[i] + cx3 * vx3y2[i];
+          double r3 = cx1 * vx1y3[i] + cx2 * vx2y3[i] + cx0 * vx0y3[i] + cx3 * vx3y3[i];
+          vres[i] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
+        }
+      }

--- a/src/snippets/interpolate_2d_cubic_grid.incpp
+++ b/src/snippets/interpolate_2d_cubic_grid.incpp
@@ -1,0 +1,88 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        vres = &(res[ncontiguous * (k * nx + j) ]);
+        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0] = ix - 1;
+        xi[1] = ix;
+        xi[2] = ix + 1;
+        xi[3] = ix + 2;
+        //make in range
+        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
+        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
+        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
+        dx = (x - xi[1]);
+        double dx2 = dx*dx;
+        double dx3 = dx2*dx;
+        double omdx = 1 - dx;
+        double omdx2 = omdx*omdx;
+        double omdx3 = omdx2*omdx;
+        double opdx = 1 + dx;
+        double opdx2 = opdx*opdx;
+        double opdx3 = opdx2*opdx;
+        double dmdx = 2 - dx;
+        double dmdx2 = dmdx*dmdx;
+        double dmdx3 = dmdx2*dmdx;
+        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+        y = yy[k]; if (y<0)y=0; if(y>n2-1)y=n2-1;
+        iy = floor(y);
+        yi[0] = iy - 1;
+        yi[1] = iy;
+        yi[2] = iy + 1;
+        yi[3] = iy + 2;
+        //make in range
+        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
+        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
+        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
+        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
+        dy = (y - yi[1]);
+        double dy2 = dy*dy;
+        double dy3 = dy2*dy;
+        double omdy = 1 - dy;
+        double omdy2 = omdy*omdy;
+        double omdy3 = omdy2*omdy;
+        double opdy = 1 + dy;
+        double opdy2 = opdy*opdy;
+        double opdy3 = opdy2*opdy;
+        double dmdy = 2 - dy;
+        double dmdy2 = dmdy*dmdy;
+        double dmdy3 = dmdy2*dmdy;
+        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+
+        vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+        vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+        vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
+        vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
+
+        vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+        vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+        vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
+        vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
+
+        vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
+        vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
+        vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
+        vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
+
+        vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
+        vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
+        vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
+        vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
+
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          double r0 = cx1 * vx1y0[i] + cx2 * vx2y0[i] + cx0 * vx0y0[i] + cx3 * vx3y0[i];
+          double r1 = cx1 * vx1y1[i] + cx2 * vx2y1[i] + cx0 * vx0y1[i] + cx3 * vx3y1[i];
+          double r2 = cx1 * vx1y2[i] + cx2 * vx2y2[i] + cx0 * vx0y2[i] + cx3 * vx3y2[i];
+          double r3 = cx1 * vx1y3[i] + cx2 * vx2y3[i] + cx0 * vx0y3[i] + cx3 * vx3y3[i];
+          vres[i] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_cubic_grid_single.incpp
+++ b/src/snippets/interpolate_2d_cubic_grid_single.incpp
@@ -1,0 +1,64 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        x = xx[j]; if (x<0)x=0; if(x>n1-1)x=n1-1;
+        ix = floor(x); //floor  ix is [0 .. n1[
+        xi[0] = ix - 1;
+        xi[1] = ix;
+        xi[2] = ix + 1;
+        xi[3] = ix + 2;
+        //make in range
+        if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 -1 ) xi[0] = n1 - 1;
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 -1 ) xi[1] = n1 - 1;
+        if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 -1 ) xi[2] = n1 - 1;
+        if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 -1 ) xi[3] = n1 - 1;
+        dx = (x - xi[1]);
+        double dx2 = dx*dx;
+        double dx3 = dx2*dx;
+        double omdx = 1 - dx;
+        double omdx2 = omdx*omdx;
+        double omdx3 = omdx2*omdx;
+        double opdx = 1 + dx;
+        double opdx2 = opdx*opdx;
+        double opdx3 = opdx2*opdx;
+        double dmdx = 2 - dx;
+        double dmdx2 = dmdx*dmdx;
+        double dmdx3 = dmdx2*dmdx;
+        double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+        double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+        double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+        double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+        y = yy[k]; if (y<0)y=0; if(y>n2-1)y=n2-1;
+        iy = floor(y);
+        yi[0] = iy - 1;
+        yi[1] = iy;
+        yi[2] = iy + 1;
+        yi[3] = iy + 2;
+        //make in range
+        if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2-1 ) yi[0] = n2 - 1;
+        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2-1 ) yi[1] = n2 - 1;
+        if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2-1 ) yi[2] = n2 - 1;
+        if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2-1 ) yi[3] = n2 - 1;
+        dy = (y - yi[1]);
+        double dy2 = dy*dy;
+        double dy3 = dy2*dy;
+        double omdy = 1 - dy;
+        double omdy2 = omdy*omdy;
+        double omdy3 = omdy2*omdy;
+        double opdy = 1 + dy;
+        double opdy2 = opdy*opdy;
+        double opdy3 = opdy2*opdy;
+        double dmdy = 2 - dy;
+        double dmdy2 = dmdy*dmdy;
+        double dmdy3 = dmdy2*dmdy;
+        double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+        double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+        double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+        double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+        double r0 = cx1 * array[yi[0] * n1 + xi[1]] + cx2 * array[yi[0] * n1 + xi[2]] + cx0 * array[yi[0] * n1 + xi[0]] + cx3 * array[yi[0] * n1 + xi[3]];
+        double r1 = cx1 * array[yi[1] * n1 + xi[1]] + cx2 * array[yi[1] * n1 + xi[2]] + cx0 * array[yi[1] * n1 + xi[0]] + cx3 * array[yi[1] * n1 + xi[3]];
+        double r2 = cx1 * array[yi[2] * n1 + xi[1]] + cx2 * array[yi[2] * n1 + xi[2]] + cx0 * array[yi[2] * n1 + xi[0]] + cx3 * array[yi[2] * n1 + xi[3]];
+        double r3 = cx1 * array[yi[3] * n1 + xi[1]] + cx2 * array[yi[3] * n1 + xi[2]] + cx0 * array[yi[3] * n1 + xi[0]] + cx3 * array[yi[3] * n1 + xi[3]];
+        res[k * nx + j] = cy1 * r1 + cy2 * r2 + cy0 * r0 + cy3*r3;
+      }
+    }

--- a/src/snippets/interpolate_2d_cubic_use_missing.incpp
+++ b/src/snippets/interpolate_2d_cubic_use_missing.incpp
@@ -1,0 +1,97 @@
+      for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j]);
+        x = xx[j];
+        if (x < 0) {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[j];
+          if (y < 0) {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x); //floor  ix is [0 .. n1[
+            xi[0] = ix - 1;
+            xi[1] = ix;
+            xi[2] = ix + 1;
+            xi[3] = ix + 2;
+            //make in range
+            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
+            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
+            dx = (x - xi[1]);
+            double dx2 = dx*dx;
+            double dx3 = dx2*dx;
+            double omdx = 1 - dx;
+            double omdx2 = omdx*omdx;
+            double omdx3 = omdx2*omdx;
+            double opdx = 1 + dx;
+            double opdx2 = opdx*opdx;
+            double opdx3 = opdx2*opdx;
+            double dmdx = 2 - dx;
+            double dmdx2 = dmdx*dmdx;
+            double dmdx3 = dmdx2*dmdx;
+            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+            iy = floor(y);
+            yi[0] = iy - 1;
+            yi[1] = iy;
+            yi[2] = iy + 1;
+            yi[3] = iy + 2;
+            //make in range
+            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
+            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
+            dy = (y - yi[1]);
+            double dy2 = dy*dy;
+            double dy3 = dy2*dy;
+            double omdy = 1 - dy;
+            double omdy2 = omdy*omdy;
+            double omdy3 = omdy2*omdy;
+            double opdy = 1 + dy;
+            double opdy2 = opdy*opdy;
+            double opdy3 = opdy2*opdy;
+            double dmdy = 2 - dy;
+            double dmdy2 = dmdy*dmdy;
+            double dmdy3 = dmdy2*dmdy;
+            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+            vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+            vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+            vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
+            vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
+
+            vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+            vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+            vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
+            vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
+
+            vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
+            vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
+            vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
+            vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
+
+            vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
+            vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
+            vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
+            vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
+
+            for (SizeT i = 0; i < ncontiguous; ++i) {
+              double r0=cx1*vx1y0[i]+cx2*vx2y0[i]+cx0*vx0y0[i]+cx3*vx3y0[i];
+              double r1=cx1*vx1y1[i]+cx2*vx2y1[i]+cx0*vx0y1[i]+cx3*vx3y1[i];
+              double r2=cx1*vx1y2[i]+cx2*vx2y2[i]+cx0*vx0y2[i]+cx3*vx3y2[i];
+              double r3=cx1*vx1y3[i]+cx2*vx2y3[i]+cx0*vx0y3[i]+cx3*vx3y3[i];
+              vres[i] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
+            }
+          } else {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          }
+        } else {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        }
+      }

--- a/src/snippets/interpolate_2d_cubic_use_missing_grid.incpp
+++ b/src/snippets/interpolate_2d_cubic_use_missing_grid.incpp
@@ -1,0 +1,98 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        vres = &(res[ncontiguous * (k * nx + j) ]);
+        x = xx[j];
+        if (x < 0) {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[k];
+          if (y < 0) {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x); //floor  ix is [0 .. n1[
+            xi[0] = ix - 1;
+            xi[1] = ix;
+            xi[2] = ix + 1;
+            xi[3] = ix + 2;
+            //make in range
+            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
+            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
+            dx = (x - xi[1]);
+            double dx2 = dx*dx;
+            double dx3 = dx2*dx;
+            double omdx = 1 - dx;
+            double omdx2 = omdx*omdx;
+            double omdx3 = omdx2*omdx;
+            double opdx = 1 + dx;
+            double opdx2 = opdx*opdx;
+            double opdx3 = opdx2*opdx;
+            double dmdx = 2 - dx;
+            double dmdx2 = dmdx*dmdx;
+            double dmdx3 = dmdx2*dmdx;
+            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+            iy = floor(y);
+            yi[0] = iy - 1;
+            yi[1] = iy;
+            yi[2] = iy + 1;
+            yi[3] = iy + 2;
+            //make in range
+            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
+            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
+            dy = (y - yi[1]);
+            double dy2 = dy*dy;
+            double dy3 = dy2*dy;
+            double omdy = 1 - dy;
+            double omdy2 = omdy*omdy;
+            double omdy3 = omdy2*omdy;
+            double opdy = 1 + dy;
+            double opdy2 = opdy*opdy;
+            double opdy3 = opdy2*opdy;
+            double dmdy = 2 - dy;
+            double dmdy2 = dmdy*dmdy;
+            double dmdy3 = dmdy2*dmdy;
+            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+            vx0y0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+            vx1y0 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+            vx2y0 = &(array[ncontiguous * (yi[0] * n1 + xi[2])]);
+            vx3y0 = &(array[ncontiguous * (yi[0] * n1 + xi[3])]);
+
+            vx0y1 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+            vx1y1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+            vx2y1 = &(array[ncontiguous * (yi[1] * n1 + xi[2])]);
+            vx3y1 = &(array[ncontiguous * (yi[1] * n1 + xi[3])]);
+
+            vx0y2 = &(array[ncontiguous * (yi[2] * n1 + xi[0])]);
+            vx1y2 = &(array[ncontiguous * (yi[2] * n1 + xi[1])]);
+            vx2y2 = &(array[ncontiguous * (yi[2] * n1 + xi[2])]);
+            vx3y2 = &(array[ncontiguous * (yi[2] * n1 + xi[3])]);
+
+            vx0y3 = &(array[ncontiguous * (yi[3] * n1 + xi[0])]);
+            vx1y3 = &(array[ncontiguous * (yi[3] * n1 + xi[1])]);
+            vx2y3 = &(array[ncontiguous * (yi[3] * n1 + xi[2])]);
+            vx3y3 = &(array[ncontiguous * (yi[3] * n1 + xi[3])]);
+            for (SizeT i = 0; i < ncontiguous; ++i) {
+              double r0=cx1*vx1y0[i]+cx2*vx2y0[i]+cx0*vx0y0[i]+cx3*vx3y0[i];
+              double r1=cx1*vx1y1[i]+cx2*vx2y1[i]+cx0*vx0y1[i]+cx3*vx3y1[i];
+              double r2=cx1*vx1y2[i]+cx2*vx2y2[i]+cx0*vx0y2[i]+cx3*vx3y2[i];
+              double r3=cx1*vx1y3[i]+cx2*vx2y3[i]+cx0*vx0y3[i]+cx3*vx3y3[i];
+              vres[i] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
+            }
+          } else {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          }
+        } else {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_cubic_use_missing_grid_single.incpp
+++ b/src/snippets/interpolate_2d_cubic_use_missing_grid_single.incpp
@@ -1,0 +1,76 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        x = xx[j];
+        if (x < 0) {
+          res[k * nx + j] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[k];
+          if (y < 0) {
+            res[k * nx + j] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x); //floor  ix is [0 .. n1[
+            xi[0] = ix - 1;
+            xi[1] = ix;
+            xi[2] = ix + 1;
+            xi[3] = ix + 2;
+            //make in range
+            if (xi[0] < 0) xi[0] = 0; else if (xi[0] > n1 - 1) xi[0] = n1 - 1;
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            if (xi[2] < 0) xi[2] = 0; else if (xi[2] > n1 - 1) xi[2] = n1 - 1;
+            if (xi[3] < 0) xi[3] = 0; else if (xi[3] > n1 - 1) xi[3] = n1 - 1;
+            dx = (x - xi[1]);
+            double dx2 = dx*dx;
+            double dx3 = dx2*dx;
+            double omdx = 1 - dx;
+            double omdx2 = omdx*omdx;
+            double omdx3 = omdx2*omdx;
+            double opdx = 1 + dx;
+            double opdx2 = opdx*opdx;
+            double opdx3 = opdx2*opdx;
+            double dmdx = 2 - dx;
+            double dmdx2 = dmdx*dmdx;
+            double dmdx3 = dmdx2*dmdx;
+            double cx1 = ((g + 2) * dx3 - (g + 3) * dx2 + 1);
+            double cx2 = ((g + 2) * omdx3 - (g + 3) * omdx2 + 1);
+            double cx0 = (g * opdx3 - 5 * g * opdx2 + 8 * g * opdx - 4 * g);
+            double cx3 = (g * dmdx3 - 5 * g * dmdx2 + 8 * g * dmdx - 4 * g);
+
+            iy = floor(y);
+            yi[0] = iy - 1;
+            yi[1] = iy;
+            yi[2] = iy + 1;
+            yi[3] = iy + 2;
+            //make in range
+            if (yi[0] < 0) yi[0] = 0; else if (yi[0] > n2 - 1) yi[0] = n2 - 1;
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            if (yi[2] < 0) yi[2] = 0; else if (yi[2] > n2 - 1) yi[2] = n2 - 1;
+            if (yi[3] < 0) yi[3] = 0; else if (yi[3] > n2 - 1) yi[3] = n2 - 1;
+            dy = (y - yi[1]);
+            double dy2 = dy*dy;
+            double dy3 = dy2*dy;
+            double omdy = 1 - dy;
+            double omdy2 = omdy*omdy;
+            double omdy3 = omdy2*omdy;
+            double opdy = 1 + dy;
+            double opdy2 = opdy*opdy;
+            double opdy3 = opdy2*opdy;
+            double dmdy = 2 - dy;
+            double dmdy2 = dmdy*dmdy;
+            double dmdy3 = dmdy2*dmdy;
+            double cy1 = ((g + 2) * dy3 - (g + 3) * dy2 + 1);
+            double cy2 = ((g + 2) * omdy3 - (g + 3) * omdy2 + 1);
+            double cy0 = (g * opdy3 - 5 * g * opdy2 + 8 * g * opdy - 4 * g);
+            double cy3 = (g * dmdy3 - 5 * g * dmdy2 + 8 * g * dmdy - 4 * g);
+            double r0=cx1*array[yi[0] * n1 + xi[1]]+cx2*array[yi[0] * n1 + xi[2]]+cx0*array[yi[0] * n1 + xi[0]]+cx3*array[yi[0] * n1 + xi[3]];
+            double r1=cx1*array[yi[1] * n1 + xi[1]]+cx2*array[yi[1] * n1 + xi[2]]+cx0*array[yi[1] * n1 + xi[0]]+cx3*array[yi[1] * n1 + xi[3]];
+            double r2=cx1*array[yi[2] * n1 + xi[1]]+cx2*array[yi[2] * n1 + xi[2]]+cx0*array[yi[2] * n1 + xi[0]]+cx3*array[yi[2] * n1 + xi[3]];
+            double r3=cx1*array[yi[3] * n1 + xi[1]]+cx2*array[yi[3] * n1 + xi[2]]+cx0*array[yi[3] * n1 + xi[0]]+cx3*array[yi[3] * n1 + xi[3]];
+            res[k * nx + j] = cy1*r1+cy2*r2+cy0*r0+cy3*r3;
+          } else {
+            res[k * nx + j] = missing;
+          }
+        } else {
+          res[k * nx + j] = missing;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_linear.incpp
+++ b/src/snippets/interpolate_2d_linear.incpp
@@ -1,0 +1,40 @@
+      for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j ]);
+        x = xx[j];
+        if (x < 0) {
+          xi[0] = 0;
+          xi[1] = 0;
+        } else if (x >= n1 - 1) {
+          xi[0] = n1 - 1;
+          xi[1] = n1 - 1;
+        } else {
+          ix = floor(x);
+          xi[0] = ix;
+          xi[1] = ix + 1;
+        }
+        y = yy[j];
+        if (y < 0) {
+          yi[0] = 0;
+          yi[1] = 0;
+        } else if (y >= n2 - 1) {
+          yi[0] = n2 - 1;
+          yi[1] = n2 - 1;
+        } else {
+          iy = floor(y);
+          yi[0] = iy;
+          yi[1] = iy + 1;
+        }
+        dx = (x - xi[0]);
+        dy = (y - yi[0]);
+        vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+        vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+        vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+        vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          double dxdy = dx*dy;
+          double c0 = (1 - dy - dx + dxdy);
+          double c1 = (dy - dxdy);
+          double c2 = (dx - dxdy);
+          vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i] * dxdy;
+        }
+      }

--- a/src/snippets/interpolate_2d_linear_grid.incpp
+++ b/src/snippets/interpolate_2d_linear_grid.incpp
@@ -1,0 +1,38 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        vres = &(res[ncontiguous * (k * nx + j) ]);
+        x = xx[j];
+        if (x < 0) {
+          xi[0] = 0; xi[1] = 0;
+        } else if (x >= n1-1 ) {
+          xi[0] = n1-1; xi[1] = n1-1;
+        } else {
+          ix = floor(x);
+          xi[0] = ix;
+          xi[1] = ix + 1;
+        }
+        y = yy[k];
+        if (y < 0) {
+          yi[0] = 0; yi[1] = 0;
+        } else if (y >= n2-1 ) {
+          yi[0] = n2-1; yi[1] = n2-1;
+        } else {
+          iy = floor(y);
+          yi[0] = iy;
+          yi[1] = iy + 1;
+        }
+        dx = (x - xi[0]);
+        dy = (y - yi[0]);
+        vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+        vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+        vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+        vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          double dxdy=dx*dy;
+          double c0=(1-dy-dx+dxdy);
+          double c1=(dy-dxdy);
+          double c2=(dx-dxdy);
+          vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i]*dxdy;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_linear_grid_single.incpp
+++ b/src/snippets/interpolate_2d_linear_grid_single.incpp
@@ -1,0 +1,31 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { 
+        x = xx[j];
+        if (x < 0) {
+          xi[0] = 0; xi[1] = 0;
+        } else if (x >= n1-1 ) {
+          xi[0] = n1-1; xi[1] = n1-1;
+        } else {
+          ix = floor(x);
+          xi[0] = ix;
+          xi[1] = ix + 1;
+        }
+        y = yy[k];
+        if (y < 0) {
+          yi[0] = 0; yi[1] = 0;
+        } else if (y >= n2-1 ) {
+          yi[0] = n2-1; yi[1] = n2-1;
+        } else {
+          iy = floor(y);
+          yi[0] = iy;
+          yi[1] = iy + 1;
+        }
+        dx = (x - xi[0]);
+        dy = (y - yi[0]);
+        double dxdy=dx*dy;
+        double c0=(1-dy-dx+dxdy);
+        double c1=(dy-dxdy);
+        double c2=(dx-dxdy);
+        res[k * nx + j] = array[yi[0] * n1 + xi[0]] * c0 + array[yi[1] * n1 + xi[0]] * c1 + array[yi[0] * n1 + xi[1]] * c2 + array[yi[1] * n1 + xi[1]] * dxdy;
+      }
+    }

--- a/src/snippets/interpolate_2d_linear_grid_use_missing.incpp
+++ b/src/snippets/interpolate_2d_linear_grid_use_missing.incpp
@@ -1,0 +1,42 @@
+      for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        vres = &(res[ncontiguous * (k * nx + j) ]);
+        x = xx[j];
+        if (x < 0) {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[k];
+          if (y < 0) {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x);
+            xi[0] = ix;
+            xi[1] = ix + 1;
+            //make in range
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            dx = (x - xi[0]);
+            iy = floor(y);
+            yi[0] = iy;
+            yi[1] = iy + 1;
+            //make in range
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            dy = (y - yi[0]);
+            vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+            vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+            vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+            vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+            for (SizeT i = 0; i < ncontiguous; ++i) {
+              double dxdy=dx*dy;
+              double c0=(1-dy-dx+dxdy);
+              double c1=(dy-dxdy);
+              double c2=(dx-dxdy);
+              vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i]*dxdy;
+            }
+          } else {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          }
+        } else {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_linear_grid_use_missing_single.incpp
+++ b/src/snippets/interpolate_2d_linear_grid_use_missing_single.incpp
@@ -1,0 +1,35 @@
+    for (SizeT k = 0; k < ny; ++k) {
+      for (SizeT j = 0; j < nx; ++j) { //nb output points
+        x = xx[j];
+        if (x < 0) {
+          res[k * nx + j] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[k];
+          if (y < 0) {
+            res[k * nx + j] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x);
+            xi[0] = ix;
+            xi[1] = ix + 1;
+            //make in range
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            dx = (x - xi[0]);
+            iy = floor(y);
+            yi[0] = iy;
+            yi[1] = iy + 1;
+            //make in range
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            dy = (y - yi[0]);
+            double dxdy=dx*dy;
+            double c0=(1-dy-dx+dxdy);
+            double c1=(dy-dxdy);
+            double c2=(dx-dxdy);
+            res[k * nx + j] = array[yi[0] * n1 + xi[0]] * c0 + array[yi[1] * n1 + xi[0]] * c1 + array[yi[0] * n1 + xi[1]] * c2 + array[yi[1] * n1 + xi[1]] * dxdy;
+          } else {
+            res[k * nx + j] = missing;
+          }
+        } else {
+          res[k * nx + j] = missing;
+        }
+      }
+    }

--- a/src/snippets/interpolate_2d_linear_use_missing.incpp
+++ b/src/snippets/interpolate_2d_linear_use_missing.incpp
@@ -1,0 +1,40 @@
+      for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j ]);
+        x = xx[j];
+        if (x < 0) {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[j];
+          if (y < 0) {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          } else if (y <= n2 - 1) {
+            ix = floor(x);
+            xi[0] = ix;
+            xi[1] = ix + 1;
+            //make in range
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            dx = (x - xi[0]);
+            iy = floor(y);
+            yi[0] = iy;
+            yi[1] = iy + 1;
+            //make in range
+            if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+            dy = (y - yi[0]);
+            vx0 = &(array[ncontiguous * (yi[0] * n1 + xi[0])]);
+            vx1 = &(array[ncontiguous * (yi[0] * n1 + xi[1])]);
+            vy0 = &(array[ncontiguous * (yi[1] * n1 + xi[0])]);
+            vy1 = &(array[ncontiguous * (yi[1] * n1 + xi[1])]);
+            for (SizeT i = 0; i < ncontiguous; ++i) {
+              double dxdy = dx*dy;
+              double c0 = (1 - dy - dx + dxdy);
+              double c1 = (dy - dxdy);
+              double c2 = (dx - dxdy);
+              vres[i] = vx0[i] * c0 + vy0[i] * c1 + vx1[i] * c2 + vy1[i] * dxdy;
+            }
+          } else {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          }
+        } else {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        }
+      }

--- a/src/snippets/interpolate_2d_nearest_grid.incpp
+++ b/src/snippets/interpolate_2d_nearest_grid.incpp
@@ -1,0 +1,25 @@
+  for (SizeT k = 0; k < ny; ++k) {
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      vres = &(res[ncontiguous * (k * nx + j) ]);
+      x = xx[j];
+      if (x < 0) {
+        xi = 0;
+      } else if (x >= n1-1 ) {
+        xi = n1-1;
+      } else {
+        xi = floor(x);
+      }
+      y = yy[k];
+      if (y < 0) {
+        yi = 0; 
+      } else if (y >= n2-1 ) {
+        yi = n2-1; 
+      } else {
+        yi = floor(y);
+      }
+      vx0 = &(array[ncontiguous * (yi * n1 + xi)]);
+      for (SizeT i = 0; i < ncontiguous; ++i) {
+        vres[i] = vx0[i];
+      }
+    }
+  }

--- a/src/snippets/interpolate_2d_nearest_grid_single.incpp
+++ b/src/snippets/interpolate_2d_nearest_grid_single.incpp
@@ -1,0 +1,21 @@
+  for (SizeT k = 0; k < ny; ++k) {
+    for (SizeT j = 0; j < nx; ++j) { //nb output points
+      x = xx[j];
+      if (x < 0) {
+        xi = 0;
+      } else if (x >= n1-1 ) {
+        xi = n1-1;
+      } else {
+        xi = floor(x);
+      }
+      y = yy[k];
+      if (y < 0) {
+        yi = 0; 
+      } else if (y >= n2-1 ) {
+        yi = n2-1; 
+      } else {
+        yi = floor(y);
+      }
+      res[k * nx + j] = array[yi * n1 + xi];
+    }
+  }

--- a/src/snippets/interpolate_3d_linear.incpp
+++ b/src/snippets/interpolate_3d_linear.incpp
@@ -1,0 +1,45 @@
+      for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j ]);
+        x = xx[j]; if (x<0) x=0; if (x>n1-1) x=n1-1;
+        y = yy[j]; if (y<0) y=0; if (y>n2-1) y=n2-1;
+        z = zz[j]; if (z<0) z=0; if (z>n3-1) z=n3-1;
+
+        ix = floor(x); 
+        xi[0] = ix;
+        xi[1] = ix + 1;
+        //make in range
+        if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+        dx = (x - xi[0]); umdx=1-dx;
+
+        iy = floor(y);
+        yi[0] = iy;
+        yi[1] = iy + 1;
+        //make in range
+        if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+        dy = (y - yi[0]); umdy=1-dy;
+
+        iz = floor(z);
+        zi[0] = iz;
+        zi[1] = iz + 1;
+        //make in range
+        if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+        dz = (z - zi[0]); umdz=1-dz;
+
+        vx0y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[0])] );
+        vx1y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[1])] );
+        vx0y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[0])] );
+        vx1y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[1])] );
+        vx0y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[0])] );
+        vx1y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[1])] );
+        vx0y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[0])] );
+        vx1y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[1])] );
+        for (SizeT i = 0; i < ncontiguous; ++i) {
+          double y0z0=umdx*vx0y0z0[i]+dx*vx1y0z0[i];
+          double y1z0=umdx*vx0y1z0[i]+dx*vx1y1z0[i];
+          double y0z1=umdx*vx0y0z1[i]+dx*vx1y0z1[i];
+          double y1z1=umdx*vx0y1z1[i]+dx*vx1y1z1[i];
+          double   z0=umdy*y0z0+dy*y1z0;
+          double   z1=umdy*y0z1+dy*y1z1;
+          vres[i] = umdz*z0+dz*z1; 
+        }
+      }

--- a/src/snippets/interpolate_3d_linear_grid.incpp
+++ b/src/snippets/interpolate_3d_linear_grid.incpp
@@ -1,0 +1,54 @@
+      for (SizeT l = 0; l < nz; ++l) {
+        for (SizeT k = 0; k < ny; ++k) {
+          z = zz[l];
+          if (z < 0) z = 0; if (z > n3 - 1) z = n3 - 1;
+          iz = floor(z);
+          zi[0] = iz;
+          zi[1] = iz + 1;
+          //make in range
+          if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+          dz = (z - zi[0]);
+          umdz = 1 - dz;
+
+          y = yy[k];
+          if (y < 0) y = 0; if (y > n2 - 1) y = n2 - 1;
+          iy = floor(y);
+          yi[0] = iy;
+          yi[1] = iy + 1;
+          //make in range
+          if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+          dy = (y - yi[0]);
+          umdy = 1 - dy;
+
+          for (SizeT j = 0; j < nx; ++j) { //nb output points
+            vres = &(res[ncontiguous * ( l*nx*ny + k * nx + j) ]);
+            x = xx[j];
+            if (x < 0) x = 0; if (x > n1 - 1) x = n1 - 1;
+            ix = floor(x);
+            xi[0] = ix;
+            xi[1] = ix + 1;
+            //make in range
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            dx = (x - xi[0]);
+            umdx = 1 - dx;
+
+            vx0y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[0])]);
+            vx1y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[1])]);
+            vx0y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[0])]);
+            vx1y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[1])]);
+            vx0y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[0])]);
+            vx1y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[1])]);
+            vx0y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[0])]);
+            vx1y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[1])]);
+            for (SizeT i = 0; i < ncontiguous; ++i) {
+              double y0z0 = umdx * vx0y0z0[i] + dx * vx1y0z0[i];
+              double y1z0 = umdx * vx0y1z0[i] + dx * vx1y1z0[i];
+              double y0z1 = umdx * vx0y0z1[i] + dx * vx1y0z1[i];
+              double y1z1 = umdx * vx0y1z1[i] + dx * vx1y1z1[i];
+              double z0 = umdy * y0z0 + dy*y1z0;
+              double z1 = umdy * y0z1 + dy*y1z1;
+              vres[i] = umdz * z0 + dz*z1;
+            }
+          }
+        }
+      }

--- a/src/snippets/interpolate_3d_linear_grid_single.incpp
+++ b/src/snippets/interpolate_3d_linear_grid_single.incpp
@@ -1,0 +1,43 @@
+      for (SizeT l = 0; l < nz; ++l) {
+        for (SizeT k = 0; k < ny; ++k) {
+          z = zz[l];
+          if (z < 0) z = 0; if (z > n3 - 1) z = n3 - 1;
+          iz = floor(z);
+          zi[0] = iz;
+          zi[1] = iz + 1;
+          //make in range
+          if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+          dz = (z - zi[0]);
+          umdz = 1 - dz;
+
+          y = yy[k];
+          if (y < 0) y = 0; if (y > n2 - 1) y = n2 - 1;
+          iy = floor(y);
+          yi[0] = iy;
+          yi[1] = iy + 1;
+          //make in range
+          if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+          dy = (y - yi[0]);
+          umdy = 1 - dy;
+
+          for (SizeT j = 0; j < nx; ++j) { //nb output points
+            x = xx[j];
+            if (x < 0) x = 0; if (x > n1 - 1) x = n1 - 1;
+            ix = floor(x);
+            xi[0] = ix;
+            xi[1] = ix + 1;
+            //make in range
+            if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+            dx = (x - xi[0]);
+            umdx = 1 - dx;
+
+            double y0z0 = umdx * array[zi[0] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[0] * n1 + xi[1]];
+            double y1z0 = umdx * array[zi[0] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[1] * n1 + xi[1]];
+            double y0z1 = umdx * array[zi[1] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[0] * n1 + xi[1]];
+            double y1z1 = umdx * array[zi[1] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[1] * n1 + xi[1]];
+            double z0 = umdy * y0z0 + dy*y1z0;
+            double z1 = umdy * y0z1 + dy*y1z1;
+            res[l*nx*ny + k * nx + j ] = umdz * z0 + dz*z1;
+          }
+        }
+      }

--- a/src/snippets/interpolate_3d_linear_grid_use_missing.incpp
+++ b/src/snippets/interpolate_3d_linear_grid_use_missing.incpp
@@ -1,0 +1,69 @@
+      for (SizeT l = 0; l < nz; ++l) {
+        for (SizeT k = 0; k < ny; ++k) {
+          for (SizeT j = 0; j < nx; ++j) { //nb output points
+            vres = &(res[ncontiguous * ( l*nx*ny + k * nx + j) ]);
+            x = xx[j];
+            if (x < 0) {
+              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+            } else if (x <= n1 - 1) {
+              y = yy[k];
+              if (y < 0) {
+                for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+              } else if (y <= n2 - 1) {
+                z = zz[l];
+                if (z < 0) {
+                  for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+                } else if (z <= n3 - 1) {
+                  ix = floor(x);
+                  xi[0] = ix;
+                  xi[1] = ix + 1;
+                  //make in range
+                  if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+                  dx = (x - xi[0]);
+                  umdx = 1 - dx;
+
+                  iy = floor(y);
+                  yi[0] = iy;
+                  yi[1] = iy + 1;
+                  //make in range
+                  if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+                  dy = (y - yi[0]);
+                  umdy = 1 - dy;
+
+                  iz = floor(z);
+                  zi[0] = iz;
+                  zi[1] = iz + 1;
+                  //make in range
+                  if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+                  dz = (z - zi[0]);
+                  umdz = 1 - dz;
+
+                  vx0y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[0])]);
+                  vx1y0z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[0] * n1 + xi[1])]);
+                  vx0y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[0])]);
+                  vx1y1z0 = &(array[ncontiguous * (zi[0] * n1n2 + yi[1] * n1 + xi[1])]);
+                  vx0y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[0])]);
+                  vx1y0z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[0] * n1 + xi[1])]);
+                  vx0y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[0])]);
+                  vx1y1z1 = &(array[ncontiguous * (zi[1] * n1n2 + yi[1] * n1 + xi[1])]);
+                  for (SizeT i = 0; i < ncontiguous; ++i) {
+                    double y0z0 = umdx * vx0y0z0[i] + dx * vx1y0z0[i];
+                    double y1z0 = umdx * vx0y1z0[i] + dx * vx1y1z0[i];
+                    double y0z1 = umdx * vx0y0z1[i] + dx * vx1y0z1[i];
+                    double y1z1 = umdx * vx0y1z1[i] + dx * vx1y1z1[i];
+                    double z0 = umdy * y0z0 + dy*y1z0;
+                    double z1 = umdy * y0z1 + dy*y1z1;
+                    vres[i] = umdz * z0 + dz*z1;
+                  }
+                } else {
+                  for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+                }
+              } else {
+                for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+              }
+            } else {
+              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+            }
+          }
+        }
+      }

--- a/src/snippets/interpolate_3d_linear_grid_use_missing_single.incpp
+++ b/src/snippets/interpolate_3d_linear_grid_use_missing_single.incpp
@@ -1,0 +1,57 @@
+      for (SizeT l = 0; l < nz; ++l) {
+        for (SizeT k = 0; k < ny; ++k) {
+          for (SizeT j = 0; j < nx; ++j) { //nb output points
+            x = xx[j];
+            if (x < 0) {
+              res[l*nx*ny + k * nx + j ] = missing;
+            } else if (x <= n1 - 1) {
+              y = yy[k];
+              if (y < 0) {
+                res[l*nx*ny + k * nx + j ] = missing;
+              } else if (y <= n2 - 1) {
+                z = zz[l];
+                if (z < 0) {
+                  res[l*nx*ny + k * nx + j ] = missing;
+                } else if (z <= n3 - 1) {
+                  ix = floor(x);
+                  xi[0] = ix;
+                  xi[1] = ix + 1;
+                  //make in range
+                  if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+                  dx = (x - xi[0]);
+                  umdx = 1 - dx;
+
+                  iy = floor(y);
+                  yi[0] = iy;
+                  yi[1] = iy + 1;
+                  //make in range
+                  if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+                  dy = (y - yi[0]);
+                  umdy = 1 - dy;
+
+                  iz = floor(z);
+                  zi[0] = iz;
+                  zi[1] = iz + 1;
+                  //make in range
+                  if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+                  dz = (z - zi[0]);
+                  umdz = 1 - dz;
+                  double y0z0 = umdx * array[zi[0] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[0] * n1 + xi[1]];
+                  double y1z0 = umdx * array[zi[0] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[0] * n1n2 + yi[1] * n1 + xi[1]];
+                  double y0z1 = umdx * array[zi[1] * n1n2 + yi[0] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[0] * n1 + xi[1]];
+                  double y1z1 = umdx * array[zi[1] * n1n2 + yi[1] * n1 + xi[0]] + dx * array[zi[1] * n1n2 + yi[1] * n1 + xi[1]];
+                  double z0 = umdy * y0z0 + dy*y1z0;
+                  double z1 = umdy * y0z1 + dy*y1z1;
+                  res[l*nx*ny + k * nx + j ] = umdz * z0 + dz*z1;
+                } else {
+                  res[l*nx*ny + k * nx + j ] = missing;
+                }
+              } else {
+                res[l*nx*ny + k * nx + j ] = missing;
+              }
+            } else {
+              res[l*nx*ny + k * nx + j ] = missing;
+            }
+          }
+        }
+      }

--- a/src/snippets/interpolate_3d_linear_use_missing.incpp
+++ b/src/snippets/interpolate_3d_linear_use_missing.incpp
@@ -1,0 +1,62 @@
+      for (SizeT j = 0; j < n; ++j) { //nb output points
+        vres = &(res[ncontiguous * j ]);
+        x = xx[j];
+        if (x < 0) {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        } else if (x <= n1 - 1) {
+          y = yy[j];
+          if (y < 0) {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          } else if (y <= n2 - 1) {
+            z = zz[j];
+            if (z < 0) {
+              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+            } else if (z <= n3 - 1) {
+              ix = floor(x);
+              xi[0] = ix;
+              xi[1] = ix + 1;
+              //make in range
+              if (xi[1] < 0) xi[1] = 0; else if (xi[1] > n1 - 1) xi[1] = n1 - 1;
+              dx = (x - xi[0]); umdx=1-dx;
+              
+              iy = floor(y);
+              yi[0] = iy;
+              yi[1] = iy + 1;
+              //make in range
+              if (yi[1] < 0) yi[1] = 0; else if (yi[1] > n2 - 1) yi[1] = n2 - 1;
+              dy = (y - yi[0]); umdy=1-dy;
+                
+              iz = floor(z);
+              zi[0] = iz;
+              zi[1] = iz + 1;
+              //make in range
+              if (zi[1] < 0) zi[1] = 0; else if (zi[1] > n3 - 1) zi[1] = n3 - 1;
+              dz = (z - zi[0]); umdz=1-dz;
+
+              vx0y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[0])] );
+              vx1y0z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[0] * n1 + xi[1])] );
+              vx0y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[0])] );
+              vx1y1z0 = &( array[ncontiguous * ( zi[0] * n1n2 + yi[1] * n1 + xi[1])] );
+              vx0y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[0])] );
+              vx1y0z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[0] * n1 + xi[1])] );
+              vx0y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[0])] );
+              vx1y1z1 = &( array[ncontiguous * ( zi[1] * n1n2 + yi[1] * n1 + xi[1])] );
+              for (SizeT i = 0; i < ncontiguous; ++i) {
+                double y0z0=umdx*vx0y0z0[i]+dx*vx1y0z0[i];
+                double y1z0=umdx*vx0y1z0[i]+dx*vx1y1z0[i];
+                double y0z1=umdx*vx0y0z1[i]+dx*vx1y0z1[i];
+                double y1z1=umdx*vx0y1z1[i]+dx*vx1y1z1[i];
+                double   z0=umdy*y0z0+dy*y1z0;
+                double   z1=umdy*y0z1+dy*y1z1;
+                vres[i] = umdz*z0+dz*z1; 
+              }
+            } else {
+              for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+            }
+          } else {
+            for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+          }
+        } else {
+          for (SizeT i = 0; i < ncontiguous; ++i) vres[i] = missing;
+        }
+      }

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -1557,6 +1557,7 @@ template <typename T, typename IndexT>
     if (!parallelize) {
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
     } else {
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
     }

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -1448,8 +1448,8 @@ template <typename T, typename IndexT>
      // same with parallelism
     DLong Left[2] = {left, i};
     DLong Right[2] = {j, right};
-    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
-    if (!parallelize) {
+    bool do_parallel = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!do_parallel) {
     for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
     } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -1492,8 +1492,8 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
-    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
-    if (!parallelize) {
+    bool do_parallel = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!do_parallel) {
     for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
     } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -1553,8 +1553,8 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
-    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
-    if (!parallelize) {
+    bool do_parallel = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!do_parallel) {
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
     } else {
     TRACEOMP(__FILE__,__LINE__)
@@ -1603,8 +1603,8 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
-    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
-    if (!parallelize) {
+    bool do_parallel = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!do_parallel) {
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
     } else {
     TRACEOMP(__FILE__,__LINE__)

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -1453,7 +1453,7 @@ template <typename T, typename IndexT>
     for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for num_threads(2)
     for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
     }
 }
@@ -1497,7 +1497,7 @@ template <typename T, typename IndexT>
     for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for num_threads(2)
     for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
     }
     // If arrays are already sorted, finished.  This is an
@@ -1557,7 +1557,7 @@ template <typename T, typename IndexT>
     if (!parallelize) {
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
     } else {
-#pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for num_threads(2)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
     }
     // If arrays are already sorted, finished.  This is an
@@ -1607,7 +1607,7 @@ template <typename T, typename IndexT>
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
     } else {
     TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
+#pragma omp parallel for num_threads(2)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
     }
     // If arrays are already sorted, finished.  This is an

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -1448,9 +1448,14 @@ template <typename T, typename IndexT>
      // same with parallelism
     DLong Left[2] = {left, i};
     DLong Right[2] = {j, right};
+    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!parallelize) {
+    for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
+    } else {
     TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
+    }
 }
 
   
@@ -1487,10 +1492,14 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
+    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!parallelize) {
+    for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
+    } else {
     TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
-
+    }
     // If arrays are already sorted, finished.  This is an
     // optimization that results in faster sorts for nearly ordered lists.
     if (val[aux[mid + 1]] >= val[aux[mid]]) {
@@ -1544,9 +1553,13 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
+    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!parallelize) {
+    for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
+    } else {
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAux(index, aux, Left[i], Right[i], val);
-
+    }
     // If arrays are already sorted, finished.  This is an
     // optimization that results in faster sorts for nearly ordered lists. No need to care about NaNs
     if (val[aux[mid + 1]] >= val[aux[mid]]) {
@@ -1589,10 +1602,14 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
+    bool parallelize = (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1);
+    if (!parallelize) {
+    for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
+    } else {
     TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
-
+    }
     // If arrays are already sorted, finished.  This is an
     // optimization that results in faster sorts for nearly ordered lists.
     if (geq(val[aux[mid + 1]] ,val[aux[mid]])) {

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -1448,6 +1448,7 @@ template <typename T, typename IndexT>
      // same with parallelism
     DLong Left[2] = {left, i};
     DLong Right[2] = {j, right};
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) QuickSortIndex(val, index, Left[i], Right[i]);
 }
@@ -1486,6 +1487,7 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) MergeSortIndexAux(index, aux, Left[i], Right[i], val);
 
@@ -1587,6 +1589,7 @@ template <typename T, typename IndexT>
     SizeT mid = low + (high - low) / 2;
     SizeT Left[2] = {low, mid + 1};
     SizeT Right[2] = {mid, high};
+    TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(2) if (length >= MERGESORT_PARALLEL_THRESHOLD && CpuTPOOL_NTHREADS > 1)
     for (int i = 0; i < 2; i++) AdaptiveSortIndexAuxWithNaN(index, aux, Left[i], Right[i], val);
 

--- a/src/tiff.cxx
+++ b/src/tiff.cxx
@@ -285,7 +285,7 @@ namespace lib
                 auto scanSize = TIFFScanlineSize(tiff_);
 
                 if(!(buffer = static_cast<char*>(_TIFFmalloc(scanSize)))) {
-                    fprintf(stderr, "Could not allocate %lu bytes for TIFF scanline buffer\n", scanSize);
+                    fprintf(stderr, "Could not allocate %lld bytes for TIFF scanline buffer\n", scanSize);
                     goto error;
                 }
 
@@ -303,7 +303,7 @@ namespace lib
                 auto tileSize = TIFFTileSize(tiff_);
 
                 if(!(buffer = static_cast<char*>(_TIFFmalloc(tileSize)))) {
-                    fprintf(stderr, "Could not allocate %lu bytes for TIFF tile buffer\n", tileSize);
+                    fprintf(stderr, "Could not allocate %lld bytes for TIFF tile buffer\n", tileSize);
                     goto error;
                 }
 

--- a/src/triangulation.cpp
+++ b/src/triangulation.cpp
@@ -40,8 +40,7 @@ namespace lib {
 
     DDoubleGDL *xVal, *yVal, *fvalue;
     DLong npts;
-    SizeT nParam = e->NParam();
-    if (nParam < 2) e->Throw("Incorrect number of arguments."); //actually IDL permits to *not* have the 3rd argument.
+    SizeT nParam = e->NParam(2);//actually IDL permits to *not* have the 3rd argument.
     bool wantsTriangles=(nParam > 2);
     bool wantsEdge=(nParam == 4);
     if (wantsTriangles)  e->AssureGlobalPar(2); //since we return values in it?  
@@ -406,8 +405,7 @@ namespace lib {
   BaseGDL* trigrid_fun_spherical(EnvT* e) {
     //NOT USED in this case: EXTRAPOLATE, MAX_VALUE, MIN_VALUE, QUINTIC, XOUT, YOUT
     static DDouble DToR=double(3.1415926535897932384626433832795)/180.0;
-    SizeT nParam = e->NParam();
-    if (nParam < 3) e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(3);
     //OK, trigrid does not care if more than 3 args in sphere mode. Limit at 6 is done at interpreter level.
 
     // Get NX, NY values if present
@@ -1118,8 +1116,7 @@ namespace lib {
   }
 
   BaseGDL* trigrid_fun_plane(EnvT* e) {
-    SizeT nParam = e->NParam();
-    if (nParam < 4) e->Throw("Incorrect number of arguments.");
+    SizeT nParam = e->NParam(4);
     //OK, trigrid does not care if more than 3 args in sphere mode. Limit at 6 is done at interpreter level.
 
 

--- a/src/typedefs.hpp
+++ b/src/typedefs.hpp
@@ -102,6 +102,15 @@
 #define TRACEOMP( file, line) 
 #endif
 
+//#define TRACE_OPCALLS
+#undef TRACE_OPCALLS
+
+#if defined(TRACE_OPCALLS)
+#define TRACE_ROUTINE(func,file,line) std::cout << func << "\t" << file << "\t" << line << std::endl;
+#else
+#define TRACE_ROUTINE(func,file,line)
+#endif
+
 // SA: fixing bug no. 3296360
 typedef unsigned long long int      SizeT;
 typedef long long int RangeT;

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -92,7 +92,8 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       DLong* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -170,7 +171,8 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       SizeT chunksize = nEl / nchunk;
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -247,7 +249,8 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       DLong64* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -325,7 +328,8 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       SizeT chunksize = nEl / nchunk;
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -402,7 +406,8 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       DLong* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -480,7 +485,8 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       SizeT chunksize = nEl / nchunk;
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -557,7 +563,8 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       DLong64* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -635,7 +642,8 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       SizeT chunksize = nEl / nchunk;
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -712,7 +720,8 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       DLong* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -790,7 +799,8 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       SizeT chunksize = nEl / nchunk;
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -867,7 +877,8 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       DLong64* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -945,7 +956,8 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       SizeT chunksize = nEl / nchunk;
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -67,7 +67,7 @@ template<>
 void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -93,7 +93,7 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -172,7 +172,7 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -224,7 +224,7 @@ template<>
 void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -250,7 +250,7 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -329,7 +329,7 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -381,7 +381,7 @@ template<>
 void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -407,7 +407,7 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -486,7 +486,7 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -538,7 +538,7 @@ template<>
 void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -564,7 +564,7 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -643,7 +643,7 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -695,7 +695,7 @@ template<>
 void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -721,7 +721,7 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -800,7 +800,7 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -852,7 +852,7 @@ template<>
 void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -878,7 +878,7 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -957,7 +957,7 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -66,8 +66,9 @@
 template<>
 void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -93,7 +94,7 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -172,7 +173,7 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -223,8 +224,9 @@ void Data_<SpDString>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong*
 template<>
 void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -250,7 +252,7 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -329,7 +331,7 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -380,8 +382,9 @@ void Data_<SpDString>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLon
 template<>
 void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -407,7 +410,7 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -486,7 +489,7 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -537,8 +540,9 @@ void Data_<SpDComplex>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong
 template<>
 void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -564,7 +568,7 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -643,7 +647,7 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -694,8 +698,9 @@ void Data_<SpDComplex>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLo
 template<>
 void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -721,7 +726,7 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -800,7 +805,7 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -851,8 +856,9 @@ void Data_<SpDComplexDbl>::Where(DLong* &ret, SizeT &passed_count, bool comp, DL
 template<>
 void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
+  GDL_NTHREADS=parallelize( nEl);
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=GDL_NTHREADS;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -878,7 +884,7 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -957,7 +963,7 @@ void Data_<SpDComplexDbl>::Where(DLong64* &ret, SizeT &passed_count, bool comp, 
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
+#pragma omp parallel num_threads(nchunk)
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;

--- a/src/where_inc.cpp
+++ b/src/where_inc.cpp
@@ -18,7 +18,7 @@ template<>
 void Data_<Sp>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong64* yes = (DLong64*)MALLOC(nEl*sizeof(DLong64)); 
@@ -44,7 +44,7 @@ void Data_<Sp>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &c
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -123,7 +123,7 @@ void Data_<Sp>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &c
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -174,7 +174,7 @@ template<>
 void Data_<Sp>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_ret) {
   SizeT nEl=this->N_Elements();
  //code is optimized for 1 thread (no thread) and for presence or absence of complement.
-  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))?CpuTPOOL_NTHREADS:1;
+  int nchunk=(nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))?CpuTPOOL_NTHREADS:1;
   if (comp) {
     if (nchunk==1) {
       DLong* yes = (DLong*)MALLOC(nEl*sizeof(DLong)); 
@@ -200,7 +200,7 @@ void Data_<Sp>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -279,7 +279,7 @@ void Data_<Sp>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
       TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;

--- a/src/where_inc.cpp
+++ b/src/where_inc.cpp
@@ -43,7 +43,8 @@ void Data_<Sp>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &c
       DLong64* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -121,7 +122,8 @@ void Data_<Sp>::Where(DLong64* &ret, SizeT &passed_count, bool comp, DLong64* &c
       SizeT chunksize = nEl / nchunk;
       DLong64* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -197,7 +199,8 @@ void Data_<Sp>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_
       DLong* partno[nchunk];
       SizeT partialCountYes[nchunk];
       SizeT partialCountNo[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;
@@ -275,7 +278,8 @@ void Data_<Sp>::Where(DLong* &ret, SizeT &passed_count, bool comp, DLong* &comp_
       SizeT chunksize = nEl / nchunk;
       DLong* part[nchunk];
       SizeT partialCount[nchunk];
-      #pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
+      TRACEOMP(__FILE__,__LINE__)
+#pragma omp parallel num_threads(nchunk) //shared(partialCount,part) //if (nEl >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS <= nEl))
       {
         int thread_id = currentThreadNumber();
         SizeT start_index, stop_index;

--- a/testsuite/LIST
+++ b/testsuite/LIST
@@ -192,3 +192,4 @@ test_xdr.pro
 test_xmlsax.pro
 test_zeropoly.pro
 test_write_csv.pro
+test_all_basic_functions.pro

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -1,0 +1,60 @@
+pro test_all_basic_functions, size=size
+
+  tic
+
+  
+  if (n_elements(size) eq 0 ) then size=1000000
+; initialisations
+
+  command=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
+  calls="ret ="+command+"(size)"
+  for i=0,n_elements(command)-1 do begin  & clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+
+  command=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
+  calls="ret ="+command+"(size)"
+  for i=0,n_elements(command)-1 do begin &  clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+
+  
+  usual_typecodes=[1,2,3,4,5,6,9,12,13,14,15]
+  seed=33
+  cote=long(sqrt(size)) > 8
+  a=randomn(seed,cote*cote,/double)*randomu(seed,cote*cote,/ulong)
+  various_types=ptrarr(11,/allo)
+k=0 & foreach i,usual_typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
+
+   command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
+      "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
+     calls="for k=0,10 do ret="+command+"(*various_types[k])"
+     for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
+  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','STRING','STRTRIM','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','ISHFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN']
+  calls=['for k=0,10 do ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100)',$
+     'for k=0,10 do ret=sort(*various_types[k])',$
+   'for k=0,10 do ret=median(*various_types[k])',$
+   'for k=0,10 do ret=mean(*various_types[k],/nan)',$
+   'for k=0,10 do ret=moment(*various_types[k],/nan)',$
+   'for k=0,10 do ret=transpose(*various_types[k])',$
+   'for k=0,10 do ret=string(*various_types[k])',$
+     'for k=0,10 do ret=strtrim(*various_types[k],2)',$
+     'for k=0,10 do ret=where(*various_types[k] eq 0)',$
+     'for k=0,10 do ret=total(*various_types[k])',$
+     'for k=0,10 do ret=product(*various_types[k])',$
+     'for k=0,10 do ret=min(*various_types[k],max=max)',$
+     'for k=0,10 do ret=max(*various_types[k],min=min)',$
+     'for k=0,10 do ret=finite(*various_types[k])',$
+     'for k=0,10 do ret=shift(*various_types[k],2)',$
+     'for k=0,10 do ret=ishft(*various_types[k],2)',$
+     'for k=0,10 do ret=logical_and(*various_types[k],!dpi)',$
+     'for k=0,10 do ret=logical_or(*various_types[k],!dpi)',$
+     'for k=0,10 do ret=logical_true(*various_types[k])',$
+     'for k=0,10 do ret=atan(*various_types[k],*various_types[k])']
+     
+
+  for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+
+  command=["LOGICAL_TRUE","SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
+
+     calls="for k=0,10 do ret="+command+"(*various_types[k])"
+     for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
+  
+  toc
+end

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -1,22 +1,15 @@
-pro test_all_basic_functions, size=size
+; in case we substract the time of 'doing nothing' in loops, this is it.
+PRO dummy, dummy
+  compile_opt hidden, strictarr
+  return
+end
 
-  masterclock=tic("ALL TESTS")
+pro test_all_basic_functions, size=size, section=section
 
   
   if (n_elements(size) eq 0 ) then size=1000000
+  if (n_elements(section) eq 0 ) then section=0
 ; initialisations
-
-  command=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
-  calls="ret ="+command+"(size)"
-  for i=0,n_elements(command)-1 do begin  & clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
-  print
-
-  command=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
-  calls="ret ="+command+"(size)"
-  for i=0,n_elements(command)-1 do begin &  clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
-  print
-
-  
   typecodes=[1,2,3,4,5,6,9,12,13,14,15]
   typenames=["		BYTE","		INT","		LONG","		FLOAT","		DOUBLE","		COMPLEX","		DCOMPLEX","		UINT","		ULONG","		LONG64","		ULONG64"]
   seed=33
@@ -25,13 +18,37 @@ pro test_all_basic_functions, size=size
   various_types=ptrarr(11,/allo)
 k=0 & foreach i,typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
 
-   command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
+; start master clock here --- random  does not obey pool 
+   masterclock=tic("ALL TESTS")
+
+   
+; array generation
+if (section eq 0 or section eq 1) then begin
+  command=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
+  calls="ret ="+command+"(size)"
+  for i=0,n_elements(command)-1 do begin  & clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+     print
+endif
+    
+;
+if (section eq 0 or section eq 2) then begin
+  command=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
+  calls="ret ="+command+"(size)"
+  for i=0,n_elements(command)-1 do begin &  clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+  print
+endif
+; conversion
+if (section eq 0 or section eq 3) then begin
+command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
       "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
-;   command=["BYTE", "FLOAT", "FLOAT", "DOUBLE", "FIX", "FLOAT", $
-;      "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
    calls="for k=0,10 do ret="+command+"(*various_types[k])"
-     for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
-  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN']
+   for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
+  print
+endif
+
+; operations
+if (section eq 0 or section eq 4) then begin
+  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN','CONVOL']
   calls=[$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=sort(*various_types[k]) & toc,subclock & end ',$
@@ -39,7 +56,7 @@ k=0 & foreach i,typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k],/nan) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=transpose(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=where(*various_types[k] eq 0) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & b=(*various_types[k] eq 0) & subclock=tic(typenames[k]) & ret=where(b) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],max=max) & toc,subclock & end ',$
@@ -49,17 +66,21 @@ k=0 & foreach i,typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_and(*various_types[k],!dpi) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_or(*various_types[k],!dpi) & toc,subclock & end ',$
    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_true(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ']
-     
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & kernel=[ [0,1,0],[-1,0,1],[0,-1,0] ] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=convol(*various_types[k],kernel) & toc,subclock & end ']
 
-  for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
-  print
+for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+     print
+  endif
+
+; FunDirect functions
+if (section eq 0 or section eq 5) then begin
   command=["SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
-
      calls="for k=0,10 do ret="+command+"(*various_types[k])"
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
   print
-  
+endif
+
   toc,masterclock
 end
 ; ishft needs integer

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -80,21 +80,14 @@ olddev=!D.NAME
 set_plot,"Z"
 device,set_resolution=[cote,cote]
 
-; functions etc
+; functions that oerate on whole array
 if (section eq 0 or section eq 5) then begin
-  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','ISHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN','CONVOL','FFT', 'INTERPOLATE' , 'POLY_2D' , 'TVSCL']
+  what=['BYTSCL','SORT','TRANSPOSE','WHERE','FINITE','SHIFT','ISHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN','CONVOL','INTERPOLATE' , 'POLY_2D' , 'TVSCL']
   calls=[$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=sort(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k],/nan) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=transpose(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & b=(*various_types[k] eq 0) & subclock=tic(typenames[k]) & ret=where(b) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],max=max) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k],min=min) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=finite(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=shift(*various_types[k],[2,3]) & toc,subclock & end ',$
    'print,what[i] & for k=0,integers_only do begin & subclock=tic(typenames[k]) & ret=ishft(*various_types[k],[2,3]) & toc,subclock & end ',$ ; ishft needs integer
@@ -103,7 +96,6 @@ if (section eq 0 or section eq 5) then begin
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=logical_true(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & kernel=[ [0,1,0],[-1,0,1],[0,-1,0] ] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=convol(*various_types[k],kernel) & toc,subclock & end ',$
-   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=fft(*various_types[k]) & toc,subclock & end ',$
    'print,what[i] & z=findgen(size) & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=interpolate(*various_types[k],z) & toc,subclock & end ',$
    'print,what[i] & for k=0,not_complex do begin & subclock=tic(typenames[k]) & ret=poly_2d(*various_types[k],p,q) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & tvscl,(*various_types[k]) & toc,subclock & end ' ]
@@ -113,15 +105,40 @@ for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i])
   endif
 set_plot,olddev
 
-; FunDirect functions
+; functions that operate also on particular dimension
 if (section eq 0 or section eq 6) then begin
+   what=['MEDIAN (all dims)','MEDIAN (dim=2)','MEAN (all dims)','MEAN (dim=2)','MOMENT (all dims)','MOMENT (dim=2)','TOTAL (all dims)','TOTAL (dim=2)','PRODUCT (all dims)','PRODUCT (dim=2)','MIN (all dims)','MIN (dim=2)','MAX (all dims)','MAX (dim=2)','FFT (all dims)','FFT (dim=2)']
+  calls=[$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k],dim=2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k], dim=2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],dim=2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k],2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k],2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],dim=2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k],dim=2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=fft(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=fft(*various_types[k],dim=2) & toc,subclock & end ']
+
+for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+     print
+  endif
+
+; FunDirect functions
+if (section eq 0 or section eq 7) then begin
   command=["SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
      calls="for k=0,all_numeric do ret="+command+"(*various_types[k])"
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
   print
 endif
 ; non-threaded functions
-if (section eq 0 or section eq 7) then begin
+if (section eq 0 or section eq 8) then begin
   what=['ROTATE','REVERSE','REFORM','ROT','BYTEORDER','INTERPOL']
   calls=[$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=ROTATE(*various_types[k],1) & toc,subclock & end ',$

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -120,6 +120,20 @@ if (section eq 0 or section eq 6) then begin
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
   print
 endif
+; non-threaded functions
+if (section eq 0 or section eq 7) then begin
+  what=['ROTATE','REVERSE','REFORM','ROT','BYTEORDER','INTERPOL']
+  calls=[$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=ROTATE(*various_types[k],1) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=REVERSE(*various_types[k],2) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=REFORM(*various_types[k],cote*cote) & toc,subclock & end ',$
+     'print,what[i] & for k=0,not_complex do begin & subclock=tic(typenames[k]) & ret=ROT(*various_types[k],33,0.6,/INTERP) & toc,subclock & end ',$
+     'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & BYTEORDER,*various_types[k],/LSWAP & toc,subclock & end ',$
+     'print,what[i] & x = FINDGEN(100)*0.02 & y=sin(x) & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & res=interpol(y,x,*various_types[k]) & toc,subclock & end ']
+
+   for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+  print
+endif
 
   toc,masterclock
 end

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -5,13 +5,14 @@ PRO dummy, dummy
 end
 
 pro test_all_basic_functions, size=size, section=section
-
   
   if (n_elements(size) eq 0 ) then size=1000000
   if (n_elements(section) eq 0 ) then section=0
-; initialisations
-  typecodes=[1,2,3,4,5,6,9,12,13,14,15]
-  typenames=["		BYTE","		INT","		LONG","		FLOAT","		DOUBLE","		COMPLEX","		DCOMPLEX","		UINT","		ULONG","		LONG64","		ULONG64"]
+; initialisations: floats at end, since some commands do not accpet floats/doubles/complex
+  typecodes=[1,2,3,12,13,14,15,4,5,6,9]
+  typenames=["		BYTE","		INT","		LONG","		UINT","		ULONG","		LONG64","		ULONG64","		FLOAT","		DOUBLE","		COMPLEX","		DCOMPLEX"]
+  all_numeric=10
+  integers_only=6
   seed=33
   cote=long(sqrt(size)) > 8
   a=randomn(seed,cote,cote,/double)*randomu(seed,cote,cote,/ulong)
@@ -40,51 +41,57 @@ endif
 ; conversion
 if (section eq 0 or section eq 3) then begin
 command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
-      "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
-   calls="for k=0,10 do ret="+command+"(*various_types[k])"
+      "LONG", "LONG64", "ULONG", "ULONG64"]
+   calls="for k=0,all_numeric do ret="+command+"(*various_types[k])"
    for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
   print
 endif
-
-; operations
 if (section eq 0 or section eq 4) then begin
-  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN','CONVOL']
+; operators 1
+what=[' + ',' - ' ,' * ',' / ']
+calls="for k=0,all_numeric do ret=(*various_types[k])"+what+'1'
+for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
+endif
+
+print
+; operations
+if (section eq 0 or section eq 5) then begin
+  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','ISHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN','CONVOL']
   calls=[$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=sort(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k],/nan) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=transpose(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & b=(*various_types[k] eq 0) & subclock=tic(typenames[k]) & ret=where(b) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],max=max) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k],min=min) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=finite(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=shift(*various_types[k],[2,3]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_and(*various_types[k],!dpi) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_or(*various_types[k],!dpi) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_true(*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ',$
-   'print,what[i] & kernel=[ [0,1,0],[-1,0,1],[0,-1,0] ] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=convol(*various_types[k],kernel) & toc,subclock & end ']
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=sort(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k],/nan) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=transpose(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & b=(*various_types[k] eq 0) & subclock=tic(typenames[k]) & ret=where(b) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],max=max) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k],min=min) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=finite(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=shift(*various_types[k],[2,3]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,integers_only do begin & subclock=tic(typenames[k]) & ret=ishft(*various_types[k],[2,3]) & toc,subclock & end ',$ ; ishft needs integer
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=logical_and(*various_types[k],!dpi) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=logical_or(*various_types[k],!dpi) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=logical_true(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & kernel=[ [0,1,0],[-1,0,1],[0,-1,0] ] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=convol(*various_types[k],kernel) & toc,subclock & end ']
 
 for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
      print
   endif
 
 ; FunDirect functions
-if (section eq 0 or section eq 5) then begin
+if (section eq 0 or section eq 6) then begin
   command=["SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
-     calls="for k=0,10 do ret="+command+"(*various_types[k])"
+     calls="for k=0,all_numeric do ret="+command+"(*various_types[k])"
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
   print
 endif
 
   toc,masterclock
 end
-; ishft needs integer
-;    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=ishft(*various_types[k],[2,3]) & toc,subclock & end ',$
-; to do :string things
-;   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=string(*various_types[k]) & toc,subclock & end ',$
-;   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=strtrim(*various_types[k],2) & toc,subclock & end ',$
+; to do :string things, that are 2 times slower than idl (up to several seconds)
+;   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=string(*various_types[k]) & toc,subclock & end ',$
+;   'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=strtrim(*various_types[k],2) & toc,subclock & end ',$

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -1,6 +1,6 @@
 pro test_all_basic_functions, size=size
 
-  tic
+  masterclock=tic("ALL TESTS")
 
   
   if (n_elements(size) eq 0 ) then size=1000000
@@ -9,52 +9,61 @@ pro test_all_basic_functions, size=size
   command=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
   calls="ret ="+command+"(size)"
   for i=0,n_elements(command)-1 do begin  & clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+  print
 
   command=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
   calls="ret ="+command+"(size)"
   for i=0,n_elements(command)-1 do begin &  clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+  print
 
   
-  usual_typecodes=[1,2,3,4,5,6,9,12,13,14,15]
+  typecodes=[1,2,3,4,5,6,9,12,13,14,15]
+  typenames=["		BYTE","		INT","		LONG","		FLOAT","		DOUBLE","		COMPLEX","		DCOMPLEX","		UINT","		ULONG","		LONG64","		ULONG64"]
   seed=33
   cote=long(sqrt(size)) > 8
-  a=randomn(seed,cote*cote,/double)*randomu(seed,cote*cote,/ulong)
+  a=randomn(seed,cote,cote,/double)*randomu(seed,cote,cote,/ulong)
   various_types=ptrarr(11,/allo)
-k=0 & foreach i,usual_typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
+k=0 & foreach i,typecodes do begin & *various_types[k]=fix(a,type=i) & k++ &end
 
    command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
       "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
-     calls="for k=0,10 do ret="+command+"(*various_types[k])"
+;   command=["BYTE", "FLOAT", "FLOAT", "DOUBLE", "FIX", "FLOAT", $
+;      "LONG", "LONG64", "STRING", "ULONG", "ULONG64"]
+   calls="for k=0,10 do ret="+command+"(*various_types[k])"
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
-  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','STRING','STRTRIM','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','ISHFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN']
-  calls=['for k=0,10 do ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100)',$
-     'for k=0,10 do ret=sort(*various_types[k])',$
-   'for k=0,10 do ret=median(*various_types[k])',$
-   'for k=0,10 do ret=mean(*various_types[k],/nan)',$
-   'for k=0,10 do ret=moment(*various_types[k],/nan)',$
-   'for k=0,10 do ret=transpose(*various_types[k])',$
-   'for k=0,10 do ret=string(*various_types[k])',$
-     'for k=0,10 do ret=strtrim(*various_types[k],2)',$
-     'for k=0,10 do ret=where(*various_types[k] eq 0)',$
-     'for k=0,10 do ret=total(*various_types[k])',$
-     'for k=0,10 do ret=product(*various_types[k])',$
-     'for k=0,10 do ret=min(*various_types[k],max=max)',$
-     'for k=0,10 do ret=max(*various_types[k],min=min)',$
-     'for k=0,10 do ret=finite(*various_types[k])',$
-     'for k=0,10 do ret=shift(*various_types[k],2)',$
-     'for k=0,10 do ret=ishft(*various_types[k],2)',$
-     'for k=0,10 do ret=logical_and(*various_types[k],!dpi)',$
-     'for k=0,10 do ret=logical_or(*various_types[k],!dpi)',$
-     'for k=0,10 do ret=logical_true(*various_types[k])',$
-     'for k=0,10 do ret=atan(*various_types[k],*various_types[k])']
+  what=['BYTSCL','SORT','MEDIAN','MEAN','MOMENT','TRANSPOSE','WHERE','TOTAL','PRODUCT','MIN','MAX','FINITE','SHIFT','LOGICAL_AND','LOGICAL_OR','LOGICAL_TRUE','ATAN']
+  calls=[$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=BYTSCL(*various_types[k],max=10,min=1,/nan,top=100) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=sort(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=median(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=mean(*various_types[k],/nan) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=moment(*various_types[k],/nan) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=transpose(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=where(*various_types[k] eq 0) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=total(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=product(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=min(*various_types[k],max=max) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=max(*various_types[k],min=min) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=finite(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=shift(*various_types[k],[2,3]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_and(*various_types[k],!dpi) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_or(*various_types[k],!dpi) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=logical_true(*various_types[k]) & toc,subclock & end ',$
+   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=atan(*various_types[k],*various_types[k]) & toc,subclock & end ']
      
 
   for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
-
-  command=["LOGICAL_TRUE","SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
+  print
+  command=["SIN","COS","TAN","SINH","COSH","TANH","ASIN","ACOS","ALOG","ALOG2","ALOG10","SQRT","ABS","EXP","CONJ","IMAGINARY","ROUND","CEIL","FLOOR"]
 
      calls="for k=0,10 do ret="+command+"(*various_types[k])"
      for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) &  toc,clock & end
+  print
   
-  toc
+  toc,masterclock
 end
+; ishft needs integer
+;    'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=ishft(*various_types[k],[2,3]) & toc,subclock & end ',$
+; to do :string things
+;   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=string(*various_types[k]) & toc,subclock & end ',$
+;   'print,what[i] & for k=0,10 do begin & subclock=tic(typenames[k]) & ret=strtrim(*various_types[k],2) & toc,subclock & end ',$

--- a/testsuite/test_rebin.pro
+++ b/testsuite/test_rebin.pro
@@ -1,11 +1,62 @@
-; by Sylwester Arabas <slayoo@igf.fuw.edu.pl>
-pro test_rebin
-  ; testing the two ways of specifying new dimensions:
+; by Sylwester Arabas <slayoo@igf.fuw.edu.pl>, GD
+pro test_rebin, test=test
+  errnum=0
+  dotest=keyword_set(test)
+
+  f=findgen(3,5,7,11,13,17)
+  b=rebin(f,3*5,5*4,7*3,11*2,13*2,17*2,/sam)
+  c=rebin(b,3,5,7,11,13,17,/sam)
+  if total(c-f) ne 0 then begin & errnum++ &  if dotest then stop & endif
+  
+;  old_cpu=!cpu
+;  cpu,tpool_nthread=1
+; these multidim arrays will give a different (and unpredictible) total if parallelism is present (see IDL's doc for TOTAL).
+; it is the same for moment(), mean() etc..
+; we cannot use total() for a test, but use where() with a selected value as guinea pig
+; the test 
+  f=findgen(3,5,7,11,13,17)*127
+  b=rebin(f,3*5,5*4,7*3,11*2,13*2,17*2) & w=where(b-1731616 lt 1, count) & if count ne  4588984  then begin & errnum++ &  if dotest then stop & endif
+  c=rebin(b,3,5,7,11,13,17) & w=where(c-1731616 lt 1, count) & if count ne 9560  then begin & errnum++ &  if dotest then stop & endif
+
+  ; this one passes with total 
+  f=bindgen(3,5,7,11,13,17)
+  b=rebin(f,3*5,5*4,7*3,11*2,13*2,17*2) & w=where(b eq 33, count) & if count ne 74045 then begin & errnum++ &  if dotest then stop & endif
+  ; not OK with IDL
+  c=rebin(b,3,5,7,11,13,17) & w=where(c eq 155, count) & if count ne 1950 then begin & errnum++ &  if dotest then stop & endif
+ ; 
+  f=indgen(3,5,7,11,13,17)
+  b=rebin(f,3*5,5*4,7*3,11*2,13*2,17*2) & w=where(b eq 32767, count) & if count ne 8 then begin & errnum++ &  if dotest then stop & endif
+  c=rebin(b,3,5,7,11,13,17) & w=where(c eq 1201, count) & if count ne 2 then begin & errnum++ &  if dotest then stop & endif
+
+  f=lindgen(3,5,7,11,13,17)
+  b=rebin(f,3*5,5*4,7*3,11*2,13*2,17*2) & w=where(b eq 32767, count) & if count ne 365 then begin & errnum++ &  if dotest then stop & endif
+  c=rebin(b,3,5,7,11,13,17) & w=where(c eq 12033, count) & if count ne 3 then begin & errnum++ &  if dotest then stop & endif
+
+
+;  cpu,restore=old_cpu
+
+; simple case that was failing 
+  a=[-320s,192] & b=rebin(a,200) & if (b[0] ne -320 or b[99] ne 186) then begin & errnum++ &  if dotest then stop & endif 
+  a=[-320l,192] & b=rebin(a,200) & if (b[0] ne -320 or b[99] ne 186) then begin & errnum++ &  if dotest then stop & endif 
+  a=[-320ll,192] & b=rebin(a,200) & if (b[0] ne -320 or b[99] ne 186) then begin & errnum++ &  if dotest then stop & endif 
+
+; testing the two ways of specifying new dimensions:
   a = randomn(seed,2,3,4,5)
   if $
     ~array_equal(size(a), size(rebin(a,2,3,4,5))) || $
     ~array_equal(size(a), size(rebin(a,[2,3,4,5]))) || $
     ~array_equal([4,6,8,10], size(rebin(a,4,6,8,10), /dim)) || $
-    ~array_equal([4,6,8,10], size(rebin(a,[4,6,8,10]), /dim)) $
-  then exit, status=1
+     ~array_equal([4,6,8,10], size(rebin(a,[4,6,8,10]), /dim)) then begin & errnum++ &  if dotest then stop & endif
+;
+; ----------------- final message ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_REBIN', errnum
+;
+if (errnum GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
 end
+
+end
+  


### PR DESCRIPTION
in the course of testing loops speed I found:
1.  that loop speed is not a real problem
2. but that specific algorithms (here is the case for many STRxxx functions such as STRTRIM, but also REBIN, etc...) can be improved
3. but more important, that resorting to openmp in very many places in GDL was not done 100% correctly, inducing noticeable delay in the treatment of small simple operations. 
More specifically, it occured to me that parallelization, using OPENMP and the 'if' clause, was not the best approach in many cases, and was definitely not right in all places.

The if clause was wrong in two ways: 
  1. it would not test if tpool_nthread==1 , where it should just not parallelize at all
  2.  the test on tpool_max_elts is wrong (probably a bad cut and paste that has been propagated everywhere)

Besides, experiences show that it is much faster to avoid entering a #pragma omp parallel section if parallelization is not needed at all.
The main purpose of this PR is institue a new scheme:
 - parallelizing a loop must be done thus:
```
      bool parallelize= yes or no depending on various values, see below
      if (!parallelize) { //which is the most frequent
        for (...) // the loop
      } else { //jump in the same loop, but inside a parallel section:
#pragma omp parallel for num_threads(CpuTPOOL_NTHREADS) if (parallelize) (... eventually other necessary openmp clauses)
        for (...)
      }
```

The "if (parallelize)" above is unnecessary of course but may be handy in case the surrounding 'if (!parallelize) {} else {] ' disappears.

I do not understand why openmp+the if clause is blatantly slower than no openmp at all, but this is the repeated case on my machine, gcc+libgomp 8.4.0 using numerous tests (by adding or removing the #pragma clause etc...)

The minimal test for 'parallelize' is parallelize = (CpuTPOOL_NTHREADS > 1 && nE >= CpuTPOOL_MIN_ELTS && (CpuTPOOL_MAX_ELTS == 0 || CpuTPOOL_MAX_ELTS >= nE));