### PR TITLE
Graphic features improved

### DIFF
--- a/src/devicewx.hpp
+++ b/src/devicewx.hpp
@@ -111,15 +111,16 @@ public:
 #else
   PLINT Quady[4] = {1, yMaxSize - y_scroll_size - 1, 1, yMaxSize - y_scroll_size - 1}; //IDL covers the linux (bottom) taskbar too
 #endif
+  int locOnScreen=(wIx>31)?(wIx+2)%4:wIx % 4; //IDL shifts /FREE windows by 2
   if (noPosx && noPosy) { //no init given, use 4 quadrants:
-   xoff = Quadx[wIx % 4];
-   yoff = Quady[wIx % 4];
+   xoff = Quadx[locOnScreen];
+   yoff = Quady[locOnScreen];
   } else if (noPosx) {
-   xoff = Quadx[wIx % 4];
+   xoff = Quadx[locOnScreen];
    yoff = yMaxSize - yPos - y_scroll_size;
   } else if (noPosy) {
    xoff = xPos;
-   yoff = Quady[wIx % 4];
+   yoff = Quady[locOnScreen];
   } else {
    xoff = xPos;
    yoff = yMaxSize - yPos - y_scroll_size;
@@ -189,12 +190,12 @@ long style = (wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxRESIZE_BORDER | wxCAPTION | wx
     plotFrame->Show(); //WithoutActivating();
   }
   plotFrame->UpdateWindowUI();
-//  //really show by letting the loop do its magic.
-//#ifdef __WXMAC__
-//  wxTheApp->Yield();
-//#else
-//  wxGetApp().MainLoop(); //central loop for wxEvents!
-//#endif
+//really show by letting the loop do its magic. Necessary.
+#ifdef __WXMAC__
+  wxTheApp->Yield();
+#else
+  wxGetApp().MainLoop(); //central loop for wxEvents!
+#endif
   return true;
  }
 

--- a/src/devicex.hpp
+++ b/src/devicex.hpp
@@ -123,15 +123,16 @@ public:
 // dynamic allocation needed!    
     PLINT Quadx[4]={xMaxSize-xleng-1,xMaxSize-xleng-1,1,1};
     PLINT Quady[4]={1,yMaxSize-yleng-1,1,yMaxSize-yleng-1};
-    if (noPosx && noPosy) { //no init given, use 4 quadrants:
-      xoff = Quadx[wIx%4];
-      yoff = Quady[wIx%4];
+  int locOnScreen=(wIx>31)?(wIx+2)%4:wIx % 4; //IDL shifts /FREE windows by 2
+  if (noPosx && noPosy) { //no init given, use 4 quadrants:
+      xoff = Quadx[locOnScreen];
+      yoff = Quady[locOnScreen];
     } else if (noPosx) {
-      xoff = Quadx[wIx%4];
+      xoff = Quadx[locOnScreen];
       yoff = yMaxSize-yPos-yleng;
     } else if (noPosy) {
       xoff = xPos;
-      yoff = Quady[wIx%4];
+      yoff = Quady[locOnScreen];
     } else {
       xoff  = xPos;
       yoff  = yMaxSize-yPos-yleng;

--- a/src/plotting_cursor.cpp
+++ b/src/plotting_cursor.cpp
@@ -48,7 +48,7 @@ void tvcrs( EnvT* e)
 
   if (nParam < 2 )
   {
-    e->Throw("TVCRS with 1 argument not implemented (fixme)");
+    return; // ignore e->Throw("TVCRS with 1 argument not implemented (fixme)");
   }
   DDoubleGDL *x,*y;
 

--- a/src/plplotdriver/deprecated_wxwidgets_gc.cpp
+++ b/src/plplotdriver/deprecated_wxwidgets_gc.cpp
@@ -250,6 +250,9 @@ void wxPLDevGC::CreateCanvas()
     {
         delete m_context;
         m_context = wxGraphicsContext::Create( *( (wxMemoryDC *) m_dc ) );
+        char* do_antialias = getenv("GDL_DO_ANTIALIASING");
+        if (do_antialias==NULL ) m_context->SetAntialiasMode(wxANTIALIAS_NONE); //GD May 2022 force no antialias as antialiasing prevents erasing lines by redrawing them ontop by a color 0
+        // see what procedure PROFILES do.
     }
 }
 


### PR DESCRIPTION
By trying the simple "PROFILES" procedure I found a series of small problems cured by this PR:
- TVCRS would not accept a single argument: patched, does not harm.
- /FREE windows (window numbers 32 and above)  would appear, if no offset given, by default on the opposite side of the screen as "normal" windows would do. 
- wxWidgets plots must not be antialiased if one wants to erase some plot regions using an overwrite with a background color. That is what "PROFILES" do. Very crude but we must also support this old but effective feature. So now, provided our 'own' wxwidgets driver (the old but fast plplot one in fact) is installed, there will by default NO ANTIALIASING except if the environment variable GDL_DO_ANTIALIASING is defined.