### PR TITLE
Sindgen was wrong ... and other related conversion error corrections.

### DIFF
--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -836,7 +836,7 @@ void GDLDelete( BaseGDL* toDelete)
   if( toDelete != NullGDL::GetSingleInstance())
     delete toDelete;
 }
-int GDL_NTHREADS;
+int GDL_NTHREADS=1;
 
 int parallelize(SizeT n, int modifier) {
 //below, please modify if you find a way to persuade behaviour of those different cases to be better if they return different number of threads.

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -865,24 +865,94 @@ namespace lib {
     // #endif
     return ret_guard.release();
   }
+  
+  BaseGDL* do_uindgen(dimension dim, DDouble off, DDouble inc) {
+      //idl uses a size superior if necessary
+    DLong64 max = off + dim.NDimElementsConst() * inc;
+    DLong64 min = off;
+    if (max < min) {
+      min = max;
+      max = off;
+    }
+    if (min < std::numeric_limits<DUInt>::min() || max > std::numeric_limits<DUInt>::max()) { 
+      DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_UINT);
+    } else {
+      return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
+    }
+  }
+  BaseGDL* do_lindgen(dimension dim, DDouble off, DDouble inc) {
+    //idl uses a size superior if necessary
+    DLong64 max=off+dim.NDimElementsConst()*inc;
+    DLong64 min=off;
+    if (max < min) { min=max; max=off;}
+    if (min < std::numeric_limits<DLong>::min() || max > std::numeric_limits<DLong>::max() ) {
+      DLong64GDL* iGen = new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_LONG);
+    } else {
+      return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
+    }
+  }
 
+  BaseGDL* do_indgen(dimension dim, DDouble off, DDouble inc) {
+      //idl uses a size superior if necessary
+    DLong64 max = off + dim.NDimElementsConst() * inc;
+    DLong64 min = off;
+    if (max < min) {
+      min = max;
+      max = off;
+    }
+    if (min < std::numeric_limits<DLong>::min() || max > std::numeric_limits<DLong>::max()) {   //and NOT numeric_limits<DInt> !! verified.
+      DLong64GDL* iGen = new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_INT);
+    } else {
+      return new DIntGDL(dim, BaseGDL::INDGEN, off, inc);
+    }
+  }  
+  BaseGDL* do_bindgen(dimension dim, DDouble off, DDouble inc) {
+    //idl uses a size superior if necessary
+    DLong64 max = off + dim.NDimElementsConst() * inc;
+    DLong64 min = off;
+    if (max < min) {
+      min = max;
+      max = off;
+    }
+    if (min < std::numeric_limits<DUInt>::min() || max > std::numeric_limits<DUInt>::max()) {
+      DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_BYTE);
+    } else {
+      return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
+    }
+  }
+  BaseGDL* do_sindgen(dimension dim, DDouble off, DDouble inc) {
+    //idl uses a size superior if necessary
+    DLong64 max = off + dim.NDimElementsConst() * inc;
+    DLong64 min = off;
+    if (max < min) {
+      min = max;
+      max = off;
+    }
+    if (min < std::numeric_limits<DLong>::min() || max > std::numeric_limits<DLong>::max()) {
+      DLong64GDL* iGen = new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_STRING);
+    } else {
+      DLongGDL* iGen = new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_STRING);
+    }
+  }
+  
+
+  
   BaseGDL* bindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
-    return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
-    /* }
-       catch( GDLException& ex)
-       {
-       e->Throw( "BINDGEN: "+ex.getMessage());
-       }
-     */
+    return do_bindgen(dim, off, inc);
   }
 
   BaseGDL* indgen(EnvT* e) {
@@ -945,8 +1015,6 @@ namespace lib {
       type = GDL_ULONG;
     }
 
-    /*try
-      {*/
     // Seeing if the user passed in a TYPE code
     static int kwIx12 = e->KeywordIx("TYPE");
     if (e->KeywordPresent(kwIx12)) {
@@ -963,31 +1031,22 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
 
     switch (type) {
-    case GDL_INT: return new DIntGDL(dim, BaseGDL::INDGEN, off, inc);
-    case GDL_BYTE: return new DByteGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_INT: return do_indgen(dim, off, inc);
+    case GDL_BYTE: return do_bindgen(dim,off,inc);
     case GDL_COMPLEX: return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
     case GDL_COMPLEXDBL: return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
     case GDL_DOUBLE: return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
     case GDL_FLOAT: return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
     case GDL_LONG64: return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
-    case GDL_LONG: return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
-    case GDL_STRING:
-    {
-      DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-      return iGen->Convert2(GDL_STRING);
-    }
-    case GDL_UINT: return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
+    case GDL_LONG: return do_lindgen(dim, off, inc);
+    case GDL_STRING: return do_sindgen(dim, off, inc);
+    case GDL_UINT: return do_uindgen(dim,off,inc);
     case GDL_ULONG64: return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
     case GDL_ULONG: return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
     default:
       e->Throw("Invalid type code specified.");
       break;
     }
-    /*      }
-        catch( GDLException& ex)
-        {
-        e->Throw( ex.getMessage());
-        }*/
     assert(false);
     return NULL;
   }
@@ -995,72 +1054,42 @@ namespace lib {
   BaseGDL* uindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
-    return new DUIntGDL(dim, BaseGDL::INDGEN, off, inc);
-    /* }
-       catch( GDLException& ex)
-       {
-       e->Throw( "UINDGEN: "+ex.getMessage());
-       }
-     */
+    return do_uindgen(dim,off,inc);
   }
 
   BaseGDL* sindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
-    // size of string is 12 if result can be of type DLong, 22 if DLong64
-    DLong64 max=off+dim.NDimElementsConst()*inc;
-    DLong64 min=off;
-    if (max < min) { min=max; max=off;}
-    if (min < std::numeric_limits<DLong>::min() || max > std::numeric_limits<DLong>::max() ) { //call format with size=22
-      DLong64GDL* iGen = new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
-      return iGen->Convert2(GDL_STRING);
-    } else {
-      DLongGDL* iGen = new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
-      return iGen->Convert2(GDL_STRING);
-    }
-    /*    }
-      catch( GDLException& ex)
-      {
-      e->Throw( "SINDGEN: "+ex.getMessage());
-      }*/
+    return do_sindgen(dim, off, inc);
   }
 
   BaseGDL* lindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
-    return new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*    }
-      catch( GDLException& ex)
-      {
-      e->Throw( "LINDGEN: "+ex.getMessage());
-      }*/
+    return do_lindgen(dim, off, inc);
   }
 
   BaseGDL* ulindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1068,17 +1097,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*    }
-      catch( GDLException& ex)
-      {
-      e->Throw( "ULINDGEN: "+ex.getMessage());
-      }*/
   }
 
   BaseGDL* l64indgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1086,17 +1109,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
-    /*  }
-    catch( GDLException& ex)
-    {
-    e->Throw( "L64INDGEN: "+ex.getMessage());
-    }*/
   }
 
   BaseGDL* ul64indgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1104,18 +1121,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DULong64GDL(dim, BaseGDL::INDGEN, off, inc);
-    /*   }
-     catch( GDLException& ex)
-     {
-     e->Throw( "UL64INDGEN: "+ex.getMessage());
-     }
-     */
   }
 
   BaseGDL* findgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1123,17 +1133,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DFloatGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*  }
-    catch( GDLException& ex)
-    {
-    e->Throw( "FINDGEN: "+ex.getMessage());
-    }*/
   }
 
   BaseGDL* dindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1141,17 +1145,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DDoubleGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*  }
-    catch( GDLException& ex)
-    {
-    e->Throw( "DINDGEN: "+ex.getMessage());
-    }*/
   }
 
   BaseGDL* cindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1159,17 +1157,11 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DComplexGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*  }
-    catch( GDLException& ex)
-    {
-    e->Throw( "CINDGEN: "+ex.getMessage());
-    }*/
   }
 
   BaseGDL* dcindgen(EnvT* e) {
     dimension dim;
     DDouble off = 0, inc = 1;
-    //     try{
     arr(e, dim);
     if (dim[0] == 0)
       throw GDLException("Array dimensions must be greater than 0");
@@ -1177,12 +1169,6 @@ namespace lib {
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
     return new DComplexDblGDL(dim, BaseGDL::INDGEN, off, inc);
-    /*  }
-    catch( GDLException& ex)
-    {
-    e->Throw( "DCINDGEN: "+ex.getMessage());
-    }
-     */
   }
 
   // only called from CALL_FUNCTION

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1021,8 +1021,17 @@ namespace lib {
 
     e->AssureDoubleScalarKWIfPresent("START", off);
     e->AssureDoubleScalarKWIfPresent("INCREMENT", inc);
-    DULongGDL* iGen = new DULongGDL(dim, BaseGDL::INDGEN, off, inc);
-    return iGen->Convert2(GDL_STRING);
+    // size of string is 12 if result can be of type DLong, 22 if DLong64
+    DLong64 max=off+dim.NDimElementsConst()*inc;
+    DLong64 min=off;
+    if (max < min) { min=max; max=off;}
+    if (min < std::numeric_limits<DLong>::min() || max > std::numeric_limits<DLong>::max() ) { //call format with size=22
+      DLong64GDL* iGen = new DLong64GDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_STRING);
+    } else {
+      DLongGDL* iGen = new DLongGDL(dim, BaseGDL::INDGEN, off, inc);
+      return iGen->Convert2(GDL_STRING);
+    }
     /*    }
       catch( GDLException& ex)
       {

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -305,14 +305,30 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING:
-  {
-    Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-    TRACEOMP(__FILE__,__LINE__)
+    {
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+      if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(8);
+          sprintf(buf, "%8i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 8);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-    for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
-    if ((mode & BaseGDL::CONVERT) != 0) delete this;
-    return dest;
-  }
+          for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(8);
+          sprintf(buf, "%8i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 8);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
+    }
   case GDL_PTR:
   case GDL_OBJ:
   case GDL_STRUCT:
@@ -385,14 +401,31 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2( DType destTy, BaseGDL::Convert2Mod
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
-  {
-    Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-    TRACEOMP(__FILE__,__LINE__)
+    {
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+      if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(8);
+          sprintf(buf, "%8i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 8);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-    for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 8);
-    if ((mode & BaseGDL::CONVERT) != 0) delete this;
-    return dest;
-  }
+          for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(8);
+          sprintf(buf, "%8i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 8);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
+    }
+
     case GDL_PTR:
     case GDL_OBJ:
     case GDL_STRUCT:
@@ -469,14 +502,30 @@ TRACE_CONVERT2
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
-      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-      TRACEOMP(__FILE__,__LINE__)
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+      if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(12);
+          sprintf(buf, "%12i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 12);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
-      if ((mode & BaseGDL::CONVERT) != 0) delete this;
-      return dest;
+          for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(12);
+          sprintf(buf, "%12i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 12);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
     }
-    case GDL_PTR:
+   case GDL_PTR:
     case GDL_OBJ:
     case GDL_STRUCT:
     case GDL_UNDEF: 
@@ -551,14 +600,30 @@ TRACE_CONVERT2
 	TRACEOMP(__FILE__,__LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
           DO_CONVERT_END
-    case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
+    case GDL_STRING: 
     {
-      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-      TRACEOMP(__FILE__,__LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 12);
-      if ((mode & BaseGDL::CONVERT) != 0) delete this;
-      return dest;
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+if((GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION))==1) {
+        for (SizeT i = 0; i < nEl; ++i) { 
+          char* buf=new char(12);
+          sprintf(buf,"%12i",(*this)[i]);
+           (*dest)[i] = std::string(buf);
+  //        (*dest)[i] = i2s((*this)[i], 12);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+} else {
+    TRACEOMP(__FILE__,__LINE__)
+  #pragma omp parallel for num_threads(GDL_NTHREADS)
+        for (SizeT i = 0; i < nEl; ++i) { 
+          char* buf=new char(12);
+          sprintf(buf,"%12i",(*this)[i]);
+           (*dest)[i] = std::string(buf);
+  //        (*dest)[i] = i2s((*this)[i], 12);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
     }
     case GDL_PTR:
     case GDL_OBJ:
@@ -1289,12 +1354,28 @@ TRACE_CONVERT2
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
-      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-      TRACEOMP(__FILE__,__LINE__)
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+      if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(22);
+          sprintf(buf, "%22i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 22);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
-      if ((mode & BaseGDL::CONVERT) != 0) delete this;
-      return dest;
+          for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(22);
+          sprintf(buf, "%22i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 22);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
     }
     case GDL_PTR:
     case GDL_OBJ:
@@ -1373,12 +1454,28 @@ TRACE_CONVERT2
           DO_CONVERT_END
     case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
     {
-      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO);
-      TRACEOMP(__FILE__,__LINE__)
+      Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+      if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
+        for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(22);
+          sprintf(buf, "%22i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 22);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      } else {
+        TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (SizeT i = 0; i < nEl; ++i) (*dest)[i] = i2s((*this)[i], 22);
-      if ((mode & BaseGDL::CONVERT) != 0) delete this;
-      return dest;
+          for (SizeT i = 0; i < nEl; ++i) {
+          char* buf = new char(22);
+          sprintf(buf, "%22i", (*this)[i]);
+          (*dest)[i] = std::string(buf);
+          //        (*dest)[i] = i2s((*this)[i], 22);
+        }
+        if ((mode & BaseGDL::CONVERT) != 0) delete this;
+        return dest;
+      }
     }
     case GDL_PTR:
     case GDL_OBJ:

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -303,10 +303,10 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
       DO_CONVERT_END
   case GDL_STRING:
   {
+    char buf[32];
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(8);
         sprintf(buf, "%8i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 8);
@@ -317,7 +317,6 @@ template<> BaseGDL* Data_<SpDInt>::Convert2(DType destTy, BaseGDL::Convert2Mode 
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(8);
         sprintf(buf, "%8i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 8);
@@ -398,10 +397,10 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2(DType destTy, BaseGDL::Convert2Mode
       DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
+    char buf[32];
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(8);
         sprintf(buf, "%8i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 8);
@@ -412,7 +411,6 @@ template<> BaseGDL* Data_<SpDUInt>::Convert2(DType destTy, BaseGDL::Convert2Mode
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(8);
         sprintf(buf, "%8i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 8);
@@ -494,10 +492,10 @@ template<> BaseGDL* Data_<SpDLong>::Convert2(DType destTy, BaseGDL::Convert2Mode
       DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
+    char buf[32];
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(12);
         sprintf(buf, "%12i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 12);
@@ -508,7 +506,6 @@ template<> BaseGDL* Data_<SpDLong>::Convert2(DType destTy, BaseGDL::Convert2Mode
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(12);
         sprintf(buf, "%12i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 12);
@@ -590,10 +587,10 @@ template<> BaseGDL* Data_<SpDULong>::Convert2(DType destTy, BaseGDL::Convert2Mod
       DO_CONVERT_END
   case GDL_STRING:
   {
+    char buf[32];
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(12);
         sprintf(buf, "%12i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 12);
@@ -604,7 +601,6 @@ template<> BaseGDL* Data_<SpDULong>::Convert2(DType destTy, BaseGDL::Convert2Mod
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(12);
         sprintf(buf, "%12i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 12);
@@ -1321,10 +1317,10 @@ template<> BaseGDL* Data_<SpDLong64>::Convert2(DType destTy, BaseGDL::Convert2Mo
       DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
+    char buf[32];
     Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(22);
         sprintf(buf, "%22i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 22);
@@ -1335,7 +1331,6 @@ template<> BaseGDL* Data_<SpDLong64>::Convert2(DType destTy, BaseGDL::Convert2Mo
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(22);
         sprintf(buf, "%22i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 22);
@@ -1418,10 +1413,10 @@ template<> BaseGDL* Data_<SpDULong64>::Convert2(DType destTy, BaseGDL::Convert2M
       DO_CONVERT_END
   case GDL_STRING: // GDL_BYTE to GDL_STRING: remove first dim
   {
-    Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
+   char buf[32];
+   Data_<SpDString>* dest = new Data_<SpDString>(dim, BaseGDL::NOZERO, 12);
     if ((GDL_NTHREADS = parallelize(nEl, TP_ARRAY_INITIALISATION)) == 1) {
       for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(22);
         sprintf(buf, "%22i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 22);
@@ -1432,7 +1427,6 @@ template<> BaseGDL* Data_<SpDULong64>::Convert2(DType destTy, BaseGDL::Convert2M
       TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < nEl; ++i) {
-        char* buf = new char(22);
         sprintf(buf, "%22i", (*this)[i]);
         (*dest)[i] = std::string(buf);
         //        (*dest)[i] = i2s((*this)[i], 22);


### PR DESCRIPTION
Sindgen should not use a ULONG intermediate array when off and inc are able to generate signed integers.

besides, based on the size of the maximum value computed (with off and inc this can be huge) the size of the string array generated can be 12 or 22 chars long.
 ex: `print,'12345678901234',sindgen(5,increment=2147483647L/4),format='(":",A,":")`
should give:
```
:12345678901234:
:           0:
:   429496729:
:   858993458:
:  1288490187:
:  1717986916:
```
GDL was outputting:
```
:12345678901234:
:           0:
:  2147483647:
:          -2:
:  2147483645:
:          -4:
```

Now sindgen uses the good integer (long or longlong) to do the work.

BUT in fact, a lot of 'nonstandard' conversions like` indgen(5,increment=-214748364LL,start=-2147483647LL)`
were also wrong because GDL used a simple equality conversion type_b[i]=type_a[i] where only the mask of bits of size type_b should be made on type_a before conversion by equality. This is the same as the fix(toto,offset,length) behaviour with offset=0 for each element.

Besides, modified convert2 for strings (only integers) because sprintf is faster that c++ (factor 2).