### PR TITLE
closes #78

### DIFF
--- a/src/basic_pro.cpp
+++ b/src/basic_pro.cpp
@@ -967,8 +967,10 @@ namespace lib {
     SizeT nParam = e->NParam(1);
 
     DLong lun;
-    e->AssureLongScalarPar(0, lun);
-
+    e->AssureLongScalarPar(0, lun, true); //throw on an input conversion error when defining lun see #78. IDL catches this too and sets !ERR
+    
+	if (lun==0) return; //see #78 . 0 is open and ready, but only for READ, READF. READU just returns without setting !ERR
+	
     istream* is = NULL;
     igzstream* igzs = NULL;
     bool f77 = false;

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -1664,10 +1664,10 @@ BaseGDL*& EnvT::GetPar(SizeT i)
 /**
  * @brief converts par if necessary and sets 'scalar' to Long . Chokes on !NULL, NULL and non-scalar
  */
-void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong64& scalar)
+void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong64& scalar, bool throwIfConversionErrorOccured)
 {
   BaseGDL* p = GetParDefined( pIx);
-  DLong64GDL* lp = static_cast<DLong64GDL*>(p->Convert2( GDL_LONG64, BaseGDL::COPY));
+  DLong64GDL* lp = static_cast<DLong64GDL*>(p->Convert2( GDL_LONG64, throwIfConversionErrorOccured?BaseGDL::COPY_THROWIOERROR:BaseGDL::COPY));
   Guard<DLong64GDL> guard_lp( lp);
   if( !lp->Scalar( scalar))
     Throw("Parameter must be a scalar or 1 element array in this context: "+
@@ -1676,10 +1676,10 @@ void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong64& scalar)
 /**
  * @brief converts par if necessary and sets 'scalar' to Long . Chokes on !NULL, NULL and non-scalar
  */
-void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong& scalar)
+void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong& scalar, bool throwIfConversionErrorOccured)
 {
   BaseGDL* p = GetParDefined( pIx);
-  DLongGDL* lp = static_cast<DLongGDL*>(p->Convert2( GDL_LONG, BaseGDL::COPY));
+  DLongGDL* lp = static_cast<DLongGDL*>(p->Convert2( GDL_LONG, throwIfConversionErrorOccured?BaseGDL::COPY_THROWIOERROR:BaseGDL::COPY));
   Guard<DLongGDL> guard_lp( lp);
   if( !lp->Scalar( scalar))
     Throw("Parameter must be a scalar or 1 element array in this context: "+
@@ -1688,16 +1688,16 @@ void EnvBaseT::AssureLongScalarPar( SizeT pIx, DLong& scalar)
 /**
  * @brief converts par if necessary and sets 'scalar' to Long . Chokes on !NULL, NULL and non-scalar
  */
-void EnvT::AssureLongScalarPar( SizeT pIx, DLong64& scalar)
+void EnvT::AssureLongScalarPar( SizeT pIx, DLong64& scalar, bool throwIfConversionErrorOccured)
 {
-  EnvBaseT::AssureLongScalarPar( pIx, scalar);
+  EnvBaseT::AssureLongScalarPar( pIx, scalar, throwIfConversionErrorOccured);
 }
 /**
  * @brief converts par if necessary and sets 'scalar' to Long . Chokes on !NULL, NULL and non-scalar
  */
-void EnvT::AssureLongScalarPar( SizeT pIx, DLong& scalar)
+void EnvT::AssureLongScalarPar( SizeT pIx, DLong& scalar, bool throwIfConversionErrorOccured)
 {
-  EnvBaseT::AssureLongScalarPar( pIx, scalar);
+  EnvBaseT::AssureLongScalarPar( pIx, scalar, throwIfConversionErrorOccured);
 }
 /**
  * @brief converts ix if necessary and sets 'scalar' to Long . scalar unchanged if !NULL, NULL. Chokes on non-scalar

--- a/src/envt.hpp
+++ b/src/envt.hpp
@@ -344,9 +344,9 @@ public:
 
   void AssureGlobalKW( SizeT ix);
 
-  // converts parameter 'ix' if necessary and sets 'scalar' 
-  void AssureLongScalarPar( SizeT ix, DLong& scalar);
-  void AssureLongScalarPar( SizeT ix, DLong64& scalar);
+  // converts parameter 'ix' if necessary and sets 'scalar' . sets scalar to 0 if a type conversion was found, or throws depending on bool
+  void AssureLongScalarPar( SizeT ix, DLong& scalar, bool throwIfConversionErrorOccured=false);
+  void AssureLongScalarPar( SizeT ix, DLong64& scalar, bool throwIfConversionErrorOccured=false);
   // get i'th parameter
   // throws if not defined (ie. never returns NULL, but can optionally return a !NULL)
   BaseGDL*& GetParDefined(SizeT i, bool rejectNulls=true); //, const std::string& subName = "");
@@ -886,8 +886,8 @@ public:
   void AssureLongScalarKW( SizeT ix, DLong& scalar);
   void AssureLongScalarKW( SizeT ix, DLong64& scalar);
   // converts parameter 'ix' if necessary and sets 'scalar' 
-  void AssureLongScalarPar( SizeT ix, DLong& scalar);
-  void AssureLongScalarPar( SizeT ix, DLong64& scalar);
+  void AssureLongScalarPar( SizeT ix, DLong& scalar, bool throwIfConversionErrorOccured=false);
+  void AssureLongScalarPar( SizeT ix, DLong64& scalar, bool throwIfConversionErrorOccured=false);
 
   // same as for Long
   void AssureDoubleScalarKWIfPresent( const std::string& kw, DDouble& scalar);


### PR DESCRIPTION
adds a boolean to AssureLongScalarPar to enable catching conversion errors at this early level if necessary.