### PR TITLE
bugifx: in routine 'h5d_open_fun()', remove '(long)'...

### DIFF
--- a/src/hdf5_fun.cpp
+++ b/src/hdf5_fun.cpp
@@ -1454,7 +1454,7 @@ hid_t
     DString h5dDatasetname;
     e->AssureScalarPar<DStringGDL>( 1, h5dDatasetname);
 
-    hid_t h5d_id= H5Dopen((long)h5f_id, h5dDatasetname.c_str());
+    hid_t h5d_id= H5Dopen( h5f_id, h5dDatasetname.c_str() );
 
     if (h5d_id < 0) { string msg; e->Throw(hdf5_error_message(msg)); }
 


### PR DESCRIPTION
 in front of 'h5f_id' when calling 'H5Dopen()'.

This is an attempt to fix issue 1742, and needs to be tested on a Windows machine (which I do not have).