### PR TITLE
Found a bug in ForInfoListT object, closes #1766

### DIFF
--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -35,6 +35,9 @@
       extern bool posixpaths;
     }
 #endif
+    
+#define MAX_LOOPS_NUMBER 32
+    
   typedef struct _SCC_STRUCT_ { //semicompiled code, small memory imprint (instead of a copy of the DNodes)
 	u_int nodeType = 0;
 	u_int ligne = 0;
@@ -592,8 +595,8 @@ class DPro: public DSubUD
 {
 public:
   // for main function, not inserted into proList
-  // should be fine (way too much): 32 NESTED loops in $MAIN$ (elswhere: unlimited)
-  DPro(): DSubUD("$MAIN$","","") { this->nForLoops = 32;}
+  // should be fine (way too much): MAX_LOOPS_NUMBER (32?) NESTED loops in $MAIN$ (elswhere: unlimited)
+  DPro(): DSubUD("$MAIN$","","") { this->nForLoops = MAX_LOOPS_NUMBER;}
 
   DPro(const std::string& n,const std::string& o="",const std::string& f=""): 
     DSubUD(n,o,f)

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -208,7 +208,7 @@ EnvUDT::EnvUDT( ProgNodeP cN, BaseGDL* self,
 
   DSubUD* proUD=static_cast<DSubUD*>(pro);
 
-  forLoopInfo.InitSize( proUD->NForLoops());
+  forLoopInfo.InitSize(proUD->NForLoops());
 
   SizeT envSize;
   //   SizeT keySize;
@@ -264,7 +264,7 @@ EnvUDT::EnvUDT( BaseGDL* self, ProgNodeP cN, const string& parent, CallContext l
 
   DSubUD* proUD=static_cast<DSubUD*>(pro);
 
-  forLoopInfo.InitSize( proUD->NForLoops());
+  forLoopInfo.InitSize(proUD->NForLoops());
 
   SizeT envSize=proUD->var.size();
   parIx=proUD->key.size();
@@ -318,7 +318,7 @@ EnvUDT::EnvUDT( ProgNodeP callingNode_, DSubUD* newPro, DObjGDL** self):
 
   DSubUD* proUD= newPro; //static_cast<DSubUD*>(pro);
   
-  forLoopInfo.InitSize( proUD->NForLoops());
+  forLoopInfo.InitSize(proUD->NForLoops());
 
   SizeT envSize;
   //   SizeT keySize;

--- a/src/envt.hpp
+++ b/src/envt.hpp
@@ -372,12 +372,14 @@ public:
 private:
   T* eArr;
   char buf[defaultLength * sizeof(T)]; // prevent constructor calls
+  SizeT currentMaxLength;
   SizeT sz;
 
 public:
 
   ForInfoListT(): eArr( reinterpret_cast<T*>(buf)), sz( 0)
-  {
+  { 
+    currentMaxLength=defaultLength;
   }
 
   ~ForInfoListT()
@@ -395,33 +397,40 @@ public:
   // must be called before access
   void InitSize( SizeT s)
   {
+//    std::cerr<<this<<": InitSize("<<s<<")\n";
     assert( sz == 0);
     if( s == 0)
       return;
-    sz = s;
-    if( s < defaultLength)
+    sz = 0;
+    if( s <= currentMaxLength) //initialise currentMaxLength objects
       {
-	for( SizeT i=0; i<s; ++i)
+	for( SizeT i=0; i<currentMaxLength; ++i)
 	  eArr[ i].Init();
 	return;
       }
     eArr = new T[ s]; // constructor called
+    currentMaxLength=s;
   }
   // only needed for EXECUTE
   void resize( SizeT s)
   {
-    if( s == sz)
+//    std::cerr<<this<<": resize("<<s<<"): ";
+    if( s == sz) {
+//    std::cerr<<" == "<<sz<<": return.\n";
       return;
+    }
     if( s < sz) // shrink
       {
+//      std::cerr << " < " << sz << ": shrink.\n";
 	for( SizeT i=s; i<sz; ++i)
 	  eArr[ i].ClearInit(); // in case eArr was allocated
 	sz = s;
 	return;
       }
     // s > sz -> grow
-    if( s <= defaultLength && eArr == reinterpret_cast<T*>(buf))
+    if( s <= currentMaxLength && eArr == reinterpret_cast<T*>(buf))
       {
+//      std::cerr << " > " << sz << " but <= currentMaxLength : grow.\n";
 	for( SizeT i=sz; i<s; ++i)
 	  eArr[ i].Init();
 	sz = s;
@@ -429,8 +438,10 @@ public:
       }
     // this should never happen (or only in extreme rarely cases)
     // the performance will go down
-    // s > defaultLength
+    // s > currentMaxLength
+//    std::cerr << " > " << sz << " and > currentMaxLength : should not happen.\n";
     T* newArr = new T[ s]; // ctor called
+    currentMaxLength=s;
     if( eArr != reinterpret_cast<T*>(buf))
       {
 	for( SizeT i=0; i<sz; ++i)
@@ -451,7 +462,7 @@ public:
     sz = s;
   }
   // T operator[]( SizeT i) const { assert( i<sz);  return eArr[i];}
-  T& operator[]( SizeT i) { assert( i<sz);  return eArr[i];}
+  T& operator[]( SizeT i) { assert( i<currentMaxLength);  return eArr[i];}
   SizeT size() const { return sz;}
   iterator begin() const { return &eArr[0];}
   iterator end() const { return &eArr[sz];}
@@ -461,7 +472,6 @@ public:
   T& back() { return eArr[sz-1];}
   const T& back() const { return eArr[sz-1];}
 };
-
 
 
 // for UD subroutines (written in GDL) ********************************
@@ -481,8 +491,7 @@ public:
   };
 
 private:
-  ForInfoListT<ForLoopInfoT, 32> forLoopInfo;
-  // std::vector<ForLoopInfoT> forLoopInfo;
+   ForInfoListT<ForLoopInfoT, MAX_LOOPS_NUMBER> forLoopInfo;  //defaults to $MAIN$ values in dpro.hpp
 
   ProgNodeP         ioError; 
   DLong             onError; // on_error setting


### PR DESCRIPTION
contrary to its intent, the loop number did not start at 0 but at 32 (the initialized default size), and would be constantly increasing in size at each new level of nested loop (remember, ForInfoListT was designed exactly for the contrary!). May even had an incidence on the loop speed.

For the record, using a simpler std::vector would be a lot less worry but would crash when the type of the loop iterator would change during the loop, which happens (see #1540).