### PR TITLE
Improvements on WIDGET_TABLE

### DIFF
--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -3271,7 +3271,7 @@ std::vector<int> GDLWidgetTable::GetSortedSelectedRowsOrColsList(DLongGDL* selec
 	  std::vector<int>::reverse_iterator riter;
 	  //find concerned rows or cols
 	  int index = 0;
-	  for (SizeT n = 0, l = 0; n < selection->Dim(1); ++n) {
+	  for (SizeT n = 0, l = 0; n < MAX(selection->Dim(1),1); ++n) {
 		index = (*selection)[l++];
 		if (doCol) allRowsOrCols.push_back(index);
 		index = (*selection)[l++];
@@ -3701,7 +3701,7 @@ bool GDLWidgetTable::GetValidTableSelection(DLongGDL* &selection) {
   int ncolsmax = vValue->Dim(0) - 1;
   int nrowsmax = vValue->Dim(1) - 1;
   if (disjointSelection) { //pairs lists
-	for (auto j=0; j<selection->Dim(1); ++j) {
+	for (auto j=0; j<MAX(selection->Dim(1),1); ++j) {
 	  DLong col = (*selection)[j*2+0];
 	  DLong row = (*selection)[j*2+1];
 	  if (col < 0 || col > ncolsmax) ThrowGDLException("USE_TABLE_SELECT value out of range.");
@@ -3869,7 +3869,7 @@ void GDLWidgetTable::DoAlign(DLongGDL* selection) {
     }
   } else { //use the passed selection, mode-dependent:
     if (disjointSelection) { //pairs lists
-      for (SizeT n=0,l=0; n<selection->Dim(1); ++n) {
+      for (SizeT n=0,l=0; n<MAX(selection->Dim(1),1); ++n) {
         int col = (*selection)[l++];
         int row = (*selection)[l++];
         int ali;
@@ -3932,7 +3932,7 @@ void GDLWidgetTable::DoBackgroundColor() {
 }
 void GDLWidgetTable::DoBackgroundColor(DLongGDL* selection) {
   SizeT nbColors=backgroundColor->N_Elements( );
-  if (nbColors==0) {return;}
+ 
   wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
   assert( grid != NULL);
   grid->BeginBatch();
@@ -3947,7 +3947,7 @@ void GDLWidgetTable::DoBackgroundColor(DLongGDL* selection) {
     }
   } else { //use the passed selection, mode-dependent:
     if (disjointSelection) { //pairs lists
-      for (SizeT n=0,l=0; n<selection->Dim(1); ++n) {
+      for (SizeT n=0,l=0; n<MAX(selection->Dim(1),1); ++n) {
         int col = (*selection)[l++];
         int row = (*selection)[l++];
         grid->SetCellBackgroundColour( row, col, wxColour((*backgroundColor)[k%nbColors],(*backgroundColor)[k%nbColors+1],(*backgroundColor)[k%nbColors+2]));
@@ -4006,7 +4006,7 @@ void GDLWidgetTable::DoForegroundColor(DLongGDL* selection) {
     }
   } else { //use the passed selection, mode-dependent:
     if (disjointSelection) { //pairs lists
-      for (SizeT n=0,l=0; n<selection->Dim(1); ++n) {
+      for (SizeT n=0,l=0; n<MAX(selection->Dim(1),1); ++n) {
         int col = (*selection)[l++];
         int row = (*selection)[l++];
         grid->SetCellTextColour( row, col, wxColour((*foregroundColor)[k%nbColors],(*foregroundColor)[k%nbColors+1],(*foregroundColor)[k%nbColors+2]));
@@ -4095,7 +4095,7 @@ void GDLWidgetTable::DoColumnWidth( DLongGDL* selection ) {
      std::vector<int> allCols;
      std::vector<int>::iterator iter;
      //find concerned cols
-     for ( SizeT n=0, l=0 ; n<selection->Dim(1); ++n) {
+     for ( SizeT n=0, l=0 ; n<MAX(selection->Dim(1),1); ++n) {
         int col = (*selection)[l++];l++;
         allCols.push_back(col);
       }
@@ -4151,7 +4151,7 @@ DFloatGDL* GDLWidgetTable::GetColumnWidth(DLongGDL* selection){
      std::vector<int>::iterator iter;
      std::vector<int> theCols;
      //find concerned cols
-     for ( SizeT n=0, l=0 ; n<selection->Dim(1); ++n) {
+     for ( SizeT n=0, l=0 ; n<MAX(selection->Dim(1),1); ++n) {
         int col = (*selection)[l++];l++;
         allCols.push_back(col);
       }
@@ -4211,7 +4211,7 @@ DFloatGDL* GDLWidgetTable::GetRowHeight(DLongGDL* selection){
      std::vector<int>::iterator iter;
      std::vector<int> theRows;
      //find concerned rows
-     for ( SizeT n=0, l=0 ; n<selection->Dim(1); ++n) {
+     for ( SizeT n=0, l=0 ; n<MAX(selection->Dim(1),1); ++n) {
         int row = (*selection)[l++];l++;
         allRows.push_back(row);
       }
@@ -4280,7 +4280,7 @@ void GDLWidgetTable::DoRowHeights( DLongGDL* selection ) {
     if (disjointSelection) { //pairs lists
      std::vector<int> allRows;
      std::vector<int>::iterator iter;
-     for ( SizeT n=0, l=0 ; n<selection->Dim(1); ++n) {
+     for ( SizeT n=0, l=0 ; n<MAX(selection->Dim(1),1); ++n) {
        l++;
        int row = (*selection)[l++];
        allRows.push_back(row);
@@ -4487,8 +4487,7 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
           if (k==nmaxVal) break;
         }
        } else {
-		SizeT m=selection->Dim(1); if (m==0) m=1;
-        for (SizeT k=0,n=0,l=0; n<m; ++n) {
+        for (SizeT k=0,n=0,l=0; n<MAX(selection->Dim(1),1); ++n) {
           int col = (*selection)[l++];
           int row = (*selection)[l++];
 		  //update vValue
@@ -4540,7 +4539,7 @@ template <typename T1, typename T2>
 void GDLWidgetTable::PopulateWithDisjointSelection(T1* res, DLongGDL* selection) {
   int data_numberCols = vValue->Dim(0);
   int data_numberRows = vValue->Dim(1);
-  for (SizeT k = 0, n = 0, l = 0; n < selection->Dim(1); ++n) {
+  for (SizeT k = 0, n = 0, l = 0; n < MAX(selection->Dim(1),1); ++n) {
 	int col = (*selection)[l++];
 	int row = (*selection)[l++];
 	if (row >= data_numberRows || col >= data_numberCols) continue;
@@ -4549,7 +4548,7 @@ void GDLWidgetTable::PopulateWithDisjointSelection(T1* res, DLongGDL* selection)
 }
 
 BaseGDL* GDLWidgetTable::GetDisjointSelectionValues(DLongGDL* selection) {
-  dimension dim(selection->Dim(1));
+  dimension dim(MAX(selection->Dim(1),1));
   switch (vValue->Type()) {
   case GDL_STRING:
   {
@@ -4797,7 +4796,7 @@ void GDLWidgetTable::SetSelection(DLongGDL* selection)
   wxPoint firstVisible=wxPoint(0,0);
   if (disjointSelection) { //pairs lists
     SizeT k=0;
-    for (SizeT i=0; i< selection->Dim(1); ++i) {
+    for (SizeT i=0; i< MAX(selection->Dim(1),1); ++i) {
       int col=(*selection)[k++];
       int row=(*selection)[k++];
       grid->SelectBlock(row,col,row,col,true);

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -3011,7 +3011,7 @@ DStringGDL* rowLabels_,
 BaseGDL* value_,
 DLong xScrollSize_,
 DLong yScrollSize_,
-DStringGDL* valueAsStrings_,
+DStringGDL* valueAsStrings,
 DULong eventFlags_
 )
 : GDLWidget( p, e, value_, eventFlags_ )
@@ -3037,7 +3037,6 @@ DULong eventFlags_
 //, tabMode( tabMode_ )
 , x_scroll_size_columns( xScrollSize_ )
 , y_scroll_size_rows( yScrollSize_)
-, valueAsStrings( valueAsStrings_ )
 , updating(false)
 {
   GDLWidget* gdlParent = GetWidget( parentID );
@@ -3048,12 +3047,12 @@ DULong eventFlags_
 
 //at this stage, valueAsStrings is OK dim 1 or 2 BUT vVALUE MAY BE NULL!
 SizeT numRows,numCols;
-if (valueAsStrings->Rank()==1) {
+if (vValue->Rank()==1) {
   numRows=1;
-  numCols=valueAsStrings->Dim(0); //lines
+  numCols=vValue->Dim(0); //lines
 } else {
-  numRows=valueAsStrings->Dim(1);
-  numCols=valueAsStrings->Dim(0);
+  numRows=vValue->Dim(1);
+  numCols=vValue->Dim(0);
 }
 
 //if wSize is not explicit, it must now be explicit:
@@ -4784,7 +4783,7 @@ void GDLWidgetTable::MakeCellEditable(DLongGDL* pos)
   assert( grid != NULL);
   grid->SetReadOnly((*pos)[0],(*pos)[1],false);
 }
-void GDLWidgetTable::SetTableNumberOfColumns( DLong ncols){
+void GDLWidgetTable::SetTableXsizeAsNumberOfColumns( DLong ncols){
   wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
   assert( grid != NULL);
   grid->BeginBatch( );
@@ -4792,6 +4791,9 @@ void GDLWidgetTable::SetTableNumberOfColumns( DLong ncols){
   int numRows=vValue->Dim(0);
   int numCols=vValue->Dim(1);
   if (ncols > old_ncols) {
+	int majority = GetMajority();
+	DStringGDL* format = GetCurrentFormat();
+	DStringGDL* newValueAsStrings = ConvertValueToStringArray(vValue, format, majority);
     grid->AppendCols(ncols-old_ncols);
     if (numCols > old_ncols) {
       int colTL,colBR,rowTL,rowBR;
@@ -4799,16 +4801,16 @@ void GDLWidgetTable::SetTableNumberOfColumns( DLong ncols){
       colBR=ncols-1;
       rowTL=0;
       rowBR=grid->GetNumberRows()-1;
-      for ( int i=rowTL; i<=rowBR; ++i) for (int j=colTL; j<=colBR; ++j)
+      for ( int j=rowTL; j<=rowBR; ++j) for (int i=colTL; i<=colBR; ++i)
       {
-        if (i < numRows && j < numCols ) grid->SetCellValue( i, j ,wxString(((*valueAsStrings)[j*numRows+i]).c_str(), wxConvUTF8 ) ); 
+        if (i < numCols && j < numRows ) grid->SetCellValue( j, i, wxString(((*newValueAsStrings)[j*numCols+i]).c_str(), wxConvUTF8 ) ); 
       }
     }
   }
   else if (ncols < old_ncols) grid->DeleteCols(ncols,old_ncols-ncols);
   grid->EndBatch( );
 }
-void GDLWidgetTable::SetTableNumberOfRows( DLong nrows){
+void GDLWidgetTable::SetTableYsizeAsNumberOfRows( DLong nrows){
   wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
   assert( grid != NULL);
   grid->BeginBatch( );
@@ -4816,6 +4818,9 @@ void GDLWidgetTable::SetTableNumberOfRows( DLong nrows){
   int numRows=vValue->Dim(0);
   int numCols=vValue->Dim(1);
   if (nrows > old_nrows) {
+	int majority = GetMajority();
+	DStringGDL* format = GetCurrentFormat();
+	DStringGDL* newValueAsStrings = ConvertValueToStringArray(vValue, format, majority);
     grid->AppendRows(nrows-old_nrows);
     if (numRows > old_nrows) {
       int colTL,colBR,rowTL,rowBR;
@@ -4823,9 +4828,9 @@ void GDLWidgetTable::SetTableNumberOfRows( DLong nrows){
       colBR=grid->GetNumberCols()-1;
       rowTL=old_nrows-1;
       rowBR=nrows-1;
-      for ( int i=rowTL; i<=rowBR; ++i) for (int j=colTL; j<=colBR; ++j)
+      for ( int j=rowTL; j<=rowBR; ++j) for (int i=colTL; i<=colBR; ++i)
       {
-        if (i < numRows && j < numCols ) grid->SetCellValue( i, j ,wxString(((*valueAsStrings)[j*numRows+i]).c_str(), wxConvUTF8 ) ); 
+        if (i < numCols && j < numRows ) grid->SetCellValue( j, i, wxString(((*newValueAsStrings)[j*numCols+i]).c_str(), wxConvUTF8 ) ); 
       }
     }
   }

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -337,39 +337,94 @@ wxString wxGridGDLCellTextEditor::GetEditedValue(int row, int col, wxGrid* grid)
   int majority=table->GetMajority();
   SizeT dim0 = value->Dim(0);
   SizeT nEl = value->N_Elements();
-  wxString ret="!!!";
   switch (value->Type()) {
   case GDL_STRING:
-	ret = table->GetRawEditingValue <DStringGDL,DString> (static_cast<DStringGDL*>(value), nEl, row*dim0+col, majority);
+	return table->GetRawEditingValue <DStringGDL, DString> (static_cast<DStringGDL*> (value), nEl, row * dim0 + col, majority);
 	break;
-  case GDL_FLOAT:
-	ret = table->GetRawEditingValue <DFloatGDL,DFloat> (static_cast<DFloatGDL*>(value), nEl, row*dim0+col, majority);
+  case GDL_BYTE:
+	return table->GetRawEditingValue <DByteGDL, DByte> (static_cast<DByteGDL*> (value), nEl, row * dim0 + col, majority);
 	break;
   case GDL_INT:
-	ret = table->GetRawEditingValue <DIntGDL,DInt> (static_cast<DIntGDL*>(value), nEl, row*dim0+col, majority);
+	return table->GetRawEditingValue <DIntGDL, DInt> (static_cast<DIntGDL*> (value), nEl, row * dim0 + col, majority);
 	break;
+  case GDL_LONG:
+	return table->GetRawEditingValue <DLongGDL, DLong> (static_cast<DLongGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_FLOAT:
+	return table->GetRawEditingValue <DFloatGDL, DFloat> (static_cast<DFloatGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_DOUBLE:
+	return table->GetRawEditingValue <DDoubleGDL, DDouble> (static_cast<DDoubleGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_COMPLEX:
+	return table->GetRawEditingValue <DComplexGDL, DComplex> (static_cast<DComplexGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_COMPLEXDBL:
+	return table->GetRawEditingValue <DComplexDblGDL, DComplexDbl> (static_cast<DComplexDblGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_UINT:
+	return table->GetRawEditingValue <DUIntGDL, DUInt> (static_cast<DUIntGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_ULONG:
+	return table->GetRawEditingValue <DULongGDL, DULong> (static_cast<DULongGDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_LONG64:
+	return table->GetRawEditingValue <DLong64GDL, DLong64> (static_cast<DLong64GDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  case GDL_ULONG64:
+	return table->GetRawEditingValue <DULong64GDL, DULong64> (static_cast<DULong64GDL*> (value), nEl, row * dim0 + col, majority);
+	break;
+  default:
+	cerr << "Unhandled Table Type, please report!" << endl;
   }
-  return ret;
+  return "";
 }
 wxString wxGridGDLCellTextEditor::SetEditedValue(wxString sval, int row, int col){
   BaseGDL* value = table->GetVvalue();
   DStringGDL* format=table->GetCurrentFormat();
   SizeT dim0 = value->Dim(0);
   SizeT nEl = value->N_Elements();
-  // update vValue with sval and get back formatted string
-  wxString ret="!!!";
   switch (value->Type()) {
   case GDL_STRING:
-	ret = table->SetEditedValue <DStringGDL,DString> (sval, static_cast<DStringGDL*>(value), nEl, row*dim0+col, format);
+	return table->SetEditedValue <DStringGDL, DString> (sval, static_cast<DStringGDL*> (value), nEl, row * dim0 + col, format);
 	break;
-  case GDL_FLOAT:
-	ret = table->SetEditedValue <DFloatGDL,DFloat> (sval, static_cast<DFloatGDL*>(value), nEl, row*dim0+col, format);
+  case GDL_BYTE:
+	return table->SetEditedValue <DByteGDL, DByte> (sval, static_cast<DByteGDL*> (value), nEl, row * dim0 + col, format);
 	break;
   case GDL_INT:
-	ret = table->SetEditedValue <DIntGDL,DInt> (sval, static_cast<DIntGDL*>(value), nEl, row*dim0+col, format);
+	return table->SetEditedValue <DIntGDL, DInt> (sval, static_cast<DIntGDL*> (value), nEl, row * dim0 + col, format);
 	break;
+  case GDL_LONG:
+	return table->SetEditedValue <DLongGDL, DLong> (sval, static_cast<DLongGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_FLOAT:
+	return table->SetEditedValue <DFloatGDL, DFloat> (sval, static_cast<DFloatGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_DOUBLE:
+	return table->SetEditedValue <DDoubleGDL, DDouble> (sval, static_cast<DDoubleGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_COMPLEX:
+	return table->SetEditedValue <DComplexGDL, DComplex> (sval, static_cast<DComplexGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_COMPLEXDBL:
+	return table->SetEditedValue <DComplexDblGDL, DComplexDbl> (sval, static_cast<DComplexDblGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_UINT:
+	return table->SetEditedValue <DUIntGDL, DUInt> (sval, static_cast<DUIntGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_ULONG:
+	return table->SetEditedValue <DULongGDL, DULong> (sval, static_cast<DULongGDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_LONG64:
+	return table->SetEditedValue <DLong64GDL, DLong64> (sval, static_cast<DLong64GDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  case GDL_ULONG64:
+	return table->SetEditedValue <DULong64GDL, DULong64> (sval, static_cast<DULong64GDL*> (value), nEl, row * dim0 + col, format);
+	break;
+  default:
+	cerr << "Unhandled Table Type, please report!" << endl;
   }
-  return ret;
+  return ""; 
 }
 
 void wxGridGDLCellTextEditor::BeginEdit(int row, int col, wxGrid* grid) {

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -218,33 +218,33 @@ public:
 
   virtual void Create(wxWindow* parent,
 	wxWindowID id,
-	wxEvtHandler* evtHandler) wxOVERRIDE;
-//  virtual void SetSize(const wxRect& rect) wxOVERRIDE;
+	wxEvtHandler* evtHandler);
+//  virtual void SetSize(const wxRect& rect);
 
   virtual void PaintBackground(wxDC& dc,
 	const wxRect& rectCell,
-	const wxGridCellAttr& attr) wxOVERRIDE;
+	const wxGridCellAttr& attr);
 
-//  virtual bool IsAcceptedKey(wxKeyEvent& event) wxOVERRIDE;
-  virtual void BeginEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+//  virtual bool IsAcceptedKey(wxKeyEvent& event);
+  virtual void BeginEdit(int row, int col, wxGrid* grid);
   virtual bool EndEdit(int row, int col, const wxGrid* grid,
-	const wxString& oldval, wxString *newval) wxOVERRIDE;
-  virtual void ApplyEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+	const wxString& oldval, wxString *newval);
+  virtual void ApplyEdit(int row, int col, wxGrid* grid);
 
-  virtual void Reset() wxOVERRIDE;
-//  virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
-//  virtual void HandleReturn(wxKeyEvent& event) wxOVERRIDE;
+  virtual void Reset();
+//  virtual void StartingKey(wxKeyEvent& event);
+//  virtual void HandleReturn(wxKeyEvent& event);
   wxString GetEditedValue(int row, int col, wxGrid* grid);
   wxString SetEditedValue(wxString s, int row, int col);
-  virtual void SetParameters(const wxString& params) wxOVERRIDE;
+  virtual void SetParameters(const wxString& params);
 #if wxUSE_VALIDATORS
   virtual void SetValidator(const wxValidator& validator);
 #endif
 
-  virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+  virtual wxGridCellEditor *Clone() const;
 
   // added GetValue so we can get the value which is in the control
-  virtual wxString GetValue() const wxOVERRIDE;
+  virtual wxString GetValue() const;
 
 protected:
   // parts of our virtual functions reused by the derived classes

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -300,10 +300,10 @@ void wxGridGDLCellTextEditor::DoCreate(wxWindow* parent,
 
   control->SetSizer(szr);
 
-#ifdef __WXOSX__
-  wxWidgetImpl* impl = m_text->GetPeer();
-  impl->SetNeedsFocusRect(false);
-#endif
+//#ifdef __WXOSX__
+//  wxWidgetImpl* impl = m_text->GetPeer();
+//  impl->SetNeedsFocusRect(false);
+//#endif
   // set max length allowed in the textctrl, if the parameter was set
   if (m_maxChars != 0) {
 	m_text->SetMaxLength(m_maxChars);

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -188,6 +188,352 @@ static const char * pixmap_checked[] = {
 #include "../resource/gdlicon.xpm"
 wxIcon wxgdlicon;
 
+
+class GDLWidgetTable;
+
+//class wxGridGDLCellStringRenderer : public wxGridCellStringRenderer {
+//public:
+//
+//  wxGridGDLCellStringRenderer() : wxGridCellStringRenderer() { }
+//
+//  virtual void Draw(wxGrid &grid, wxGridCellAttr &attr, wxDC &dc,
+//	const wxRect &rect, int row, int col, bool isSelected) {
+////	dc.SetBackground(attr.GetBackgroundColour());
+////	dc.Clear();
+//    // Get text
+////	GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(grid.GetWidgetTableID()));
+////    std::cerr<<table->GetVvalue()->N_Elements()<<std::endl;
+//	
+//	// Draw the text.
+//
+//	wxGridCellStringRenderer::Draw(grid, attr, dc, rect,
+//	  row, col, isSelected);
+//  }
+//};
+
+class wxGridGDLCellTextEditor : public wxGridCellEditor {
+GDLWidgetTable* table;
+public:
+  explicit wxGridGDLCellTextEditor(size_t maxChars = 0);
+
+  virtual void Create(wxWindow* parent,
+	wxWindowID id,
+	wxEvtHandler* evtHandler) wxOVERRIDE;
+//  virtual void SetSize(const wxRect& rect) wxOVERRIDE;
+
+  virtual void PaintBackground(wxDC& dc,
+	const wxRect& rectCell,
+	const wxGridCellAttr& attr) wxOVERRIDE;
+
+//  virtual bool IsAcceptedKey(wxKeyEvent& event) wxOVERRIDE;
+  virtual void BeginEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+  virtual bool EndEdit(int row, int col, const wxGrid* grid,
+	const wxString& oldval, wxString *newval) wxOVERRIDE;
+  virtual void ApplyEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+
+  virtual void Reset() wxOVERRIDE;
+//  virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
+//  virtual void HandleReturn(wxKeyEvent& event) wxOVERRIDE;
+  wxString GetEditedValue(int row, int col, wxGrid* grid);
+  wxString SetEditedValue(wxString s, int row, int col);
+  virtual void SetParameters(const wxString& params) wxOVERRIDE;
+#if wxUSE_VALIDATORS
+  virtual void SetValidator(const wxValidator& validator);
+#endif
+
+  virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+
+  // added GetValue so we can get the value which is in the control
+  virtual wxString GetValue() const wxOVERRIDE;
+
+protected:
+  // parts of our virtual functions reused by the derived classes
+  void DoCreate(wxWindow* parent, wxWindowID id, wxEvtHandler* evtHandler,
+	long style = 0);
+  void DoBeginEdit(const wxString& startValue);
+  void DoReset(const wxString& startValue);
+
+  wxTextCtrl* Text() {
+	return m_text;
+  }
+private:
+  size_t m_maxChars; // max number of chars allowed
+#if wxUSE_VALIDATORS
+  wxScopedPtr<wxValidator> m_validator;
+#endif
+  wxString m_value;
+
+  wxDECLARE_NO_COPY_CLASS(wxGridGDLCellTextEditor);
+
+  wxEvtHandler* m_handler;
+  wxTextCtrl* m_text;
+};
+
+wxGridGDLCellTextEditor::wxGridGDLCellTextEditor(size_t maxChars) {
+  m_maxChars = maxChars;
+}
+
+void wxGridGDLCellTextEditor::Create(wxWindow* parent,
+  wxWindowID id,
+  wxEvtHandler* evtHandler) {
+  DoCreate(parent, id, evtHandler);
+}
+
+void wxGridGDLCellTextEditor::DoCreate(wxWindow* parent,
+  wxWindowID id,
+  wxEvtHandler* evtHandler,
+  long style) {
+  wxControl* control = new wxControl(parent, id, wxDefaultPosition,
+	wxDefaultSize, wxNO_BORDER);
+  m_handler = evtHandler;
+
+  style |= wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB | wxNO_BORDER;
+  m_text = new wxTextCtrl(control, wxID_ANY, wxEmptyString,
+	wxDefaultPosition, wxDefaultSize,
+	style);
+  m_text->SetMargins(0, 0);
+
+  m_control = control;
+
+  wxBoxSizer* szr = new wxBoxSizer(wxHORIZONTAL);
+  szr->Add(m_text, wxSizerFlags(1));
+
+  control->SetSizer(szr);
+
+#ifdef __WXOSX__
+  wxWidgetImpl* impl = m_text->GetPeer();
+  impl->SetNeedsFocusRect(false);
+#endif
+  // set max length allowed in the textctrl, if the parameter was set
+  if (m_maxChars != 0) {
+	m_text->SetMaxLength(m_maxChars);
+  }
+#if wxUSE_VALIDATORS
+  // validate text in textctrl, if validator is set
+  if (m_validator) {
+	m_text->SetValidator(*m_validator);
+  }
+#endif
+
+  wxGridCellEditor::Create(parent, id, evtHandler);
+}
+
+void wxGridGDLCellTextEditor::PaintBackground(wxDC& dc,
+  const wxRect& WXUNUSED(rectCell),
+  const wxGridCellAttr& WXUNUSED(attr)) {
+  // as we fill the entire client area,
+  // don't do anything here to minimize flicker
+}
+
+//void wxGridGDLCellTextEditor::SetSize(const wxRect& rectOrig) {
+//  wxRect rect = AdjustRectForPlatform(rectOrig);
+//
+//  wxGridCellEditor::SetSize(rect);
+//}
+wxString wxGridGDLCellTextEditor::GetEditedValue(int row, int col, wxGrid* grid){
+  wxGridGDL* mygrid=static_cast<wxGridGDL*>(grid);
+  table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(mygrid->GetWidgetTableID()));
+  BaseGDL* value = table->GetVvalue();
+  int majority=table->GetMajority();
+  SizeT dim0 = value->Dim(0);
+  SizeT nEl = value->N_Elements();
+  wxString ret="!!!";
+  switch (value->Type()) {
+  case GDL_STRING:
+	ret = table->GetRawEditingValue <DStringGDL,DString> (static_cast<DStringGDL*>(value), nEl, row*dim0+col, majority);
+	break;
+  case GDL_FLOAT:
+	ret = table->GetRawEditingValue <DFloatGDL,DFloat> (static_cast<DFloatGDL*>(value), nEl, row*dim0+col, majority);
+	break;
+  case GDL_INT:
+	ret = table->GetRawEditingValue <DIntGDL,DInt> (static_cast<DIntGDL*>(value), nEl, row*dim0+col, majority);
+	break;
+  }
+  return ret;
+}
+wxString wxGridGDLCellTextEditor::SetEditedValue(wxString sval, int row, int col){
+  BaseGDL* value = table->GetVvalue();
+  DStringGDL* format=table->GetCurrentFormat();
+  SizeT dim0 = value->Dim(0);
+  SizeT nEl = value->N_Elements();
+  // update vValue with sval and get back formatted string
+  wxString ret="!!!";
+  switch (value->Type()) {
+  case GDL_STRING:
+	ret = table->SetEditedValue <DStringGDL,DString> (sval, static_cast<DStringGDL*>(value), nEl, row*dim0+col, format);
+	break;
+  case GDL_FLOAT:
+	ret = table->SetEditedValue <DFloatGDL,DFloat> (sval, static_cast<DFloatGDL*>(value), nEl, row*dim0+col, format);
+	break;
+  case GDL_INT:
+	ret = table->SetEditedValue <DIntGDL,DInt> (sval, static_cast<DIntGDL*>(value), nEl, row*dim0+col, format);
+	break;
+  }
+  return ret;
+}
+
+void wxGridGDLCellTextEditor::BeginEdit(int row, int col, wxGrid* grid) {
+  wxASSERT_MSG(m_control, wxT("The wxGridCellEditor must be created first!"));
+  wxGridGDL* mygrid=static_cast<wxGridGDL*>(grid);
+  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(mygrid->GetWidgetTableID()));
+  BaseGDL* value = table->GetVvalue();
+  int majority=table->GetMajority();
+  SizeT dim0 = value->Dim(0);
+  SizeT nEl = value->N_Elements();
+  m_value=GetEditedValue(row, col, grid);
+  std::cerr<<"wxGridGDLCellTextEditor::BeginEdit(): "<<m_value<<std::endl;
+  DoBeginEdit(m_value);
+}
+
+void wxGridGDLCellTextEditor::DoBeginEdit(const wxString& startValue) {
+  m_text->SetValue(startValue);
+  m_text->SetInsertionPointEnd();
+  m_text->SelectAll();
+  m_text->SetFocus();
+
+  m_control->Layout();
+}
+
+bool wxGridGDLCellTextEditor::EndEdit(int row,
+  int col,
+  const wxGrid* grid,
+  const wxString& WXUNUSED(oldval),
+  wxString *newval) {
+  wxCHECK_MSG(m_control, false,
+	"wxGridCellTextAndButtonEditor must be created first!");
+
+  const wxString value = m_text->GetValue();
+  if (value == m_value)	return false; else m_value=value;
+  m_value = SetEditedValue(m_value, row, col); //value;
+
+  if (newval)
+	*newval = m_value;
+
+  return true;
+}
+
+void wxGridGDLCellTextEditor::ApplyEdit(int row, int col, wxGrid* grid) {
+  grid->GetTable()->SetValue(row, col, m_value);
+  m_value.clear();
+}
+
+void wxGridGDLCellTextEditor::Reset() {
+  wxASSERT_MSG(m_control, "wxGridCellTextAndButtonEditor must be created first!");
+
+  DoReset(m_value);
+}
+
+void wxGridGDLCellTextEditor::DoReset(const wxString& startValue) {
+  m_text->SetValue(startValue);
+  m_text->SetInsertionPointEnd();
+}
+
+//bool wxGridGDLCellTextEditor::IsAcceptedKey(wxKeyEvent& event) {
+//  switch (event.GetKeyCode()) {
+//  case WXK_DELETE:
+//  case WXK_BACK:
+//	return true;
+//
+//  default:
+//	return wxGridCellEditor::IsAcceptedKey(event);
+//  }
+//}
+
+//void wxGridGDLCellTextEditor::StartingKey(wxKeyEvent& event) {
+//  // Since this is now happening in the EVT_CHAR event EmulateKeyPress is no
+//  // longer an appropriate way to get the character into the text control.
+//  // Do it ourselves instead.  We know that if we get this far that we have
+//  // a valid character, so not a whole lot of testing needs to be done.
+//
+//  int ch;
+//
+//  bool isPrintable;
+//
+//#if wxUSE_UNICODE
+//  ch = event.GetUnicodeKey();
+//  if (ch != WXK_NONE)
+//	isPrintable = true;
+//  else
+//#endif // wxUSE_UNICODE
+//  {
+//	ch = event.GetKeyCode();
+//	isPrintable = ch >= WXK_SPACE && ch < WXK_START;
+//  }
+//
+//  switch (ch) {
+//  case WXK_DELETE:
+//	// Delete the initial character when starting to edit with DELETE.
+//	m_text->Remove(0, 1);
+//	break;
+//
+//  case WXK_BACK:
+//	// Delete the last character when starting to edit with BACKSPACE.
+//  {
+//	const long pos = m_text->GetLastPosition();
+//	m_text->Remove(pos - 1, pos);
+//  }
+//	break;
+//
+//  default:
+//	if (isPrintable)
+//	  m_text->WriteText(static_cast<wxChar> (ch));
+//	break;
+//  }
+//}
+
+//void wxGridGDLCellTextEditor::HandleReturn(wxKeyEvent& event) {
+//#if defined(__WXMOTIF__) || defined(__WXGTK__)
+//  // wxMotif needs a little extra help...
+//  size_t pos = (size_t) (Text()->GetInsertionPoint());
+//  wxString s(Text()->GetValue());
+//  s = s.Left(pos) + wxT("\n") + s.Mid(pos);
+//  Text()->SetValue(s);
+//  Text()->SetInsertionPoint(pos);
+//#else
+//  // the other ports can handle a Return key press
+//  //
+//  event.Skip();
+//#endif
+//}
+
+void wxGridGDLCellTextEditor::SetParameters(const wxString& params) {
+  if (!params) {
+	// reset to default
+	m_maxChars = 0;
+  } else {
+	long tmp;
+	if (params.ToLong(&tmp)) {
+	  m_maxChars = (size_t) tmp;
+	} else {
+	  wxLogDebug(wxT("Invalid wxGridCellTextAndButtonEditor parameter string '%s' ignored"), params.c_str());
+	}
+  }
+}
+
+#if wxUSE_VALIDATORS
+
+void wxGridGDLCellTextEditor::SetValidator(const wxValidator& validator) {
+  m_validator.reset(static_cast<wxValidator*> (validator.Clone()));
+}
+#endif
+
+wxGridCellEditor *wxGridGDLCellTextEditor::Clone() const {
+  wxGridGDLCellTextEditor* editor = new wxGridGDLCellTextEditor(m_maxChars);
+#if wxUSE_VALIDATORS
+  if (m_validator) {
+	editor->SetValidator(*m_validator);
+  }
+#endif
+  return editor;
+}
+
+// return the value in the text control
+
+wxString wxGridGDLCellTextEditor::GetValue() const {
+  return m_text->GetValue();
+}
+
+
 const WidgetIDT GDLWidget::NullID = 0;
 
 // instantiation
@@ -2666,8 +3012,11 @@ if (wSize.x<=0) wSize.x=numCols; else grid_ncols=wSize.x;
   theWxContainer = theWxWidget = grid;
 // important: use adapted font for further sizes & shapes. Define font for labels AND  cells.
   this->setFont();
+// editor & renderer:
+  grid->SetDefaultEditor(new wxGridGDLCellTextEditor(10));
+//	grid->SetDefaultRenderer(new wxGridGDLCellStringRenderer);
 //Alignment
-bool hasAlignment=(table_alignment!=NULL);
+	bool hasAlignment=(table_alignment!=NULL);
 if (hasAlignment) {
   if (table_alignment->N_Elements()==1) { //singleton case
     switch( (*table_alignment)[0] ){
@@ -2834,6 +3183,7 @@ grid->SelectBlock(0,0,0,0,FALSE); //hyperimportant
       this->AddToDesiredEvents( wxEVT_GRID_RANGE_SELECT,wxGridRangeSelectEventHandler(wxGridGDL::OnTableRangeSelection),grid);
       this->AddToDesiredEvents( wxEVT_GRID_SELECT_CELL,wxGridEventHandler(wxGridGDL::OnTableCellSelection),grid);
       this->AddToDesiredEvents( wxEVT_GRID_CELL_CHANGING,wxGridEventHandler(wxGridGDL::OnTextChanging),grid);
+      this->AddToDesiredEvents( wxEVT_GRID_CELL_CHANGED,wxGridEventHandler(wxGridGDL::OnTextChanged),grid);
 // UpdateGui();
  REALIZE_IF_NEEDED
 }
@@ -2905,12 +3255,9 @@ DStringGDL* CallStringFunction(BaseGDL* val, BaseGDL* format) {
   return s;
 }
 
-DStringGDL* ConvertValueToStringArray(BaseGDL* &value, DStringGDL* format, int majority) {
+DStringGDL* ConvertValueToStringArray(BaseGDL* &value, DStringGDL* format, const int majority) {
   DStringGDL* valueAsStrings;
-  if (value->Type() == GDL_STRING) {
-	valueAsStrings = static_cast<DStringGDL*> (value->Dup());
-  } else if (value->Type() == GDL_STRUCT) {
-	if (majority == GDLWidgetTable::NONE_MAJOR) majority = GDLWidgetTable::ROW_MAJOR;
+  if (value->Type() == GDL_STRUCT) {
 	//convert to STRING
 	DStructGDL *input = static_cast<DStructGDL*> (value);
 	SizeT nTags = input->NTags();
@@ -3035,8 +3382,8 @@ BaseGDL* GetNewTypedBaseGDLColRemoved(BaseGDL* var, std::vector<int> &list) {
 	RemoveGDLCols<DULongGDL>(res, var, list);
 	break;
   case GDL_LONG64:
-	res = new DULongGDL(dim, BaseGDL::NOZERO);
-	RemoveGDLCols<DULongGDL>(res, var, list);
+	res = new DLong64GDL(dim, BaseGDL::NOZERO);
+	RemoveGDLCols<DLong64GDL>(res, var, list);
 	break;
   case GDL_ULONG64:
 	res = new DULong64GDL(dim, BaseGDL::NOZERO);
@@ -3097,8 +3444,8 @@ BaseGDL* GetNewTypedBaseGDLColAdded(BaseGDL* var, int iCol, int n_add, bool befo
 	AddGDLCols<DULongGDL>(res, var,  iCol, n_add, before);
 	break;
   case GDL_LONG64:
-	res = new DULongGDL(dim, BaseGDL::ZERO);
-	AddGDLCols<DULongGDL>(res, var,  iCol, n_add, before);
+	res = new DLong64GDL(dim, BaseGDL::ZERO);
+	AddGDLCols<DLong64GDL>(res, var,  iCol, n_add, before);
 	break;
   case GDL_ULONG64:
 	res = new DULong64GDL(dim, BaseGDL::ZERO);
@@ -3159,8 +3506,8 @@ BaseGDL* GetNewTypedBaseGDLRowRemoved(BaseGDL* var, std::vector<int> &list) {
     RemoveGDLRows<DULongGDL>( res, var, list);
 	break;
   case GDL_LONG64:
-	res = new DULongGDL(dim, BaseGDL::NOZERO);
-    RemoveGDLRows<DULongGDL>( res, var, list);
+	res = new DLong64GDL(dim, BaseGDL::NOZERO);
+    RemoveGDLRows<DLong64GDL>( res, var, list);
 	break;
   case GDL_ULONG64:
 	res = new DULong64GDL(dim, BaseGDL::NOZERO);
@@ -3221,8 +3568,8 @@ BaseGDL* GetNewTypedBaseGDLRowAdded(BaseGDL* var, int iRow, int n_add, bool befo
 	AddGDLRows<DULongGDL>(res, var, iRow, n_add, before);
 	break;
   case GDL_LONG64:
-	res = new DULongGDL(dim, BaseGDL::ZERO);
-	AddGDLRows<DULongGDL>(res, var, iRow, n_add, before);
+	res = new DLong64GDL(dim, BaseGDL::ZERO);
+	AddGDLRows<DLong64GDL>(res, var, iRow, n_add, before);
 	break;
   case GDL_ULONG64:
 	res = new DULong64GDL(dim, BaseGDL::ZERO);
@@ -3257,8 +3604,8 @@ bool GDLWidgetTable::GetValidTableSelection(DLongGDL* &selection) {
 	  if (selection->Rank() != 1 || selection->Dim(0) != 4) ThrowGDLException("USE_TABLE_SELECT (continuous mode) Array must have dimensions of (4) ");
 	}
   }
-  int ncolsmax = valueAsStrings->Dim(0) - 1;
-  int nrowsmax = valueAsStrings->Dim(1) - 1;
+  int ncolsmax = vValue->Dim(0) - 1;
+  int nrowsmax = vValue->Dim(1) - 1;
   if (disjointSelection) { //pairs lists
 	for (auto j=0; j<selection->Dim(1); ++j) {
 	  DLong col = (*selection)[j*2+0];
@@ -3291,8 +3638,8 @@ DLongGDL* GDLWidgetTable::GetSelection( bool dothrow) {
   SizeT k = 0;
   DLongGDL * sel;
   Guard<BaseGDL> guard;
-  int ncolsmax = valueAsStrings->Dim(0) - 1;
-  int nrowsmax = valueAsStrings->Dim(1) - 1;
+  int ncolsmax = vValue->Dim(0) - 1;
+  int nrowsmax = vValue->Dim(1) - 1;
   if ( disjointSelection ) { //pairs lists
 	std::vector<wxPoint> list = grid->GetSelectedDisjointCellsList();
 	if (list.size() < 1) {
@@ -3907,14 +4254,14 @@ void GDLWidgetTable::DeleteColumns(DLongGDL* selection) {
   assert(grid != NULL);
   std::vector<int> list= GetSortedSelectedRowsOrColsList(selection, true);
   //check "memory" selection is good:
-  int ncolsmax = valueAsStrings->Dim(0) - 1;
+  int ncolsmax = vValue->Dim(0) - 1;
   for (int it = list.size() - 1; it > -1; --it) if (list[it] < 0 || list[it] > ncolsmax) ThrowGDLException("USE_TABLE_SELECT value out of range.");
   // if possible, unset background of end rows:
   int count=list.size();
   int grid_ncols = grid->GetNumberCols();
-  int data_ncols = valueAsStrings->Dim(0) - count;
+  int data_ncols = vValue->Dim(0) - count;
   int ncols = MIN( data_ncols , grid_ncols);
-  int data_nrows = valueAsStrings->Dim(1);
+  int data_nrows = vValue->Dim(1);
   for (SizeT j = 0; j < data_nrows; ++j) for (SizeT i = data_ncols; i < grid_ncols; ++i) grid->SetCellBackgroundColour(j, i, *wxLIGHT_GREY);
   //OK, resize vValue:
   BaseGDL* newVal=GetNewTypedBaseGDLColRemoved(vValue,list);
@@ -3929,13 +4276,13 @@ void GDLWidgetTable::DeleteRows(DLongGDL* selection) {
   assert(grid != NULL);
   std::vector<int> list= GetSortedSelectedRowsOrColsList(selection, false);
   //check "memory" selection is good:
-  int nrowsmax = valueAsStrings->Dim(1) - 1;
+  int nrowsmax = vValue->Dim(1) - 1;
   for (int it = list.size() - 1; it > -1; --it) if (list[it] < 0 || list[it] > nrowsmax) ThrowGDLException("USE_TABLE_SELECT value out of range.");
   // if possible, set grayed background of count end rows:
   int count=list.size();
   int grid_nrows = grid->GetNumberRows();
-  int data_ncols = valueAsStrings->Dim(0);
-  int data_nrows = valueAsStrings->Dim(1)-count;
+  int data_ncols = vValue->Dim(0);
+  int data_nrows = vValue->Dim(1)-count;
   int nrows=MIN(data_nrows,grid_nrows);
   for (SizeT j = data_nrows; j < grid_nrows; ++j) for (SizeT i = 0; i < data_ncols; ++i) grid->SetCellBackgroundColour(j, i, *wxLIGHT_GREY);
   //OK, resize vValue:
@@ -3951,15 +4298,15 @@ bool GDLWidgetTable::InsertColumns(DLong count, bool insertAtEnd, DLongGDL* sele
   assert(grid != NULL);
   std::vector<int> list= GetSortedSelectedRowsOrColsList(selection, true);
   //check "memory" selection is good:
-  int ncolsmax = valueAsStrings->Dim(0) - 1;
+  int ncolsmax = vValue->Dim(0) - 1;
   for (int it = list.size() - 1; it > -1; --it) if (list[it] < 0 || list[it] > ncolsmax) ThrowGDLException("USE_TABLE_SELECT value out of range.");
   int iCol=list[0];
   if (insertAtEnd) iCol=vValue->Dim(0)-1; 
   // if possible, unset background of count end rows:
   int grid_ncols=grid->GetNumberCols();
-  int data_ncols=valueAsStrings->Dim(0);
+  int data_ncols=vValue->Dim(0);
   int ncols=MIN(data_ncols+count,grid_ncols);
-  int data_nrows=valueAsStrings->Dim(1);
+  int data_nrows=vValue->Dim(1);
   for (SizeT j = 0; j < data_nrows; ++j) for (SizeT i = data_ncols; i < ncols ; ++i) grid->SetCellBackgroundColour(j, i, *wxWHITE);
   //OK, resize vValue:
   BaseGDL* newVal=GetNewTypedBaseGDLColAdded(vValue,iCol,count,!insertAtEnd);
@@ -3975,14 +4322,14 @@ bool GDLWidgetTable::InsertRows(DLong count, bool insertAtEnd, DLongGDL* selecti
   assert(grid != NULL);
   std::vector<int> list= GetSortedSelectedRowsOrColsList(selection, true);
   //check "memory" selection is good:
-  int nrowsmax = valueAsStrings->Dim(1) - 1;
+  int nrowsmax = vValue->Dim(1) - 1;
   for (int it = list.size() - 1; it > -1; --it) if (list[it] < 0 || list[it] > nrowsmax) ThrowGDLException("USE_TABLE_SELECT value out of range.");
   int iRow=list[0];
   if (insertAtEnd) iRow=vValue->Dim(1)-1;
   // if possible, unset background of count end rows:
   int grid_nrows = grid->GetNumberRows();
-  int data_ncols = valueAsStrings->Dim(0);
-  int data_nrows = valueAsStrings->Dim(1);
+  int data_ncols = vValue->Dim(0);
+  int data_nrows = vValue->Dim(1);
   int nrows=MIN(data_nrows+count,grid_nrows);
   for (SizeT j = data_nrows; j < nrows; ++j) for (SizeT i = 0; i < data_ncols; ++i) grid->SetCellBackgroundColour(j, i, *wxWHITE);
   //OK, resize vValue:
@@ -4001,19 +4348,16 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
   
   grid->BeginBatch();
   
-  if ( selection==NULL ){ //reset table to everything. val replaces valueAsStrings.
+  if ( selection==NULL ){ //reset table to everything. val replaces newValueAsStrings.
 	// replace all vValue
 	SetValue(value);
-	//replace all valueAsStrings
-	GDLDelete(valueAsStrings);
-    valueAsStrings=newValueAsStrings->Dup();
     SizeT numRows,numCols;
-    if (valueAsStrings->Rank()==1) {
+    if (newValueAsStrings->Rank()==1) {
       numRows=1;
-      numCols=valueAsStrings->Dim(0); //lines
+      numCols=newValueAsStrings->Dim(0); //lines
     } else {
-      numRows=valueAsStrings->Dim(1);
-      numCols=valueAsStrings->Dim(0);
+      numRows=newValueAsStrings->Dim(1);
+      numCols=newValueAsStrings->Dim(0);
     }
     grid->ClearGrid();
     int curr_rows=grid->GetNumberRows();
@@ -4025,7 +4369,7 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
 	{
 	  SizeT k = 0;
 	  for (SizeT i = 0; i < numRows; ++i) for (SizeT j = 0; j < numCols; ++j) {
-		  grid->SetCellValue(i, j, wxString(((*valueAsStrings)[k]).c_str(), wxConvUTF8));
+		  grid->SetCellValue(i, j, wxString(((*newValueAsStrings)[k]).c_str(), wxConvUTF8));
 		  ++k;
 		}
 	}
@@ -4042,8 +4386,6 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
         for (std::vector<wxPoint>::iterator it = list.begin(); it !=list.end(); ++it) {
 		  //update vValue
 //		  (*vValue)[it->y*vVal_Ncols+it->x]=(*value)[k];
-		  //update ValueAsStrings
-		  (*valueAsStrings)[(*it).y*vVal_Ncols+(*it).x]=(*newValueAsStrings)[k];
 		  //Show in widget
           grid->SetCellValue( (*it).x, (*it).y ,wxString(((*newValueAsStrings)[k]).c_str(), wxConvUTF8 ) );
 		  k++; //next one
@@ -4055,8 +4397,6 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
           int row = (*selection)[l++];
 		  //update vValue
 //		  (*vValue)[row*vVal_Ncols +col]=(*value)[k];
-		  //update ValueAsStrings
-		  (*valueAsStrings)[row*vVal_Ncols +col]=(*newValueAsStrings)[k];
 		  //Show in widget
           grid->SetCellValue( row, col ,wxString(((*newValueAsStrings)[k]).c_str(), wxConvUTF8 ) );
 		  k++; //next one
@@ -4090,8 +4430,6 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
 	  {
 		  //update vValue
 //		  (*vValue)[j * vVal_Ncols + i] = (*value)[jVal*numRows+iVal]
-		  //update ValueAsStrings
-		  (*valueAsStrings)[j * vVal_Ncols + i] = (*newValueAsStrings)[jVal*numRows+iVal];
 		  //Show in widget
         if (iVal < numRows && jVal < numCols ) grid->SetCellValue( i, j ,wxString(((*newValueAsStrings)[jVal*numRows+iVal]).c_str(), wxConvUTF8 ) ); 
       }
@@ -4099,226 +4437,256 @@ void GDLWidgetTable::SetTableValues(BaseGDL* value, DStringGDL* newValueAsString
   }
   grid->EndBatch( );
 }
-BaseGDL* GDLWidgetTable::GetTableValuesAsStruct(DLongGDL* selection)
-{
-  wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
-  assert( grid != NULL);
-  BaseGDL* res;
-  int numRows=valueAsStrings->Dim(0);
-  int numCols=valueAsStrings->Dim(1);
-  DStringGDL* stringres=this->GetTableValues(selection);
-  if (stringres==NULL) return NULL; //pass error back.
 
-  if ( selection==NULL ){ //just convert
-    res=vValue->Dup();
-    stringstream is;
-//    if (majority == GDLWidgetTable::ROW_MAJOR ) {
-//      BaseGDL* tmp=static_cast<BaseGDL*>(stringres)->Transpose(NULL);
-//      GDLDelete(stringres);
-//      stringres=static_cast<DStringGDL*>(tmp);
-//      for( SizeT i = 0; i < stringres->N_Elements(); i++)  is << (*stringres)[ i] << '\n';
-//    } else {
-      for( SizeT i = 0; i < stringres->N_Elements(); i++)  is << (*stringres)[ i] << '\n';
-//    }
-    res->FromStream( is);
-  } 
-  else { //use the wxWidget selection or the passed selection, mode-dependent:
-    if (disjointSelection) { //pairs lists
-      std::vector<wxPoint> list;
-      if (selection->Rank()==0) { //use current wxWidgets selection. Result is a STRUCT
-        list=grid->GetSelectedDisjointCellsList();
-      } else {                   //make equivalent vector.
-        for (SizeT k=0,n=0,l=0; n<selection->Dim(1); ++n) {
-          int col = (*selection)[l++];
-          int row = (*selection)[l++];
-          list.push_back(wxPoint(row,col));
-        }
-      }
-      SizeT k=0;
-      DStructGDL*  typecodes = new DStructGDL( "GDL_TYPECODES_AS_STRUCT"); 
-      // creating the output anonymous structure
-      DStructDesc* res_desc = new DStructDesc("$truct");
-      for ( std::vector<wxPoint>::iterator it = list.begin(); it !=list.end(); ++it, ++k) {
-        //get tag values:
-        BaseGDL* tested;
-        if (majority == GDLWidgetTable::ROW_MAJOR )
-          tested=static_cast<DStructGDL*>(vValue)->GetTag((*it).y); //table columns are tags
-        else
-          tested=static_cast<DStructGDL*>(vValue)->GetTag((*it).x); //table rows are tags
-        stringstream os;
-        os << std::setfill ('_') << std::setw (12) << k ; //as IDL does
-        std::string tagName;
-        os >> tagName; 
-        res_desc->AddTag(tagName, typecodes->GetTag(tested->Type()));
-      }
-      stringstream is;
-      for( SizeT i = 0; i < stringres->N_Elements(); i++)  is << (*stringres)[ i] << '\n';
-      res = new DStructGDL(res_desc, dimension());
-      res->FromStream( is);
-    } else { //IDL maintains the 2D-structure of val!
-      int colTL,colBR,rowTL,rowBR;
-      if (selection->Rank()==0) { 
-        wxArrayInt block=grid->GetSelectedBlockOfCells();
-        //normally only ONE block is available.
-        colTL = block[0];
-        rowTL = block[1];
-        colBR = block[2];
-        rowBR = block[3];
-      } else {
-        colTL = (*selection)[0];
-        rowTL = (*selection)[1];
-        colBR = (*selection)[2];
-        rowBR = (*selection)[3];
-      }
-      //complication: if only one row (col) is selected, result is an array of <type>.
-      //else result is a structure with correct tag names. Very clever!
-      if ((majority == GDLWidgetTable::ROW_MAJOR && colTL==colBR)||(majority == GDLWidgetTable::COLUMN_MAJOR && rowTL==rowBR)) {
-        DType what=GDL_BYTE;
-        SizeT size;
-        if (majority == GDLWidgetTable::ROW_MAJOR && colTL==colBR) {
-          what=static_cast<DStructGDL*>(vValue)->GetTag(colTL)->Type();
-          size=rowBR-rowTL+1;
-        } else if (rowTL==rowBR) {
-          what=static_cast<DStructGDL*>(vValue)->GetTag(rowTL)->Type();
-          size=colBR-colTL+1;
-        } 
-        switch(what) {
-          case GDL_STRING:
-            res=new DStringGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_BYTE:
-            res=new DByteGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_INT: 
-            res=new DIntGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_LONG:
-            res=new DLongGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_FLOAT:
-            res=new DFloatGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_DOUBLE:
-            res=new DDoubleGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_COMPLEX:
-            res=new DComplexGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_COMPLEXDBL:
-            res=new DComplexDblGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_UINT:
-            res=new DUIntGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_ULONG:
-            res=new DULongGDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_LONG64:
-            res=new DLong64GDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          case GDL_ULONG64:
-            res=new DULong64GDL(dimension(size),BaseGDL::NOZERO);
-            break;
-          default:
-            cerr<<"Unhandled Table Type, please report!"<<endl;
-            return NULL; //signal error
-        }
-      } else { //create dedicated struct
-        DStructGDL*  typecodes = new DStructGDL( "GDL_TYPECODES_AS_STRUCT"); 
-        // creating the output anonymous structure
-        DStructDesc* res_desc = new DStructDesc("$truct");
-        SizeT size;
-        if (majority == GDLWidgetTable::ROW_MAJOR) { //data is in rows of structures. Columns are tags
-          size=rowBR-rowTL+1;
-          for (SizeT j=colTL; j<=colBR; ++j) {
-          //get tag values:
-            BaseGDL* tested;
-            std::string tagName;
-            tested=static_cast<DStructGDL*>(vValue)->GetTag(j);
-            tagName=static_cast<DStructGDL*>(vValue)->Desc()->TagName(j); //preserve tag names
-            res_desc->AddTag(tagName, typecodes->GetTag(tested->Type()));
-          }          
-        } else {
-          size=colBR-colTL+1;
-          for (SizeT i=rowTL; i<=rowBR; ++i) { 
-          //get tag values:
-            BaseGDL* tested;
-            std::string tagName;
-            tested=static_cast<DStructGDL*>(vValue)->GetTag(i);
-            tagName=static_cast<DStructGDL*>(vValue)->Desc()->TagName(i); //preserve tag names
-            res_desc->AddTag(tagName, typecodes->GetTag(tested->Type()));
-          }
-        }
-        //create res with correct dim:
-        res = new DStructGDL(res_desc, dimension(size));
-      }
-      //populate res:
-      stringstream is;
-      for( SizeT i = 0; i < stringres->N_Elements(); i++)  is << (*stringres)[ i] << '\n';
-      res->FromStream( is);        
-    }
+template <typename T1, typename T2>
+void GDLWidgetTable::PopulateWithDisjointSelection(T1* res, DLongGDL* selection) {
+  int data_numberCols = vValue->Dim(0);
+  int data_numberRows = vValue->Dim(1);
+  for (SizeT k = 0, n = 0, l = 0; n < selection->Dim(1); ++n) {
+	int col = (*selection)[l++];
+	int row = (*selection)[l++];
+	if (row >= data_numberRows || col >= data_numberCols) continue;
+	(*res)[k++] = static_cast<T2*> (vValue->DataAddr())[col + row * data_numberCols];
   }
-  return res;
 }
 
-DStringGDL* GDLWidgetTable::GetTableValues(DLongGDL* selection)
-{
-  wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
-  assert( grid != NULL);
-  if ( selection==NULL ) return valueAsStrings;
-  
-  DStringGDL * stringres;
-  int data_numberCols=valueAsStrings->Dim(0);
-  int data_numberRows=valueAsStrings->Dim(1);
-  int grid_ncols=grid->GetNumberCols();
-  int grid_nrows=grid->GetNumberRows();
-  //use the wxWidget selection or the passed selection, mode-dependent:
-  if (disjointSelection) { //pairs lists
-	if (selection->Rank()==0) { //use current wxWidgets selection
-	  std::vector<wxPoint> list=grid->GetSelectedDisjointCellsList();
-	  stringres=new DStringGDL(list.size(),BaseGDL::NOZERO); 
-	  SizeT k=0;
-	  for ( std::vector<wxPoint>::iterator it = list.begin(); it !=list.end(); ++it) {
-		if ((*it).x >= data_numberRows || (*it).y >= data_numberCols) return static_cast<DStringGDL*>(NULL); 
-		(*stringres)[k++]=grid->GetCellValue( (*it).x, (*it).y ).mb_str(wxConvUTF8);
-	  }
-	} else {
-	  stringres=new DStringGDL(selection->Dim(1),BaseGDL::NOZERO);
-	  for (SizeT k=0,n=0,l=0; n<selection->Dim(1); ++n) {
-		int col = (*selection)[l++];
-		int row = (*selection)[l++];
-		if ( row >= data_numberRows || col >= data_numberCols) return static_cast<DStringGDL*>(NULL); 
-		(*stringres)[k++]=grid->GetCellValue( row, col).mb_str(wxConvUTF8);
-	  }
-	}
-  } else { //IDL maintains the 2D-structure of val!
-	int colTL,colBR,rowTL,rowBR;
-	if (selection->Rank()==0) { 
-	  wxArrayInt block=grid->GetSelectedBlockOfCells();
-	  //normally only ONE block is available.
-	  colTL = block[0]; if ( colTL < 0 || colTL > data_numberCols-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  rowTL = block[1]; if ( rowTL < 0 || rowTL > data_numberRows-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  colBR = block[2]; if ( colBR < 0 || colBR > data_numberCols-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  rowBR = block[3]; if ( rowBR < 0 || rowBR > data_numberRows-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	} else {
-	  colTL = (*selection)[0]; if ( colTL < 0 || colTL > data_numberCols-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  rowTL = (*selection)[1]; if ( rowTL < 0 || rowTL > data_numberRows-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  colBR = (*selection)[2]; if ( colBR < 0 || colBR > data_numberCols-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	  rowBR = (*selection)[3]; if ( rowBR < 0 || rowBR > data_numberRows-1 ) ThrowGDLException("USE_TABLE_SELECT value out of range.");
-	}
-	SizeT dims[2];
-	dims[1]=(rowBR-rowTL+1);
-	dims[0]=(colBR-colTL+1);
-	dimension dim(dims,2);
-	stringres=new DStringGDL(dim,BaseGDL::NOZERO);
-	for (SizeT k=0,j=rowTL; j<=rowBR; ++j) for (SizeT i=colTL; i<=colBR; ++i) 
-	{
-	  (*stringres)[k++]=(*valueAsStrings)[j*data_numberCols+i];
-	}
+BaseGDL* GDLWidgetTable::GetDisjointSelectionValues(DLongGDL* selection) {
+  dimension dim(selection->Dim(1));
+  switch (vValue->Type()) {
+  case GDL_STRING:
+  {
+	DStringGDL* res = new DStringGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DStringGDL, DString>(res, selection);
+	return res;
+	break;
   }
-  //convention: if value is of type struct, string array will always be row_major. thus if we are column major, transpose return string array
-  if (vValue->Type()==GDL_STRUCT && majority==GDLWidgetTable::COLUMN_MAJOR) return static_cast<DStringGDL*>(stringres->Transpose(NULL))->Dup();  
-  else return stringres;
+  case GDL_BYTE:
+  {
+	DByteGDL* res = new DByteGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DByteGDL, DByte>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_INT:
+  {
+	DIntGDL* res = new DIntGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DIntGDL, DInt>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_LONG:
+  {
+	DLongGDL* res = new DLongGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DLongGDL, DLong>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_FLOAT:
+  {
+	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DFloatGDL, DFloat>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_DOUBLE:
+  {
+	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DDoubleGDL, DDouble>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_COMPLEX:
+  {
+	DComplexGDL* res = new DComplexGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DComplexGDL, DComplex>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_COMPLEXDBL:
+  {
+	DComplexDblGDL* res = new DComplexDblGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DComplexDblGDL, DComplexDbl>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_UINT:
+  {
+	DUIntGDL* res = new DUIntGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DUIntGDL, DUInt>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_ULONG:
+  {
+	DULongGDL* res = new DULongGDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DULongGDL, DULong>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_LONG64:
+  {
+	DLong64GDL* res = new DLong64GDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DLong64GDL, DLong64>(res, selection);
+	return res;
+	break;
+  }
+  case GDL_ULONG64:
+  {
+	DULong64GDL* res = new DULong64GDL(dim, BaseGDL::NOZERO);
+	PopulateWithDisjointSelection<DULong64GDL, DULong64>(res, selection);
+	return res;
+	break;
+  }
+  default:
+	cerr << "Unhandled Table Type, please report!" << endl;
+	return NULL; //signal error
+  }
+  return NULL;
+}
+
+template <typename T1, typename T2>
+void GDLWidgetTable::PopulateWithSelection(T1* res, int colTL, int colBR, int rowTL, int rowBR) {
+  int data_numberCols = vValue->Dim(0);
+  for (SizeT k = 0, j = rowTL; j <= rowBR; ++j) for (SizeT i = colTL; i <= colBR; ++i) {
+	(*res)[k++] = static_cast<T2*> (vValue->DataAddr())[j * data_numberCols + i];
+	}
+}
+
+BaseGDL* GDLWidgetTable::GetSelectionValues(int colTL, int colBR, int rowTL, int rowBR) {
+	SizeT dims[2];
+	dims[1] = (rowBR - rowTL + 1);
+	dims[0] = (colBR - colTL + 1);
+	dimension dim(dims, 2);
+  switch (vValue->Type()) {
+  case GDL_STRING:
+  {
+	DStringGDL* res = new DStringGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DStringGDL, DString>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_BYTE:
+  {
+	DByteGDL* res = new DByteGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DByteGDL, DByte>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_INT:
+  {
+	DIntGDL* res = new DIntGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DIntGDL, DInt>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_LONG:
+  {
+	DLongGDL* res = new DLongGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DLongGDL, DLong>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_FLOAT:
+  {
+	DFloatGDL* res = new DFloatGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DFloatGDL, DFloat>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_DOUBLE:
+  {
+	DDoubleGDL* res = new DDoubleGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DDoubleGDL, DDouble>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_COMPLEX:
+  {
+	DComplexGDL* res = new DComplexGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DComplexGDL, DComplex>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_COMPLEXDBL:
+  {
+	DComplexDblGDL* res = new DComplexDblGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DComplexDblGDL, DComplexDbl>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_UINT:
+  {
+	DUIntGDL* res = new DUIntGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DUIntGDL, DUInt>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_ULONG:
+  {
+	DULongGDL* res = new DULongGDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DULongGDL, DULong>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_LONG64:
+  {
+	DLong64GDL* res = new DLong64GDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DLong64GDL, DLong64>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  case GDL_ULONG64:
+  {
+	DULong64GDL* res = new DULong64GDL(dim, BaseGDL::NOZERO);
+	PopulateWithSelection<DULong64GDL, DULong64>(res, colTL, colBR, rowTL, rowBR);
+	return res;
+	break;
+  }
+  default:
+	cerr << "Unhandled Table Type, please report!" << endl;
+	return NULL; //signal error
+  }
+  return NULL;
+}
+BaseGDL* GDLWidgetTable::GetTableValues(DLongGDL* selection) {
+  wxGridGDL * grid = dynamic_cast<wxGridGDL*> (theWxWidget);
+  assert(grid != NULL);
+  if (selection == NULL) return vValue->Dup();
+
+  BaseGDL * res;
+  int data_numberCols = vValue->Dim(0);
+  int data_numberRows = vValue->Dim(1);
+  int grid_ncols = grid->GetNumberCols();
+  int grid_nrows = grid->GetNumberRows();
+  //use the wxWidget selection or the passed selection, mode-dependent:
+  if (disjointSelection) { 
+	return GetDisjointSelectionValues(selection);
+  } else { //IDL maintains the 2D-structure of val!
+	int colTL, colBR, rowTL, rowBR;
+	if (selection->Rank() == 0) {
+	  wxArrayInt block = grid->GetSelectedBlockOfCells();
+	  //normally only ONE block is available.
+	  colTL = block[0];
+	  if (colTL < 0 || colTL > data_numberCols - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  rowTL = block[1];
+	  if (rowTL < 0 || rowTL > data_numberRows - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  colBR = block[2];
+	  if (colBR < 0 || colBR > data_numberCols - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  rowBR = block[3];
+	  if (rowBR < 0 || rowBR > data_numberRows - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	} else {
+	  colTL = (*selection)[0];
+	  if (colTL < 0 || colTL > data_numberCols - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  rowTL = (*selection)[1];
+	  if (rowTL < 0 || rowTL > data_numberRows - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  colBR = (*selection)[2];
+	  if (colBR < 0 || colBR > data_numberCols - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	  rowBR = (*selection)[3];
+	  if (rowBR < 0 || rowBR > data_numberRows - 1) ThrowGDLException("USE_TABLE_SELECT value out of range.");
+	}
+	return GetSelectionValues(colTL, colBR, rowTL, rowBR);
+  }
+  return NULL;
 }
 
 void GDLWidgetTable::SetSelection(DLongGDL* selection)
@@ -4366,8 +4734,8 @@ void GDLWidgetTable::SetTableNumberOfColumns( DLong ncols){
   assert( grid != NULL);
   grid->BeginBatch( );
   int old_ncols=grid->GetNumberCols();
-  int numRows=valueAsStrings->Dim(0);
-  int numCols=valueAsStrings->Dim(1);
+  int numRows=vValue->Dim(0);
+  int numCols=vValue->Dim(1);
   if (ncols > old_ncols) {
     grid->AppendCols(ncols-old_ncols);
     if (numCols > old_ncols) {
@@ -4390,8 +4758,8 @@ void GDLWidgetTable::SetTableNumberOfRows( DLong nrows){
   assert( grid != NULL);
   grid->BeginBatch( );
   SizeT old_nrows=grid->GetNumberRows();
-  int numRows=valueAsStrings->Dim(0);
-  int numCols=valueAsStrings->Dim(1);
+  int numRows=vValue->Dim(0);
+  int numCols=vValue->Dim(1);
   if (nrows > old_nrows) {
     grid->AppendRows(nrows-old_nrows);
     if (numRows > old_nrows) {

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -4795,6 +4795,7 @@ void GDLWidgetTable::SetTableXsizeAsNumberOfColumns( DLong ncols){
 	DStringGDL* format = GetCurrentFormat();
 	DStringGDL* newValueAsStrings = ConvertValueToStringArray(vValue, format, majority);
     grid->AppendCols(ncols-old_ncols);
+	for (SizeT i = old_ncols; i < ncols; ++i) grid->SetColLabelValue(i, wxString(i2s(i)));
     if (numCols > old_ncols) {
       int colTL,colBR,rowTL,rowBR;
       colTL=old_ncols-1;

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -1621,7 +1621,6 @@ class GDLWidgetTable: public GDLWidget
 //  DLong tabMode;
   DLong x_scroll_size_columns;
   DLong y_scroll_size_rows;
-  DStringGDL * valueAsStrings;
   bool         updating; //widget is modified by program (avoid sending events)
 
 public:
@@ -1651,9 +1650,9 @@ public:
 		  BaseGDL* value_,
 		  DLong xScrollSize_,
 		  DLong yScrollSize_,
-                  DStringGDL* valueAsStrings_,
-                  DULong eventFlags_
-         );
+      DStringGDL* valueAsStrings,
+      DULong eventFlags_
+  );
 
 ~GDLWidgetTable();
   std::vector<int> GetSortedSelectedRowsOrColsList(DLongGDL* selection, bool doCol);
@@ -1741,8 +1740,8 @@ public:
   
   void SetTableView(DLongGDL* pos);
   void MakeCellEditable(DLongGDL* pos);
-  void SetTableNumberOfColumns( DLong ncols);
-  void SetTableNumberOfRows( DLong nrows);
+  void SetTableXsizeAsNumberOfColumns( DLong ncols);
+  void SetTableYsizeAsNumberOfRows( DLong nrows);
   
   bool IsSomethingSelected();
   bool GetValidTableSelection(DLongGDL* &selection);

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -1718,238 +1718,88 @@ void wxGridGDL::OnTableColResizing(wxGridSizeEvent & event){
     GDLWidget::PushEvent( baseWidgetID, widgtablerowheight );
   } else event.Skip();
 }
-void  wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event){
+
+void wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event) {
 #if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_OTHER_EVENTS)
-  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTableRangeSelection: %d\n"),event.GetId());
+  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTableRangeSelection: %d\n"), event.GetId());
 #endif
   //this event is called when a selection is added or changed (control-click, etc).
   //If we are not in disjoint mode, clear previous selection to mimick idl's when the user control-clicked.
-  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(GDLWidgetTableID));
-
-  DULong eventFlags=table->GetEventFlags();
-  if (eventFlags & GDLWidget::EV_ALL  && !table->IsUpdating() ) {
-    if (event.Selecting()) 
-    {
-      WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId( ) );
-      DStructGDL* widgtablecelsel = new DStructGDL( "WIDGET_TABLE_CELL_SEL");
-      widgtablecelsel->InitTag("ID",  DLongGDL( event.GetId( ) ));
-      widgtablecelsel->InitTag("TOP", DLongGDL( baseWidgetID));
-      widgtablecelsel->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-      widgtablecelsel->InitTag("TYPE",DIntGDL(4)); // 4 or 9
-      widgtablecelsel->InitTag("SEL_LEFT",  DLongGDL( event.GetLeftCol()));
-      widgtablecelsel->InitTag("SEL_TOP",  DLongGDL( event.GetTopRow()));
-      widgtablecelsel->InitTag("SEL_RIGHT",  DLongGDL( event.GetRightCol()));
-      widgtablecelsel->InitTag("SEL_BOTTOM",  DLongGDL( event.GetBottomRow()));
-      GDLWidget::PushEvent( baseWidgetID, widgtablecelsel );
-    } else {
-      int ncols = static_cast<wxGrid*>(event.GetEventObject())->GetNumberCols();
-      int nrows = static_cast<wxGrid*>(event.GetEventObject())->GetNumberRows();
-      if (event.GetLeftCol()==0 && event.GetRightCol()==ncols-1 && event.GetTopRow()==0 && event.GetBottomRow()==nrows-1 ) {
-        WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId( ) );
-        DStructGDL* widgtablecelsel = new DStructGDL( "WIDGET_TABLE_CELL_SEL");
-        widgtablecelsel->InitTag("ID",  DLongGDL( event.GetId( ) ));
-        widgtablecelsel->InitTag("TOP", DLongGDL( baseWidgetID ));
-        widgtablecelsel->InitTag("HANDLER", DLongGDL( baseWidgetID ) );
-        widgtablecelsel->InitTag("TYPE",DIntGDL( 4 )); // 
-        widgtablecelsel->InitTag("SEL_LEFT",  DLongGDL( -1 ));
-        widgtablecelsel->InitTag("SEL_TOP",  DLongGDL( -1 ));
-        widgtablecelsel->InitTag("SEL_RIGHT",  DLongGDL( -1 ));
-        widgtablecelsel->InitTag("SEL_BOTTOM",  DLongGDL( -1 ));
-        GDLWidget::PushEvent( baseWidgetID, widgtablecelsel );
-      } else {
-        if (!table->GetDisjointSelection()  && event.ControlDown() ) this->ClearSelection(); else {
-        WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId( ) );
-        DStructGDL* widgtablecelsel = new DStructGDL( "WIDGET_TABLE_CELL_DESEL");
-        widgtablecelsel->InitTag("ID",  DLongGDL( event.GetId( ) ));
-        widgtablecelsel->InitTag("TOP", DLongGDL( baseWidgetID ));
-        widgtablecelsel->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-        widgtablecelsel->InitTag("TYPE",DIntGDL( 9 )); // 9
-        widgtablecelsel->InitTag("SEL_LEFT",  DLongGDL( event.GetLeftCol() ));
-        widgtablecelsel->InitTag("SEL_TOP",  DLongGDL( event.GetTopRow() ));
-        widgtablecelsel->InitTag("SEL_RIGHT",  DLongGDL( event.GetRightCol() ));
-        widgtablecelsel->InitTag("SEL_BOTTOM",  DLongGDL( event.GetBottomRow()));
-        GDLWidget::PushEvent( baseWidgetID, widgtablecelsel );
-        }
-      }
-    }
-}
-  else event.Skip();
-}
-
- void  wxGridGDL::OnTableCellSelection(wxGridEvent & event){
-#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_OTHER_EVENTS)
-  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTableCellSelection: %d\n"),event.GetId());
-#endif
-//This event is called only when the user left-clicks somewhere, thus deleting all previous selection.
-  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(GDLWidgetTableID));
-  if (!table->GetDisjointSelection()  && event.ControlDown() ) {
-    table->ClearSelection();
+  GDLWidgetTable* table = static_cast<GDLWidgetTable*> (GDLWidget::GetWidget(GDLWidgetTableID));
+  if (table->IsUpdating()) return;
+  
+  DULong eventFlags = table->GetEventFlags();
+  WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase(event.GetId());
+//  std::cerr << table->GetDisjointSelection() << ":" << event.Selecting() << ":" << event.ControlDown() << ":" << event.AltDown() << ":" << event.CmdDown() << ":" << event.GetModifiers() << std::endl;
+  int lc = event.GetLeftCol();
+  int tr = event.GetTopRow();
+  int rc = event.GetRightCol();
+  int br = event.GetBottomRow();
+  
+  if (event.Selecting()) { 
+	if (eventFlags & GDLWidget::EV_ALL) {
+	  DStructGDL* widgtablecelsel2 = new DStructGDL("WIDGET_TABLE_CELL_SEL"); //sel 
+	  widgtablecelsel2->InitTag("ID", DLongGDL(event.GetId()));
+	  widgtablecelsel2->InitTag("TOP", DLongGDL(baseWidgetID));
+	  widgtablecelsel2->InitTag("HANDLER", DLongGDL(baseWidgetID));
+	  widgtablecelsel2->InitTag("TYPE", DIntGDL(4)); // 4 or 9
+	  widgtablecelsel2->InitTag("SEL_LEFT", DLongGDL(lc));
+	  widgtablecelsel2->InitTag("SEL_TOP", DLongGDL(tr));
+	  widgtablecelsel2->InitTag("SEL_RIGHT", DLongGDL(rc));
+	  widgtablecelsel2->InitTag("SEL_BOTTOM", DLongGDL(br));
+	  GDLWidget::PushEvent(baseWidgetID, widgtablecelsel2);
+	}
+  } else { //remove
+	if (table->GetDisjointSelection() && event.ControlDown()) {
+	  if (eventFlags & GDLWidget::EV_ALL) {
+		DStructGDL* widgtablecelsel = new DStructGDL("WIDGET_TABLE_CELL_DESEL");
+		widgtablecelsel->InitTag("ID", DLongGDL(event.GetId()));
+		widgtablecelsel->InitTag("TOP", DLongGDL(baseWidgetID));
+		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
+		widgtablecelsel->InitTag("TYPE", DIntGDL(9)); // 9
+		widgtablecelsel->InitTag("SEL_LEFT", DLongGDL(lc));
+		widgtablecelsel->InitTag("SEL_TOP", DLongGDL(tr));
+		widgtablecelsel->InitTag("SEL_RIGHT", DLongGDL(rc));
+		widgtablecelsel->InitTag("SEL_BOTTOM", DLongGDL(br));
+		GDLWidget::PushEvent(baseWidgetID, widgtablecelsel);
+	  }
+	} else {
+	  if (!(table->GetDisjointSelection() && event.ControlDown())) { //desel 
+		DStructGDL* widgtablecelsel = new DStructGDL("WIDGET_TABLE_CELL_SEL");
+		widgtablecelsel->InitTag("ID", DLongGDL(event.GetId()));
+		widgtablecelsel->InitTag("TOP", DLongGDL(baseWidgetID));
+		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
+		widgtablecelsel->InitTag("TYPE", DIntGDL(4)); // 
+		widgtablecelsel->InitTag("SEL_LEFT", DLongGDL(-1));
+		widgtablecelsel->InitTag("SEL_TOP", DLongGDL(-1));
+		widgtablecelsel->InitTag("SEL_RIGHT", DLongGDL(-1));
+		widgtablecelsel->InitTag("SEL_BOTTOM", DLongGDL(-1));
+		GDLWidget::PushEvent(baseWidgetID, widgtablecelsel);
+	  }
+	}
   }
-//For compatibility with idl, we should force to select the current table entry.
-  this->SelectBlock(event.GetRow(),event.GetCol(),event.GetRow(),event.GetCol(),FALSE);
   event.Skip();
 }
 
-
-//Forget this function for the time being!
-
-//  void  gdlGrid::OnTableCellSelection(wxGridEvent & event){
-//#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_ALL_EVENTS)
-//  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTableCellSelection: %d\n"),event.GetId());
-//#endif
+void  wxGridGDL::OnTableCellSelection(wxGridEvent & event){
+#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_OTHER_EVENTS)
+  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTableCellSelection: %d\n"),event.GetId());
+#endif
 ////This event is called only when the user left-clicks somewhere, thus deleting all previous selection.
-//
 //  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(GDLWidgetTableID));
-//  DULong eventFlags=table->GetEventFlags();
-//
-//  if (eventFlags & GDLWidget::EV_ALL && !table->IsUpdating()) {
-//    WidgetIDT baseWidgetID = GDLWidget::GetTopLevelBase( event.GetId( ) );
-//    DStructGDL* widgtablecelsel = new DStructGDL( "WIDGET_TABLE_CELL_SEL");
-//    widgtablecelsel->InitTag("ID",  DLongGDL( event.GetId( ) ));
-//    widgtablecelsel->InitTag("TOP", DLongGDL( baseWidgetID));
-//    widgtablecelsel->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//    widgtablecelsel->InitTag("TYPE",DIntGDL(4)); // 4
-//    widgtablecelsel->InitTag("SEL_LEFT",  DLongGDL(event.Selecting()?event.GetCol():-1));
-//    widgtablecelsel->InitTag("SEL_TOP",  DLongGDL(event.Selecting()?event.GetRow(): -1 ));
-//    widgtablecelsel->InitTag("SEL_RIGHT",  DLongGDL( event.Selecting()?event.GetCol():-1 ));
-//    widgtablecelsel->InitTag("SEL_BOTTOM",  DLongGDL( event.Selecting()?event.GetCol():-1 ));
-//    GDLWidget::PushEvent( baseWidgetID, widgtablecelsel );
-//  }
-//  else event.Skip();
-////For compatibility with idl, we should force to select the current table entry.
-////  this->SelectBlock(event.GetRow(),event.GetCol(),event.GetRow(),event.GetCol(),FALSE);
-//  if (table->IsUpdating()) {cerr<<"cleared"<<endl; table->ClearUpdating();}
-//  }
+//   if (table->IsUpdating()) return;
 
+//  int c = event.GetCol();
+//  int r = event.GetRow();
+//  std::cerr << table->GetDisjointSelection() << ":" << event.Selecting() << ":" << event.ControlDown() << ":" << event.AltDown() << ":" << event.CmdDown() << ":" << event.GetModifiers() << std::endl;
  
-//void gdlGrid::OnTextEntered( wxGridEvent & event)
-//{
-//#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_ALL_EVENTS)
-//  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTextEnter: %d\n"),event.GetId());
-//#endif
-//} 
- 
- //this apparently does not work
-//void wxGridGDL::OnText( wxCommandEvent& event)
-//{
-//#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_ALL_EVENTS)
-//  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnText: %d\n"),event.GetId());
-//#endif
-//  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(GDLWidgetTableID));
-//  DULong eventFlags=table->GetEventFlags();
-//
-//    WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId( ) );
-//
-//  bool isModified;
-//  long selStart, selEnd;
-//  DLong offset;
-//  std::string lastValue;
-//  std::string newValue;
-//  
-//  wxTextCtrl* textCtrl = dynamic_cast<wxTextCtrl*>(event.GetEventObject());
-//  if( textCtrl == NULL)
-//  {
-//    event.Skip();
-//    std::cerr<<"No wxWidget!"<<std::endl; return; // happens on construction 
-//  }
-//  textCtrl->GetSelection( &selStart, &selEnd);
-//  offset = textCtrl->GetInsertionPoint();
-//  lastValue = textCtrl->GetLabelText().mb_str(wxConvUTF8);
-//  newValue = textCtrl->GetValue().mb_str(wxConvUTF8);
-//  isModified = lastValue != newValue;
-////  textCtrl->SetValue(wxString(newValue, wxConvUTF8));
-////return without producing event struct if eventType is not set
-//  if (!(eventFlags & GDLWidget::EV_ALL )) return;
-//
-//  DStructGDL*  widg;
-//  if( !isModified)
-//  {
-//    widg = new DStructGDL( "WIDGET_TABLE_TEXT_SEL");
-//    widg->InitTag("ID", DLongGDL( GDLWidgetTableID));
-//    widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//    widg->InitTag("TYPE", DIntGDL( 3)); // selection
-//    widg->InitTag("OFFSET", DLongGDL( offset));
-//    widg->InitTag("LENGTH", DLongGDL( selEnd-selStart));
-//    widg->InitTag("X", DLongGDL( 0 ));
-//    widg->InitTag("Y", DLongGDL( 0 ));
-//  }
-//  else
-//  {
-//    int lengthDiff = newValue.length() - lastValue.length();
-//    if( lengthDiff < 0) // deleted
-//    {
-//      widg = new DStructGDL( "WIDGET_TABLE_DEL");
-//      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-//      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//      widg->InitTag("TYPE", DIntGDL( 2)); // delete
-//      widg->InitTag("OFFSET", DLongGDL( offset-1));
-//      widg->InitTag("LENGTH", DLongGDL( -lengthDiff));
-//      widg->InitTag("X", DLongGDL( 0 ));
-//      widg->InitTag("Y", DLongGDL( 0 ));
-//    }
-//    else if( lengthDiff == 0) // replace TODO: just flag the real change
-//    {   
-//      // 1st delete all
-//      widg = new DStructGDL( "WIDGET_TABLE_DEL");
-//      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-//      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//      widg->InitTag("TYPE", DIntGDL( 2)); // delete
-//      widg->InitTag("OFFSET", DLongGDL( 0));
-//      widg->InitTag("LENGTH", DLongGDL( lastValue.length()));
-//      widg->InitTag("X", DLongGDL( 0 ));
-//      widg->InitTag("Y", DLongGDL( 0 ));
-//    
-//      GDLWidget::PushEvent( baseWidgetID, widg);
-//
-//      // 2nd insert new
-//      widg = new DStructGDL( "WIDGET_TABLE_STR");
-//      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-//      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//      widg->InitTag("TYPE", DIntGDL( 1)); // multiple char
-//      widg->InitTag("OFFSET", DLongGDL( 0));
-//      widg->InitTag("STR", DStringGDL( newValue));
-//      widg->InitTag("X", DLongGDL( 0 ));
-//      widg->InitTag("Y", DLongGDL( 0 ));
-//    }
-//    else if( lengthDiff == 1)
-//    {
-//      widg = new DStructGDL( "WIDGET_TABLE_CH");
-//      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-//      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//      widg->InitTag("TYPE", DIntGDL( 0)); // single char
-//      widg->InitTag("OFFSET", DLongGDL( offset+1));
-//      widg->InitTag("CH", DByteGDL( newValue[offset<newValue.length()?offset:newValue.length()-1]));
-//      widg->InitTag("X", DLongGDL( 0 ));
-//      widg->InitTag("Y", DLongGDL( 0 ));
-//    }
-//    else // lengthDiff > 1
-//    {
-//      int nVLenght = newValue.length();
-//      if( offset < lengthDiff)  lengthDiff = offset;
-//      std::string str = "";
-//      if( offset <= nVLenght && lengthDiff > 0)	 str = newValue.substr(offset-lengthDiff,lengthDiff+1);
-//      
-//      widg = new DStructGDL( "WIDGET_TABLE_STR");
-//      widg->InitTag("ID", DLongGDL( GDLWidgetTableID));
-//      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-//      widg->InitTag("TYPE", DIntGDL( 1)); // multiple char
-//      widg->InitTag("OFFSET", DLongGDL( offset));
-//      widg->InitTag("STR", DStringGDL( str));
-//      widg->InitTag("X", DLongGDL( 0 ));
-//      widg->InitTag("Y", DLongGDL( 0 ));
-//    }
-//  }
-//  GDLWidget::PushEvent( baseWidgetID, widg);
-//}
+//////For compatibility with idl, we should force to select the current table entry.---> DOES NOT WORK!!
+////  this->SelectBlock(event.GetRow(),event.GetCol(),event.GetRow(),event.GetCol(),true);
+//  event.Skip();
+}
 
- 
- //returns -1 if unchanged, or pos of last common character
+
+
  int firstChange(std::string &s1, std::string &s2) {
    int index = 0;
         int minsize = min(s1.length(), s2.length());
@@ -1958,103 +1808,6 @@ void  wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event){
 
         return (index == minsize && s1.length() == s2.length()) ? -1 : index;
  }
-void  wxGridGDL::OnTextChanging( wxGridEvent & event)
-{
-#if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_ALL_EVENTS)
-  wxMessageOutputStderr().Printf(_T("in gdlGrid::OnTextChanging: %d\n"),event.GetId());
-#endif
-  GDLWidgetTable* table = static_cast<GDLWidgetTable*>(GDLWidget::GetWidget(GDLWidgetTableID));
-  DULong eventFlags=table->GetEventFlags();
-  if (!(eventFlags & GDLWidget::EV_KEYBOARD)) return;
-
-  WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId( ) );
-
-  std::string newValue;
-  std::string previousValue;
-  int x=event.GetCol();
-  int y=event.GetRow();
-  previousValue = this->GetCellValue(y,x);
-  newValue = event.GetString(); 
-  bool isModified = (newValue != previousValue);
-  if( !isModified) return;
-
-  DLong offset = firstChange(previousValue,newValue);
-
-  DStructGDL*  widg;
- 
-    int lengthDiff = newValue.length() - previousValue.length();
-    if( lengthDiff < 0) //only deleted
-    {
-      widg = new DStructGDL( "WIDGET_TABLE_DEL");
-      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-      widg->InitTag("TYPE", DIntGDL( 2)); // delete
-      widg->InitTag("OFFSET", DLongGDL( offset));
-      widg->InitTag("LENGTH", DLongGDL( -lengthDiff));
-      widg->InitTag("X", DLongGDL( x ));
-      widg->InitTag("Y", DLongGDL( y ));
-	  GDLWidget::PushEvent(baseWidgetID, widg);
-	  return;
-    } else if( lengthDiff == 0) //empty to empty, but RETURN entered
-    {
-      widg = new DStructGDL( "WIDGET_TABLE_CH");
-      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-      widg->InitTag("TYPE", DIntGDL( 0)); // single char
-      widg->InitTag("OFFSET", DLongGDL( offset));
-      widg->InitTag("CH", DByteGDL( 10 )); //newline
-      widg->InitTag("X", DLongGDL( x ));
-      widg->InitTag("Y", DLongGDL( y ));
-	  GDLWidget::PushEvent(baseWidgetID, widg);
-	  return;
-    }
-    else if( lengthDiff == 1) //only character added only
-    {
-      widg = new DStructGDL( "WIDGET_TABLE_CH");
-      widg->InitTag("ID", DLongGDL(  GDLWidgetTableID));
-      widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
-      widg->InitTag("TYPE", DIntGDL( 0)); // single char
-      widg->InitTag("OFFSET", DLongGDL( offset));
-      widg->InitTag("CH", DByteGDL( (newValue.substr(offset,offset).c_str())[0] ));
-      widg->InitTag("X", DLongGDL( x ));
-      widg->InitTag("Y", DLongGDL( y ));
-	  GDLWidget::PushEvent(baseWidgetID, widg);
-	  return;
-    }
-    else // lengthDiff > 1 We just imagine it is deleted from there to the end, and the new characters are added
-    {
-		if (previousValue.length()!=0) {
-			// 1st delete from offset to (old) end
-		  widg = new DStructGDL("WIDGET_TABLE_DEL");
-		  widg->InitTag("ID", DLongGDL(GDLWidgetTableID));
-		  widg->InitTag("TOP", DLongGDL(baseWidgetID));
-		  widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
-		  widg->InitTag("TYPE", DIntGDL(2)); // delete
-		  widg->InitTag("OFFSET", DLongGDL(offset));
-		  widg->InitTag("LENGTH", DLongGDL(previousValue.length()-offset));
-      widg->InitTag("X", DLongGDL( x ));
-      widg->InitTag("Y", DLongGDL( y ));
-
-		  GDLWidget::PushEvent(baseWidgetID, widg);
-		}
-		DStructGDL*  widg2;
-		// 2nd insert new
-		widg2 = new DStructGDL("WIDGET_TABLE_STR");
-		widg2->InitTag("ID", DLongGDL(GDLWidgetTableID));
-		widg2->InitTag("TOP", DLongGDL(baseWidgetID));
-		widg2->InitTag("HANDLER", DLongGDL(baseWidgetID));
-		widg2->InitTag("TYPE", DIntGDL(1)); // multiple char
-		widg2->InitTag("OFFSET", DLongGDL(offset));
-		widg2->InitTag("STR", DStringGDL(newValue.substr(offset)));
-      widg2->InitTag("X", DLongGDL( x ));
-      widg2->InitTag("Y", DLongGDL( y ));
-		GDLWidget::PushEvent(baseWidgetID, widg2);
-		return;
-    }
-}
 
 void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 #if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_ALL_EVENTS)

--- a/src/shm.cpp
+++ b/src/shm.cpp
@@ -244,7 +244,7 @@ namespace lib {
 	} else e->Throw("Shared Memory Segment not found: " + segmentName + ".");
 	//if candidate for deletion and nothing referencing it, delete right now:
 	if ((*i).second.refcount==0) {
-	  if ((*i).second.flags & USE_SYSV == USE_SYSV) {
+	  if (((*i).second.flags & USE_SYSV) == USE_SYSV) {
 		int result=shmdt((*i).second.mapped_address);
 		if (result ==-1) e->Throw("SYSV Shared Memory Segment " + segmentName + " Unmapping unsucessfull, reason: "+ std::string(strerror(errno))+".");
 	  } else {
@@ -396,7 +396,7 @@ namespace lib {
 		if ((((*i).second.flags & DELETE_PENDING)==DELETE_PENDING) && (*i).second.refcount<1) {
 		  //no more reference, if shmap is pending delete, delete it.
 		  //if candidate for deletion and nothing referencing, delete right now:
-		  if ((*i).second.flags & USE_SYSV == USE_SYSV) {
+		  if (((*i).second.flags & USE_SYSV) == USE_SYSV) {
 			int result = shmdt((*i).second.mapped_address);
 			if (result == -1) Warning("SYSV Shared Memory Segment " + (*i).first  + " Unmapping unsucessfull after deleting last mapped variable, reason: " + std::string(strerror(errno)) + ".");
 		  } else {

--- a/src/shm.hpp
+++ b/src/shm.hpp
@@ -26,12 +26,12 @@
 typedef struct {
   void* mapped_address;
   std::string osHandle;
-  size_t length=0;
-  off_t offset=0;
-  int   refcount=0;
+  size_t length;
+  off_t offset;
+  int   refcount;
   dimension dim;
-  int type=0;
-  int flags=0;
+  int type;
+  int flags;
 } SHMAP_STRUCT;
 
 enum Shmap_flags {

--- a/src/shm.hpp
+++ b/src/shm.hpp
@@ -24,7 +24,7 @@
 #ifndef _WIN32
 
 typedef struct {
-  void* mapped_address=NULL;
+  void* mapped_address;
   std::string osHandle;
   size_t length=0;
   off_t offset=0;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3102,7 +3102,7 @@ void widget_control( EnvT* e ) {
         GDLWidgetTable *table = (GDLWidgetTable *) widget;
 		if (useATableSelection) {
 		  if (format != NULL) e->Throw("Unable to set format for table widget."); //format not allowed if selection
-		  format=table->GetCurrentFormat(); //use stored form
+		  format=table->GetCurrentFormat(); //use stored format
 		  //convert 'value' to vValue type FIRST...
 		  DType type = table->GetVvalue()->Type();
 		  value = value->Convert2(type);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2223,6 +2223,7 @@ BaseGDL* widget_info( EnvT* e ) {
       GDLWidget *widget = GDLWidget::GetWidget( widgetID );
       if ( widget == NULL ) e->Throw("Invalid widget identifier:"+i2s(widgetID));
       if ( widget->IsText()) return static_cast<GDLWidgetText*>(widget)->GetTextSelection();
+      if ( widget->IsTable()) std::cerr<<"sorry, TEXT_SELECT not ready for WIDGET_TABLE, Fixme!";
       //other cases return [0,0]
       DLongGDL* pos=new DLongGDL(dimension(2),BaseGDL::ZERO);
       return pos;
@@ -2655,9 +2656,6 @@ void widget_control( EnvT* e ) {
   static int setvalueIx = e->KeywordIx( "SET_VALUE" );
   bool setvalue = e->KeywordPresent( setvalueIx );
   
-  static int settextselectIx  = e->KeywordIx( "SET_TEXT_SELECT" );
-  bool settextselect = e->KeywordPresent( settextselectIx ); 
-
   static int getvalueIx = e->KeywordIx( "GET_VALUE" );
   bool getvalue = e->KeywordPresent( getvalueIx );
 
@@ -2776,12 +2774,15 @@ void widget_control( EnvT* e ) {
 
   static int base_set_titleIx = e->KeywordIx( "BASE_SET_TITLE" );
   bool set_base_title = e->KeywordSet( base_set_titleIx );
-  
+
+//TEXT and TABLE
+  static int USE_TEXT_SELECT = e->KeywordIx("USE_TEXT_SELECT");
+  static int settextselectIx = e->KeywordIx("SET_TEXT_SELECT");
+  bool settextselect = e->KeywordPresent(settextselectIx); 
   
   //TABLE
-  	static int USE_TABLE_SELECT = e->KeywordIx("USE_TABLE_SELECT");
-	static int USE_TEXT_SELECT = e->KeywordIx("USE_TEXT_SELECT");
-  	static int FORMAT = e->KeywordIx("FORMAT");
+  static int USE_TABLE_SELECT = e->KeywordIx("USE_TABLE_SELECT");
+  static int FORMAT = e->KeywordIx("FORMAT");
 	
 //    static int IGNORE_ACCELERATORS = e->KeywordIx( "IGNORE_ACCELERATORS" );
 	
@@ -2812,6 +2813,8 @@ void widget_control( EnvT* e ) {
   DLongGDL* tableSelectionToUse = NULL;  
   DStringGDL* format = NULL;
   if (widget->IsTable()) { //set and throw if table selection is bad.
+	if (e->KeywordPresent( USE_TEXT_SELECT )) e->Throw("Sorry, USE_TEXT_SELECT is not ready for WIDGET_TABLE, Fixme!"); //need to process the text_select events in the wxGridGDLCellTextEditor object. Just DO it.
+	if (settextselect) e->Throw("Sorry, SET_TEXT_SELECT is not ready for WIDGET_TABLE, Fixme!");  //need to process the text_select events in the wxGridGDLCellTextEditor object. Just DO it.
 	GDLWidgetTable *table = (GDLWidgetTable *) widget;
 	tableSelectionToUse = GetKeywordAs<DLongGDL>(e, USE_TABLE_SELECT);
 	useATableSelection=table->GetValidTableSelection(tableSelectionToUse); //will throw if a syntax problem
@@ -3518,7 +3521,7 @@ void widget_control( EnvT* e ) {
       if (value->N_Elements() > 2) e->Throw( "Keyword array parameter SET_TEXT_SELECT must have from 1 to 2 elements." );
       GDLWidgetText *textWidget = (GDLWidgetText *) widget;
       textWidget->SetTextSelection( value );
-    } else if ( wType == "TABLE" ) e->Throw( "SET_TEXT_SELECT not ready for Table Widgets, FIXME." );
+    } else if ( wType == "TABLE" ) e->Throw( "SET_TEXT_SELECT not ready for Table Widgets, FIXME." ); //need to process the text_select events in the wxGridGDLCellTextEditor object. Just DO it.
   }
 
   if ( editable ) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2955,7 +2955,8 @@ void widget_control( EnvT* e ) {
     widget->SetWidgetVirtualSize(xsize,ysize);   
    }
   
-  if (hasXsize || hasYsize) {
+  if ((hasXsize || hasYsize) && !widget->IsTable()) { //widgetTable tested separately
+	
     if ( widget->IsButton()) {
       GDLWidgetButton* whatSortofBut=static_cast<GDLWidgetButton*>(widget);
       if (whatSortofBut->IsMenu() || whatSortofBut->IsEntry()) e->Throw("Geometry request not allowed for menubar or pulldown menus.");
@@ -2974,14 +2975,7 @@ void widget_control( EnvT* e ) {
         if (hasXsize) xsize*=fact.x;
         if (hasYsize) ysize*=fact.y;
       }     
-    } else {
-      if ( widget->IsTable()) {
-        wxGridGDL* grid=dynamic_cast<wxGridGDL*>(widget->GetWxWidget());
-        if (!grid) e->Throw("Internal GDL error with widgets, please report.");
-        if (hasXsize) xsize=xsize*grid->GetColSize(0)+grid->GetRowLabelSize(); 
-        if (hasYsize) ysize=ysize*grid->GetRowSize(0)+grid->GetColLabelSize();
-      }
-    }
+    } 
     widget->SetWidgetSize(xsize,ysize);
   }
 
@@ -3702,6 +3696,8 @@ void widget_control( EnvT* e ) {
     
     bool tablexsize=e->KeywordSet(TABLE_XSIZE);
     bool tableysize=e->KeywordSet(TABLE_YSIZE);
+    bool justxsize=e->KeywordSet(XSIZE);
+    bool justysize=e->KeywordSet(YSIZE);
 
     bool hasTableDisjointSelection = e->KeywordPresent(TABLE_DISJOINT_SELECTION);
     if (hasTableDisjointSelection) {
@@ -3782,11 +3778,17 @@ void widget_control( EnvT* e ) {
     }
     if (tablexsize) {
       DLong xsize= (*e->GetKWAs<DLongGDL>(TABLE_XSIZE))[0];
-      table->SetTableNumberOfColumns(xsize);
+      table->SetTableXsizeAsNumberOfColumns(xsize);
+    } else if (justxsize) {
+      DLong xsize= (*e->GetKWAs<DLongGDL>(XSIZE))[0];
+      table->SetTableXsizeAsNumberOfColumns(xsize);
     }
     if (tableysize) {
       DLong ysize= (*e->GetKWAs<DLongGDL>(TABLE_YSIZE))[0];
-      table->SetTableNumberOfRows(ysize);
+      table->SetTableYsizeAsNumberOfRows(ysize);
+    } else if (justysize) {
+      DLong ysize= (*e->GetKWAs<DLongGDL>(YSIZE))[0];
+      table->SetTableYsizeAsNumberOfRows(ysize);
     }
   }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2840,67 +2840,6 @@ void widget_control( EnvT* e ) {
         GDLWidgetTable *table = (GDLWidgetTable *) widget;
 		  if (valueKW) GDLDelete((*valueKW));
 		  *valueKW = table->GetTableValues( tableSelectionToUse );
-//        if ( retval == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." );
-//        else if ( table->GetVvalue( ) == NULL ) {
-//          e->Throw( " Class of specified widget has no value: 1" );
-//        }//Just as IDL does!
-//        else if ( table->GetVvalue( )->Type( ) == GDL_STRING ) {
-//          if (valueKW) GDLDelete( (*valueKW) );      
-//          *valueKW = retval->Dup( );
-//        }
-//        else if ( table->GetVvalue( )->Type( ) == GDL_STRUCT ) {
-//          BaseGDL* val;
-//          //use a special case handling transpositions due to column or row majority.
-//          val = table->GetTableValuesAsStruct( tableSelectionToUse );
-//          if ( val == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." ); //superfluous.
-//          if (valueKW) GDLDelete( (*valueKW) );
-//          *valueKW = val->Dup( );
-//        }
-//        else {
-//          BaseGDL* val;
-//          switch ( table->GetVvalue( )->Type( ) ) {
-//            case GDL_BYTE:
-//              val = new DByteGDL( retval->Dim( ) );
-//              break;
-//            case GDL_INT:
-//              val = new DIntGDL( retval->Dim( ) );
-//              break;
-//            case GDL_LONG:
-//              val = new DLongGDL( retval->Dim( ) );
-//              break;
-//            case GDL_FLOAT:
-//              val = new DFloatGDL( retval->Dim( ) );
-//              break;
-//            case GDL_DOUBLE:
-//              val = new DDoubleGDL( retval->Dim( ) );
-//              break;
-//            case GDL_COMPLEX:
-//              val = new DComplexGDL( retval->Dim( ) );
-//              break;
-//            case GDL_COMPLEXDBL:
-//              val = new DComplexDblGDL( retval->Dim( ) );
-//              break;
-//            case GDL_UINT:
-//              val = new DUIntGDL( retval->Dim( ) );
-//              break;
-//            case GDL_ULONG:
-//              val = new DULongGDL( retval->Dim( ) );
-//              break;
-//            case GDL_LONG64:
-//              val = new DLong64GDL( retval->Dim( ) );
-//              break;
-//            case GDL_ULONG64:
-//              val = new DULong64GDL( retval->Dim( ) );
-//              break;
-//            default:
-//              e->Throw("Internal GDL error, please report!");
-//          }
-//          stringstream is;
-//          for ( SizeT i = 0; i < val->N_Elements( ); i++ ) is << (*retval)[ i] << '\n';
-//          val->FromStream( is );
-//          if (valueKW) GDLDelete( (*valueKW) );
-//          *valueKW = val->Dup( );
-//        }
       } else if ( widget->IsSlider( ) ) {
         GDLWidgetSlider *s = (GDLWidgetSlider *) widget;
         if (valueKW) GDLDelete( (*valueKW) );

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -444,11 +444,7 @@ DStringGDL*  GetTableValueAsString(EnvT* e, BaseGDL* &value, DStringGDL* format,
 	dimension dim(dims, 2);
 	valueAsStrings = new DStringGDL(dim);
 	majority=GDLWidgetTable::NONE_MAJOR;
-  } else if (value->Type() == GDL_STRING) {
-	valueAsStrings = static_cast<DStringGDL*> (value->Dup());
-	majority=GDLWidgetTable::NONE_MAJOR;
-  }
-  else if (value->Type() == GDL_STRUCT) {
+  } else if (value->Type() == GDL_STRUCT) {
 	if (value->Rank() > 1) e->Throw("Multi dimensional arrays of structures not allowed.");
 	if(majority==GDLWidgetTable::NONE_MAJOR) majority=GDLWidgetTable::ROW_MAJOR;
 	//convert to STRING
@@ -2842,68 +2838,69 @@ void widget_control( EnvT* e ) {
     } else { 
         if ( widget->IsTable( ) ) { //TABLE
         GDLWidgetTable *table = (GDLWidgetTable *) widget;
-        DStringGDL* retval = table->GetTableValues( tableSelectionToUse );
-        if ( retval == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." );
-        else if ( table->GetVvalue( ) == NULL ) {
-          e->Throw( " Class of specified widget has no value: 1" );
-        }//Just as IDL does!
-        else if ( table->GetVvalue( )->Type( ) == GDL_STRING ) {
-          if (valueKW) GDLDelete( (*valueKW) );      
-          *valueKW = retval->Dup( );
-        }
-        else if ( table->GetVvalue( )->Type( ) == GDL_STRUCT ) {
-          BaseGDL* val;
-          //use a special case handling transpositions due to column or row majority.
-          val = table->GetTableValuesAsStruct( tableSelectionToUse );
-          if ( val == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." ); //superfluous.
-          if (valueKW) GDLDelete( (*valueKW) );
-          *valueKW = val->Dup( );
-        }
-        else {
-          BaseGDL* val;
-          switch ( table->GetVvalue( )->Type( ) ) {
-            case GDL_BYTE:
-              val = new DByteGDL( retval->Dim( ) );
-              break;
-            case GDL_INT:
-              val = new DIntGDL( retval->Dim( ) );
-              break;
-            case GDL_LONG:
-              val = new DLongGDL( retval->Dim( ) );
-              break;
-            case GDL_FLOAT:
-              val = new DFloatGDL( retval->Dim( ) );
-              break;
-            case GDL_DOUBLE:
-              val = new DDoubleGDL( retval->Dim( ) );
-              break;
-            case GDL_COMPLEX:
-              val = new DComplexGDL( retval->Dim( ) );
-              break;
-            case GDL_COMPLEXDBL:
-              val = new DComplexDblGDL( retval->Dim( ) );
-              break;
-            case GDL_UINT:
-              val = new DUIntGDL( retval->Dim( ) );
-              break;
-            case GDL_ULONG:
-              val = new DULongGDL( retval->Dim( ) );
-              break;
-            case GDL_LONG64:
-              val = new DLong64GDL( retval->Dim( ) );
-              break;
-            case GDL_ULONG64:
-              val = new DULong64GDL( retval->Dim( ) );
-              break;
-            default:
-              e->Throw("Internal GDL error, please report!");
-          }
-          stringstream is;
-          for ( SizeT i = 0; i < val->N_Elements( ); i++ ) is << (*retval)[ i] << '\n';
-          val->FromStream( is );
-          if (valueKW) GDLDelete( (*valueKW) );
-          *valueKW = val->Dup( );
-        }
+		  if (valueKW) GDLDelete((*valueKW));
+		  *valueKW = table->GetTableValues( tableSelectionToUse );
+//        if ( retval == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." );
+//        else if ( table->GetVvalue( ) == NULL ) {
+//          e->Throw( " Class of specified widget has no value: 1" );
+//        }//Just as IDL does!
+//        else if ( table->GetVvalue( )->Type( ) == GDL_STRING ) {
+//          if (valueKW) GDLDelete( (*valueKW) );      
+//          *valueKW = retval->Dup( );
+//        }
+//        else if ( table->GetVvalue( )->Type( ) == GDL_STRUCT ) {
+//          BaseGDL* val;
+//          //use a special case handling transpositions due to column or row majority.
+//          val = table->GetTableValuesAsStruct( tableSelectionToUse );
+//          if ( val == NULL ) e->Throw( "USE_TABLE_SELECT value out of range." ); //superfluous.
+//          if (valueKW) GDLDelete( (*valueKW) );
+//          *valueKW = val->Dup( );
+//        }
+//        else {
+//          BaseGDL* val;
+//          switch ( table->GetVvalue( )->Type( ) ) {
+//            case GDL_BYTE:
+//              val = new DByteGDL( retval->Dim( ) );
+//              break;
+//            case GDL_INT:
+//              val = new DIntGDL( retval->Dim( ) );
+//              break;
+//            case GDL_LONG:
+//              val = new DLongGDL( retval->Dim( ) );
+//              break;
+//            case GDL_FLOAT:
+//              val = new DFloatGDL( retval->Dim( ) );
+//              break;
+//            case GDL_DOUBLE:
+//              val = new DDoubleGDL( retval->Dim( ) );
+//              break;
+//            case GDL_COMPLEX:
+//              val = new DComplexGDL( retval->Dim( ) );
+//              break;
+//            case GDL_COMPLEXDBL:
+//              val = new DComplexDblGDL( retval->Dim( ) );
+//              break;
+//            case GDL_UINT:
+//              val = new DUIntGDL( retval->Dim( ) );
+//              break;
+//            case GDL_ULONG:
+//              val = new DULongGDL( retval->Dim( ) );
+//              break;
+//            case GDL_LONG64:
+//              val = new DLong64GDL( retval->Dim( ) );
+//              break;
+//            case GDL_ULONG64:
+//              val = new DULong64GDL( retval->Dim( ) );
+//              break;
+//            default:
+//              e->Throw("Internal GDL error, please report!");
+//          }
+//          stringstream is;
+//          for ( SizeT i = 0; i < val->N_Elements( ); i++ ) is << (*retval)[ i] << '\n';
+//          val->FromStream( is );
+//          if (valueKW) GDLDelete( (*valueKW) );
+//          *valueKW = val->Dup( );
+//        }
       } else if ( widget->IsSlider( ) ) {
         GDLWidgetSlider *s = (GDLWidgetSlider *) widget;
         if (valueKW) GDLDelete( (*valueKW) );

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -176,7 +176,7 @@ pro handle_Event,ev
   endif
 
   if tag_names(ev, /structure_name) eq 'WIDGET_TABLE_CELL_DESEL' then begin
-     col=[255,255,255]
+     col=[255b,255,255]
      disj=widget_info(ev.id,/table_disj)
      if disj then begin
         desel=[ev.sel_left,ev.sel_top]

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -174,7 +174,38 @@ pro handle_Event,ev
      endif
      
   endif
-  
+
+  if tag_names(ev, /structure_name) eq 'WIDGET_TABLE_CELL_DESEL' then begin
+     col=[255,255,255]
+     disj=widget_info(ev.id,/table_disj)
+     if disj then begin
+        desel=[ev.sel_left,ev.sel_top]
+        nel=1
+     endif else  begin
+        desel=[ev.sel_left,ev.sel_top,ev.sel_right,ev.sel_bottom]
+        nel=(ev.sel_right+1-ev.sel_left)*(ev.sel_bottom+1-ev.sel_top)
+     endelse
+     widget_control,ev.id,use_table_select=desel,background_color=col,set_value=replicate(-1,nel)
+     
+     return
+  endif
+  if tag_names(ev, /structure_name) eq 'WIDGET_TABLE_CELL_SEL' then begin
+     if ev.sel_left eq -1 then begin
+        ;widget_control,ev.id,background_color=[255,255,255]
+        return
+     endif
+     col=byte(randomu(seed,3)*255) 
+     widget_control,ev.id,background_color=col,/use_table_select
+     z=widget_info(ev.id,/table_select)
+     col=byte(randomu(seed,3)*255)
+     nel=n_elements(z)
+     if nel gt 0 then widget_control,ev.id,foreground_color=col,set_value=indgen(nel),use_table_select=z
+     ;; disj=widget_info(ev.id,/table_disj)
+     ;; if disj then dozero=[-1,-1] else dozero=[-1,-1,-1,-1]
+     ;; widget_control,ev.id,set_table_select=dozero
+     return
+  endif
+ 
   widget_control,ev.id,get_uvalue=uv 
   widget_control,ev.top,get_uvalue=topuv
   if n_elements(uv) gt 0 then begin
@@ -525,13 +556,14 @@ if total(strcmp('TABLE',present,/fold)) then begin
    table_base = widget_base( tabbed_base, TITLE="TABLEs",_extra=extra) & offy=0
 
 ;
-   mytable1=widget_table(yoff=offy,table_base,value=dist(7),xsize=5,ysize=5,/editable);,font=fontname,frame=30) & offy+=200 ;
+   mytable1=widget_table(yoff=offy,table_base,value=dist(7),xsize=5,ysize=5,/all);,font=fontname,frame=30) & offy+=200 ;
 ;to be implemented! ;widget_control,mytable1,/editable,use_table_sel=[1,1,4,4]
-   widget_control,mytable1,edit_cell=[0,0]
+   widget_control,mytable1,edit_cell=[1,1]
    widget_control,mytable1,background_color=[255,255,0],use_table_sel=[1,1,4,4]
+   widget_control,mytable1,/table_disjoint
    nrows=n_elements(table)
    subsize=nrows < 6
-   mytable2=widget_table(yoff=offy,table_base,value=table[0:subsize-1],/row_major,row_labels='',column_labels=tags,column_width=60,/resizeable_columns,y_scroll_size=40,/disjoint,/all_events,/editable,alignment=2,frame=50) & offy+=10 ;
+   mytable2=widget_table(yoff=offy,table_base,value=table[0:subsize-1],/row_major,row_labels='',column_labels=tags,column_width=60,/resizeable_columns,y_scroll_size=40,/all,alignment=2,frame=20) & offy+=10 ;
 endif
 
 if total(strcmp('TREE',present,/fold)) then begin


### PR DESCRIPTION
Added editor support and corrected many many errors.
Still not able to edit Struct values and does know about set_text_select and use_text_select. But  TABLE_SELECTions are OK, on bith normal and disjointed modes. FORMAT is also respected in read and write of values.

For the record, WIDGET_TABLE initial implementation (object oriented) was based on a misinterpretation of the IDL documentation that could not be easily tested on the simple examples then used.