### PR TITLE
various small tests ...

### DIFF
--- a/src/basic_fun_jmg.cpp
+++ b/src/basic_fun_jmg.cpp
@@ -207,8 +207,8 @@ namespace lib {
     }
 
     if(type == "OBJREF"){
-      rank=1; // alway array following ISA() doc.
-      //cout << "OBJREF" << endl;
+      // AC 2024/03/21 wrong here rank=1; // alway array following ISA() doc.
+      // cout << "OBJREF" << endl;
       DObjGDL* obj = static_cast<DObjGDL*>(p0);
       DObj objID = (*obj)[0];
       if(objID == 0) res = false; else res = true;
@@ -224,7 +224,11 @@ namespace lib {
 	else {
 	  objectName = str->Desc()->Name();
 	}
-	// cout << objectName << endl;
+	SizeT nEl;
+	if (str->Desc()->IsParent("LIST")) nEl=LIST_count(str);
+	if (str->Desc()->IsParent("HASH")) nEl=HASH_count(str);
+	if (debug) cout << objectName << " " << nEl<< endl;
+	if (nEl > 0) rank=1;
       }
     }
 
@@ -456,14 +460,13 @@ namespace lib {
 	    if( oStructGDL != NULL) // if object not valid -> default behaviour
 	      {  
 		DStructDesc* desc = oStructGDL->Desc();
-
 		if( desc->IsParent("LIST"))
 		  {
-				isObjectContainer = true; nEl = LIST_count(oStructGDL);
+		    isObjectContainer = true; nEl = LIST_count(oStructGDL);
 		  }
 		if( desc->IsParent("HASH"))
 		  {
-				isObjectContainer = true; nEl = HASH_count(oStructGDL);
+		    isObjectContainer = true; nEl = HASH_count(oStructGDL);
 		  }
 	      }
 	  }
@@ -471,7 +474,7 @@ namespace lib {
 
     if( isObjectContainer)
       {
-	LogicalRank = 1;
+	if (nEl > 0) LogicalRank = 1; // AC2024/03/21 bug  #1725
       }
     
     // DIMENSIONS

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -2125,7 +2125,8 @@ BaseGDL* list__toarray( EnvUDT* e)
 
 BaseGDL* list__isempty( EnvUDT* e)
 {
-      
+             std::cout << "par par ici et là" << std::endl;
+   
     GDL_LIST_STRUCT()
         
   static int kwSELFIx = 0;
@@ -2137,16 +2138,20 @@ BaseGDL* list__isempty( EnvUDT* e)
 
 SizeT LIST_count( DStructGDL* list)
 {// straight through, no checks
-  static unsigned nListTag = structDesc::LIST->TagIndex( "NLIST");
-    return (*static_cast<DLongGDL*>( list->GetTag( nListTag, 0)))[0];         
 
+  static unsigned nListTag = structDesc::LIST->TagIndex( "NLIST");
+  
+  //  std::cout << nListTag << std::endl;
+  return (*static_cast<DLongGDL*>( list->GetTag( nListTag, 0)))[0];
 }
+
 BaseGDL* list__count( EnvUDT* e)
 {
     static int kwSELFIx = 0; // no keywords
     static int kwVALUEIx = 1;
-   
-//    DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
+
+    //    std::cout << "ici ici" << std::endl;
+    //    DStructGDL* self = GetOBJ( e->GetKW( kwSELFIx), e);
     SizeT nParam = e->NParam(1);
     if( nParam == 1)
         return new DLongGDL( LIST_count( GetOBJ( e->GetTheKW( kwSELFIx), e)));

--- a/testsuite/LIST
+++ b/testsuite/LIST
@@ -38,7 +38,6 @@ test_bug_3189072.pro
 test_bug_3199465.pro
 test_bug_3285659.pro
 test_bug_3286031.pro
-test_bug_3288652.pro
 test_bug_3290532.pro
 test_bug_3296360.pro
 test_bug_3298378.pro
@@ -96,6 +95,7 @@ test_file_readlink.pro
 test_file_which.pro
 test_finite.pro
 test_fixprint.pro
+test_foreach.pro
 test_fx_root.pro
 test_fz_roots.pro
 test_gaussfit.pro
@@ -144,6 +144,7 @@ test_null.pro
 test_numeric_limits.pro
 test_obj_hasmethod.pro
 test_obj_valid.pro
+test_operators.pro
 test_parse_url.pro
 test_plot_ranges.pro
 test_plot_usersym.pro
@@ -202,5 +203,6 @@ test_wordexp.pro
 test_wordexp_null_string.pro
 test_xdr.pro
 test_xmlsax.pro
+test_xyztick_get.pro
 test_zeropoly.pro
 test_write_csv.pro

--- a/testsuite/benchmark/bench_loops.pro
+++ b/testsuite/benchmark/bench_loops.pro
@@ -1,0 +1,315 @@
+;
+; AC 2024-Feb-27
+;
+; more systematics tests on loops
+; showing the serious/critical issue on OSX ...
+;
+; the procedure PLOT_BENCH_LOOPS for plot
+; is fully derived from the one PLOT_BASIC_BENCHMARKS
+; located in same directory
+;
+; on my laptop :
+; BENCH_LOOPS,/save
+; BENCH_LOOPS,/save, nb=1e6
+; PLOT_BENCH_LOOPS,/ylo, yrang=[0.001,0.5]
+;
+; --------------------------------------------------------------
+;
+function LISTE_OF_NBP, liste, debug=debug
+nbps=0L
+for ii=0, N_elements(liste)-1 do begin
+   RESTORE, liste[ii]
+   if KEYWORD_SET(debug) then print, nbp, liste[ii]
+   nbps=[nbps, nbp]
+endfor
+nbps=nbps[1:*]
+return, nbps[UNIQ(nbps, SORT(nbps))]
+end
+;
+pro SYMBOLS_TO_BE_USED, nbp, nbps, family_type, psymb, my_line, test=test
+;
+calcul=MIN(ABS(nbps-nbp), indice)
+;
+family_type=STRING(nbps[indice], format='(g10.5)')
+case indice of
+   0 : begin
+      psymb=4
+      my_line=0
+   end
+   1 : begin
+      psymb=6
+      my_line=2
+   end
+   2 : begin
+      psymb=2
+      my_line=1
+   end
+ENDCASE
+;
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+pro PLOT_BENCH_LOOPS, path=path, filter=filter, type=type, $
+                      select=select, title=title, $
+                      xrange=xrange, yrange=yrange, $
+                      xlog=xlog, ylog=ylog, $
+                      svg=svg, special=special, $
+                      help=help, test=test, debug=debug, verbose=verbose
+;
+if KEYWORD_SET(help) then begin
+    print, 'pro PLOT_BENCH_LOOPS, path=path, filter=filter, $'
+    print, '                      xrange=xrange, yrange=yrange, $'
+    print, '                      xlog=xlog, ylog=ylog, $'
+    print, '                      svg=svg, $'
+    print, '                      help=help, test=test'
+    return
+endif
+;
+if ~KEYWORD_SET(test) then ON_ERROR, 2
+;
+CHECK_SAVE_RESTORE
+;
+if ~KEYWORD_SET(filter) then filter='bench_loops*.xdr'
+;
+liste=BENCHMARK_FILE_SEARCH(filter, 'bench_loops', path=path)
+if N_ELEMENTS(liste) EQ 0 then begin
+   print, 'Used filter : ', filter
+   MESSAGE, 'No file found !'
+endif
+;
+; name for the output, if needed (+ type name if selected)
+;
+RESTORE, liste[0]
+fig_name='bench_loops_'
+;if STRLEN(keep_type) GT 0 then fig_name=fig_name+keep_type+'_'
+fig_name=fig_name+info_os.generic_osname+'_'+info_os.hostname+'.svg'
+BENCHMARK_SVG, svg=svg, /on, filename=fig_name, infosvg=infosvg 
+;
+; not useful now, maybe later ...
+if KEYWORD_SET(xrange) then MESSAGE,/info, "keyword Xrange not effective !"
+if KEYWORD_SET(xlog) then MESSAGE,/info, "keyword Xrange not effective !"
+;
+;; Which ranges ? fake Xrange (we don't care)
+BENCHMARK_COMPUTE_RANGE, liste, xrange, yrange_new, 'nbp', 'op_val', $
+                         xelems=xelems, yelems=yelems
+if ~KEYWORD_SET(yrange) then yrange=yrange_new
+;
+xelems=N_ELEMENTS(op_name)
+;
+; in fact, we overwrite xrange ...
+xval=INDGEN(xelems)+1
+xrange=[0, xelems+1]
+;
+DEVICE, decompose=1
+;
+; reading a first time all the XDR in liste to get infos
+BENCHMARK_GRAPHIC_STYLE, liste, colors, mypsym, myline, flags, $
+                         languages, select=select
+;
+bb_title='Basic Benchmark on Loops'
+if KEYWORD_SET(title) then bb_title=bb_title+' : '+title
+;
+PLOT, FINDGEN(xelems), /nodata, xstyle=5, /ystyle, ylog=ylog, $
+      xrange=xrange, yrange=yrange, $
+      xtitle='Operations', ytitle='time [s]', $
+      title=bb_title, pos=[0.07,0.05, 0.75, 0.9]
+;
+XYOUTS, 0.78, 0.95, SYSTIME(), /normal
+XYOUTS, 0.78, 0.90, info_os.hostname, /normal
+XYOUTS, 0.78, 0.85, info_os.generic_osname,/normal
+XYOUTS, 0.78, 0.80, info_os.family_osname+' '+info_os.accurate_osname,/normal
+XYOUTS, 0.78, 0.75, info_cpu.model,/normal
+XYOUTS, 0.78, 0.70, 'nb cores : '+STRING(info_cpu.nb_cores), /normal
+;
+liste_nbps=LISTE_OF_NBP(liste)
+;
+for ii=0, N_ELEMENTS(liste)-1 do begin
+   if KEYWORD_SET(verbose) then print, 'Restoring '+liste[ii]
+   RESTORE, liste[ii]
+   ;;
+   ;; at the end, plotting missing Xaxis !
+   if ii EQ 0 then $
+      AXIS, xtickname=['',op_name,''], xticks=N_ELEMENTS(op_name)+1
+   ;;
+   ;; type ?
+   ;;
+   SYMBOLS_TO_BE_USED, nbp, liste_nbps, family_type, psymb, my_line, test=test
+   ;;
+   ;; skipped unwanted inputs if Type= provided
+   if KEYWORD_SET(type) then if (keep_type NE family_type) then continue
+   ;;
+   jj=flags[ii]
+   if jj GE 0 then begin
+      OPLOT, xval, op_val, line=my_line, col=colors[jj], thick=2
+      OPLOT, xval, op_val, psym=psymb, col=colors[jj], thick=2
+   endif
+   ;;   print, ii, jj, mypsym[jj], myline, colors[jj]
+endfor
+;
+; adding vertical lines separating the 4 cases
+;
+BENCHMARK_PLOT_CARTOUCHE, pos=[0.75,0.05,0.98,0.4], languages, /box, $
+                          colors=colors, lines=lines, /all, /absolute, $
+                          thick=2, title='Languages'
+;
+; populate symbols lists
+nbs=N_ELEMENTS(liste_nbps)
+ls=INTARR(nbs)
+ss=STRARR(nbs)
+psym=INTARR(nbs)
+for ii=0, nbs-1 do begin
+   SYMBOLS_TO_BE_USED, liste_nbps[ii], liste_nbps, family_type, psymb, my_line
+   ss[ii]=family_type
+   ls[ii]=my_line
+   psym[ii]=-psymb
+endfor
+;
+BENCHMARK_PLOT_CARTOUCHE, pos=[0.75,0.4,0.98,0.7], ss, /box, $
+    ;                      colors=color2color(!color.white), $
+                          linestyle=ls, psym=psym, /all, /absolute, $
+                          thick=2, title='Types'
+;
+if KEYWORD_SET(special) then begin
+   colors=[colors[0],colors[0]]
+   info=['git_11','git_19']
+   lines=[2,0]
+   BENCHMARK_PLOT_CARTOUCHE, pos=[0.75,0.55,0.98,0.95], info, /box, $
+                             colors=colors, lines=lines, /all, /absolute, $
+                             thick=1.5, title='Git version'
+endif
+;
+BENCHMARK_SVG, svg=svg, /off, infosvg=infosvg
+;
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+
+
+; --------------------------------------------------------------
+; begin og the core code for benchmarking
+; ----------------- REPEAT ------
+;
+pro TEST_LOOP_REPEAT, dt, nbp=nbp, quiet=quiet
+;
+if ~KEYWORD_SET(nbp) then nbp=100000L
+;
+a=0L
+TIC
+;
+repeat begin
+   a=a+1L
+endrep until A GT nbp
+;
+dt=TOC()
+if ~KEYWORD_SET(quiet) then print, 'time loop REPEAT :', dt
+;
+end
+;
+; ----------------- WHILE ------
+;
+pro TEST_LOOP_WHILE, dt, nbp=nbp, quiet=quiet
+;
+if ~KEYWORD_SET(nbp) then nbp=100000L
+;
+a=0L
+;
+TIC
+;
+While (a LT nbp) do begin
+   a=a+1L
+endwhile
+;
+dt=TOC()
+if ~KEYWORD_SET(quiet) then print, 'time loop WHILE :', dt
+;
+end
+;
+; ----------------- FOR ------
+;
+pro TEST_LOOP_FOR, dt, nbp=nbp, quiet=quiet
+;
+if ~KEYWORD_SET(nbp) then nbp=100000L
+;
+a=0L
+;
+TIC
+;
+for ii=0, nbp do begin
+   a=a+1L
+endfor
+;
+dt=TOC()
+if ~KEYWORD_SET(quiet) then print, 'time loop FOR :', dt
+;
+end
+;
+; ----------------- FOREACH ------
+;
+pro TEST_LOOP_FOREACH, dt, nbp=nbp, quiet=quiet
+;
+if ~KEYWORD_SET(nbp) then nbp=100000L
+;
+a=LINDGEN(nbp)
+;
+TIC
+;
+foreach elem, a do begin
+   a[elem]=0
+endforeach
+;
+if TOTAL(a) GT 0 then MESSAGE, 'pb here'
+;
+dt=TOC()
+if ~KEYWORD_SET(quiet) then print, 'time loop FOREACH :', dt
+;
+end
+;
+; ----------------- call all of them ------
+;
+pro BENCH_LOOPS, nbp=nbp, quiet=quiet, display=display, $
+                 help=help, save=save, test=test
+;
+if KEYWORD_SET(help) then begin
+   print, 'pro BENCH_LOOPS, nbp=nbp, quiet=quiet, display=display, $'
+   print, '                 help=help, save=save, test=test'
+   return
+endif
+;
+if KEYWORD_SET(save) then CHECK_SAVE_RESTORE
+
+if ~KEYWORD_SET(nbp) then begin
+   nbp=100000L
+   print, 'Running tests for default value : ', nbp
+endif else print, 'Running tests for value : ', nbp
+nbp=LONG(nbp)
+;
+TEST_LOOP_REPEAT, dt1, nbp=nbp, quiet=quiet
+TEST_LOOP_WHILE, dt2, nbp=nbp, quiet=quiet
+TEST_LOOP_FOR, dt3, nbp=nbp, quiet=quiet
+TEST_LOOP_FOREACH, dt4, nbp=nbp, quiet=quiet
+;
+op_name=['REPEAT','WHILE', 'FOR', 'FOREACH']
+op_val=[dt1,dt2,dt3,dt4]
+;
+if KEYWORD_SET(display) then begin
+   plot, times, title='nbp='+string(nbp)
+endif
+;
+if KEYWORD_SET(save) then begin
+   radical='loops'
+   filename=BENCHMARK_GENERATE_FILENAME(radical)
+   ;;
+   info_cpu=BENCHMARK_INFO_CPU()
+   info_os=BENCHMARK_INFO_OS()
+   info_soft=BENCHMARK_INFO_SOFT()
+   ;;
+   SAVE, file=filename, nbp, op_name, op_val, $
+      info_cpu, info_os, info_soft
+endif
+;
+if KEYWORD_SET(test) then STOP
+;
+end
+

--- a/testsuite/gdl_version.pro
+++ b/testsuite/gdl_version.pro
@@ -16,6 +16,9 @@
 ; (A.B should be lower than A.B.C)
 ; * should work with IDL too (!version.release)
 ;
+; AC 2024-Mars-08 : hum, now GDL have a Git suffix,
+; and is prefixed by "v" ... We need also to remove the part after '-'
+;
 ; ---------------------------------------
 ;
 pro APRINT, tab3nbps
@@ -54,11 +57,22 @@ endelse
 ;
 if KEYWORD_SET(debug) then print, suite
 ;
+; extra processing for GDL :(
+if GDL_IDL_FL() EQ 'GDL' then begin
+   if (STRUPCASE(STRMID(suite,0,1)) EQ 'V') then suite=STRMID(suite,1)
+   if (STRPOS(suite, '-') GT 0) then suite=STRMID(suite,0,STRPOS(suite, '-'))
+endif
+;
+if KEYWORD_SET(debug) then print, suite
+;
 indices=STRSPLIT(suite,'.',/extract)
 if KEYWORD_SET(debug) then APRINT, indices
 ;
 if  N_ELEMENTS(indices) EQ 2 then indices=[indices,'0']
 int_indices=FIX(indices)
+for iii=0, N_ELEMENTS(int_indices)-1 do begin
+   if int_indices[iii] GT 99 then MESSAGE,/cont, 'Value greater than 99'
+endfor
 ;
 if KEYWORD_SET(debug) then APRINT, int_indices
 ;

--- a/testsuite/test_bug_3288652.pro
+++ b/testsuite/test_bug_3288652.pro
@@ -1,7 +1,0 @@
-; by Sylwester Arabas <slayoo@igf.fuw.edu.pl>
-; part of GDL - GNU Data Language
-pro test_bug_3288652
-  arr = routine_names(/s_fun)
-  foreach a, arr do if a eq 'WTN' then exit, status=0
-  exit, status=1
-end

--- a/testsuite/test_foreach.pro
+++ b/testsuite/test_foreach.pro
@@ -1,0 +1,183 @@
+;
+; AC 2024/03/06
+;
+; Trying to collect and classify known bugs related to FOREACH
+; Some of those bugs have been solved but it is always a good
+; idea to keep the test if we know how to test it !
+; As usual, event "stupid" tests migth be useful any time in the
+; future !
+;
+; As usual, it is not easy to write exhaustif tests, please contribute !
+;
+; -------------------------------------------------------------
+; https://sourceforge.net/p/gnudatalanguage/bugs/273/
+pro TEST_FOREACH_SF_273, cumul_errors, test=test
+;
+nb_errors=0
+;
+a=1000
+FOREACH a, [0] do a = 0
+if a NE 0 then ERRORS_ADD, nb_errors, '<<a>> should be 0'
+;
+b=1000
+FOREACH a, [0] do b = 0
+if b NE 0 then ERRORS_ADD, nb_errors, '<<b>> should be 0'
+;
+BANNER_FOR_TESTSUITE, 'TEST_FOREACH_SF_273', nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; -------------------------------------------------------------
+; https://sourceforge.net/p/gnudatalanguage/bugs/630/
+; copy in https://github.com/gnudatalanguage/gdl/issues/29
+pro TEST_FOREACH_SF_630, cumul_errors, test=test, verbose=verbose
+;
+nb_errors=0
+;
+res=0
+a = [1,2,3]
+FOREACH a, a DO BEGIN
+   res=[res,a]
+ENDFOREACH
+;
+if (N_ELEMENTS(res) NE 2) then begin
+   ERRORS_ADD, nb_errors, '<<res>> shoudl contain 2 elements only'
+   print, 'the case is : a = [1,2,3] & FOREACH a, a DO print, a'
+endif
+;print, 'I don''t know how to change that into a test :('
+;
+BANNER_FOR_TESTSUITE, 'TEST_FOREACH_SF_630', nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; -------------------------------------------------------------
+; by Sylwester Arabas <slayoo@igf.fuw.edu.pl>
+; part of GDL - GNU Data Language
+; former file "test_bug_3288652.pro" in the test suite
+;
+pro TEST_BUG_3288652, cumul_errors, test=test
+;
+; get the list of all system (internal) functions
+arr = ROUTINE_NAMES(/s_fun)
+;
+nb_errors=0
+;
+; WTN should be detected one and only one time !
+count=0
+FOREACH a, arr do if a eq 'WTN' then count++
+;
+if (count NE 1) then begin
+   if (count LT 1) then message, /count, 'WTN not counted, but should be !'
+   if (count GT 1) then message, /count, 'WTN counted more than one time :('
+   ERRORS_ADD, nb_errors, 'bad count in FOREACH loop'
+endif
+;
+BANNER_FOR_TESTSUITE, 'TEST_BUG_3288652', nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; -------------------------------------------------------------
+; This test is also a test on LIST() !
+;
+pro TEST_FOREACH_LIST, cumul_errors, test=test
+;
+nb_errors=0
+;
+el0='toto'
+el1=COMPLEX(0.,1.)
+el2=!pi
+el3=[!pi]
+el4=indgen(4)
+mylist=LIST(el0,el1,el2,el3,el4)
+;
+ii=0
+;
+; since LIST() should be processed in order we can test !
+FOREACH element, mylist DO BEGIN
+   if ii EQ 0 then begin
+      if ~ARRAY_EQUAL(element, el0) then ERRORS_ADD, nb_errors, 'bad <<el0>>'
+   endif
+   if ii EQ 1 then begin
+      if ~ARRAY_EQUAL(element, el1) then ERRORS_ADD, nb_errors, 'bad <<el1>>'
+   endif
+   if ii EQ 2 then begin
+      if ~ARRAY_EQUAL(element, el2) then ERRORS_ADD, nb_errors, 'bad <<el2>>'
+   endif
+   if ii EQ 3 then begin
+      if ~ARRAY_EQUAL(element, el3) then ERRORS_ADD, nb_errors, 'bad <<el3>>'
+   endif
+   if ii EQ 4 then begin
+      if ~ARRAY_EQUAL(element, el4) then ERRORS_ADD, nb_errors, 'bad <<el4>>'
+   endif
+   
+   ii++
+   ;;   if a NE 0 then ERRORS_ADD, nb_errors, '<<a>> should be 0'
+ENDFOREACH
+;
+nb_elts_list=N_ELEMENTS(mylist)
+if (ii NE nb_elts_list)  then ERRORS_ADD, nb_errors, 'bad internal count'
+;
+b=1000
+FOREACH a, [0] do b = 0
+if b NE 0 then ERRORS_ADD, nb_errors, '<<b>> should be 0'
+;
+BANNER_FOR_TESTSUITE, 'TEST_FOREACH_LIST', nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; -------------------------------------------------------------
+;
+pro TEST_FOREACH_INDEX, cumul_errors, test=test, verbose=verbose
+;
+nb_errors=0
+;
+ramp=INDGEN(6)
+ii=0
+;
+FOREACH element, ramp, index DO BEGIN
+   if element NE ramp[index] then ERRORS_ADD, nb_errors, 'bad <<el0>>'
+   if KEYWORD_SET(verbose) then begin
+      print, 'Index ', index, ' Value = ', element, 'Expected = ', ramp[index]
+   endif
+ENDFOREACH
+;
+; ---------------------
+;
+BANNER_FOR_TESTSUITE, 'TEST_FOREACH_INDEX', nb_errors, /short
+ERRORS_CUMUL, cumul_errors, nb_errors
+if KEYWORD_set(test) then STOP
+;
+end
+;
+; -------------------------------------------------------------
+;
+pro TEST_FOREACH, help=help, test=test, verbose=verbose, no_exit=no_exit 
+;
+if KEYWORD_SET(help) then begin
+   print, 'pro TEST_FOREACH, help=help, test=test, verbose=verbose, no_exit=no_exit'
+   return
+endif 
+;
+cumul_errors=0
+;
+TEST_FOREACH_SF_273, cumul_errors, test=test
+TEST_FOREACH_SF_630, cumul_errors, test=test
+TEST_BUG_3288652, cumul_errors, test=test
+TEST_FOREACH_LIST, cumul_errors, test=test
+TEST_FOREACH_INDEX, cumul_errors, test=test
+;
+; ----------------- final message ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_FOREACH', cumul_errors
+;
+if (cumul_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+end

--- a/testsuite/test_operators.pro
+++ b/testsuite/test_operators.pro
@@ -1,0 +1,139 @@
+;
+; AC 2024 Mars 13
+; quick tests for operators.
+; need GIVE_LIST_NUMERIC procedure in the testsuite
+;
+; We don't play with negative numbers because for Int/Long & unsigned
+; we will have other difficulties related to modulo
+;
+; --------------------------------------
+;
+pro PROCESS_RESULTS, operateur, type, val, expected, errors, verbose=verbose
+;
+if KEYWORD_SET(verbose) then print, operateur, ' ', type,  val, expected
+if (TOTAL(ABS(val-expected)) GT 1e-6) then begin
+   ERRORS_ADD, errors, operateur+' '+type
+endif
+end
+; --------------------------------------
+;
+pro TEST_OP_DIV, cumul_errors, value, expected, verbose=verbose, test=test
+;
+errors=0
+;
+GIVE_LIST_NUMERIC,a,b,c
+;
+for ii=0, N_ELEMENTS(a)-1 do begin
+   val=FIX(value, type=a[ii])
+   val /=2
+   ;;
+   PROCESS_RESULTS, 'DIV', b[ii], val, expected, errors, verbose=verbose
+endfor
+;
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_OP_DIV", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; --------------------------------------
+;
+pro TEST_OP_MUL, cumul_errors, value, expected, verbose=verbose, test=test
+;
+errors=0
+;
+GIVE_LIST_NUMERIC,a,b,c
+
+for ii=0, n_elements(a)-1 do begin
+   val=FIX(value, type=a[ii])
+   val *=2
+   PROCESS_RESULTS, 'MUL', b[ii], val, expected, errors, verbose=verbose
+endfor
+;
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_OP_MUL", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; --------------------------------------
+;
+pro TEST_OP_ADD, cumul_errors, value, expected, verbose=verbose, test=test
+;
+errors=0
+;
+GIVE_LIST_NUMERIC,a,b,c
+;
+for ii=0, n_elements(a)-1 do begin
+   val=FIX(value, type=a[ii])
+   val +=2
+   PROCESS_RESULTS, 'ADD', b[ii], val, expected, errors, verbose=verbose
+endfor
+;
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_OP_ADD", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; --------------------------------------
+;
+pro TEST_OP_SUB, cumul_errors, value, expected, verbose=verbose, test=test
+;
+errors=0
+;
+GIVE_LIST_NUMERIC,a,b,c
+
+for ii=0, n_elements(a)-1 do begin
+   val=FIX(value, type=a[ii])
+   val -=2
+   PROCESS_RESULTS, 'SUB', b[ii], val, expected, errors, verbose=verbose
+endfor
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_OP_SUB", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; --------------------------------------
+;
+pro TEST_OPERATORS, help=help, test=test, verbose=verbose, no_exit=no_exit
+;
+if KEYWORD_SET(help) then begin
+   print, 'pro TEST_TOTAL, help=help, test=test, verbose=verbose, no_exit=no_exit'
+   return
+endif
+;
+TEST_OP_ADD, cumul_errors, 10, 12., verbose=verbose
+TEST_OP_ADD, cumul_errors, [10], 12., verbose=verbose
+TEST_OP_ADD, cumul_errors, [10,20], [12.,22], verbose=verbose
+;
+TEST_OP_SUB, cumul_errors, 10, 8, verbose=verbose
+TEST_OP_SUB, cumul_errors, [10], 8, verbose=verbose
+TEST_OP_SUB, cumul_errors, [10,20], [8,18], verbose=verbose
+;
+TEST_OP_MUL, cumul_errors, 10, 20, verbose=verbose
+TEST_OP_MUL, cumul_errors, [10], 20, verbose=verbose
+TEST_OP_MUL, cumul_errors, [10,20], [20,40], verbose=verbose
+;
+TEST_OP_DIV, cumul_errors, 10, 5, verbose=verbose
+TEST_OP_DIV, cumul_errors, [10], 5, verbose=verbose
+TEST_OP_DIV, cumul_errors, [10,20], [5,10], verbose=verbose
+;
+; ----------------- final message ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_OPERATORS', cumul_errors, short=short
+;
+if (cumul_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
+end

--- a/testsuite/test_xyztick_get.pro
+++ b/testsuite/test_xyztick_get.pro
@@ -1,0 +1,224 @@
+;
+; AC 2024-mars-13
+;
+; Regression in the GET_TICK as reported in issue #1778
+; https://github.com/gnudatalanguage/gdl/issues/1778
+;
+; As usual in tests, errors flags can be triggered more that one time
+; but only one bug is detected ! We have a special situation here
+; than some calls don't return values ... 
+;
+; These tests are also tests on the ranges computed for PLOT & SURFACE ...
+;
+; -------------------------------------------------
+; simple debug print when needed ...
+pro MODE_DEBUG, exp, val, valname, debug=debug, test=test
+if KEYWORD_SET(debug) then begin
+   svalname=STRING(valname, format='(A9)')+':'
+   print, 'expected :', STRING(exp, form='(g10.5)')
+   print, svalname,     STRING(val, form='(g10.5)')
+endif
+if KEYWORD_SET(test) then STOP
+end
+; -------------------------------------------------
+;
+pro TEST_TICK_GET_PLOT, cumul_errors, debug=debug, test=test, verbose=verbose
+;
+errors=0
+;
+; testing only XTICK_GET
+;
+res=EXECUTE('plot, FINDGEN(10), xtick_get=xt')
+;
+if (res EQ 0) then ERRORS_ADD, errors, 'bad execution, X fields only'
+;
+if ISA(xt) then begin
+   expected=2.*DINDGEN(6)
+   if ~ARRAY_EQUAL(expected, xt) then ERRORS_ADD, errors, 'bad X-axis (1)'
+   MODE_DEBUG, expected, xt, 'X axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined xtick_get (X-axis (1))'
+;
+; testing only YTICK_GET
+;
+res=EXECUTE('PLOT, -FINDGEN(10), ytick_get=yt')
+;
+if (res EQ 0) then ERRORS_ADD, errors, 'bad execution, Y fields only'
+;
+if ISA(yt) then begin
+   expected=-10.+2.*DINDGEN(6)
+   if ~ARRAY_EQUAL(expected, yt) then ERRORS_ADD, errors, 'bad Y-axis (1)'
+   MODE_DEBUG, expected, yt, 'Y axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined ytick_get (Y-axis (1))'
+;
+; -----
+;
+res=EXECUTE('PLOT, FINDGEN(10), xtick_get=xt, ytick_get=yt')
+;
+if (res EQ 0) then ERRORS_ADD, errors, 'bad execution, two fields'
+;
+if ISA(xt) AND ISA(yt) then begin
+   expected=2.*DINDGEN(6)
+   if ~ARRAY_EQUAL(expected, xt) then ERRORS_ADD, errors, 'bad X-axis'
+   if ~ARRAY_EQUAL(expected, yt) then ERRORS_ADD, errors, 'bad Y-axis'
+   MODE_DEBUG, expected, xt, 'X axis', debug=debug
+   MODE_DEBUG, expected, yt, 'Y axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined xtick_get OR ytick_get'
+;
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_TICK_GET_PLOT", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; ----------------------------
+;
+pro TEST_TICK_GET_SURFACE, cumul_errors, test=test, debug=debug, verbose=verbose
+;
+errors=0
+;
+; expected values
+data1=DIST(53,63)
+exp_x1=10.*DINDGEN(7)
+exp_y1=20.*DINDGEN(5)
+exp_z1=10.*DINDGEN(6)
+;
+; one field
+; (we use xti1/yti1/zti1 to avoid mixing with next vars, in case of
+; undefined ...)
+;
+if KEYWORD_SET(debug) then print, "Testing ONE in the THREE fields"
+;
+res1=EXECUTE('SURFACE, data1, xtick_get=xti1')
+res2=EXECUTE('SURFACE, data1, ytick_get=yti1')
+res3=EXECUTE('SURFACE, data1, ztick_get=zti1')
+if (res1 EQ 0) then ERRORS_ADD, errors, 'bad execution, one field, X case'
+if (res2 EQ 0) then ERRORS_ADD, errors, 'bad execution, one field, Y case'
+if (res3 EQ 0) then ERRORS_ADD, errors, 'bad execution, one field, Z case'
+if ISA(xti1) then begin
+   if ~ARRAY_EQUAL(xti1, exp_x1) then ERRORS_ADD, errors, 'bad X-axis value'
+   MODE_DEBUG, exp_x1, xti1, 'X axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined XTICK_GET, one field, X case'
+if ISA(yti1) then begin
+   if ~ARRAY_EQUAL(yti1, exp_y1) then ERRORS_ADD, errors, 'bad Y-axis value'
+   MODE_DEBUG, exp_y1, yti1, 'Y axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined YTICK_GET, one field, Y case'
+if ISA(zti1) then begin
+   if ~ARRAY_EQUAL(zti1, exp_z1) then ERRORS_ADD, errors, 'bad Z-axis value'
+   MODE_DEBUG, exp_z1, zti1, 'Z axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined ZTICK_GET, one field, Z case'
+;
+; two fields
+;
+if KEYWORD_SET(debug) then print, "Testing TWO in the THREE fields"
+; expected values
+data2=DIST(23,73)
+exp_x2=5.*DINDGEN(6)
+exp_y2=20.*DINDGEN(5)
+exp_z2=10.*DINDGEN(5)
+;
+res1=EXECUTE('SURFACE, data2, xtick_get=xt1, ytick_get=yt1')
+res2=EXECUTE('SURFACE, data2, ytick_get=yt2, ztick_get=zt2')
+res3=EXECUTE('SURFACE, data2, xtick_get=xt3, ztick_get=zt3')
+if (res1 EQ 0) then ERRORS_ADD, errors, 'bad execution, two fields, X&Y case'
+if (res2 EQ 0) then ERRORS_ADD, errors, 'bad execution, two fields, Y&Z case'
+if (res3 EQ 0) then ERRORS_ADD, errors, 'bad execution, two fields, X&Z case'
+;
+messcase=' in two fields, X&Y case'
+if ISA(xt1) then begin
+   if ~ARRAY_EQUAL(exp_x2, xt1) then ERRORS_ADD, errors, 'bad X value'+messcase
+   MODE_DEBUG, exp_x2 , xt1, 'X axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined XTICK_GET'+messcase
+if ISA(yt1) then begin
+   if ~ARRAY_EQUAL(exp_y2, yt1) then ERRORS_ADD, errors, 'bad Y value'+messcase
+   MODE_DEBUG, exp_y2, yt1, 'Y axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined YTICK_GET'+messcase
+;
+messcase=' in two fields, X&Y case'
+if ISA(yt2) then begin
+   if ~ARRAY_EQUAL(exp_y2, yt2) then ERRORS_ADD, errors, 'bad Y value'+messcase
+   MODE_DEBUG, exp_y2, yt2, 'Y axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined YTICK_GET'+messcase
+if ISA(zt2) then begin
+   if ~ARRAY_EQUAL(exp_z2, zt2) then ERRORS_ADD, errors, 'bad Z value '+messcase
+   MODE_DEBUG, exp_z2, zt2, 'Z axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined ZTICK_GET'+messcase
+;
+messcase=' in two fields, X&Z case'
+if ISA(xt3) then begin
+   if ~ARRAY_EQUAL(xt3, exp_x2) then ERRORS_ADD, errors, 'bad X value'+messcase
+   MODE_DEBUG, xt3, exp_x2, 'X axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined XTICK_GET'+messcase
+if ISA(zt3) then begin
+   if ~ARRAY_EQUAL(zt3, exp_z2) then ERRORS_ADD, errors, 'bad Z value'+messcase
+   MODE_DEBUG, zt2, exp_z2, 'Z axis', debug=debug
+endif else ERRORS_ADD, errors, 'undefined ZTICK_GET'+messcase
+;
+; three field
+;
+if KEYWORD_SET(debug) then print, "Testing THREE in the THREE fields"
+; expected values
+exp_x3=20.*DINDGEN(7)
+exp_y3=50.*DINDGEN(6)
+messcase=' value in three fields'
+;
+for ii=-1, 1, 1 do begin
+   data3=DIST(120,240)+ii*500
+   exp_z3=50*DINDGEN(4)+ii*500.
+   ;;
+   res=EXECUTE('SURFACE, data3, xtick_get=xt, ytick_get=yt, ztick_get=zt')
+   ;;
+   if (res EQ 0) then ERRORS_ADD, errors, 'bad execution, 3 fields'
+   ;;
+   if ISA(xt) then begin
+      if ~ARRAY_EQUAL(exp_x3, xt) then ERRORS_ADD, errors, 'bad X'+messcase
+      MODE_DEBUG, exp_x3, xt, 'X axis', debug=debug
+   endif else ERRORS_ADD, errors, 'undefined XTICK_GET'+messcase
+   if ISA(yt) then begin
+      if ~ARRAY_EQUAL(exp_y3, yt) then ERRORS_ADD, errors, 'bad Y'+messcase
+      MODE_DEBUG, exp_y3, yt, 'Y axis', debug=debug
+   endif else ERRORS_ADD, errors, 'undefined YTICK_GET'+messcase
+   if ISA(zt) then begin
+      if ~ARRAY_EQUAL(exp_z3, zt) then ERRORS_ADD, errors, 'bad Z'+messcase
+      MODE_DEBUG, exp_z3, zt, 'Z axis', debug=debug
+   endif else ERRORS_ADD, errors, 'undefined ZTICK_GET, one field, Z case'
+endfor
+;
+; --------------
+;
+BANNER_FOR_TESTSUITE, "TEST_TICK_GET_SURFACE", errors, /short, verb=verbose
+ERRORS_CUMUL, cumul_errors, errors
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+; --------------------------------------
+;
+pro TEST_XYZTICK_GET, devicename=devicename, help=help, test=test, $
+                        verbose=verbose, no_exit=no_exit
+;
+if KEYWORD_SET(help) then begin
+   print, 'pro TEST_PLOT_TICK_GET, devicename=devicename, help=help, $'
+   print, '                        test=test, verbose=verbose, no_exit=no_exit'
+   return
+endif
+;
+init_devicename=!d.name
+;
+if ~KEYWORD_SET(devicename) then SET_PLOT, 'Z' else  SET_PLOT, devicename
+;
+TEST_TICK_GET_PLOT, cumul_errors, test=test, verbose=verbose
+TEST_TICK_GET_SURFACE, cumul_errors, test=test, verbose=verbose
+;
+SET_PLOT, init_devicename
+;
+; ----------------- final message ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_OPERATORS', cumul_errors, short=short
+;
+if (cumul_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
+end

--- a/testsuite/test_xyztick_get.pro
+++ b/testsuite/test_xyztick_get.pro
@@ -215,7 +215,7 @@ SET_PLOT, init_devicename
 ;
 ; ----------------- final message ----------
 ;
-BANNER_FOR_TESTSUITE, 'TEST_OPERATORS', cumul_errors, short=short
+BANNER_FOR_TESTSUITE, 'TEST_XYZTICK_GET', cumul_errors, short=short
 ;
 if (cumul_errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
 ;


### PR DESCRIPTION
OK, this is a merging of various codes in GDL syntax for tests : 

* test_xyztick_get.pro tests [xyz]tick_get for PLOT & SURFACE, with various combinations of fields and ranges
(@GillesDuvert that shows PR #1785 is not the definitive one)
* test_operators.pro tests /=, *=, +=, -=. Might be redundant with test_indepth_basic_functions.pro
* gdl_version.pro does manages the new version schema #1780 (for naming convention in i.e. bench out files)
* test_foreach.pro merges some tests related to FOREACH (SF 273, 630 and test_bug_3288652.pro (removed outside)
* bench_loops.pro

![bench_loops_Linux_planck4](https://github.com/gnudatalanguage/gdl/assets/38264661/df683c78-0364-4bb4-a895-1595f308c83d)
