### PR TITLE
Speed plots

### DIFF
--- a/src/gdlgstream.cpp
+++ b/src/gdlgstream.cpp
@@ -64,25 +64,22 @@ void GDLGStream::Color( ULong color, DLong decomposed) {
     if (decomposed == 0) {
       if (printer && (color & 0xFF) == 0) { color=(bw)?WHITE:BLACK; //note that if bw other colors will be a gray value 
         GDLGStream::SetColorMap1SingleColor(color);
-        plstream::col1(1); //send specifically color ZERO = black.
-        return;
       } else plstream::col0(color & 0xFF); //just set color index [0..255]. simple and fast.
     } else {
       if (printer && color == 0) color=(bw)?WHITE:BLACK;
       GDLGStream::SetColorMap1SingleColor(color);
-      plstream::col1(1); //send specifically color ZERO = black.
-      return;
     }
 }
 #undef BLACK
 
 void GDLGStream::SetColorMap1SingleColor( ULong color)
 {
-    PLINT red[2],green[2],blue[2];
-    red[0] =red[1] = color & 0xFF;
-    green[0] = green[1] =(color >> 8)  & 0xFF;
-    blue[0]= blue[1]=(color >> 16) & 0xFF;
-    SetColorMap1(red, green, blue, 2); 
+    PLINT red[1],green[1],blue[1];
+    red[0] = color & 0xFF;
+    green[0] = (color >> 8)  & 0xFF;
+    blue[0]=(color >> 16) & 0xFF;
+    SetColorMap1(red, green, blue, 1);
+    plstream::col1(0); 
 }
 
 void GDLGStream::SetColorMap1DefaultColors(PLINT ncolors, DLong decomposed)

--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -250,7 +250,7 @@ public:
   static void SetErrorHandlers();
 
   virtual void Init()=0;
-
+  virtual bool IsWxStream(){return false;}
   // called after draw operation
   //virtual void Update() {}
   virtual void Update(){plstream::cmd(PLESC_EXPOSE, NULL);}

--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -82,6 +82,7 @@ GDLWXStream::GDLWXStream( int width, int height )
     GDLCT* myCT=GraphicsDevice::GetGUIDevice( )->GetCT();
     myCT->Get( r, g, b);
     SetColorMap0( r, g, b, ctSize); //set colormap 0 to 256 values
+    SetColorMap1( r, g, b, ctSize); //set colormap 1 to 256 values
 
     // need to be called initially. permit to fix things
     plstream::ssub( 1, 1 ); // plstream below stays with ONLY ONE page

--- a/src/gdlwxstream.hpp
+++ b/src/gdlwxstream.hpp
@@ -47,7 +47,8 @@ public:
 
     GDLWXStream( int width, int height );  
     ~GDLWXStream(); 
-    
+    virtual bool IsWxStream() final{return true;}
+
     wxMemoryDC* GetStreamDC() const { return streamDC;}
 
 //     void set_stream();   //!< Calls some code before every PLplot command.

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -43,8 +43,8 @@ namespace lib
   
 //static values
   static DLong savedStyle=0;
-  static DDouble savedPointX=0.0;
-  static DDouble savedPointY=0.0;
+  static DDouble savedPointX=std::numeric_limits<double>::quiet_NaN();
+  static DDouble savedPointY=std::numeric_limits<double>::quiet_NaN();
   static DFloat sym1x[6]={1, -1, 0, 0, 0, 0}; // +
   static DFloat sym1y[6]={0, 0, 0, -1, 1, 0}; // +
   static DFloat sym2x[12]= {1, -1, 0, 0, 0, 0,1,-1,0,1,-1, 0}; //*
@@ -823,13 +823,9 @@ namespace lib
     if (append) //start with the old point
     {
       getLastPoint(a, x, y);
-      isBad = (!isfinite(x) || !isfinite(y) || isnan(x) || isnan(y));
-      if (!isBad) {
-        x_buff[i_buff]=x;
-        y_buff[i_buff]=y;
-        i_buff++;
-        append=true;
-      } else append=false;
+      x_buff[i_buff]=x;
+      y_buff[i_buff]=y;
+      i_buff++;
     } else {
       if (!flag_x_const) x = static_cast<PLFLT> ((*xVal)[0]);
       else x = x_ref;

--- a/src/plotting_oplot.cpp
+++ b/src/plotting_oplot.cpp
@@ -174,7 +174,8 @@ namespace lib {
         //at draw_polyline level!
         gdlSetGraphicsForegroundColorFromKw(e, actStream); //COLOR
         doColor = false;
-      }
+      } else if (color->N_Elements() > 1) e->Throw("Expression must be a scalar or 1 element array in this context:"+ e->GetString(colorIx));
+
       gdlSetPenThickness(e, actStream); //THICK
       gdlSetLineStyle(e, actStream); //LINESTYLE
       gdlGetPsym(e, psym); //PSYM

--- a/src/plotting_plot.cpp
+++ b/src/plotting_plot.cpp
@@ -280,7 +280,7 @@ namespace lib {
         //at draw_polyline level!
         gdlSetGraphicsForegroundColorFromKw(e, actStream); //COLOR
         doColor = false;
-      }
+      } else if (color->N_Elements() > 1) e->Throw("Expression must be a scalar or 1 element array in this context:"+ e->GetString(colorIx));
       gdlSetPenThickness(e, actStream); //THICK
       gdlSetLineStyle(e, actStream); //LINESTYLE
       gdlGetPsym(e, psym); //PSYM

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -198,9 +198,9 @@ namespace lib {
       if (e->GetKW(colorIx) != NULL) {
         color = e->GetKWAs<DLongGDL>(colorIx);
         doColor = true;
+        //if color is not a singleton, its number of elements MUST be larger that nEl
+        if (!(color->Scalar()) && color->N_Elements() < nEl) e->Throw("Color array does not have enough elements.");
       }
-      //if color is not a singleton, its number of elements MUST be larger that nEl
-      if (!(color->Scalar()) && color->N_Elements() < nEl) e->Throw("Color array does not have enough elements.");
       //properties
       if (!doColor || color->N_Elements() == 1) {
         //if no KW or only 1 color, no need to complicate things

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -199,7 +199,8 @@ namespace lib {
         color = e->GetKWAs<DLongGDL>(colorIx);
         doColor = true;
       }
-
+      //if color is not a singleton, its number of elements MUST be larger that nEl
+      if (!(color->Scalar()) && color->N_Elements() < nEl) e->Throw("Color array does not have enough elements.");
       //properties
       if (!doColor || color->N_Elements() == 1) {
         //if no KW or only 1 color, no need to complicate things


### PR DESCRIPTION
Should provide a speedup for all plot, oplot and plots command. Corrected a few discrepancies with IDL (/continue in PLOTS, COLOR option cannot be an array for PLOT and OPLOT, etc)

**This is sensitive, please exercise this update as there may be some bugs introduced by the large refactoring of this function.**