### PR TITLE
The cure for #1387 and #1402, test_pmulti passes.

### DIFF
--- a/src/plotting_contour.cpp
+++ b/src/plotting_contour.cpp
@@ -342,7 +342,7 @@ namespace lib {
         if (doT3d) gdlStop3DDriverTransform(actStream);
       }
 
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream); //normal clip meaning
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream)) return true; //normal clip meaning
 
       return false;
     }

--- a/src/plotting_oplot.cpp
+++ b/src/plotting_oplot.cpp
@@ -154,7 +154,7 @@ namespace lib {
     bool prepareDrawArea(EnvT* e, GDLGStream* actStream) {
       //box defined in previous PLOT command, we pass in normalized coordinates w/clipping if needed 
       gdlSetSymsize(e, actStream); //set symsize BEFORE switching (TBC)
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream, false, false); //normal clip meaning but does not know about DATA, DEVICE and NORMAL
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream, false, false)) return true; //normal clip meaning but does not know about DATA, DEVICE and NORMAL
       return false; //do not abort
     }
 

--- a/src/plotting_plot.cpp
+++ b/src/plotting_plot.cpp
@@ -258,7 +258,7 @@ namespace lib {
       
       //box plotted, we pass in normalized coordinates w/clipping if needed 
       gdlSetSymsize(e, actStream); //set symsize BEFORE switching (TBC)
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream);
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream)) return true;
 
       return false;
     }

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -186,7 +186,7 @@ namespace lib {
     bool prepareDrawArea(EnvT* e, GDLGStream* actStream) {
       //box defined in previous PLOT command, we pass in normalized coordinates w/clipping if needed 
       gdlSetSymsize(e, actStream); //set symsize BEFORE switching (TBC)
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream, true); //inverted clip meaning
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream, true)) return true; //inverted clip meaning
        return false;
     }
 

--- a/src/plotting_polyfill.cpp
+++ b/src/plotting_polyfill.cpp
@@ -196,7 +196,7 @@ namespace lib {
 
     bool prepareDrawArea(EnvT* e, GDLGStream* actStream) {
       //box defined in previous PLOT command, we pass in normalized coordinates w/clipping if needed 
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream, true); //inverted clip meaning
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream, true)) return true; //inverted clip meaning
       return false; //do not abort
     }
 

--- a/src/plotting_shade_surf.cpp
+++ b/src/plotting_shade_surf.cpp
@@ -288,7 +288,8 @@ namespace lib
       gdlStop3DDriverTransform(actStream); 
       
       //we now pass EVERYTHING in normalized coordinates w/o clipping and set up a transformation to have plplot mesh correct on the 2D vpor.
-//      gdlSwitchToClippedNormalizedCoordinates(e, actStream, true); //true=noclip
+      //however we need to check that clip values are OK to reproduce IDL's behaviour (no plot at all):
+      if (gdlTestClipValidity(e, actStream)) return true; //note clip meaning is normal
       const COORDSYS coordinateSystem = DATA;
       SelfConvertToNormXYZ(xStart, xLog, yStart, yLog, zStart, zLog, coordinateSystem); 
       SelfConvertToNormXYZ(xEnd, xLog, yEnd, yLog, zEnd, zLog, coordinateSystem);

--- a/src/plotting_surface.cpp
+++ b/src/plotting_surface.cpp
@@ -291,7 +291,8 @@ namespace lib
       gdlStop3DDriverTransform(actStream); 
       
       //we now pass EVERYTHING in normalized coordinates w/o clipping and set up a transformation to have plplot mesh correct on the 2D vpor.
-//      gdlSwitchToClippedNormalizedCoordinates(e, actStream, true); //true=noclip
+      //however we need to check that clip values are OK to reproduce IDL's behaviour (no plot at all):
+      if (gdlTestClipValidity(e, actStream)) return true; //note clip meaning is normal
       const COORDSYS coordinateSystem = DATA;
       SelfConvertToNormXYZ(xStart, xLog, yStart, yLog, zStart, zLog, coordinateSystem); 
       SelfConvertToNormXYZ(xEnd, xLog, yEnd, yLog, zEnd, zLog, coordinateSystem);

--- a/src/plotting_xyouts.cpp
+++ b/src/plotting_xyouts.cpp
@@ -148,7 +148,7 @@ namespace lib {
       gdlGetAxisType(YAXIS, yLog);
       
       //box plotted, we pass in normalized coordinates w/clipping if needed 
-      gdlSwitchToClippedNormalizedCoordinates(e, actStream, true);
+      if (gdlSwitchToClippedNormalizedCoordinates(e, actStream, true)) return true; //inverted clip meaning
 
       SelfProjectXY(minEl, (DDouble*) xVal->DataAddr(), (DDouble*) yVal->DataAddr(), coordinateSystem);
       //input coordinates converted to NORMAL


### PR DESCRIPTION
Passing an invalid clipbox will cause an absence of plot, but erasing the screen if MULTI=0 or just jumping to next plot if MULTI>1 . This is a better response to #1387 because the IDL behaviour is to erase the screen in case of a bad clipbox.
BTW, note that the IDL 3D clipbox is really a 2D DEVICE clipbox which is not what one would expect and certainly a bug. This feature is not reproduced by GDL that clips in 3D (but who needs to clip in 3d?) 