### PR TITLE
Use new python initialisation, if old one is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ src/gdl
 testsuite/launchtest.c
 nbproject/
 build/
+cmake-build*/
 install/
 gdlde/
 gdlde*.zip
 .vscode
+.idea/

--- a/src/gdlpython.cpp
+++ b/src/gdlpython.cpp
@@ -54,7 +54,15 @@ void PythonInit()
   static char* arg0 = (char*)"./py/python.exe";
   static char* argv[] = {arg0};
 #endif
+
+// use new python configuration (PEP 587), legacy initialisation is marked deprecated in Python 3.11
+#if PY_VERSION_HEX >= 0x030B0000
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+  PyConfig_SetArgv(&config, argc, argv);
+#else
   PySys_SetArgv(argc, argv);
+#endif
 
   // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#miscellaneous
   import_array();
@@ -212,7 +220,14 @@ namespace lib {
 	  argv[i] = const_cast<char*>((*argvS)[ i].c_str()); 
 #endif
 
+// use new python configuration (PEP 587), legacy initialisation is marked deprecated in Python 3.11
+#if PY_VERSION_HEX >= 0x030B0000
+      PyConfig config;
+      PyConfig_InitPythonConfig(&config);
+      PyConfig_SetArgv(&config, argc, argv);
+#else
 	PySys_SetArgv(argc, argv);
+#endif
 	delete[] argv;
       }
 


### PR DESCRIPTION
See [issue](https://github.com/python/cpython/issues/88279), and [PEP 587](https://peps.python.org/pep-0587/).

Since Python version 3.11 the old legacy initialisation functions are marked deprecated, the upgrade path is specified in the PEP. GDL uses those deprecated functions in two locations, this PR updates those locations to use the new API in case Python version is 3.11 or above.