### PR TITLE
Major refurbishing of XMANAGER and EventLoop . Plus extras.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 src/gdl
 testsuite/launchtest.c
 nbproject/

--- a/src/GDLInterpreter.hpp
+++ b/src/GDLInterpreter.hpp
@@ -118,6 +118,7 @@ public:
     static int GetFunIx( const std::string& subName);
     static int GetProIx( ProgNodeP);//const std::string& subName);
     static int GetProIx( const std::string& subName);
+    static bool CheckProExist( const std::string& subName);
     DStructGDL* ObjectStruct( DObjGDL* self, ProgNodeP mp);
     void SetRootR( ProgNodeP tt, DotAccessDescT* aD, BaseGDL* r, ArrayIndexListT* aL);
     void SetRootL( ProgNodeP tt, DotAccessDescT* aD, BaseGDL* r, ArrayIndexListT* aL);

--- a/src/dinterpreter.cpp
+++ b/src/dinterpreter.cpp
@@ -554,7 +554,23 @@ int GDLInterpreter::GetProIx( const string& subName)
     }
   return proIx;
 }
-
+//Before calling GetProIx in CallEventPro, better check procedure exist for reasons explicited in CallEventPro. This is the way.
+bool GDLInterpreter::CheckProExist( const string& subName)
+{
+  int proIx=ProIx(subName);
+  if( proIx == -1)
+    {
+      // trigger reading/compiling of source file
+      /*bool found=*/ SearchCompilePro(subName, true);
+	  
+      proIx=ProIx(subName);
+      if( proIx == -1)
+	{
+        return false;
+	}
+    }
+  return true;
+}
 // converts inferior type to superior type
 void GDLInterpreter::AdjustTypes(BaseGDL* &a, BaseGDL* &b)
 {

--- a/src/gdlc.i.g
+++ b/src/gdlc.i.g
@@ -170,6 +170,7 @@ public:
     static int GetFunIx( ProgNodeP);
     static int GetFunIx( const std::string& subName);
     static int GetProIx( ProgNodeP);//const std::string& subName);
+    static bool CheckProExist( const std::string& subName);
     static int GetProIx( const std::string& subName);
     DStructGDL* ObjectStruct( DObjGDL* self, ProgNodeP mp);
     void SetRootR( ProgNodeP tt, DotAccessDescT* aD, BaseGDL* r, ArrayIndexListT* aL);

--- a/src/gdleventhandler.cpp
+++ b/src/gdleventhandler.cpp
@@ -37,7 +37,7 @@ int GDLEventHandler()
 {
 
 #ifdef HAVE_LIBWXWIDGETS
-  if (useWxWidgets) GDLWidget::HandleWidgetEvents();
+  if (useWxWidgets) GDLWidget::HandleUnblockedWidgetEvents();
 #endif
   GraphicsDevice::HandleEvents();
 

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -189,8 +189,8 @@ WidgetListT GDLWidget::widgetList;
 wxImageList *gdlDefaultTreeStateImages;
 wxImageList *gdlDefaultTreeImages;
 
-GDLEventQueue GDLWidget::BlockingWidgetEventQueue; // the event queue
-GDLEventQueue GDLWidget::readlineEventQueue; // for process at command line level
+GDLEventQueue GDLWidget::BlockingEventQueue; // the event queue in which all widget events are versed in case of blocking (XMANAGER)
+GDLEventQueue GDLWidget::InteractiveEventQueue; // event queue used when no blocking is made -- part of the main GDLEventHandler() 
 bool GDLWidget::wxIsOn=false;
 bool GDLWidget::handlersOk=false;
 wxFont GDLWidget::defaultFont=wxNullFont; //the font defined by widget_control,default_font.
@@ -782,17 +782,17 @@ void GDLWidget::SendWidgetTimerEvent(DDouble secs) {
 }
 
 void GDLWidget::ClearEvents() {
-  if (!this->GetXmanagerActiveCommand()) BlockingWidgetEventQueue.Purge(this->GetWidgetID());
-  else readlineEventQueue.Purge(this->GetWidgetID());
+    InteractiveEventQueue.Purge(this->GetWidgetID());
+    BlockingEventQueue.Purge(this->GetWidgetID());
 }
 
-void GDLWidget::HandleWidgetEvents()
+void GDLWidget::HandleUnblockedWidgetEvents()
 {
-  //make one loop for wxWidgets Events. Forcibly, as HandleWidgetEvents() is called by the readline eventLoop, we are in a non-blocked case.
+  //make one loop for wxWidgets Events. Forcibly, as HandleUnblockedWidgetEvents() is called by the readline eventLoop, we are in a non-blocked case.
   CallWXEventLoop();
   //treat our GDL events...
     DStructGDL* ev = NULL;
-    while( (ev = GDLWidget::readlineEventQueue.Pop()) != NULL)
+    while( (ev = GDLWidget::InteractiveEventQueue.Pop()) != NULL)
     {
 //        static int idIx = ev->Desc( )->TagIndex( "ID" ); // 0
 //        static int topIx = ev->Desc( )->TagIndex( "TOP" ); // 1
@@ -820,13 +820,17 @@ void GDLWidget::PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev) {
   // Get XmanagerActiveCommand status
   GDLWidget *baseWidget = GDLWidget::GetWidget( baseWidgetID );
   if ( baseWidget != NULL ) {
-    bool xmanActCom = baseWidget->GetXmanagerActiveCommand( );
-    if ( !xmanActCom ) { //blocking: events in eventQueue.
-      //     wxMessageOutputStderr().Printf(_T("eventQueue.Push: %d\n"),baseWidgetID);
-      BlockingWidgetEventQueue.PushBack( ev );
-    } else { //non-Blocking: events in readlineeventQueue.
-      //     wxMessageOutputStderr().Printf(_T("readLineEventQueue.Push: %d\n"),baseWidgetID);
-      readlineEventQueue.PushBack( ev );
+    bool interactive = baseWidget->IsUsingInteractiveEventLoop( );
+    if ( interactive ) { //non-Blocking: events in InteractiveEventQueue.
+#ifdef GDL_DEBUG_WIDGETS
+           wxMessageOutputStderr().Printf(_T("InteractiveEventQueue.PushEvent: %d\n"),baseWidgetID);
+#endif
+      InteractiveEventQueue.PushBack( ev );
+    } else { //blocking: events in BlockingEventQueue.
+#ifdef GDL_DEBUG_WIDGETS
+           wxMessageOutputStderr().Printf(_T("BlockingEventQueue.PushEvent: %d\n"),baseWidgetID);
+#endif
+      BlockingEventQueue.PushBack( ev );
     }
   } else cerr << "NULL baseWidget (possibly Destroyed?) found in GDLWidget::PushEvent( WidgetIDT baseWidgetID=" << baseWidgetID << ", DStructGDL* ev=" << ev << "), please report!\n";
 }
@@ -838,40 +842,50 @@ void GDLWidget::InformAuthorities(const std::string& message){
         ev->InitTag( "TOP", DLongGDL( 0 ) );
         ev->InitTag( "HANDLER", DLongGDL( 0 ) );
         ev->InitTag( "MESSAGE", DStringGDL(message) );
-          readlineEventQueue.PushFront( ev ); // push front (will be handled next)
+          InteractiveEventQueue.PushFront( ev ); // push front (will be handled next)
     }
-
-bool GDLWidget::GetXmanagerBlock() 
+//return false if already blocked by XManager (one managed realized top Widget is not marked as interactive).
+bool GDLWidget::IsXmanagerBlocking() 
 {
-  bool xmanBlock = false;
   WidgetListT::iterator it;
   // (*it).first is widgetID
   // (*it).second is pointer to widget
 
-  bool managed;
-  bool xmanActCom;
-
-#ifdef GDL_DEBUG_WIDGETS
-  std::cout << "+ GetXmanagerBlock: widgetList:" << std::endl;
   for ( it = widgetList.begin( ); it != widgetList.end( ); ++it ) {
-    std::cout << (*it).first << ": " << (*it).second->widgetID << "  parentID: " <<
-    (*it).second->parentID << "  uname: " << (*it).second->uName << std::endl;
-  }
-  std::cout << "- GetXmanagerBlock: widgetList end" << std::endl;
-#endif
-  for ( it = widgetList.begin( ); it != widgetList.end( ); ++it ) {
-    // Only consider base widgets
+    // Only consider managed top base widgets
     if ( (*it).second->parentID == GDLWidget::NullID ) {
-      managed = (*it).second->GetManaged( );
-      xmanActCom = (*it).second->GetXmanagerActiveCommand( );
-    }
-    if ( managed && !xmanActCom ) {
-      xmanBlock = true;
-      break;
+      bool managed = (*it).second->GetManaged( );
+      bool realized = (*it).second->IsRealized( );
+      if (managed & realized) {
+        bool IsBlocked = ((*it).second->IsUsingInteractiveEventLoop( )==false);
+        if (IsBlocked) {
+          //std::cerr<<"Found Blocked by "<<(*it).second->GetWidgetID()<<std::endl;
+          return true;
+        }
+      }
     }
   }
-  return xmanBlock;
+  //std::cerr<<"Found UnBlocked"<<std::endl;
+  return false;
 }
+//return true if at least one Managed Realized Top Widget is present in the hierarchy
+bool GDLWidget::IsActive() 
+{
+  WidgetListT::iterator it;
+  // (*it).first is widgetID
+  // (*it).second is pointer to widget
+
+  for ( it = widgetList.begin( ); it != widgetList.end( ); ++it ) {
+    // Only consider managed realized top base widgets
+    if ( (*it).second->parentID == GDLWidget::NullID ) {
+      bool managed = (*it).second->GetManaged( );
+      bool realized = (*it).second->IsRealized( );
+      if (managed && realized) return true;
+    }
+  }
+  return false;
+}
+
 DLong GDLWidget::GetNumberOfWidgets() {
   WidgetListT::iterator it;
   DLong result=0;
@@ -1025,8 +1039,8 @@ void GDLWidget::UnInit() {
   if (wxIsStarted()) {
     ResetWidgets();
     //clear all events --- otherwise baoum!)
-    readlineEventQueue.Purge();
-    BlockingWidgetEventQueue.Purge();
+    InteractiveEventQueue.Purge();
+    BlockingEventQueue.Purge();
     // the following cannot be done: once unitialized, the wxWidgets library cannot be safely initilized again.:  wxUninitialize( );
     UnsetWxStarted(); //reset handlersOk too.
   }
@@ -1164,10 +1178,6 @@ bool GDLWidget::GetSensitive()
   return sensitive;
 }
 
-bool GDLWidget::GetXmanagerActiveCommand() {
-  GDLWidgetTopBase* w = GetMyTopLevelBaseWidget();
-  return w->GetXmanagerActiveCommand();
-}
   
 DLong GDLWidget::GetSibling()
 {
@@ -1958,7 +1968,7 @@ int xpad_, int ypad_,
 DLong x_scroll_size, DLong y_scroll_size, bool grid_layout, long children_alignment, int space_)
 : GDLWidgetBase( GDLWidget::NullID, e, eventFlags_, mapWid, col, row, exclusiveMode_, resource_name, rname_mbar, title_, display_name, xpad_, ypad_, x_scroll_size, y_scroll_size, grid_layout, children_alignment, space_)
 , mbarID(mBarIDInOut)
-, xmanActCom(false)
+, UseInteractiveEvents(false) //TopBases are blocking by default
 , modal(modal_)
 , realized(false)
 {
@@ -2086,8 +2096,8 @@ GDLWidgetTopBase::~GDLWidgetTopBase() {
   topFrame->UnblockIfModal();
   topFrame->NullGDLOwner();
   //what if delay_destroy ?
-  //IMPORTANT: unxregister TLB if was managed 
-  if (this->GetManaged()) CallEventPro("UNXREGISTER", new DLongGDL(widgetID)); //UNXREGISTER defined in XMANAGER.PRO
+  //IMPORTANT: xunregister TLB if was managed 
+  if (this->GetManaged()) CallEventPro("XUNREGISTER", new DLongGDL(widgetID)); //XUNREGISTER defined in XMANAGER.PRO
 
   //send RIP 
   // create GDL event struct
@@ -2095,11 +2105,17 @@ GDLWidgetTopBase::~GDLWidgetTopBase() {
   ev->InitTag("ID", DLongGDL(widgetID));
   ev->InitTag("TOP", DLongGDL(widgetID));
   ev->InitTag("HANDLER", DLongGDL(0));
-  if (this->GetXmanagerActiveCommand() || !this->GetManaged()) {
-    readlineEventQueue.PushFront(ev); // push front (will be handled next)
-  } else {
-    BlockingWidgetEventQueue.PushFront(ev); // push front (will be handled next)
-  }
+  if (this->IsUsingInteractiveEventLoop()) {
+#ifdef GDL_DEBUG_WIDGETS
+            wxMessageOutputStderr().Printf(_T("~GDLWidgetTopBase InteractiveEventQueue.Push: %d\n"),widgetID);
+#endif
+   InteractiveEventQueue.PushFront(ev); // push front (will be handled next)
+   } else {
+#ifdef GDL_DEBUG_WIDGETS
+           wxMessageOutputStderr().Printf(_T("~GDLWidgetTopBase BlockingEventQueue.Push: %d\n"),widgetID);
+#endif           
+    BlockingEventQueue.PushFront(ev); // push front (will be handled next)
+ }
 }
 /*********************************************************/
 // Context Menu pseudo-base

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1103,6 +1103,7 @@ GDLWidget::GDLWidget( WidgetIDT p, EnvT* e, BaseGDL* vV, DULong eventFlags_)
 , proValue("")
 , funcValue("")
 , uName("")
+//, delay_destroy(false)
 {
   m_windowTimer = NULL;
   
@@ -2084,7 +2085,7 @@ GDLWidgetTopBase::~GDLWidgetTopBase() {
 #endif
   topFrame->UnblockIfModal();
   topFrame->NullGDLOwner();
-
+  //what if delay_destroy ?
   //IMPORTANT: unxregister TLB if was managed 
   if (this->GetManaged()) CallEventPro("UNXREGISTER", new DLongGDL(widgetID)); //UNXREGISTER defined in XMANAGER.PRO
 
@@ -6148,6 +6149,9 @@ GDLWXStream* gdlwxGraphicsPanel::GetStream(){return pstreamP;};
 void gdlwxGraphicsPanel::DeleteUsingWindowNumber(){
   pstreamP->SetValid(false);
   GraphicsDevice::GetGUIDevice()->TidyWindowsList(); //tidy Window List will delete widget by itself
+}
+void gdlwxGraphicsPanel::SetUndecomposed(){
+  GraphicsDevice::GetGUIDevice()->Decomposed(0); //indexed
 }
 void gdlwxGraphicsPanel::SetStream(GDLWXStream* s) {
   pstreamP = s;

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -189,7 +189,7 @@ WidgetListT GDLWidget::widgetList;
 wxImageList *gdlDefaultTreeStateImages;
 wxImageList *gdlDefaultTreeImages;
 
-GDLEventQueue GDLWidget::eventQueue; // the event queue
+GDLEventQueue GDLWidget::BlockingWidgetEventQueue; // the event queue
 GDLEventQueue GDLWidget::readlineEventQueue; // for process at command line level
 bool GDLWidget::wxIsOn=false;
 bool GDLWidget::handlersOk=false;
@@ -782,7 +782,7 @@ void GDLWidget::SendWidgetTimerEvent(DDouble secs) {
 }
 
 void GDLWidget::ClearEvents() {
-  if (!this->GetXmanagerActiveCommand()) eventQueue.Purge(this->GetWidgetID());
+  if (!this->GetXmanagerActiveCommand()) BlockingWidgetEventQueue.Purge(this->GetWidgetID());
   else readlineEventQueue.Purge(this->GetWidgetID());
 }
 
@@ -823,7 +823,7 @@ void GDLWidget::PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev) {
     bool xmanActCom = baseWidget->GetXmanagerActiveCommand( );
     if ( !xmanActCom ) { //blocking: events in eventQueue.
       //     wxMessageOutputStderr().Printf(_T("eventQueue.Push: %d\n"),baseWidgetID);
-      eventQueue.PushBack( ev );
+      BlockingWidgetEventQueue.PushBack( ev );
     } else { //non-Blocking: events in readlineeventQueue.
       //     wxMessageOutputStderr().Printf(_T("readLineEventQueue.Push: %d\n"),baseWidgetID);
       readlineEventQueue.PushBack( ev );
@@ -1026,7 +1026,7 @@ void GDLWidget::UnInit() {
     ResetWidgets();
     //clear all events --- otherwise baoum!)
     readlineEventQueue.Purge();
-    eventQueue.Purge();
+    BlockingWidgetEventQueue.Purge();
     // the following cannot be done: once unitialized, the wxWidgets library cannot be safely initilized again.:  wxUninitialize( );
     UnsetWxStarted(); //reset handlersOk too.
   }
@@ -2098,7 +2098,7 @@ GDLWidgetTopBase::~GDLWidgetTopBase() {
   if (this->GetXmanagerActiveCommand() || !this->GetManaged()) {
     readlineEventQueue.PushFront(ev); // push front (will be handled next)
   } else {
-    eventQueue.PushFront(ev); // push front (will be handled next)
+    BlockingWidgetEventQueue.PushFront(ev); // push front (will be handled next)
   }
 }
 /*********************************************************/

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -373,7 +373,7 @@ private:
 public:
   static wxFont defaultFont;
   static wxFont systemFont;
-  static GDLEventQueue eventQueue;
+  static GDLEventQueue BlockingWidgetEventQueue;
   static GDLEventQueue readlineEventQueue;
   static void PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev);
   static void InformAuthorities(const std::string& message);

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -373,12 +373,12 @@ private:
 public:
   static wxFont defaultFont;
   static wxFont systemFont;
-  static GDLEventQueue BlockingWidgetEventQueue;
-  static GDLEventQueue readlineEventQueue;
+  static GDLEventQueue BlockingEventQueue;
+  static GDLEventQueue InteractiveEventQueue;
   static void PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev);
   static void InformAuthorities(const std::string& message);
   
-  static void HandleWidgetEvents();
+  static void HandleUnblockedWidgetEvents();
   static const WidgetIDT NullID;
   
   GDLWidget( WidgetIDT p, EnvT* e, BaseGDL* vV=NULL, DULong eventFlags_=0);
@@ -663,9 +663,9 @@ public:
   //returns a list of IDs of all the widgets starting at me and below.
   DLongGDL* GetAllHeirs();
   
-  virtual void SetXmanagerActiveCommand() {std::cerr<<"XMANAGER ACTIVE COMMAND on a not-top widget, please report."<<std::endl;}
+  virtual void MakeInteractive() {std::cerr<<"XMANAGER ACTIVE COMMAND on a not-top widget, please report."<<std::endl;}
   
-  bool GetXmanagerActiveCommand();
+  virtual bool IsUsingInteractiveEventLoop() {std::cerr<<"IsEventLoopBlocked on a not-top widget, please report."<<std::endl;return false;} //default for a normal widget
 
   void SetEventPro( const DString& ePro) { eventPro = StrUpCase( ePro);}
   const DString& GetEventPro() const { return eventPro;};
@@ -676,7 +676,8 @@ public:
   void SetKillNotify( const DString& eKN) { killNotify = StrUpCase( eKN);}
   const DString& GetKillNotify() const { return killNotify;}
 
-  static bool GetXmanagerBlock();
+  static bool IsXmanagerBlocking();
+  static bool IsActive();
   static DLong GetNumberOfWidgets();
   static BaseGDL* GetWidgetsList();
   static BaseGDL* GetManagedWidgetsList();
@@ -876,7 +877,7 @@ public:
 class GDLWidgetTopBase : public GDLWidgetBase {
  WidgetIDT mbarID;
 public:
- bool xmanActCom; //set by /XMANAGER_ACTIVE_COMMAND (GDL's) aka NO_BLOCK . indirectly used in pushEvent, selfDestroy, ~GDLWidgetContainer, ClearEvents
+ bool UseInteractiveEvents; //set by /XMANAGER_ACTIVE_COMMAND (GDL's) aka NO_BLOCK . indirectly used in pushEvent, selfDestroy, ~GDLWidgetContainer, ClearEvents
  gdlwxFrame* topFrame;
  bool modal;
  bool realized;
@@ -941,12 +942,18 @@ public:
 
 // void SelfDestroy(); // sends delete event to itself
 
- void SetXmanagerActiveCommand() {
-  xmanActCom = true;
+ virtual void MakeInteractive() final {
+#ifdef GDL_DEBUG_WIDGETS
+          wxMessageOutputStderr().Printf(_T("MakeInteractive(%d)\n"),widgetID);
+#endif
+  UseInteractiveEvents = true; //unblocks base
  }
-
- bool GetXmanagerActiveCommand() const {
-  return xmanActCom;
+// returns UseInteractiveEvents
+ virtual bool IsUsingInteractiveEventLoop() final {
+#ifdef GDL_DEBUG_WIDGETS
+          wxMessageOutputStderr().Printf(_T("IsUsingInteractiveEventLoop(%d): %d\n"),widgetID,UseInteractiveEvents);
+#endif
+  return UseInteractiveEvents;  //false (blocked) by default
  }
  
 };

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -470,6 +470,7 @@ protected:
   DString      notifyRealize;
   
   wxTimer * m_windowTimer;
+//  bool delay_destroy;
   
 private:  
 
@@ -485,6 +486,8 @@ private:
   
 public:
 
+//  void SetDelayDestroy(bool val){delay_destroy=val;}
+//  bool GetDelayDestroy(){return delay_destroy;}
  void setFont();
  void setFont(wxObject* o);
 
@@ -2113,6 +2116,7 @@ public:
  wxPoint WhereIsMouse(wxKeyEvent &e);
  void ResizeDrawArea(const wxSize s);
  void DeleteUsingWindowNumber();
+ void SetUndecomposed();
  void SetStream(GDLWXStream* s);
 
  void OnErase(wxEraseEvent& event);

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -982,7 +982,7 @@ void gdlwxPlotFrame::OnPlotWindowSize(wxSizeEvent &event) {
 
   wxSize panelSize=this->GetClientSize(); //event.GetSize();
 #if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_SIZE_EVENTS)
-  wxMessageOutputStderr().Printf(_T("in gdlwxPlotFrame::OnPlotWindowSize: event %d  size: (%d,%d) processed."), event.GetId(), frameSize.x, frameSize.y);
+  wxMessageOutputStderr().Printf(_T("in gdlwxPlotFrame::OnPlotWindowSize: event %d  size: (%d,%d) processed."), event.GetId(), panelSize.x, panelSize.y);
 #endif
    wxSizeEvent sizeEvent(panelSize, w->GetId());
    w->OnPlotWindowSize(sizeEvent);

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -947,7 +947,7 @@ void LibInit()
     };
    const string polyfillWarnKey[]=
     {
-     "IMAGE_COORD","IMAGE_INTERP", "PATTERN", "TRANSPARENT",KLISTEND
+     "IMAGE_COORD","IMAGE_INTERP", "PATTERN", "FILL_PATTERN", "TRANSPARENT",KLISTEND
     };
   new DLibPro(lib::polyfill, string("POLYFILL"), 3, polyfillKey,polyfillWarnKey);
 

--- a/src/libinit_jp.cpp
+++ b/src/libinit_jp.cpp
@@ -145,7 +145,7 @@ void LibInit_jp()
   new DLibFunRetNew(lib::widget_event, string("WIDGET_EVENT"), 1, widget_eventKey, widget_eventWarnKey);
   //INFO
   const string widget_infoKey[] = {"DEBUG", "ACTIVE", "VALID_ID", "MODAL", "MANAGED",
-    "XMANAGER_BLOCK", //only GDL, used in xmanager.pro , may even not be useful now.
+    "XMANAGER_BLOCK", // in IDL too
     "CHILD", "VERSION", "GEOMETRY", "UNAME", "DISPLAY",
     "FONTNAME", "STRING_SIZE",
     "BUTTON_SET", "PARENT", "TEXT_SELECT", "FIND_BY_UNAME", "TYPE", "NAME",

--- a/src/libinit_jp.cpp
+++ b/src/libinit_jp.cpp
@@ -95,12 +95,11 @@ void LibInit_jp()
     "SET_TAB_CURRENT", "UNITS", "DYNAMIC_RESIZE", "SET_SLIDER_MIN", "SET_SLIDER_MAX",
     "X_BITMAP_EXTRA", "DEFAULT_FONT", "FONT", "EDITABLE", "BASE_SET_TITLE", "SET_TREE_EXPANDED", 
     "SET_TREE_SELECT","SET_TREE_INDEX","SET_DRAG_NOTIFY","SET_DRAGGABLE","SET_TREE_CHECKED",
-    "SET_TREE_BITMAP","SET_MASK","SET_TREE_VISIBLE","RESET","ICONIFY",
+    "SET_TREE_BITMAP","SET_MASK","SET_TREE_VISIBLE","RESET","ICONIFY", "DELAY_DESTROY",
     //unsupported but warning is a pain.
     "TAB_MODE", 
     KLISTEND};
-  const string widget_WarnControlKey[] = { "DELAY_DESTROY",
-    "PUSHBUTTON_EVENTS", "TABLE_BLANK", "SET_TAB_MULTILINE", "ICONIFY"
+  const string widget_WarnControlKey[] = { "PUSHBUTTON_EVENTS", "TABLE_BLANK", "SET_TAB_MULTILINE", "ICONIFY"
     , "CANCEL_BUTTON" //obsoleted in 6.2
     , "DEFAULT_BUTTON" //obsoleted in 6.2
     , KLISTEND}; //LIST NOT CLOSE!!!  
@@ -126,11 +125,11 @@ void LibInit_jp()
     , "GRAPHICS_LEVEL"//not taken into account, but not useful, too.
     , "IGNORE_ACCELERATORS"//not taken into account, but not useful, too.
     , "RENDERER"//not taken into account, but not useful, too.
+    , "COLOR_MODEL" //decomposed if 0 , decomposed=0 if 1 
     , KLISTEND};
   const string widget_drawWarnKey[] = {
     "DRAG_NOTIFY" //should be implemented 
     , "CLASSNAME" //obscure object class not implemented
-    , "COLOR_MODEL" //obscure object class not implemented
     , KLISTEND
   };
   new DLibFunRetNew(lib::widget_draw, string("WIDGET_DRAW"), 1, widget_drawKey, widget_drawWarnKey);

--- a/src/plotting_xyouts.cpp
+++ b/src/plotting_xyouts.cpp
@@ -191,6 +191,7 @@ namespace lib {
       if (e->GetKW(charsizeIx) != NULL) {
         size = e->GetKWAs<DFloatGDL>(charsizeIx);
         docharsize = true;
+        for (auto i=0; i < size->N_Elements(); ++i) if ((*size)[i] <=0)  (*size)[i]=1.0;
       } else //for security in future conditional evaluation...
       {
         size = new DFloatGDL(dimension(1), BaseGDL::ZERO);

--- a/src/pro/idl_validname.pro
+++ b/src/pro/idl_validname.pro
@@ -32,6 +32,8 @@ function IDL_VALIDNAME, in_list, $
                         convert_all=convert_all, $
                         help=help, test=test
 ;
+on_error, 2
+compile_opt hidden,idl2
 if KEYWORD_SET(help) then begin
     print, 'function IDL_VALIDNAME, in_list, $'
     print, '                        convert_spaces=convert_spaces, $'

--- a/src/pro/strmatch.pro
+++ b/src/pro/strmatch.pro
@@ -7,6 +7,8 @@
 ; of STRLEN ! We ensure to work on pure STRING = '' , not STRING = Array[1]
 ; 
 function STRMATCH_STRREPLACE, str, a, b
+compile_opt hidden, idl2
+on_error, 2
 pos = STRPOS(str, a)
 if (pos eq -1) then return, str
 ret = STRMID(str,0,pos)
@@ -26,6 +28,7 @@ end
 ;
 function STRMATCH, mstr, sstr, fold_case=fold_case
 ;
+compile_opt hidden, idl2
 on_error, 2
 if (SIZE(sstr))[0] ne 0 then MESSAGE, 'second argument must be a scalar string'
 ;

--- a/src/pro/uniq.pro
+++ b/src/pro/uniq.pro
@@ -67,7 +67,7 @@
 
 function UNIQ, arr, index
 
-compile_opt hidden, idl2
+compile_opt idl2
 
 ON_ERROR, 2
 

--- a/src/pro/value_locate.pro
+++ b/src/pro/value_locate.pro
@@ -190,6 +190,9 @@ end
 ; ---------------------------------------
 ;
 function VALUE_LOCATE, x, u, l64=l64
+compile_opt idl2, hidden
+
+ON_ERROR, 2
 ;
 ;increasing or decreasing
 ;default, l64,0

--- a/src/pro/xmanager.pro
+++ b/src/pro/xmanager.pro
@@ -67,7 +67,7 @@ return
 
 end
 
-pro UNXREGISTER, id
+pro XUNREGISTER, id
 
 compile_opt hidden, idl2
 
@@ -92,65 +92,92 @@ end
 
 
 pro XMANAGER, name, id, NO_BLOCK = noBlock, GROUP_LEADER=groupLeader, EVENT_HANDLER=eventHandler, $
-    CLEANUP=Cleanup, JUST_REG=just_reg, CATCH=catch, MODAL=modal, BACKGROUND=background
+   CLEANUP=Cleanup, JUST_REG=just_reg, CATCH=catch, MODAL=modal, BACKGROUND=background
 
+  compile_opt hidden, idl2
+  
+  ON_ERROR, 2
 
-compile_opt hidden, idl2
+  common managed, ids, names, modalList
+  ;;; Debug: uncomment the ;;
+  ;; common me,nx
+  ;; if n_elements(nx) eq 0 then nx=0
+  ;; nx++;
+  ;; print,"**************************************Entering Xmanager #"+strtrim(nx,2)+"**************************************"
 
-ON_ERROR, 2
+  if keyword_set(modal) then message,/informational,"The MODAL keyword to the XMANAGER procedure is obsolete."+$
+     " It is superseded by the MODAL keyword to the WIDGET_BASE function. This will *not* work. Please modify your code."
+  if keyword_set(background) then message,/informational,"The BACKGROUND keyword to the XMANAGER procedure is obsolete."+$
+     " It is superseded by the TIMER keyword to the WIDGET_CONTROL procedure. Please modify your code."
 
-common managed, ids, names, modalList
+  ValidateManagedWidgets
 
-if keyword_set(modal) then message,/informational,"The MODAL keyword to the XMANAGER procedure is obsolete."+$
-" It is superseded by the MODAL keyword to the WIDGET_BASE function. This will *not* work. Please modify your code."
-if keyword_set(background) then message,/informational,"The BACKGROUND keyword to the XMANAGER procedure is obsolete."+$
-" It is superseded by the TIMER keyword to the WIDGET_CONTROL procedure. Please modify your code."
+  if (n_params() eq 0) then begin
+     if ~ids[0] then message,/informational, 'No widgets are currently being managed.'
+     return
+  endif else if (n_params() ne 2) then message, 'Wrong number of arguments, usage: XMANAGER [, name, id]'
 
-ValidateManagedWidgets
+  if (n_elements(just_reg) eq 0) then just_reg = 0
 
-if (n_params() eq 0) then begin
-   if ~ids[0] then message,/informational, 'No widgets are currently being managed.'
-   return
-endif else if (n_params() ne 2) then message, 'Wrong number of arguments, usage: XMANAGER [, name, id]'
-
-if (n_elements(just_reg) eq 0) then just_reg = 0
-
-if n_params() eq 2 then begin
-   if not keyword_set(eventHandler) then begin
-      eventHandler = name + '_event'
-   endif
+  if n_params() eq 2 then begin
+     if not keyword_set(eventHandler) then begin
+        eventHandler = name + '_event'
+     endif
 ;if id is not the top base, get the top base:
-   while (widget_info(id,/parent) ne 0) do id=widget_info(id,/parent)
-   
-   widget_control, id, event_pro=eventHandler
-   widget_control, id, /managed
+     while (widget_info(id,/parent) ne 0) do id=widget_info(id,/parent)
+     
 ; add to common
-   if (ids[0] ne 0) then begin
-      ids = [ids, id]
-      names = [names, name]
-   endif else begin
-      ids = id
-      names = name
-   endelse
-   
-   if keyword_set(groupLeader) then begin
-      widget_control, id, GROUP_LEADER=groupLeader
-   endif
+     if (ids[0] ne 0) then begin
+        ids = [ids, id]
+        names = [names, name]
+     endif else begin
+        ids = id
+        names = name
+     endelse
+  AlreadyBlocked = widget_info(/XMANAGER_BLOCK)
+  ;; print,'before widget registration, AlreadyBlocked is=',AlreadyBlocked
+
+; We can now define the widget as managed 
+     widget_control, id, /managed
+; define handler
+     widget_control, id, event_pro=eventHandler
+; define group leader     
+     if keyword_set(groupLeader) then begin
+        widget_control, id, GROUP_LEADER=groupLeader
+     endif
 ; cleanup is implemented now
-   if n_elements(cleanup) then begin
-      widget_control, id, KILL_NOTIFY=Cleanup
-   endif
+     if n_elements(cleanup) then begin
+        widget_control, id, KILL_NOTIFY=Cleanup
+     endif
+; return if just registering (use of registering only still not clear for me -- probably a relic from the past)
+     if (just_reg) then return
+     
+; XMANAGER must block, i.e. call widget_event until the widget that blocked is destroyed.
+; besides, ony one blocking widget is permitted, so if xmanager is blocking, a subsequent call to xmanager must not block.
 
-   if (not just_reg) then begin
-      if keyword_set(noBlock) then begin
-         widget_control, /XMANAGER_ACTIVE_COMMAND, id
-      endif else begin
-         tmp = widget_event(/XMANAGER_BLOCK) ; will block until TLB widget is closed
-      endelse
-      ValidateManagedWidgets
-   endif
+; all TopWidgets are blocking by default in GDL (makes no difference as long as XMANAGER is not called).
+; of course we consider only managed widgets.
+; if there was a blocking widget before registering this one, or if noBlocks is asked for, we 'unBlock' this widget:
 
-endif
 
+     if AlreadyBlocked or keyword_set(noBlock) then begin
+        widget_control, /XMANAGER_ACTIVE_COMMAND, id ; mark as non-blocking
+        return                                       ; passthrough
+     endif
+     
+; eventloop
+; are we blocked now, with the newly registered widget?     
+  Blocked = widget_info(/XMANAGER_BLOCK)
+  ;; print,'after last tweaks, active is=',Blocked
+  WHILE (Blocked NE 0) DO BEGIN
+      tmp = widget_event(/XMANAGER_BLOCK)
+      Blocked = widget_info(/XMANAGER_BLOCK)
+  ;; print,'active=',Blocked
+  ENDWHILE
+
+ ; end of eventloop, cleanup       
+     ValidateManagedWidgets
+  endif
+  ;; print,"**************************************Exiting Xmanager #"+strtrim(nx,2)+"**************************************"
 end
 


### PR DESCRIPTION
#1555 showed that our eventloop handling by XMANAGER was not correct. And indeed it did not follow the (rather undigest) documentation.
This PR should provide a consistent behaviour independent of the number, order of top-level base widgets created and how and when they call the Xmanager command.

Besides, in order to get the SSW software suite to work, a number of less important features were cured.