### PR TITLE
Patch for #1433 #1432 and test for wrong install of drivers.

### DIFF
--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -278,6 +278,11 @@ namespace lib
         max = 0.98 * val_ref;
         min = 1.02 * val_ref;
       }
+      if (max==min) { //case "PLOT, [0]"
+        max=1;
+        min=0;
+      }
+      range = max - min;
     }
 
     if (range >= 0) {
@@ -444,10 +449,25 @@ namespace lib
         min = imin;
         max = imax;
       } else {
-        const double max_allowed_leak_factor = 1 - 1.25e-6;
+        const double leak_factor = 1.25e-6;
         PLFLT intv = AutoIntv(range);
-        max =  ceil((max * max_allowed_leak_factor) / intv) * intv;
-        min = floor((min * max_allowed_leak_factor) / intv) * intv;
+        //diminish max a little to avoid a jump of 'intv' when max value is practically indifferentiable from a 'intv' mark:
+        if (max >0) {
+          max *= (1 - leak_factor); 
+          max =  ceil(max/ intv) * intv;
+        } else {
+          max *= (1 + leak_factor); 
+          max =  ceil(max/ intv) * intv;
+        }
+        //same for min, in the otehr direction
+        if (min > 0) {
+          min *= (1 + leak_factor);
+          min = floor(min / intv) * intv;
+        } else {
+          min *= (1 - leak_factor);
+          min = floor(min / intv) * intv;
+        }
+        //min = floor((min * max_allowed_leak_factor) / intv) * intv;
       }
     }
 

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -74,7 +74,6 @@ namespace lib {
       if (nPar == 1) {
         SizeT dim0 = p0->Dim(0);
         if (dim0 < 2 || dim0 > 3) e->Throw("When only 1 param, dims must be (2,n) or (3,n)");
-        if (p0->Dim(1) < 3) e->Throw("Not enough valid and unique points specified.");
 
         DDoubleGDL *val = e->GetParAs< DDoubleGDL>(0);
         nEl = p0->N_Elements() / dim0;

--- a/testsuite/LIST
+++ b/testsuite/LIST
@@ -75,6 +75,7 @@ test_correlate.pro
 test_delvarrnew.pro
 test_diag_matrix.pro
 test_dilate.pro
+test_dynamic_drivers.pro
 test_erfinv.pro
 test_erode.pro
 test_execute.pro

--- a/testsuite/test_dynamic_drivers.pro
+++ b/testsuite/test_dynamic_drivers.pro
@@ -1,0 +1,24 @@
+; Should test if GDL uses 'our' drivers, and if not, it must mean that
+; the installed plplot is not linked with option 'DYNDRIVERS'
+; If this is not the case, GDL WILL NOT WORK!
+;
+
+pro test_dynamic_drivers
+  ret=execute("set_plot,'z'")
+  if (ret ne 1) then exit       ; no need to go further, no useful devices.
+  
+  surfr                         ; set up default 3D
+  !P.T3D=1
+  set_plot,'z'
+  device,set_resolu=[100,100]
+  ; plot a box passing at pixel [0,0] if unprojected,
+  ; which would be the case if the driver is not 'ours'.
+  ; this trick works only with axes, as the other drawings use normal
+  ; plplot lines, having reprojected the points ourselves.
+  plot,[0,1],[0,1],/nodata,pos=[0,0,1,1]
+  a=tvrd()
+  ; the 3D projection makes a[0]=0b
+  ; when our driver is used. Otherwise
+  ; no 3D effect and a[0]=255b
+  if (a[0] ne 0b) then EXIT, status=1
+end


### PR DESCRIPTION
(edited): initially motivated by #1433, but also solve the problem with **test_usersym** and #1432

#1433 : hm, the algorithm to get the same automatic ranges as IDL is bit more… complicated than expected.

Indeed, we need to insure that the !X or !Y.CRANGE, computed by FLOOR and CEIL on the (double precision) [X|Y]RANGE values do not 'jump' to the next interval due to numeric precision problems. I note that IDL behaves differently in this respect when the  [X|Y]RANGE is explicitely set to double precision: b=randomu(seed, 100000) & offset=2399.999d & plot, b, xrange=[offset, offset+24*24-1] will set lower bound to 2200 b=randomu(seed, 100000) & offset=2399.999 & plot, b, xrange=[offset, offset+24*24-1] will set lower bound to 2400

also, found a bug for PLOT,[0] where X.CRANGE was [0,0] instead of [0,1]