### PR TITLE
insure .RET stops at the return (or end) of current procedure

### DIFF
--- a/src/GDLInterpreter.cpp
+++ b/src/GDLInterpreter.cpp
@@ -364,9 +364,11 @@ GDLInterpreter::GDLInterpreter()
 		sigControlC = false;
 		retCode = NewInterpreterInstance(last->getLine()); //-1);
 		} else if (interruptEnable && _retTree == NULL && debugMode == DEBUG_RETURN) {
-		DebugMsg(last, "Return encountered: ");
-		debugMode = DEBUG_CLEAR;
-		retCode = NewInterpreterInstance(last->getLine()); //-1);
+		if (callStack.back()->GetProName() == MyProName) {
+      DebugMsg(last, "Return encountered: ");
+		  debugMode = DEBUG_CLEAR;
+		  retCode = NewInterpreterInstance(last->getLine()); //-1);
+    }
 		} else if (debugMode != DEBUG_CLEAR) {
 		if (debugMode == DEBUG_STOP) {
 		DebugMsg(last, "Stop encountered: ");

--- a/src/dinterpreter.cpp
+++ b/src/dinterpreter.cpp
@@ -872,6 +872,7 @@ DInterpreter::CommandCode DInterpreter::ExecuteCommand(const string& command) {
     return CmdRun(command);
   } else if (cmd("RETURN")) {
     debugMode = DEBUG_RETURN;
+    MyProName=callStack.back()->GetProName();
     return CC_CONTINUE;
   } else if (cmd("RESET_SESSION")) {
     return CmdReset();

--- a/src/gdlc.i.g
+++ b/src/gdlc.i.g
@@ -1178,9 +1178,11 @@ statement returns[ RetCode retCode]
       sigControlC = false;
       retCode = NewInterpreterInstance(last->getLine()); //-1);
     } else if (interruptEnable && _retTree == NULL && debugMode == DEBUG_RETURN) {
-      DebugMsg(last, "Return encountered: ");
-      debugMode = DEBUG_CLEAR;
-      retCode = NewInterpreterInstance(last->getLine()); //-1);
+		if (callStack.back()->GetProName() == MyProName) { //only for current procedure (will hang if reentrant! wait for the case to be present!)
+          DebugMsg(last, "Return encountered: ");
+		  debugMode = DEBUG_CLEAR;
+		  retCode = NewInterpreterInstance(last->getLine()); //-1);
+    }
     } else if (debugMode != DEBUG_CLEAR) {
       if (debugMode == DEBUG_STOP) {
         DebugMsg(last, "Stop encountered: ");


### PR DESCRIPTION
not inside procedures.
A necessary complement for #1414 
All this is very fragile, though.