### PR TITLE
Restore 64bits pointers inRESTORE procedure. Solves #1545

### DIFF
--- a/src/saverestore.cpp
+++ b/src/saverestore.cpp
@@ -1611,17 +1611,15 @@ enum {
         nextptr = my_ulong64;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
-      } else
+      } else //the 2 pointers may point together to a l64 address, bug #1545
       {
         if (!xdr_uint32_t(xdrs, &ptrs0)) break;
-        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
-        if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         nextptr = ptrs0;
-        if (ptrs1 > 0)
-        {
-          DULong64 tmp = ptrs1;
-          nextptr &= (tmp << 32);
-        }
+        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
+        DULong64 tmp = ptrs1;
+        nextptr |= (tmp << 32);
+        if (!xdr_int32_t(xdrs, &UnknownLong)) break;
+        if (nextptr <=LONG) e->Throw("error in pointers, please report.");
       }
 
       //dispatch accordingly:
@@ -1796,14 +1794,11 @@ enum {
       } else
       {
         if (!xdr_uint32_t(xdrs, &ptrs0)) break;
-        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
-        if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         nextptr = ptrs0;
-        if (ptrs1 > 0)
-        {
-          DULong64 tmp = ptrs1;
-          nextptr &= (tmp << 32);
-        }
+        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
+        DULong64 tmp = ptrs1;
+        nextptr |= (tmp << 32);
+        if (!xdr_int32_t(xdrs, &UnknownLong)) break;
       }
 
       //dispatch accordingly:


### PR DESCRIPTION
solve #1545 by using correctly the 2 locations of 32 bits provided in a SAVE file made by IDL.

However, the reverse is not true **due to our XDR library, GDL cannot write such files**. This will be the subject of a new Issue.

SAVE has been protected and throws an error when trying to write >4GB files.