### PR TITLE
various changes for T_PDF, Besel*, GaussInt 

### DIFF
--- a/src/math_fun_ac.cpp
+++ b/src/math_fun_ac.cpp
@@ -75,8 +75,8 @@
 									\
   if  (e->NParam() == 1)						\
     {									\
-      p1 = new DIntGDL(1, BaseGDL::NOZERO);				\
-      (*p1)[0]=0;							\
+      p1 = new DIntGDL(BaseGDL::NOZERO);				\
+      (*p1)[0]=0;        						\
       nElp1=1;								\
       t1 = GDL_INT;							\
       p1_float = new DFloatGDL(1, BaseGDL::NOZERO);			\
@@ -91,7 +91,9 @@
     }									\
 									\
   const double dzero = 0.0000000000000000000 ;				\
-									\
+
+  //  cout << "helo " << t1 << " " << (*p1_float)[0] << " " << nElp1 << endl; \
+  //									\
   //    throw GDLException(e->CallingNode(), "Variable is undefined: "+e->GetParString(1)); 
   									
   //  DType t1 = e->GetParDefined(1)->Type();				\
@@ -207,6 +209,7 @@ namespace lib {
 
   BaseGDL* beseli_fun(EnvT* e)
   {
+
     AC_HELP();
     GM_5P0(1);
     AC_2P1();

--- a/src/saverestore.cpp
+++ b/src/saverestore.cpp
@@ -109,6 +109,10 @@ enum {
   // Following https://www.gnu.org/software/gnulib/manual/html_node/xdr_005fint16_005ft.html
   // it may be needed for others OS : Cygwin, Mingw (seems to be OK for *BSD)
 
+  // AC 2023-12-27
+  // xdr_uint16_t are defined in old Linux systems (but no xdr_u_int16_t)
+  // xdr_uint16_t and xdr_u_int16_t in new (eg u2204) Linux systems
+  // xdr_u_int16_t are defined in OSX since 2017 (but no xdr_uint16_t )
 #ifdef __APPLE__
 #define xdr_uint16_t xdr_u_int16_t
 #define xdr_uint32_t xdr_u_int32_t
@@ -160,7 +164,7 @@ enum {
 	  case GDL_ULONG64:
 	  {
 		u_int64_t ul6 = (*static_cast<DULong64GDL*> (savenode.var))[0];
-		xdr_u_int64_t(xdrs, & ul6);
+		xdr_uint64_t(xdrs, & ul6);
 		break;
 	  }
 	  case GDL_LONG64:
@@ -196,7 +200,7 @@ enum {
 	  case GDL_ULONG:
 	  {
 		u_int32_t ul = (*static_cast<DULongGDL*> (savenode.var))[0];
-		xdr_u_int32_t(xdrs, & ul);
+		xdr_uint32_t(xdrs, & ul);
 		break;
 	  }
 	  case GDL_STRING:
@@ -277,7 +281,7 @@ enum {
 	  case GDL_ULONG64:
 	  {
 		u_int64_t ul6 = 0;
-		xdr_u_int64_t(xdrs, & ul6);
+		xdr_uint64_t(xdrs, & ul6);
 		savenode.var = new DULong64GDL(ul6);
 		break;
 	  }
@@ -319,7 +323,7 @@ enum {
 	  case GDL_ULONG:
 	  {
 		u_int32_t ul = 0;
-		xdr_u_int32_t(xdrs, & ul);
+		xdr_uint32_t(xdrs, & ul);
 		savenode.var = new DULongGDL(ul);
 		break;
 	  }
@@ -428,8 +432,8 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
     xdr_int32_t(xdrs, &rectype); //-16
     u_int32_t ptrs0=0;
     u_int32_t ptrs1=0;
-    xdr_u_int32_t(xdrs, &ptrs0); //-12 //void, to be updated
-    xdr_u_int32_t(xdrs, &ptrs1); //-8
+    xdr_uint32_t(xdrs, &ptrs0); //-12 //void, to be updated
+    xdr_uint32_t(xdrs, &ptrs1); //-8
     int32_t UnknownLong=0;
     xdr_int32_t(xdrs, &UnknownLong);
     return xdr_get_gdl_pos(xdrs); //end of header
@@ -459,13 +463,13 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
     xdr_set_gdl_pos(xdrs, cur-12); //ptrs0
     //copy next (64 bit) as two 32 bits. Should be OK on 32 bit machines as next is u_int64.
     if (BigEndian()) { //first 32 bit is low, second high (XDRS is BigEndian)
-	  xdr_u_int64_t(xdrs, &next);
+	  xdr_uint64_t(xdrs, &next);
 	} else {
     u_int32_t first,second;
     first = ((u_int32_t *) &next)[0];
     second = ((u_int32_t *) &next)[1];
-    xdr_u_int32_t(xdrs, &first);
-    xdr_u_int32_t(xdrs, &second);
+    xdr_uint32_t(xdrs, &first);
+    xdr_uint32_t(xdrs, &second);
 	}
     xdr_set_gdl_pos(xdrs, next);
     return next;
@@ -510,7 +514,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
 	  wr_writeNode((*i), xdrs);
 	}
 	//finish by ENDOFLIST address
-	xdr_u_int64_t(xdrs, &ENDOFLIST); //ENDOFLIST
+	xdr_uint64_t(xdrs, &ENDOFLIST); //ENDOFLIST
 	return updateNewRecordHeader(xdrs, cur);
   }
 
@@ -1427,7 +1431,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_UINT:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DUInt), (xdrproc_t) xdr_u_int16_t)) cerr << "error GDL_UINT" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DUInt), (xdrproc_t) xdr_uint16_t)) cerr << "error GDL_UINT" << endl;
       }
         break;
       case GDL_LONG:
@@ -1437,7 +1441,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_ULONG:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong), (xdrproc_t) xdr_u_int32_t)) cerr << "error GDL_ULONG" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong), (xdrproc_t) xdr_uint32_t)) cerr << "error GDL_ULONG" << endl;
       }
         break;
       case GDL_LONG64:
@@ -1447,7 +1451,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_ULONG64:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong64), (xdrproc_t) xdr_u_int64_t)) cerr << "error GDL_ULONG64" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong64), (xdrproc_t) xdr_uint64_t)) cerr << "error GDL_ULONG64" << endl;
       }
         break;
       case GDL_FLOAT:
@@ -1543,7 +1547,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_UINT:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DUInt), (xdrproc_t) xdr_u_int16_t)) cerr << "error GDL_UINT" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DUInt), (xdrproc_t) xdr_uint16_t)) cerr << "error GDL_UINT" << endl;
       }
         break;
       case GDL_LONG:
@@ -1553,7 +1557,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_ULONG:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong), (xdrproc_t) xdr_u_int32_t)) cerr << "error GDL_ULONG" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong), (xdrproc_t) xdr_uint32_t)) cerr << "error GDL_ULONG" << endl;
       }
         break;
       case GDL_LONG64:
@@ -1563,7 +1567,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
         break;
       case GDL_ULONG64:
       {
-        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong64), (xdrproc_t) xdr_u_int64_t)) cerr << "error GDL_ULONG64" << endl;
+        if (!xdr_vector(xdrs, (char*) var->DataAddr(), nEl, sizeof (DULong64), (xdrproc_t) xdr_uint64_t)) cerr << "error GDL_ULONG64" << endl;
       }
         break;
       case GDL_FLOAT:
@@ -1616,7 +1620,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
           heapT::iterator it=heapIndexMapSave.find(ptr);
           if (it!=heapIndexMapSave.end()) heapNumber[i]=(*it).second;
         }
-        if (!xdr_vector(xdrs, (char*) &heapNumber, nEl, sizeof (int32_t), (xdrproc_t) xdr_u_int32_t)) cerr << "error PTR" << endl;
+        if (!xdr_vector(xdrs, (char*) &heapNumber, nEl, sizeof (int32_t), (xdrproc_t) xdr_uint32_t)) cerr << "error PTR" << endl;
         break;
       }
       case GDL_OBJ:
@@ -1629,7 +1633,7 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
           heapT::iterator it=heapIndexMapSave.find(ptr);
           if (it!=heapIndexMapSave.end()) heapNumber[i]=(*it).second; 
         }
-        if (!xdr_vector(xdrs, (char*) &heapNumber, nEl, sizeof (int32_t), (xdrproc_t) xdr_u_int32_t)) cerr << "error OBJ" << endl;
+        if (!xdr_vector(xdrs, (char*) &heapNumber, nEl, sizeof (int32_t), (xdrproc_t) xdr_uint32_t)) cerr << "error OBJ" << endl;
         break;
       }
       default: assert(false);
@@ -2065,14 +2069,14 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
       if (isHdr64)
       {
         u_int64_t my_ulong64;
-        if (!xdr_u_int64_t(xdrs, &my_ulong64)) break;
+        if (!xdr_uint64_t(xdrs, &my_ulong64)) break;
         nextptr = my_ulong64; //HDR64 is followed by 2 longs.
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
       } else //the 2 pointers may point together to a l64 address, bug #1545
       { //we read a sort of BigEndian format
-		if (!xdr_u_int32_t(xdrs, &ptr_low)) break;
-		if (!xdr_u_int32_t(xdrs, &ptr_high)) break;
+		if (!xdr_uint32_t(xdrs, &ptr_low)) break;
+		if (!xdr_uint32_t(xdrs, &ptr_high)) break;
 		nextptr = ptr_low;
 		u_int64_t tmp = ptr_high;
         nextptr |= (tmp << 32);
@@ -2261,13 +2265,13 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
 		  if (DEBUG_SAVERESTORE) cerr << "Offset " << nextptr << ": record type " << rectypes[min(24,rectype)] << endl;
 		  if (isHdr64) {
 			u_int64_t my_ulong64;
-			if (!xdr_u_int64_t(xdrs, &my_ulong64)) break;
+			if (!xdr_uint64_t(xdrs, &my_ulong64)) break;
 			nextptr = my_ulong64;
 			if (!xdr_int32_t(xdrs, &UnknownLong)) break;
 			if (!xdr_int32_t(xdrs, &UnknownLong)) break;
 		  } else {//we read a sort of BigEndian format
-			if (!xdr_u_int32_t(xdrs, &ptr_low)) break;
-			if (!xdr_u_int32_t(xdrs, &ptr_high)) break;
+			if (!xdr_uint32_t(xdrs, &ptr_low)) break;
+			if (!xdr_uint32_t(xdrs, &ptr_high)) break;
 			nextptr = ptr_low;
 			u_int64_t tmp = ptr_high;
 			nextptr |= (tmp << 32);
@@ -2300,13 +2304,13 @@ bool_t xdr_set_gdl_pos(XDR *x, long int y){
       if (isHdr64)
       {
         u_int64_t my_ulong64;
-        if (!xdr_u_int64_t(xdrs, &my_ulong64)) break;
+        if (!xdr_uint64_t(xdrs, &my_ulong64)) break;
         nextptr = my_ulong64;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
         if (!xdr_int32_t(xdrs, &UnknownLong)) break;
       } else {//we read a sort of BigEndian format
-		if (!xdr_u_int32_t(xdrs, &ptr_low)) break;
-		if (!xdr_u_int32_t(xdrs, &ptr_high)) break;
+		if (!xdr_uint32_t(xdrs, &ptr_low)) break;
+		if (!xdr_uint32_t(xdrs, &ptr_high)) break;
 		nextptr = ptr_low;
 		u_int64_t tmp = ptr_high;
         nextptr |= (tmp << 32);

--- a/testsuite/test_math_function_dim.pro
+++ b/testsuite/test_math_function_dim.pro
@@ -31,14 +31,18 @@
 ;
 ; Modifications history :
 ; 2018-01-16 : AC, adding GAUSSINT
-; 2018-01-17 : AC, including test done in (former) "test_bug_3298378.pro"
+; 2018-01-17 : AC, including test done in (former)
+; "test_bug_3298378.pro"
+;
+; 2023-12-22 : AC, adding T_PDF. Adding 1D case ... rename 
+;   TEST_ONE_MATH_FUNCTION_DIM into TEST_MATH_FUNC_TWO_INPUTS
 ;
 ; -----------------------------------------
 ;
 function COMPARE_2SIZE, size1, size2, message, quiet=quiet
 ;
 if (N_ELEMENTS(size1) NE N_ELEMENTS(size2)) then begin
-   print, message+' Problem : Effective and expected size for output are different'
+   print, message+' Problem : Effective and Expected sizes for output are different'
    return, 1
 endif
 ;
@@ -49,7 +53,7 @@ for ii=0, N_ELEMENTS(size1)-1 do begin
    endif
 endfor
 ;
-if NOT(KEYWORD_SET(quiet)) then print, message+' Test OK'
+if ~KEYWORD_SET(quiet) then print, message+' Test OK'
 ;
 return, 0
 ;
@@ -57,8 +61,8 @@ end
 ;
 ; -----------------------------------------
 ;
-pro TEST_ONE_MATH_FUNCTION_DIM, function_name, cumul_errors, type=type, $
-                                quiet=quiet, test=test, help=help
+pro TEST_MATH_FUNC_TWO_INPUTS, function_name, cumul_errors, type=type, $
+                               quiet=quiet, test=test, help=help
 ;
 if (N_PARAMS() LT 1) then begin
 	print, 'You MUST provide a FUNCTION NAME'
@@ -66,8 +70,8 @@ if (N_PARAMS() LT 1) then begin
 endif
 ;
 if KEYWORD_SET(help) then begin
-	print, 'pro TEST_ONE_MATH_FUNCTION_DIM, function_name, cumul_errors, type=type, $'
-        print, '                                quiet=quiet, test=test, help=help'
+	print, 'pro TEST_MATH_FUNC_TWO_INPUTS, function_name, cumul_errors, type=type, $'
+        print, '                               quiet=quiet, test=test, help=help'
 	print, ' '
 	print, '"function_name" is a function name (a STRING) like BESELI, VOIGT, ...'
 	return
@@ -78,6 +82,9 @@ if ~KEYWORD_SET(quiet) then print, 'Processing function : ',  function_name
 ;
 error=0
 info=STRUPCASE(function_name)+' : Case '
+;
+; All the following functions return FLOAT except if DOUBLE for one of
+; the inputs (then "expected_type" is 4 (AKA FLOAT)
 ;
 if ~KEYWORD_SET(type) then type=4 ;; double =5, Dcomplex=9
 if ((type EQ 5) OR (type EQ 9)) then expected_type=5 else expected_type=4
@@ -155,15 +162,60 @@ expected_size=SIZE(FIX(x, type=expected_type))
 resu=CALL_FUNCTION(function_name, x, y)
 error=error+COMPARE_2SIZE(expected_size, SIZE(resu), message, quiet=quiet)
 ;
-if (error EQ 0) then begin
-   txt='all Dims Tests done with SUCCESS for function : '
-   print, txt+function_name+' and TYPE : '+TYPENAME(FIX(1.,type=type))
-endif else begin
-   txt='when processing function : '+function_name
-   print, txt+', we have: '+STRING(error)+' ERRORS'
-endelse
+;if (error EQ 0) then begin
+;   txt='all Dims Tests done with SUCCESS for function : '
+;   print, txt+function_name+' and TYPE : '+TYPENAME(FIX(1.,type=type))
+;endif else begin
+;   txt='when processing function : '+function_name
+;   print, txt+', we have: '+STRING(error)+' ERRORS'
+;endelse
 ;
-if ISA(cumul_errors) then cumul_errors=error+cumul_errors else cumul_errors=error
+; --------------
+;
+if ~quiet then BANNER_FOR_TESTSUITE, prefix="TEST_MATH_FUNC_TWO_INPUTS", $
+                                     STRUPCASE(function_name), error, /short
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+
+; -----------------------------------------
+;
+pro TEST_MATH_FUNC_ONE_INPUT, function_name, cumul_errors, type=type, $
+                              quiet=quiet, test=test, help=help
+;
+error=0
+;
+in=0.5
+expected_size=SIZE(in, type=expected_type)
+resu=CALL_FUNCTION(function_name, in)
+error=error+COMPARE_2SIZE(expected_size, SIZE(resu), 'singleton', quiet=quiet)
+;
+in=[0.5]
+expected_size=SIZE(in, type=expected_type)
+resu=CALL_FUNCTION(function_name, in)
+error=error+COMPARE_2SIZE(expected_size, SIZE(resu), '[singleton]', quiet=quiet)
+;
+in=REPLICATE(0.5,10)
+expected_size=SIZE(in, type=expected_type)
+resu=CALL_FUNCTION(function_name, in)
+error=error+COMPARE_2SIZE(expected_size, SIZE(resu), '[10]', quiet=quiet)
+;
+in=DIST(2,13)
+expected_size=SIZE(in, type=expected_type)
+resu=CALL_FUNCTION(function_name, in)
+error=error+COMPARE_2SIZE(expected_size, SIZE(resu), 'DIST(2,13)', quiet=quiet)
+;
+in=TRANSPOSE(DIST(2,13))
+expected_size=SIZE(in, type=expected_type)
+resu=CALL_FUNCTION(function_name, in)
+error=error+COMPARE_2SIZE(expected_size, SIZE(resu), 'DIST(13,2)', quiet=quiet)
+;
+; --------------
+;
+if ~quiet then BANNER_FOR_TESTSUITE, prefix="TEST_MATH_FUNC_ONE_INPUT", $
+                                     STRUPCASE(function_name), error, /short
+ERRORS_CUMUL, cumul_errors, errors
 if KEYWORD_SET(test) then STOP
 ;
 end
@@ -173,12 +225,16 @@ end
 pro TEST_MATH_FUNCTION_DIM, quiet=quiet, help=help, $
                             test=test, verbose=verbose, no_exit=no_exit
 ;
-liste=['BESELI','BESELJ','BESELK','BESELY']
-liste=[[liste],'VOIGT','EXPINT','GAUSSINT','BETA','IGAMMA']
+liste_2D=['BESELI','BESELJ','BESELK','BESELY']
+liste_2D=[[liste_2D],'VOIGT','EXPINT','GAUSSINT','BETA','IGAMMA', 'T_PDF']
 ;
-flags_complex=REPLICATE(1, N_ELEMENTS(liste))
-flags_complex[WHERE(STRPOS(liste, 'BETA') EQ 0)]=0
-flags_complex[WHERE(STRPOS(liste, 'IGAMMA') EQ 0)]=0
+liste_1D=['BESELI','BESELJ','BESELK','BESELY']
+liste_1D=[[liste_1D],'ERF','ERFC']
+;
+flags_complex=REPLICATE(1, N_ELEMENTS(liste_2D))
+flags_complex[WHERE(STRPOS(liste_2D, 'BETA') EQ 0)]=0
+flags_complex[WHERE(STRPOS(liste_2D, 'IGAMMA') EQ 0)]=0
+flags_complex[WHERE(STRPOS(liste_2D, 'T_PDF') EQ 0)]=0
 ;
 if KEYWORD_SET(help) then begin
    print, 'pro TEST_MATH_FUNCTION_DIM, quiet=quiet, help=help, $'
@@ -186,10 +242,11 @@ if KEYWORD_SET(help) then begin
    print, ''
    print, 'This program will run a test suite'
    print, 'for checking the DIMENSIONS of the OUTPUTS'
-   print, 'following the TWO (2) INPUTS for some mathematical functions'
+   print, 'following the ONE or TWO INPUTS for some mathematical functions'
    print, '(no checks on numerical values are done here !)'
    print, 'Current functions under test are: '
-   print, TRANSPOSE(liste)
+   print, 'ONE input :', liste_1D
+   print, 'TWO inputs :', liste_2D
    return
 endif
 ;
@@ -198,16 +255,30 @@ if KEYWORD_SET(verbose) then use_quiet=0
 ;
 errors_cumul=0
 ;
-for ii=0, N_ELEMENTS(liste)-1 do begin
-    TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=2
-    TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=3
-    TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=4
-    TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=5
-    ;;
-    if flags_complex[ii] then begin
-       TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=6
-       TEST_ONE_MATH_FUNCTION_DIM, liste[ii], errors_cumul, quiet=use_quiet, type=9
-    endif
+for ii=0, N_ELEMENTS(liste_1D)-1 do begin
+   tmp_errors=0
+   for jj=2,5 do begin
+      TEST_MATH_FUNC_ONE_INPUT, liste_1D[ii], tmp_errors, quiet=use_quiet, type=jj
+   endfor
+   BANNER_FOR_TESTSUITE, prefix="TEST_MATH_FUNC_ONE_INPUT", $
+                         STRUPCASE(liste_1D[ii])+' all types', tmp_errors, /short
+   ERRORS_CUMUL, errors_cumul, tmp_errors 
+endfor
+;
+for ii=0, N_ELEMENTS(liste_2D)-1 do begin
+   tmp_errors=0
+   TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=2
+   TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=3
+   TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=4
+   TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=5
+   ;;
+   if flags_complex[ii] then begin
+      TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=6
+      TEST_MATH_FUNC_TWO_INPUTS, liste_2D[ii], tmp_errors, quiet=use_quiet, type=9
+   endif
+   BANNER_FOR_TESTSUITE, prefix="TEST_MATH_FUNC_TWO_INPUTS", $
+                         STRUPCASE(liste_2D[ii])+' all types', tmp_errors, /short
+   ERRORS_CUMUL, errors_cumul, tmp_errors 
 endfor
 ;
 ; ----------------- final message ----------


### PR DESCRIPTION
As mentioned in #1691 several Math functions don't respect fully the way the inputs are provided (1 vs [1], array vs transpose of the same array ...)
We also realize that in the Besel family, when second argument is not provided, it is by default equal to 0.

The test `test_math_function_dim.pro` was extended to _T_PDF_ and the case on Math functions accepting only one input (Besel, Erf, Erfc). Please remember that this function don't check the numerical outputs, it does check only the conformation of the output

