### PR TITLE
Remove unitialized values in plplot driver

### DIFF
--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -820,13 +820,13 @@ namespace lib {
         }
       } else {
         DLongGDL* pL;
-        Guard<DLongGDL> pL_guard(pL);
         if (pType != GDL_LONG) {
           pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
           pL_guard.Init(pL);
         } else {
           pL = static_cast<DLongGDL*> (p);
-        }
+		}
+		Guard<DLongGDL> pL_guard(pL); //pL is initialized. 
         for (SizeT i = 0; i < nEl; ++i)
           (*ret)[ i] = interpreter->RefCountHeap((*pL)[ i]);
       }
@@ -845,13 +845,13 @@ namespace lib {
           //  if(trace_me)
           //  cout << " heap_refcount(prm=lonarr, KeywordPresent(IS_ENABLEDIx) "<< endl;
           DLongGDL* pL;
-          Guard<DLongGDL> pL_guard(pL);
           if (pType != GDL_LONG) {
             pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
             pL_guard.Init(pL);
           } else {
             pL = static_cast<DLongGDL*> (p);
-          }
+		  }
+		  Guard<DLongGDL> pL_guard(pL);
           DPtrGDL* ptr = new DPtrGDL(p->Dim());
           Guard<DPtrGDL> ptr_guard(ptr);
           for (SizeT i = 0; i < nEl; ++i)

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -820,13 +820,13 @@ namespace lib {
         }
       } else {
         DLongGDL* pL;
+        Guard<DLongGDL> pL_guard;
         if (pType != GDL_LONG) {
           pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
           pL_guard.Init(pL);
         } else {
           pL = static_cast<DLongGDL*> (p);
-		}
-		Guard<DLongGDL> pL_guard(pL); //pL is initialized. 
+        }
         for (SizeT i = 0; i < nEl; ++i)
           (*ret)[ i] = interpreter->RefCountHeap((*pL)[ i]);
       }
@@ -845,13 +845,13 @@ namespace lib {
           //  if(trace_me)
           //  cout << " heap_refcount(prm=lonarr, KeywordPresent(IS_ENABLEDIx) "<< endl;
           DLongGDL* pL;
+          Guard<DLongGDL> pL_guard;
           if (pType != GDL_LONG) {
             pL = static_cast<DLongGDL*> (p->Convert2(GDL_LONG, BaseGDL::COPY));
             pL_guard.Init(pL);
           } else {
             pL = static_cast<DLongGDL*> (p);
-		  }
-		  Guard<DLongGDL> pL_guard(pL);
+          }
           DPtrGDL* ptr = new DPtrGDL(p->Dim());
           Guard<DPtrGDL> ptr_guard(ptr);
           for (SizeT i = 0; i < nEl; ++i)

--- a/src/plplotdriver/deprecated_wxwidgets.cpp
+++ b/src/plplotdriver/deprecated_wxwidgets.cpp
@@ -750,7 +750,7 @@ void plD_bop_wxwidgets( PLStream *pls )
         // }
 
         // clear background
-        PLINT bgr, bgg, bgb;                  // red, green, blue
+        PLINT bgr=0, bgg=0, bgb=0;                  // red, green, blue
         plgcolbg( &bgr, &bgg, &bgb );         // get background color information
         dev->ClearBackground( bgr, bgg, bgb );
 
@@ -1045,7 +1045,7 @@ void wx_set_size( PLStream* pls, int width, int height )
     // it must be cleared anyway?)
     if ( dev->ready )
     {
-        PLINT bgr, bgg, bgb;                  // red, green, blue
+        PLINT bgr=0, bgg=0, bgb=0;                  // red, green, blue
         plgcolbg( &bgr, &bgg, &bgb );         // get background color information
 
         dev->CreateCanvas();

--- a/src/plplotdriver/deprecated_wxwidgets_app.cpp
+++ b/src/plplotdriver/deprecated_wxwidgets_app.cpp
@@ -864,7 +864,7 @@ void wxPLplotWindow::DrawCrosshair()
 //--------------------------------------------------------------------------
 void wxPLplotWindow::SetOrientation( int rot )
 {
-    PLINT bgr, bgg, bgb; // red, green, blue
+    PLINT bgr=0, bgg=0, bgb=0; // red, green, blue
 
     //plsstrm( m_pls );
     plsdiori( rot );

--- a/src/plplotdriver/deprecated_wxwidgets_gc.cpp
+++ b/src/plplotdriver/deprecated_wxwidgets_gc.cpp
@@ -354,7 +354,7 @@ PLINT wxPLDevGC::GetPixel( short x, short y )
     (void) y;
     // The GetPixel method is incredible slow for wxGTK. Therefore we set the colour
     // always to the background color, since this is the case anyway 99% of the time.
-    PLINT bgr, bgg, bgb;           // red, green, blue
+    PLINT bgr=0, bgg=0, bgb=0;           // red, green, blue
     plgcolbg( &bgr, &bgg, &bgb );  // get background color information
     return RGB( bgr, bgg, bgb );
 #else

--- a/src/pro/tic.pro
+++ b/src/pro/tic.pro
@@ -15,7 +15,7 @@ common ourtictoc,  NewReferenceTime
 if ~isa(NewReferenceTime) eq 0 then NewReferenceTime=0d
 if ~isa(tagname) then tagname=''
 ; TOC must be alredy compiled when it will be called, so:
-resolve_routine, 'toc', /no_recompile
+resolve_routine, 'toc', /no_recompile, /either
 
   time = systime(/seconds)
   return_value = {name: tagname, time: time}


### PR DESCRIPTION
unitialized values were crashing GDL on Apple (OSX not permitting such things anymore).

Unitialized values are seen with Valgrind and -Wuninitialized

This patch alone does not solve all problems on Apple M1 