### PR TITLE
solve #1501

### DIFF
--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -2245,6 +2245,48 @@ int Data_<Sp>::Scalar2Index( SizeT& st) const
   return 1;
 }
 
+template<>
+int Data_<SpDFloat>::Scalar2Index(SizeT& st) const {
+  if (dd.size() != 1) return 0;
+  if (isfinite((*this)[0])) {
+    if ((*this)[0] < 0) {
+      if (this->dim.Rank() != 0)
+        return -2;
+      else
+        return -1;
+    }
+
+    st = static_cast<SizeT> ((*this)[0]);
+    if (this->dim.Rank() != 0) return 2;
+    return 1;
+  } else {
+    if (this->dim.Rank() != 0)
+      return -2;
+    else
+      return -1;
+  }
+}
+template<>
+int Data_<SpDDouble>::Scalar2Index(SizeT& st) const {
+  if (dd.size() != 1) return 0;
+  if (isfinite((*this)[0])) {
+    if ((*this)[0] < 0 ) {
+      if (this->dim.Rank() != 0)
+        return -2;
+      else
+        return -1;
+    }
+
+    st = static_cast<SizeT> ((*this)[0]);
+    if (this->dim.Rank() != 0) return 2;
+    return 1;
+  } else {
+    if (this->dim.Rank() != 0)
+      return -2;
+    else
+      return -1;
+  }
+}
 template<class Sp> 
 int Data_<Sp>::Scalar2RangeT( RangeT& st) const
 { 
@@ -2260,10 +2302,15 @@ int Data_<SpDComplex>::Scalar2Index( SizeT& st) const
 { 
   if( dd.size() != 1) return 0;
   float r=real((*this)[0]);
-  if( r < 0.0) return -1;
-  st= static_cast<SizeT>(r);
-  if( this->dim.Rank() != 0) return 2;
-  return 1;
+  if (finite(r)) {
+    if( r < 0.0) return -1;
+    st= static_cast<SizeT>(r);
+    if( this->dim.Rank() != 0) return 2;
+    return 1;
+  } else {
+    if( this->dim.Rank() != 0) return -2;
+    return -1;
+  }
 }
 
 template<> 
@@ -2277,14 +2324,19 @@ int Data_<SpDComplex>::Scalar2RangeT( RangeT& st) const
 }
 
 template<>
-int Data_<SpDComplexDbl>::Scalar2Index( SizeT& st) const
-{ 
-  if( dd.size() != 1) return 0;
-  double r=real((*this)[0]);
-  if( r < 0.0) return -1;
-  st= static_cast<SizeT>(r);
-  if( this->dim.Rank() != 0) return 2;
-  return 1;
+int Data_<SpDComplexDbl>::Scalar2Index(SizeT& st) const
+{
+  if (dd.size() != 1) return 0;
+  float r = real((*this)[0]);
+  if (finite(r)) {
+    if (r < 0.0) return -1;
+    st = static_cast<SizeT> (r);
+    if (this->dim.Rank() != 0) return 2;
+    return 1;
+  } else {
+    if (this->dim.Rank() != 0) return -2;
+    return -1;
+  }
 }
 
 template<> 


### PR DESCRIPTION
will mimic IDL's behaviour see #1501 
Could be improved (message advertizing there is an Inf or Nan in the scope) but probably not worth it.
This patch cures all places where dimensions are collected by function `arr()` or using the (misnomed) `Scalar2Index()`, not necessarily everywhere.