### PR TITLE
Remove deprecated std::unary_function and std::binary_function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,14 +80,15 @@ jobs:
       - name: Install Dependencies (macOS, Homebrew)
         if: contains(matrix.os, 'macos')                    # && steps.cache.outputs.cache-hit != 'true'  #removed as the cached state is bad.
         run: |
-          find /usr/local -path /usr/local/miniconda -prune -false -or -type l -or -type f | sort > ~/snapshot1.txt
+          find /usr/local -path /usr/local/miniconda -prune -false -or -type l -or -type f | sort -o ~/snapshot1.txt
           scripts/build_gdl.sh prep
-          find /usr/local -path /usr/local/miniconda -prune -false -or -type l -or -type f | sort > ~/snapshot2.txt
+          find /usr/local -path /usr/local/miniconda -prune -false -or -type l -or -type f | sort -o ~/snapshot2.txt
           echo "Setting up cache..."
+          rm -rf ${{ runner.temp }}/cache
           mkdir -p ${{ runner.temp }}/cache
-          for fn in $(comm -13 ~/snapshot1.txt ~/snapshot2.txt); do
-            rsync -aR ${fn} ${{ runner.temp }}/cache || true
-          done
+          while IFS= read -r fn; do
+            rsync -aR "${fn}" ${{ runner.temp }}/cache
+          done < <(comm -13 ~/snapshot1.txt ~/snapshot2.txt)
       - name: Install Dependencies (Linux, Apt)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -95,10 +96,13 @@ jobs:
       - name: Restore cache (macOS, Homebrew)
         if: contains(matrix.os, 'macos') && steps.cache.outputs.cache-hit == 'true'
         run: |
-          cd ${{ runner.temp }}
-          for d in `ls cache`; do
-            sudo rsync -rt --links --no-t --inplace cache/$d/ /$d
-          done
+          echo "Checking cache..."
+          if cd ${{ runner.temp }}/cache; then
+            echo "Extracting cache..."
+            while IFS= read -r fn; do
+              rsync -aR "${fn}" /
+            done < <(find -- * -maxdepth 0 -type d)
+          fi
       - name: Build GDL
         run: |
           scripts/build_gdl.sh configure
@@ -168,6 +172,7 @@ jobs:
             make
             git
             rsync
+            patch
       - name: Checkout GDL
         uses: actions/checkout@v2
       - name: Cache Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1035,7 +1035,7 @@ endif(NOT PYTHON_MODULE)
 install(FILES ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_SOURCE_DIR}/README DESTINATION ${CMAKE_INSTALL_PREFIX}/${GDL_DATA_DIR})
 install(FILES ${CMAKE_SOURCE_DIR}/doc/gdl.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1)
 
-# substitute variables in configure.h.cmake and move it to configure.h
+# substitute variables in config.h.cmake and move it to config.h
 configure_file(${CMAKE_SOURCE_DIR}/config.h.cmake ${CMAKE_BINARY_DIR}/config.h)
 
 # display macro

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -106,7 +106,7 @@ elif [ ${BUILD_OS} == "Linux" ]; then
     ) # JP 2021 Mar 21: SuSE lacks eccodes
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
-        llvm libomp ncurses readline zlib libpng gsl wxmac graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
+        llvm libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
         eccodes glpk shapelib expat gcc@10 qhull
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
@@ -372,7 +372,6 @@ function prep_packages {
             exit 1
         fi
         brew update-reset
-        brew unlink python@2
         log "Installing packages: ${BREW_PACKAGES[@]}"
         if [ ${DRY_RUN} == "true" ]; then
             log "Please run below command to install required packages to build GDL."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,13 @@ target_link_libraries(gdl ${LIBRARIES})
 
 add_definitions(-DHAVE_CONFIG_H)
 
+# Workaround MinGW build problem: force problematic large file to be optimized to prevent string table overflow error
+# see also: https://github.com/assimp/assimp/pull/2418/files
+if ((MINGW) AND (CMAKE_BUILD_TYPE MATCHES Debug))
+	message("-- Applying MinGW basic_op.cpp Debug Workaround")
+	set_source_files_properties(basic_op.cpp PROPERTIES COMPILE_OPTIONS "-Os")
+endif()
+
 if(PYTHON_MODULE)
         find_package( PythonInterp ${PYTHONVERSION} REQUIRED )
 	execute_process(COMMAND ${PYTHON_EXECUTABLE} -c

--- a/src/antlr/CharScanner.hpp
+++ b/src/antlr/CharScanner.hpp
@@ -31,6 +31,9 @@
 # include <stdio.h>
 #endif
 
+// std::function needs this one
+#include <functional>
+
 #include <antlr/TokenStream.hpp>
 #include <antlr/RecognitionException.hpp>
 #include <antlr/SemanticException.hpp>
@@ -71,7 +74,7 @@ ANTLR_C_USING(strcasecmp)
 
 /** Functor for the literals map
  */
-class ANTLR_API CharScannerLiteralsLess : public ANTLR_USE_NAMESPACE(std)binary_function<ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string,bool> {
+class ANTLR_API CharScannerLiteralsLess : public ANTLR_USE_NAMESPACE(std)function<bool(ANTLR_USE_NAMESPACE(std)string,ANTLR_USE_NAMESPACE(std)string)> {
 private:
 	const CharScanner* scanner;
 public:

--- a/src/dcommon.hpp
+++ b/src/dcommon.hpp
@@ -65,7 +65,7 @@ public:
   DCommon* getCommon(void) { return this; };
 };
 
-class DCommon_eq: public std::unary_function<DCommon,bool>
+class DCommon_eq: public std::function<bool(DCommon)>
 {
   std::string name;
 public:
@@ -102,7 +102,7 @@ public:
 typedef std::vector<DCommonBase*> CommonBaseListT;
 typedef std::vector<DCommon*>     CommonListT;
 
-class DCommon_contains_var: public std::unary_function<DCommonBase,bool>
+class DCommon_contains_var: public std::function<bool(DCommonBase*)>
 {
   std::string name;
 public:

--- a/src/dcompiler.hpp
+++ b/src/dcompiler.hpp
@@ -94,7 +94,7 @@ public:
   EnvBaseT* GetEnv() const { return env;}
   void SetEnv( EnvBaseT* e) { env = e;}
   // for sorting lists by name
-  struct CompLibFunName: public std::binary_function< DLibFun*, DLibFun*, bool>
+  struct CompLibFunName: public std::function<bool(DLibFun*, DLibFun*)>
   {
     bool operator() ( DLibFun* f1, DLibFun* f2) const
     { return f1->ObjectName() < f2->ObjectName();}

--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -36,7 +36,7 @@
       extern bool posixpaths;
     }
 #endif
-template<typename T>  class Is_eq: public std::unary_function<T,bool>
+template<typename T>  class Is_eq: public std::function<bool(T)>
 {
   std::string name;
 public:
@@ -208,7 +208,7 @@ public:
 
   // for sorting lists by name. Not used (lists too short to make a time gain. Long lists would, if existing,
   // benefit from sorting by hash number in a std::map instead of a std::list.
-  struct CompLibFunName: public std::binary_function< DLib*, DLib*, bool>
+  struct CompLibFunName: public std::function<bool(DLib*, DLib*)>
   {
     bool operator() ( DLib* f1, DLib* f2) const
     { return f1->ObjectName() < f2->ObjectName();}

--- a/src/dstructdesc.hpp
+++ b/src/dstructdesc.hpp
@@ -362,7 +362,7 @@ public:
 };
 
 
-class DStruct_eq: public std::unary_function<DStructDesc,bool>
+class DStruct_eq: public std::function<bool(DStructDesc)>
 {
   std::string name;
 

--- a/src/dvar.hpp
+++ b/src/dvar.hpp
@@ -57,7 +57,7 @@ public:
 
 typedef std::vector<DVar*>        VarListT;
 
-class DVar_eq: public std::unary_function<DVar,bool>
+class DVar_eq: public std::function<bool(DVar)>
 {
   std::string name;
   BaseGDL*  pp;

--- a/src/gdlhelp.cpp
+++ b/src/gdlhelp.cpp
@@ -126,7 +126,7 @@ extern "C" {
 
 
 // for sorting compiled pro/fun lists by name
-struct CompFunName: public std::binary_function< DFun*, DFun*, bool>
+struct CompFunName: public std::function<bool(DFun*, DFun*)>
 {
   bool operator() ( DFun* f1, DFun* f2) const
 	{
@@ -134,7 +134,7 @@ struct CompFunName: public std::binary_function< DFun*, DFun*, bool>
   }
 };
 
-struct CompProName: public std::binary_function< DPro*, DPro*, bool>
+struct CompProName: public std::function<bool(DPro*, DPro*)>
 {
   bool operator() ( DPro* f1, DPro* f2) const
 	{

--- a/src/str.hpp
+++ b/src/str.hpp
@@ -88,7 +88,7 @@ void StrLowCaseInplace(std::string&);
 std::string StrCompress(const std::string&,bool removeAll);
 void StrPut(std::string& s1, const std::string& s2, DLong pos);
 
-class String_abbref_eq: public std::unary_function< std::string, bool>
+class String_abbref_eq: public std::function<bool(std::string)>
 {
   std::string s;
 public:
@@ -100,7 +100,7 @@ public:
   }
 };
 
-class String_eq: public std::unary_function< std::string, bool>
+class String_eq: public std::function<bool(std::string)>
 {
   std::string s;
 public:


### PR DESCRIPTION
std::unary_function and std::binary_function are deprecated in the C++11 standard. This PR changes those to C++11's std::function instead.

Additionally, there are some updates to GitHub actions workflow:
1. Fix caching/restoring deps jobs, I could not get the MacOS build job to work otherwise
2. Fix compile definitions fpr one file in the debug windows build by adding "-Os" to its compile flags, since I got a build error on this.