### PR TITLE
fix codecov git submodule

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,6 +33,7 @@ jobs:
           echo "SETUP_TARGET_FOR_COVERAGE_LCOV(NAME codecov EXECUTABLE \${CMAKE_BUILD_TOOL} test)" >> testsuite/CMakeLists.txt
       - name: Build GDL
         run: |
+          git submodule update --init
           scripts/build_gdl.sh configure
           scripts/build_gdl.sh build
       - name: Test GDL


### PR DESCRIPTION
the codecov workflow script has been broken for the past 5 months due to the whereami module changing (error message: "The src/whereami git submodule is not initialised.")
simply adding "git submodule update --init" as per the error's suggestion before the "scripts/build.sh configure" line in the .yml file fixes the problem