### PR TITLE
device, COPY=[...] was wrong.

### DIFF
--- a/src/devicex.hpp
+++ b/src/devicex.hpp
@@ -129,7 +129,7 @@ public:
     xp=(*static_cast<DFloatGDL*>( dStruct->GetTag(dStruct->Desc()->TagIndex("X_PX_CM"))))[0]*2.5;
     yp=(*static_cast<DFloatGDL*>( dStruct->GetTag(dStruct->Desc()->TagIndex("Y_PX_CM"))))[0]*2.5;
 
-    winList[ wIx] = new GDLXStream(xp , yp, xleng, yleng, xoff, yoff, title);
+    winList[ wIx] = new GDLXStream(xp , yp, xleng, yleng, xoff, yoff, title, hide);
     oList[ wIx]   = oIx++;    
 
     SetActWin( wIx);
@@ -140,11 +140,7 @@ public:
   winList[wIx]->SetBackingStore(-1);
 
     bool success;
-    if ( hide )
-    {
-      success=this->Hide();
-    }
-    else success=this->UnsetFocus();
+    if ( !hide ) success=this->UnsetFocus();
     return true; 
     }
   

--- a/src/gdlgstream.cpp
+++ b/src/gdlgstream.cpp
@@ -1400,26 +1400,38 @@ void GDLGStream::getSubpageRegion(PLFLT *sxmin, PLFLT *symin, PLFLT *sxmax, PLFL
 }
 //get region (3BPP data)
 
-bool GDLGStream::GetRegion(DLong& xoff, DLong& yoff, DLong& nx, DLong& ny) {
+int GDLGStream::GetRegion(DLong& xoff, DLong& yoff, DLong& nPixelsX, DLong& nPixelsY) {
   long nxOrig,nyOrig;
   this->GetGeometry(nxOrig,nyOrig);
-
-  DLong xmax = xoff + nx - 1;
-  DLong ymax = yoff + ny - 1;
-  if (yoff < 0 || yoff > nyOrig - 1) return false;
-  if (xoff < 0 || xoff > nxOrig - 1) return false;
-  if (xmax < 0 || xmax > nxOrig - 1) return false;
-  if (ymax < 0 || ymax > nyOrig - 1) return false;
-
-  DByteGDL *bitmap = static_cast<DByteGDL*> (this->GetBitmapData(xoff,yoff,nx,ny));
-  if (bitmap == NULL) return false; //need to GDLDelete bitmap on exit after this line.
+  if (nPixelsX <= 0) return 1;
+  int xmin=xoff;
+  int xmax = xoff + nPixelsX - 1;
+  if (xmax < 0 || xmin > nxOrig - 1) return 1;
+  
+  if (nPixelsY <= 0) return 1;
+  int ymin=yoff;
+  int ymax = yoff + nPixelsY - 1;
+  if (ymax < 0 || ymin > nyOrig - 1) return 1;
+ 
+  if ( xmax > nxOrig - 1) xmax = nxOrig - 1;
+  if ( xmin < 0 ) xmin=0;
+  if ( xmin > xmax) return 1;
+  
+  if ( ymax > nyOrig - 1) ymax = nyOrig - 1;
+  if ( ymin < 0 ) ymin=0;
+  if ( ymin > ymax) return 1;
+  //give back updated number of pixels! important!
+  nPixelsX=xmax-xmin+1;
+  nPixelsY=ymax-ymin+1;
+  DByteGDL *bitmap = static_cast<DByteGDL*> (this->GetBitmapData(xmin,ymin,nPixelsX,nPixelsY));
+  if (bitmap == NULL) return 2; //need to GDLDelete bitmap on exit after this line.
   DByte* bmp=static_cast<DByte*>(bitmap->DataAddr());
 
   GraphicsDevice* actDevice = GraphicsDevice::GetDevice();
-  unsigned char* data = actDevice->SetCopyBuffer(nx * ny * 3);
-  for (auto k=0; k< nx*ny*3; ++k) data[k] = bmp[k];
+  unsigned char* data = actDevice->SetCopyBuffer(nPixelsX * nPixelsY * 3);
+  for (auto k=0; k< nPixelsX*nPixelsY*3; ++k) data[k] = bmp[k];
   GDLDelete(bitmap);
-  return true;
+  return 0; //0 is OK
 }
 
 bool GDLGStream::SetRegion(DLong& xs, DLong& ys, DLong& nx, DLong& ny){

--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -296,7 +296,7 @@ public:
   virtual bool IsPlot() {return true;} //except some wxWidgets
   virtual BaseGDL* GetBitmapData(int xoff, int yoff, int nx, int ny){return NULL;}
   virtual void SetCurrentFont(std::string fontname){}//do nothing
-  bool GetRegion(DLong& xs, DLong& ys, DLong& nx, DLong& ny);//{return false;}
+  int GetRegion(DLong& xs, DLong& ys, DLong& nx, DLong& ny);//{return false;}
   bool SetRegion(DLong& xd, DLong& yd, DLong& nx, DLong& ny);//{return false;}
 
   virtual void CheckValid() {}

--- a/src/gdlxstream.cpp
+++ b/src/gdlxstream.cpp
@@ -359,6 +359,9 @@ void GDLXStream::UnSetDoubleBuffering() {
   pls->db = 0;
 }
 
+void GDLXStream::UglyPatchMakeHidden() {
+  pls->arrow_npts=999;
+}
 //modified version. Will not tell double buffering is available if current graphic function is not pure "copy".
 bool GDLXStream::HasSafeDoubleBuffering() {
     XwDev *dev = (XwDev *) pls->dev;

--- a/src/gdlxstream.cpp
+++ b/src/gdlxstream.cpp
@@ -104,7 +104,10 @@ bool GDLXStream::SetGraphicsFunction( long value) {
     gcValues.function = (value<0)?0:(value>15)?15:value;
     XwDev *dev = (XwDev *) pls->dev;
     XwDisplay *xwd = (XwDisplay *) dev->xwd;
-    return XChangeGC( xwd->display, dev->gc, GCFunction, &gcValues );
+//    int ret=XChangeGC( xwd->display, dev->gc, GCFunction, &gcValues );
+	
+	plstream::cmd( PLESC_XORMOD, &value );
+	return true;
 }
 
 bool GDLXStream::GetWindowPosition(long& xpos, long& ypos ) {

--- a/src/gdlxstream.hpp
+++ b/src/gdlxstream.hpp
@@ -28,7 +28,7 @@ class GDLXStream: public GDLGStream
   Atom wm_delete_window;
   Window term_window;
 public:
-  GDLXStream( PLINT xp , PLINT yp, PLINT nx, PLINT ny, PLINT xoff, PLINT yoff, const std::string &title)
+  GDLXStream( PLINT xp , PLINT yp, PLINT nx, PLINT ny, PLINT xoff, PLINT yoff, const std::string &title, bool hide=false)
     : GDLGStream( nx, ny, "xwin") 
     , term_window(0)
 {
@@ -60,6 +60,8 @@ public:
     // Please no threads, no gain especially in remote X11 
     setopt("drvopt", "noinitcolors=1,nobuffered=1,usepth=0");
 
+    if (hide) UglyPatchMakeHidden(); 
+ 
     FindTerminalWindow(); //to pro
     //all the options must be passed BEFORE INIT=plinit.
     init(); //creates the X11 window.
@@ -128,6 +130,7 @@ public:
   void Flush();
   void SetDoubleBuffering();
   void UnSetDoubleBuffering();
+  void UglyPatchMakeHidden(); 
   bool HasSafeDoubleBuffering();
   bool PaintImage(unsigned char *idata, PLINT nx, PLINT ny,  DLong *pos, DLong tru, DLong chan);
   virtual bool HasCrossHair() {return true;}

--- a/src/graphicsdevice.cpp
+++ b/src/graphicsdevice.cpp
@@ -595,6 +595,10 @@ bool GraphicsMultiDevice::CopyRegion(DLongGDL* me) {
   yd = (*me)[5];
   if (me->N_Elements() == 7) source = (*me)[6];
   else source = actWin;
-  if (!winList[ source]->GetRegion(xs, ys, nx, ny)) return false;
+  int ret=winList[ source]->GetRegion(xs, ys, nx, ny);
+  if (ret!=0){
+	if (ret=1) return true; //region is ot of view. not a problem.
+	return false; //CopyRegion is not allowed for this device
+  }
   return winList[ actWin ]->SetRegion(xd, yd, nx, ny);
 }

--- a/src/plotting_windows.cpp
+++ b/src/plotting_windows.cpp
@@ -103,9 +103,7 @@ namespace lib {
     success = actDevice->WOpen(wIx, title, xSize, ySize, xPos, yPos, hide);
     if (!success)
       e->Throw("Unable to create window.");
-    if (e->KeywordSet(PIXMAPIx)) {
-      success = actDevice->Hide();
-    } else success = actDevice->UnsetFocus();
+    if (!hide)  success = actDevice->UnsetFocus();
     actDevice->GetStream()->DefaultBackground();
     actDevice->GetStream()->Clear();
 

--- a/src/plplotdriver/deprecated_wxwidgets.h
+++ b/src/plplotdriver/deprecated_wxwidgets.h
@@ -21,7 +21,7 @@
 #define __WXWIDGETS_H__
 
 ////with graphic_context GDL can erase drawings by writing with !P.BACKGROUND since antialiasing can be removed.
-//
+// So we force no antialiasing (way faster plots) and thus prefer GC.
 //#undef wxUSE_GRAPHICS_CONTEXT
 //
 

--- a/src/plplotdriver/deprecated_wxwidgets_gc.cpp
+++ b/src/plplotdriver/deprecated_wxwidgets_gc.cpp
@@ -250,8 +250,6 @@ void wxPLDevGC::CreateCanvas()
     {
         delete m_context;
         m_context = wxGraphicsContext::Create( *( (wxMemoryDC *) m_dc ) );
-        char* do_antialias = getenv("GDL_DO_ANTIALIASING");
-        if (do_antialias==NULL ) m_context->SetAntialiasMode(wxANTIALIAS_NONE); //GD May 2022 force no antialias as antialiasing prevents erasing lines by redrawing them ontop by a color 0
         // see what procedure PROFILES do.
     }
 }
@@ -317,6 +315,9 @@ void wxPLDevGC::SetExternalBuffer( void* dc )
 
     m_dc      = (wxDC *) dc; // Add the dc to the device
     m_context = wxGraphicsContext::Create( *( (wxMemoryDC *) m_dc ) );
+    char* do_antialias = getenv("GDL_DO_ANTIALIASING");
+    if (do_antialias == NULL) m_context->SetAntialiasMode(wxANTIALIAS_NONE); //GD May 2022 force no antialias as antialiasing prevents erasing lines by redrawing them ontop by a color 0.
+	//NOTE: antialiasing and no double buffer makes plots very slow.
     ready     = true;
     ownGUI    = false;
 }

--- a/src/plplotdriver/xwin.c
+++ b/src/plplotdriver/xwin.c
@@ -1188,8 +1188,9 @@ Init( PLStream *pls )
         XSetFillRule( xwd->display, dev->gc, WindingRule );
 
 // If main window, need to map it and wait for exposure
-
-    if ( dev->is_main )
+// Ugly Patch: use pls->arrow_npts=999 to make window hiden and no MapMain
+    int hide=(pls->arrow_npts==999);
+    if ( dev->is_main && !hide)
         MapMain( pls );
 }
 

--- a/src/plplotdriver/xwin.c
+++ b/src/plplotdriver/xwin.c
@@ -193,6 +193,7 @@ static void  ConfigBufferingCmd( PLStream *pls, PLBufferingCB *ptr );
 static void  GetCursorCmd( PLStream *pls, PLGraphicsIn *ptr );
 static void  FillPolygonCmd( PLStream *pls );
 static void  XorMod( PLStream *pls, PLINT *mod );
+static void  AnyMod( PLStream *pls, PLINT *mod );
 static void  DrawImage( PLStream *pls );
 
 // Miscellaneous
@@ -415,6 +416,15 @@ XorMod( PLStream *pls, PLINT *mod )
         XSetFunction( xwd->display, dev->gc, GXxor );
 }
 
+static void
+AnyMod( PLStream *pls, PLINT *mod )
+{
+    XwDev     *dev = (XwDev *) pls->dev;
+    XwDisplay *xwd = (XwDisplay *) dev->xwd;
+
+    XGCValues values_return;
+    XSetFunction( xwd->display, dev->gc, *mod );
+}
 //--------------------------------------------------------------------------
 // plD_polyline_xw()
 //
@@ -802,7 +812,7 @@ plD_esc_xw( PLStream *pls, PLINT op, void *ptr )
         break;
 
     case PLESC_XORMOD:
-        XorMod( pls, (PLINT *) ptr );
+        AnyMod( pls, (PLINT *) ptr );
         break;
 
     case PLESC_DOUBLEBUFFERING:


### PR DESCRIPTION
 - tricked xwin driver to not show brievely PIXMAP windows as it was doing before
 - removing antialiasing for wxWidget plot windows improves greatly the use of XOR or INVERT graphic functions used, e.g., in BOX_CURSOR. (besides, speeds up a lot the plots).
 - Antialiasing can be forced by creating an environment variable GDL_DO_ANTIALIASING.
 - Checked thorougly that with this version, all X11 or wxWidgets uses of BOX_CURSOR were OK under linux.