### PR TITLE
Revert "try to make save/restore 64 bits work for 64b bits BigEndian machines."

### DIFF
--- a/src/saverestore.cpp
+++ b/src/saverestore.cpp
@@ -186,13 +186,8 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
     uint32_t first,second;
     first = ((uint32_t *) &next)[0];
     second = ((uint32_t *) &next)[1];
-    if (BigEndian()) { //swap: we write in LittleEndian
-	  xdr_uint32_t(xdrs, &second);
-      xdr_uint32_t(xdrs, &first);
-	} else {
-	  xdr_uint32_t(xdrs, &first);
-      xdr_uint32_t(xdrs, &second);
-	}
+    xdr_uint32_t(xdrs, &first);
+    xdr_uint32_t(xdrs, &second);
     xdr_set_gdl_pos(xdrs, next);
     return next;
   }
@@ -1606,7 +1601,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
     //will start at TMESTAMP
     uint64_t currentptr = 0;
     uint64_t nextptr = LONG;
-    uint32_t ptr_low, ptr_high;
+    uint32_t ptrs0, ptrs1;
     int32_t rectype;
     int32_t UnknownLong;
     bool SomethingFussyHappened = true;
@@ -1634,18 +1629,12 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
       } else //the 2 pointers may point together to a l64 address, bug #1545
-      { //we read LittleEndian format
-		if (!xdr_uint32_t(xdrs, &ptr_low)) break;
-		if (!xdr_uint32_t(xdrs, &ptr_high)) break;
-		if (BigEndian()) { //swap & merge
-		  nextptr = ptr_high;
-		  uint64_t tmp = ptr_low;
-		  nextptr |= (tmp << 32);
-		} else { //merge
-		  nextptr = ptr_low;
-		  uint64_t tmp = ptr_high;
-		  nextptr |= (tmp << 32);
-		}
+      {
+        if (!xdr_uint32_t(xdrs, &ptrs0)) break;
+        nextptr = ptrs0;
+        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
+        DULong64 tmp = ptrs1;
+        nextptr |= (tmp << 32);
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (nextptr <=LONG) e->Throw("error in pointers, please report.");
       }
@@ -1819,19 +1808,14 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         nextptr = my_ulong64;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
-      } else {//we read LittleEndian format
-		if (!xdr_uint32_t(xdrs, &ptr_low)) break;
-		if (!xdr_uint32_t(xdrs, &ptr_high)) break;
-		if (BigEndian()) { //swap & merge
-		  nextptr = ptr_high;
-		  uint64_t tmp = ptr_low;
-		  nextptr |= (tmp << 32);
-		} else { //merge
-		  nextptr = ptr_low;
-		  uint64_t tmp = ptr_high;
-		  nextptr |= (tmp << 32);
-		}
-		if (!xdr_int32_t(xdrs, &UnknownLong)) break;
+      } else
+      {
+        if (!xdr_uint32_t(xdrs, &ptrs0)) break;
+        nextptr = ptrs0;
+        if (!xdr_uint32_t(xdrs, &ptrs1)) break;
+        DULong64 tmp = ptrs1;
+        nextptr |= (tmp << 32);
+        if (!xdr_int32_t(xdrs, &UnknownLong)) break;
       }
 
       //dispatch accordingly:

--- a/testsuite/test_save_restore.pro
+++ b/testsuite/test_save_restore.pro
@@ -115,15 +115,8 @@ for ii=0,N_ELEMENTS(list_numeric_names)-1 do begin
    ok2=EXECUTE(type_name+'_s_a2d=INDGEN(dim2, type=type_value)')
    if KEYWORD_SET(test) then print, type_name, ok0, ok1, ok2
 endfor
-; This just to manage all options, and augment the coverage of our functions by the coverage programs.
-; Does not test the accuracy of what is saved with the following options: /COMM /SYSTEM
-common test_saverestore,toto,tata
-toto=10
-tata=!X
-
 ;
-SAVE, file=file, /COMM, /SYSTEM, DESCRIPTION="made by test_save_restore",  $
-      compress=compress, dim1, dim2, $
+SAVE, file=file, compress=compress, dim1, dim2, $
       byte_s, byte_s_a1d, byte_s_a2d, $
       int_s, int_s_a1d, int_s_a2d, $
       long_s, long_s_a1d, long_s_a2d, $


### PR DESCRIPTION
Reverts gnudatalanguage/gdl#1666.
There are other issues created by this patch.