### PR TITLE
enable cleaning of internal gdl objects at exit in debug mode 

### DIFF
--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -120,29 +120,30 @@ void InitOpenMP() {
 #endif
 }
 
+#if GDL_DO_ATEXIT
 void AtExit()
 {
   //this function probably cleans otherwise cleaned objets and should be called only for debugging purposes.
-  cerr << "Using AtExit() for debugging" << endl;
-  cerr << flush; cout << flush; clog << flush;
+//  cerr << "Using AtExit() for debugging" << endl;
   // clean up everything
   // (for debugging memory leaks)
   ResetObjects();
   PurgeContainer(libFunList);
   PurgeContainer(libProList);
 }
+#endif
 
 #ifndef _WIN32
 void GDLSetLimits()
 {
 #define GDL_PREFERED_STACKSIZE  1024000000 //1000000*1024 like IDL
-struct rlimit* gdlstack=new struct rlimit;
-  int r=getrlimit(RLIMIT_STACK,gdlstack); 
+struct rlimit gdlstack;
+  int r=getrlimit(RLIMIT_STACK,&gdlstack); 
 //  cerr <<"Current rlimit = "<<gdlstack->rlim_cur<<endl;
 //  cerr<<"Max rlimit = "<<  gdlstack->rlim_max<<endl;
-  if (gdlstack->rlim_cur >= GDL_PREFERED_STACKSIZE ) return; //the bigger the better.
-  if (gdlstack->rlim_max > GDL_PREFERED_STACKSIZE ) gdlstack->rlim_cur=GDL_PREFERED_STACKSIZE; //not completely satisfactory.
-  r=setrlimit(RLIMIT_STACK,gdlstack);
+  if (gdlstack.rlim_cur >= GDL_PREFERED_STACKSIZE ) return; //the bigger the better.
+  if (gdlstack.rlim_max > GDL_PREFERED_STACKSIZE ) gdlstack.rlim_cur=GDL_PREFERED_STACKSIZE; //not completely satisfactory.
+  r=setrlimit(RLIMIT_STACK,&gdlstack);
 }
 #endif
 
@@ -242,7 +243,7 @@ namespace MyPaths {
 
 int main(int argc, char *argv[])
 {
-#ifdef GDL_DEBUG
+#ifdef GDL_DO_ATEXIT
   if( atexit( AtExit) != 0) cerr << "atexit registration failed." << endl;
 #endif
   // indicates if the user wants to see the welcome message

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -129,6 +129,8 @@ void ResetObjects()
 
   PurgeContainer(sysVarList);
   sysVarRdOnlyList.clear(); // data is owned by sysVarList
+  obsoleteSysVarList.clear();
+  sysVarNoSaveList.clear();
   PurgeContainer(funList);
   PurgeContainer(proList);
 


### PR DESCRIPTION
if gdl is compiled with `-DCMAKE_CXX_FLAGS='-DGDL_DO_ATEXIT=1  ...' `, i.e, if `GDL_DO_ATEXIT` is defined, then gdl will clean up all its objects before exit. 
_This removes a tremendous list of supposed memory leaks as reported by Valgrind or Sanitizers._ 
To be used in debug mode of course. 
Mostly, with the exception of a small list of internal objects that cannot be destroyed before exit (because they share memory with another, destroyed, object) the (still long) list of supposed memory leaks is dues to wxWidgets or other external libraries (probably beacause we do not correctly use their respective cleanup functions).
