### PR TITLE
Last adjustements to plot functions -- test_coyote OK

### DIFF
--- a/src/gdlgstream.cpp
+++ b/src/gdlgstream.cpp
@@ -1399,7 +1399,7 @@ void GDLGStream::getSubpageRegion(PLFLT *sxmin, PLFLT *symin, PLFLT *sxmax, PLFL
  }
 }
 
-void GDLGStream::getCurrentSubpageInfo(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement) {
+void GDLGStream::compute3DCubeLimits(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement) {
   int p=thePage.curPage-1;
   int nx = thePage.nx;
   int ny = thePage.ny;

--- a/src/gdlgstream.cpp
+++ b/src/gdlgstream.cpp
@@ -385,7 +385,7 @@ void GDLGStream::SetCharSize(DLong ichx, DLong chy) {
 
 void GDLGStream::NextPlot( bool erase ) {
   // restore charsize to default for newpage at beginning since adv() uses charsize to get box position.
-  if (!erase) sizeChar(1.0);
+//  if (!erase) sizeChar(1.0);
   DLongGDL* pMulti = SysVar::GetPMulti();
 
   DLong nx = (*pMulti)[ 1];
@@ -433,22 +433,18 @@ void GDLGStream::NextPlot( bool erase ) {
   }
   else
   {
-    if( dir == 0 )
-    {
-//      plstream::adv(nx*ny - pMod + 1);
-      adv(nsub - pMod + 1);
-    }
-    else
-    {
-      int p = nsub - pMod;
-      int pp = p*nx % (nx*ny) + p/ny + 1;
-//      plstream::adv(pp);
-      adv(pp);
-    }
-    if( erase )
-    {
-      --(*pMulti)[0];
-    }
+    if( erase) {
+	  if (dir == 0) {
+		//      plstream::adv(nx*ny - pMod + 1);
+		adv(nsub - pMod + 1);
+	  } else {
+		int p = nsub - pMod;
+		int pp = p * nx % (nx * ny) + p / ny + 1;
+		//      plstream::adv(pp);
+		adv(pp);
+	  }
+	  --(*pMulti)[0];
+	}
   }
 
 }

--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -640,7 +640,7 @@ public:
   void ssub( PLINT nx, PLINT ny, PLINT nz=1);
   void adv(PLINT page);
   void getSubpageRegion(PLFLT *sxmin, PLFLT *symin, PLFLT *sxmax, PLFLT *symax, PLFLT *zmin=NULL, PLFLT *zmax=NULL);
-  void getCurrentSubpageInfo(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement);
+  void compute3DCubeLimits(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement);
   void SetPageDPMM(float setPsCharFudge=1.0, float setPsSymFudge=1.0);
   void syncPageInfo();
   void updateBoxDeviceCoords();

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1270,7 +1270,30 @@ namespace lib
     return position;
 }
 
-  //Stores [XYZ].WINDOW, .REGION and .S
+	//Stores Axis Region
+  void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* p)
+  {
+    DStructGDL* Struct=SysVar::X(); 
+    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
+    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[0];
+    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[2];
+  }  
+ void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* p)
+  {
+    DStructGDL* Struct=SysVar::Y(); 
+    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
+    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[1];
+    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[3];
+  }
+ void gdlStoreZAxisRegion(GDLGStream* actStream, PLFLT* p)
+  {
+   // ??? will see when needed.
+//    DStructGDL* Struct=SysVar::Z(); 
+//    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
+//    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[1];
+//    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[3];
+  }
+ //Stores [XYZ].WINDOW, TYPE, CRANGE and .S
   void gdlStoreXAxisParameters(GDLGStream* actStream, DDouble Start, DDouble End, bool log)
   {
     // !X etc parameters relative to the VIEWPORT:
@@ -3300,6 +3323,7 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
     static PLFLT P_position_normed[4] = {0, 0, 0, 0};
     static PLFLT P_region_normed[4] = {0, 0, 0, 0};
     static PLFLT position[4];
+    static PLFLT axis_region[4];
     // Set to default values:
 
     //compute position removing margins
@@ -3381,6 +3405,14 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
 
     actStream->wind(xStart, xEnd, yStart, yEnd);
 
+      //compute axis_region adding margins (information in !X.REGION etc)
+      axis_region[0] = position[0] - xMarginL * actStream->nCharLength();
+      axis_region[1] = position[1] - yMarginB * actStream->nLineSpacing();
+      axis_region[2] = position[2] + xMarginR * actStream->nCharLength();
+      axis_region[3] = position[3] + yMarginT * actStream->nLineSpacing();
+	  gdlStoreXAxisRegion(actStream, axis_region);
+	  gdlStoreYAxisRegion(actStream, axis_region);
+	  gdlStoreZAxisRegion(actStream, axis_region);
     //set ![XYZ].CRANGE ![XYZ].type ![XYZ].WINDOW and ![XYZ].S
     gdlStoreXAxisParameters(actStream, xStart, xEnd, xLog); //already in log here if relevant!
     gdlStoreYAxisParameters(actStream, yStart, yEnd, yLog);

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1270,9 +1270,9 @@ namespace lib
     return position;
 }
  //Get [XYZ].REGION
-  DFloat* gdlGetRegion() {
+  PLFLT* gdlGetRegion() {
     static const SizeT REGIONTAG=12;
-    static DFloat position[6];
+    static PLFLT position[6];
     position[0]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(REGIONTAG, 0)))[0];
     position[1]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(REGIONTAG, 0)))[1];
     position[2]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(REGIONTAG, 0)))[0];

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1259,7 +1259,8 @@ namespace lib
 
   //Get [XYZ].WINDOW
   DFloat* gdlGetWindow() {
-    static const SizeT WINDOWTAG=11;
+    DStructGDL* Struct=SysVar::X(); //same for all
+    static unsigned WINDOWTAG=Struct->Desc()->TagIndex("WINDOW");
     static DFloat position[6];
     position[0]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(WINDOWTAG, 0)))[0];
     position[1]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(WINDOWTAG, 0)))[1];
@@ -1271,11 +1272,12 @@ namespace lib
 }
  //Get [XYZ].REGION
   PLFLT* gdlGetRegion() {
-    static const SizeT REGIONTAG=12;
+    DStructGDL* Struct=SysVar::X(); //same for all
+    static unsigned REGIONTAG=Struct->Desc()->TagIndex("REGION");
     static PLFLT position[6];
     position[0]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(REGIONTAG, 0)))[0];
-    position[1]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(REGIONTAG, 0)))[1];
-    position[2]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(REGIONTAG, 0)))[0];
+    position[2]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(REGIONTAG, 0)))[1];
+    position[1]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(REGIONTAG, 0)))[0];
     position[3]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(REGIONTAG, 0)))[1];
     position[4]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(REGIONTAG, 0)))[0];
     position[5]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(REGIONTAG, 0)))[1];
@@ -1285,24 +1287,20 @@ namespace lib
   void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* p)
   {
     DStructGDL* Struct=SysVar::X(); 
-    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
-    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[0];
-    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[2];
+    static unsigned regionTag=Struct->Desc()->TagIndex("REGION");
+    (*static_cast<DFloatGDL*>(Struct->GetTag(regionTag, 0)))[0]=p[0];
+    (*static_cast<DFloatGDL*>(Struct->GetTag(regionTag, 0)))[1]=p[2];
   }  
  void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* p)
   {
     DStructGDL* Struct=SysVar::Y(); 
-    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
-    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[1];
-    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[3];
+    static unsigned regionTag=Struct->Desc()->TagIndex("REGION");
+    (*static_cast<DFloatGDL*>(Struct->GetTag(regionTag, 0)))[0]=p[1];
+    (*static_cast<DFloatGDL*>(Struct->GetTag(regionTag, 0)))[1]=p[3];
   }
  void gdlStoreZAxisRegion(GDLGStream* actStream, PLFLT* p)
   {
    // ??? will see when needed.
-//    DStructGDL* Struct=SysVar::Z(); 
-//    static unsigned windowTag=Struct->Desc()->TagIndex("REGION");
-//    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[0]=p[1];
-//    (*static_cast<DFloatGDL*>(Struct->GetTag(windowTag, 0)))[1]=p[3];
   }
  //Stores [XYZ].WINDOW, TYPE, CRANGE and .S
   void gdlStoreXAxisParameters(GDLGStream* actStream, DDouble Start, DDouble End, bool log)

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1258,6 +1258,18 @@ namespace lib
   }
 
   //Get [XYZ].WINDOW
+  DFloat* gdlGetWindow() {
+    static const SizeT WINDOWTAG=11;
+    static DFloat position[6];
+    position[0]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(WINDOWTAG, 0)))[0];
+    position[1]=(*static_cast<DFloatGDL*>(SysVar::X()->GetTag(WINDOWTAG, 0)))[1];
+    position[2]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(WINDOWTAG, 0)))[0];
+    position[3]=(*static_cast<DFloatGDL*>(SysVar::Y()->GetTag(WINDOWTAG, 0)))[1];
+    position[4]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(WINDOWTAG, 0)))[0];
+    position[5]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(WINDOWTAG, 0)))[1];
+    return position;
+}
+ //Get [XYZ].REGION
   DFloat* gdlGetRegion() {
     static const SizeT REGIONTAG=12;
     static DFloat position[6];
@@ -1269,7 +1281,6 @@ namespace lib
     position[5]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(REGIONTAG, 0)))[1];
     return position;
 }
-
 	//Stores Axis Region
   void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* p)
   {
@@ -3266,9 +3277,17 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
     DDouble zValue_input, //input
     bool iso) {
 
-    COORDSYS coordinateSystem = DATA;
     DDouble xStart, yStart, xEnd, yEnd, zStart, zEnd;
 
+	static PLFLT aspect = 0.0;
+
+	static PLFLT P_position_normed[4] = {0, 0, 0, 0};
+	static PLFLT P_region_normed[4] = {0, 0, 0, 0};
+	static PLFLT position[4];
+	static PLFLT axis_region[4];
+	// Set to default values:
+
+	
     //work on local values, taking account loginess
     xStart = x0;
     xEnd = x1;
@@ -3288,113 +3307,99 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
     if (zLog) {
       zStart = log10(zStart);
       zEnd = log10(zEnd);
-    }
-
-    // MARGIN
-    DFloat xMarginL, xMarginR, yMarginB, yMarginT, zMarginB, zMarginT; //, zMarginB, zMarginT;
-    gdlGetDesiredAxisMargin(e, XAXIS, xMarginL, xMarginR);
-    gdlGetDesiredAxisMargin(e, YAXIS, yMarginB, yMarginT);
-    gdlGetDesiredAxisMargin(e, ZAXIS, zMarginB, zMarginT);
-
+	}
+	
     PLFLT sxmin, symin, sxmax, symax, szmin, szmax;
     actStream->getSubpageRegion(&sxmin, &symin, &sxmax, &symax, &szmin, &szmax);
     //Special for Z: for Z.S, Z.WINDOW and Z.REGION, in case of POSITION having 6 elements
 
-    DDouble zposStart, zposEnd;
-    if (std::isfinite(zValue_input)) {
-      zposStart = zValue_input;
-      zposEnd = ZVALUEMAX;
-    } else {
-      zposStart = szmin;
-      zposEnd = szmax;
-    }
+	DDouble zposStart, zposEnd;
+	if (std::isfinite(zValue_input)) {
+	  zposStart = zValue_input;
+	  zposEnd = ZVALUEMAX;
+	} else {
+	  zposStart = szmin;
+	  zposEnd = szmax;
+	}
+	
+    // GET MARGIN
+    DFloat xMarginL, xMarginR, yMarginB, yMarginT, zMarginB, zMarginT; //, zMarginB, zMarginT;
+    gdlGetDesiredAxisMargin(e, XAXIS, xMarginL, xMarginR);
+    gdlGetDesiredAxisMargin(e, YAXIS, yMarginB, yMarginT);
+    gdlGetDesiredAxisMargin(e, ZAXIS, zMarginB, zMarginT);
+  
+	// Compute BOX position
 
-    PLFLT xMR, xML, yMB, yMT, zMB, zMT;
-    CheckMargin(actStream,
-      xMarginL,
-      xMarginR,
-      yMarginB,
-      yMarginT,
-      xMR, xML, yMB, yMT);
+	// if position given, take it
+	int positionIx = e->KeywordIx("POSITION");
+	DFloatGDL* boxPosition = e->IfDefGetKWAs<DFloatGDL>(positionIx);
+	if (boxPosition != NULL) {
+	  for (SizeT i = 0; i < 4 && i < boxPosition->N_Elements(); ++i) position[i] = (*boxPosition)[i];
+	  if (boxPosition->N_Elements() > 4) {
+		zposStart = fmin((*boxPosition)[4], ZVALUEMAX);
+		zposStart = fmax(zposStart, 0);
+		if (boxPosition->N_Elements() > 5) {
+		  zposEnd = fmin((*boxPosition)[5], ZVALUEMAX);
+		  zposEnd = fmax(zposEnd, 0);
+		}
+	  }
+	  //check presence of DEVICE  options
+	  int DEVICEIx = e->KeywordIx("DEVICE");
+	  if (e->KeywordSet(DEVICEIx)) {
+		// modify position to NORMAL if DEVICE is present
+		actStream->DeviceToNormedDevice(position[0], position[1], position[0], position[1]);
+		actStream->DeviceToNormedDevice(position[2], position[3], position[2], position[3]);
+	  }
+	  //compatibility again: Position NEVER outside [0,1]:
+	  position[0] = max(0.0, position[0]);
+	  position[1] = max(0.0, position[1]);
+	  position[2] = min(1.0, position[2]);
+	  position[3] = min(1.0, position[3]);
+	} else {
+    //POSITION not Ggiven, compute best position
+	  PLFLT xMR, xML, yMB, yMT, zMB, zMT;
+	  CheckMargin(actStream,
+		xMarginL,
+		xMarginR,
+		yMarginB,
+		yMarginT,
+		xMR, xML, yMB, yMT);
 
-    // viewport - POSITION overrides
-    static PLFLT aspect = 0.0;
+	  //compute position removing margins
+	  position[0] = sxmin + xMarginL * actStream->nCharLength();
+	  position[1] = symin + yMarginB * actStream->nLineSpacing();
+	  position[2] = sxmax - xMarginR * actStream->nCharLength();
+	  position[3] = symax - yMarginT * actStream->nLineSpacing();
+	  DStructGDL* pStruct = SysVar::P(); //MUST NOT BE STATIC, due to .reset 
+	  // Get !P.position values. !P.REGION is superseded by !P.POSITION
+	  if (pStruct != NULL) {
+		unsigned regionTag = pStruct->Desc()->TagIndex("REGION");
+		for (SizeT i = 0; i < 4; ++i) P_region_normed[i] = (PLFLT) (*static_cast<DFloatGDL*> (pStruct->GetTag(regionTag, 0)))[i];
+		unsigned positionTag = pStruct->Desc()->TagIndex("POSITION");
+		for (SizeT i = 0; i < 4; ++i) P_position_normed[i] = (PLFLT) (*static_cast<DFloatGDL*> (pStruct->GetTag(positionTag, 0)))[i];
+	  }
+	  if (P_region_normed[0] != P_region_normed[2]) //exist, so it is a first approx to position: 
+	  {
+		//compute position removing margins
+		position[0] = P_region_normed[0] + xMarginL * actStream->nCharLength();
+		position[1] = P_region_normed[1] + yMarginB * actStream->nLineSpacing();
+		position[2] = P_region_normed[2] - xMarginR * actStream->nCharLength();
+		position[3] = P_region_normed[3] - yMarginT * actStream->nLineSpacing();
+	  }
+	  if (P_position_normed[0] != P_position_normed[2]) //exist, so it is a second approx to position, this one dos not include margins:
+	  {
+		position[0] = P_position_normed[0];
+		position[1] = P_position_normed[1];
+		position[2] = P_position_normed[2];
+		position[3] = P_position_normed[3];
+	  }
+	  //compatibility: Position NEVER outside [0,1]:
+	  position[0] = max(0.0, position[0]);
+	  position[1] = max(0.0, position[1]);
+	  position[2] = min(1.0, position[2]);
+	  position[3] = min(1.0, position[3]);
 
-    static PLFLT P_position_normed[4] = {0, 0, 0, 0};
-    static PLFLT P_region_normed[4] = {0, 0, 0, 0};
-    static PLFLT position[4];
-    static PLFLT axis_region[4];
-    // Set to default values:
-
-    //compute position removing margins
-    position[0] = sxmin + xMarginL * actStream->nCharLength();
-    position[1] = symin + yMarginB * actStream->nLineSpacing();
-    position[2] = sxmax - xMarginR * actStream->nCharLength();
-    position[3] = symax - yMarginT * actStream->nLineSpacing();
-    DStructGDL* pStruct = SysVar::P(); //MUST NOT BE STATIC, due to .reset 
-    // Get !P.position values. !P.REGION is superseded by !P.POSITION
-    if (pStruct != NULL) {
-      unsigned regionTag = pStruct->Desc()->TagIndex("REGION");
-      for (SizeT i = 0; i < 4; ++i) P_region_normed[i] = (PLFLT) (*static_cast<DFloatGDL*> (pStruct->GetTag(regionTag, 0)))[i];
-      unsigned positionTag = pStruct->Desc()->TagIndex("POSITION");
-      for (SizeT i = 0; i < 4; ++i) P_position_normed[i] = (PLFLT) (*static_cast<DFloatGDL*> (pStruct->GetTag(positionTag, 0)))[i];
-    }
-    if (P_region_normed[0] != P_region_normed[2]) //exist, so it is a first approx to position: 
-    {
-      //compute position removing margins
-      position[0] = P_region_normed[0] + xMarginL * actStream->nCharLength();
-      position[1] = P_region_normed[1] + yMarginB * actStream->nLineSpacing();
-      position[2] = P_region_normed[2] - xMarginR * actStream->nCharLength();
-      position[3] = P_region_normed[3] - yMarginT * actStream->nLineSpacing();
-    }
-    if (P_position_normed[0] != P_position_normed[2]) //exist, so it is a second approx to position, this one dos not include margins:
-    {
-      position[0] = P_position_normed[0];
-      position[1] = P_position_normed[1];
-      position[2] = P_position_normed[2];
-      position[3] = P_position_normed[3];
-    }
-    //compatibility: Position NEVER outside [0,1]:
-    position[0] = max(0.0, position[0]);
-    position[1] = max(0.0, position[1]);
-    position[2] = min(1.0, position[2]);
-    position[3] = min(1.0, position[3]);
-
-    //check presence of DATA,DEVICE and NORMAL options
-    int DATAIx = e->KeywordIx("DATA");
-    int DEVICEIx = e->KeywordIx("DEVICE");
-    int NORMALIx = e->KeywordIx("NORMAL");
-
-    if (e->KeywordSet(DATAIx)) coordinateSystem = DATA;
-    if (e->KeywordSet(DEVICEIx)) coordinateSystem = DEVICE;
-    if (e->KeywordSet(NORMALIx)) coordinateSystem = NORMAL;
-
-    // read boxPosition if needed
-    int positionIx = e->KeywordIx("POSITION");
-    DFloatGDL* boxPosition = e->IfDefGetKWAs<DFloatGDL>(positionIx);
-    if (boxPosition != NULL) {
-      for (SizeT i = 0; i < 4 && i < boxPosition->N_Elements(); ++i) position[i] = (*boxPosition)[i];
-      if (boxPosition->N_Elements() > 4) {
-        zposStart = fmin((*boxPosition)[4], ZVALUEMAX);
-        zposStart = fmax(zposStart, 0);
-        if (boxPosition->N_Elements() > 5) {
-          zposEnd = fmin((*boxPosition)[5], ZVALUEMAX);
-          zposEnd = fmax(zposEnd, 0);
-        }
-      }
-    }
-    if (boxPosition != NULL) { //use passed values
-      if (coordinateSystem == DEVICE) {
-        // modify position to NORMAL if DEVICE is present
-        actStream->DeviceToNormedDevice(position[0], position[1], position[0], position[1]);
-        actStream->DeviceToNormedDevice(position[2], position[3], position[2], position[3]);
-      }
-      //compatibility again: Position NEVER outside [0,1]:
-      position[0] = max(0.0, position[0]);
-      position[1] = max(0.0, position[1]);
-      position[2] = min(1.0, position[2]);
-      position[3] = min(1.0, position[3]);
-    }
+	}
 
     aspect = 0.0; // vpas with aspect=0.0 equals vpor.
     if (iso) aspect = abs((yEnd - yStart) / (xEnd - xStart)); //log-log or lin-log
@@ -3406,10 +3411,10 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
     actStream->wind(xStart, xEnd, yStart, yEnd);
 
       //compute axis_region adding margins (information in !X.REGION etc)
-      axis_region[0] = position[0] - xMarginL * actStream->nCharLength();
-      axis_region[1] = position[1] - yMarginB * actStream->nLineSpacing();
-      axis_region[2] = position[2] + xMarginR * actStream->nCharLength();
-      axis_region[3] = position[3] + yMarginT * actStream->nLineSpacing();
+      axis_region[0] = max(0.0,position[0] - xMarginL * actStream->nCharLength());
+      axis_region[1] = max(0.0,position[1] - yMarginB * actStream->nLineSpacing());
+      axis_region[2] = min(1.0,position[2] + xMarginR * actStream->nCharLength());
+      axis_region[3] = min(1.0,position[3] + yMarginT * actStream->nLineSpacing());
 	  gdlStoreXAxisRegion(actStream, axis_region);
 	  gdlStoreYAxisRegion(actStream, axis_region);
 	  gdlStoreZAxisRegion(actStream, axis_region);

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -565,7 +565,7 @@ namespace lib
 
       applyGraphics(e, actStream);
 
-      restoreDrawArea(actStream);
+//      restoreDrawArea(actStream); //doing this would mess the /NOERASE logic when MULTI
 
       post_call(e, actStream);
       // IDEM: SLOW
@@ -3190,11 +3190,9 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
 
   //advance to next plot unless the noerase flag is set
 
-  void gdlNextPlotHandlingNoEraseOption(EnvT *e, GDLGStream *a, bool noe) {
+  void gdlNextPlotHandlingNoEraseOption(EnvT *e, GDLGStream *a) {
     bool noErase = false;
     DStructGDL* pStruct = SysVar::P(); //MUST NOT BE STATIC, due to .reset 
-
-    if (!noe) {
       DLong LnoErase = (*static_cast<DLongGDL*>
         (pStruct->
         GetTag(pStruct->Desc()->TagIndex("NOERASE"), 0)))[0];
@@ -3204,9 +3202,6 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
       if (e->KeywordSet(NOERASEIx)) {
         noErase = true;
       }
-    } else {
-      noErase = true;
-    }
 
     a->NextPlot(!noErase);
     // all but the first element of !P.MULTI are ignored if POSITION kw or !P.POSITION or !P.REGION is specified

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -179,7 +179,7 @@ namespace lib
   PLFLT AutoLogTickIntv(DDouble min, DDouble max)
   {
     DDouble x=abs(log10(max)-log10(min));
-    if (!isfinite(x)) return 0; //trouble ahead...
+    if (!isfinite(x)) return 1; //trouble ahead...
     if ( x==0.0 ) return 1.0;
     if (x < 8) return 1;
     if (x < 15) return 2;
@@ -3624,7 +3624,9 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
 	  if (SUBTITLEIx >= 0) {
 		e->AssureStringScalarKWIfPresent(SUBTITLEIx, subTitle);
 	  } else goto NoTitlesAccepted;
-
+	  
+      if (subTitle.empty() && title.empty()) goto NoTitlesAccepted; //escape early, saves code
+	  
 	  a->plstream::vpor(refboxxmin, refboxxmax, refboxymin, refboxymax);
 	  a->wind(owboxxmin, owboxxmax, owboxymin, owboxymax); //restore old values
 	  gdlSetPlotCharthick(e, a);
@@ -3798,7 +3800,7 @@ NoTitlesAccepted:
 	gdlLineStyle(a, GridStyle);
 	// ticklayout2 has no log and no subticks
 	if (Log) {
-	  if (TickInterval < 1) { //if log and tickinterval was >1 then we pass in 'linear, no subticks' mode (see issue #1112)
+	  if (TickInterval <= 1) { //if log and tickinterval was >1 then we pass in 'linear, no subticks' mode (see issue #1112)
 		tickOpt += SUBTICKS LOG;
 		Minor = 0;
 	  } else if (TickInterval < 2) {
@@ -3908,7 +3910,9 @@ NoTitlesAccepted:
 	  defineLabeling(a, axisId, gdlNoLabelTickFunc, &tickdata); //prevent plplot to write labels (but writes something, so that label positions are reported in getLabelingValues())
 	  if (axisId == XAXIS) {
 		a->plstream::vpor(boxxmin, boxxmax, (otheraxis)?boxymin:boxymin - xdisplacement, (otheraxis)?boxymax + xdisplacement:boxymax);
-		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
+	  if (Log) a->plstream::wind(log10(Start), log10(End), owboxymin, owboxymax);
+	  else a->plstream::wind(Start, End, owboxymin, owboxymax);
+//		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
 		if (doplot) {
 		  bool isTickv = (hasTickv && i == 0);
 		  if (isTickv) {
@@ -3926,7 +3930,9 @@ NoTitlesAccepted:
 		if (!inverted_ticks && TickLayout != 2) xdisplacement += ticklen_as_norm; //every axis after the first will be separated by this
 	  } else {
 		a->plstream::vpor((otheraxis)?boxxmin:boxxmin - ydisplacement, (otheraxis)?boxxmax+ydisplacement:boxxmax, boxymin, boxymax);
-		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
+	  if (Log) a->plstream::wind(owboxxmin, owboxxmax, log10(Start), log10(End));
+	  else a->plstream::wind(owboxxmin, owboxxmax, Start, End);
+//		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
 		if (doplot) {
 		  bool isTickv = (hasTickv && i == 0);
 		  if (isTickv) {

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -255,6 +255,9 @@ namespace lib {
   void gdlSetGraphicsPenColorToBackground(GDLGStream *a);
   void gdlLineStyle(GDLGStream *a, DLong style);
   DFloat* gdlGetRegion();
+  void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* r);
+  void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* r);
+  void gdlStoreZAxisRegion(GDLGStream* actStream, PLFLT* r);
   void gdlStoreXAxisParameters(GDLGStream* actStream, DDouble Start, DDouble End, bool log);
   void gdlStoreYAxisParameters(GDLGStream* actStream, DDouble Start, DDouble End, bool log);
   void gdlStoreZAxisParameters(GDLGStream* actStream, DDouble Start, DDouble End, bool log, DDouble zposStart, DDouble zposEnd);

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -238,6 +238,7 @@ namespace lib {
   void gdlMakeSubpageRotationMatrix2d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans);
   bool gdlInterpretT3DMatrixAsPlplotRotationMatrix(DDouble &az, DDouble &alt, DDouble &ay, DDouble *scale, /* DDouble *trans,*/  T3DEXCHANGECODE &axisExchangeCode, bool &below);
   DDoubleGDL* gdlGetT3DMatrix();
+  void get3DMatrixParametersFor2DPosition(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement);
   void gdlStartT3DMatrixDriverTransform(GDLGStream *a, DDouble zValue);
   void gdlStartSpecial3DDriverTransform( GDLGStream *a, GDL_3DTRANSFORMDEVICE &PlotDevice3D);
   void gdlExchange3DDriverTransform( GDLGStream *a);
@@ -255,6 +256,7 @@ namespace lib {
   void gdlSetGraphicsPenColorToBackground(GDLGStream *a);
   void gdlLineStyle(GDLGStream *a, DLong style);
   DFloat* gdlGetRegion();
+  DFloat* gdlGetWindow();
   void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* r);
   void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* r);
   void gdlStoreZAxisRegion(GDLGStream* actStream, PLFLT* r);

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -406,7 +406,7 @@ namespace lib {
   //advance to next plot unless the noerase flag is set
   // function declared static (local to each function using it) to avoid messing the NOERASEIx index which is not the same.
 
-  void gdlNextPlotHandlingNoEraseOption(EnvT *e, GDLGStream *a, bool noe = false);
+  void gdlNextPlotHandlingNoEraseOption(EnvT *e, GDLGStream *a);
 
   //handling of Z bounds is not complete IMHO.
 

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -235,7 +235,7 @@ namespace lib {
   void PDotTTransformXYZval(PLFLT x, PLFLT y, PLFLT *xt, PLFLT *yt, PLPointer data);
   DDoubleGDL* gdlDefinePlplotRotationMatrix(DDouble az, DDouble alt, DDouble *scale, bool save);
   void gdlMakeSubpageRotationMatrix3d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans);
-  void gdlMakeSubpageRotationMatrix2d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans);
+  void gdlMakeSubpageRotationMatrix2d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans, PLFLT shift=0, bool invert=false);
   bool gdlInterpretT3DMatrixAsPlplotRotationMatrix(DDouble &az, DDouble &alt, DDouble &ay, DDouble *scale, /* DDouble *trans,*/  T3DEXCHANGECODE &axisExchangeCode, bool &below);
   DDoubleGDL* gdlGetT3DMatrix();
   void get3DMatrixParametersFor2DPosition(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement);
@@ -255,7 +255,7 @@ namespace lib {
   void GDLgrPlotProjectedPolygon(GDLGStream * a, DDoubleGDL *lonlat, bool const doFill, DLongGDL *conn);
   void gdlSetGraphicsPenColorToBackground(GDLGStream *a);
   void gdlLineStyle(GDLGStream *a, DLong style);
-  DFloat* gdlGetRegion();
+  PLFLT* gdlGetRegion();
   DFloat* gdlGetWindow();
   void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* r);
   void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* r);

--- a/src/plotting_axis.cpp
+++ b/src/plotting_axis.cpp
@@ -111,9 +111,9 @@ namespace lib {
       if (yAxisWasLog) {oyStart=pow(10,oyStart);oyEnd=pow(10,oyEnd);}
       if (zAxisWasLog) {ozStart=pow(10,ozStart);ozEnd=pow(10,ozEnd);}
       
-      gdlAdjustAxisRange(e, XAXIS, oxStart, oxEnd, xAxisWasLog); //Box adjustement
-      gdlAdjustAxisRange(e, YAXIS, oyStart, oyEnd, yAxisWasLog); //Box adjustement
-      gdlAdjustAxisRange(e, ZAXIS, ozStart, ozEnd, zAxisWasLog); //Box adjustement
+//      gdlAdjustAxisRange(e, XAXIS, oxStart, oxEnd, xAxisWasLog); //Box adjustement
+//      gdlAdjustAxisRange(e, YAXIS, oyStart, oyEnd, yAxisWasLog); //Box adjustement
+//      gdlAdjustAxisRange(e, ZAXIS, ozStart, ozEnd, zAxisWasLog); //Box adjustement
 
       //position values are in the 'old' system just defined above.
       xPos = (xaxis_value==0) ? oxStart : oxEnd;
@@ -174,11 +174,6 @@ namespace lib {
       ConvertToNormXY(1, &xPos, xAxisWasLog, &yPos, yAxisWasLog, coordinateSystem);
       ConvertToNormZ(1, &zPos,  zAxisWasLog, coordinateSystem);
            
-      //default axis values: start with 'old' values.
-      xLog = xAxisWasLog;
-      yLog = yAxisWasLog; //by default logness is similar until another option is set
-      zLog = zAxisWasLog;
-
       xStart = oxStart;
       xEnd = oxEnd;
       yStart = oyStart;
@@ -192,15 +187,16 @@ namespace lib {
       static int xLogIx = e->KeywordIx("XLOG");
       static int yLogIx = e->KeywordIx("YLOG");
       static int zLogIx = e->KeywordIx("ZLOG");
-      if (e->KeywordPresent(xLogIx)) xLog = e->KeywordSet(xLogIx);
-      if (e->KeywordPresent(yLogIx)) yLog = e->KeywordSet(yLogIx);
-      if (e->KeywordPresent(zLogIx)) zLog = e->KeywordSet(zLogIx);
+      if (e->KeywordPresent(xLogIx)) xLog = e->KeywordSet(xLogIx); else xLog = xAxisWasLog;
+      if (e->KeywordPresent(yLogIx)) yLog = e->KeywordSet(yLogIx); else yLog = yAxisWasLog; //by default logness is similar until another option is set
+      if (e->KeywordPresent(zLogIx)) zLog = e->KeywordSet(zLogIx); else zLog = zAxisWasLog;
 
       // note: undocumented keywords [xyz]type still exist and
       // have priority on [xyz]log ! In fact, it is the modulo (1, 3, 5 ... --> /log)   
       static int xTypeIx = e->KeywordIx("XTYPE");
       static int yTypeIx = e->KeywordIx("YTYPE");
-      static int xType, yType;
+      static int zTypeIx = e->KeywordIx("ZTYPE");
+      static int xType, yType, zType;
       if (e->KeywordPresent(xTypeIx)) {
         e->AssureLongScalarKWIfPresent(xTypeIx, xType);
         if ((xType % 2) == 1) xLog = true;
@@ -210,6 +206,11 @@ namespace lib {
         e->AssureLongScalarKWIfPresent(yTypeIx, yType);
         if ((yType % 2) == 1) yLog = true;
         else yLog = false;
+      }
+      if (e->KeywordPresent(zTypeIx)) {
+        e->AssureLongScalarKWIfPresent(zTypeIx, zType);
+        if ((yType % 2) == 1) zLog = true;
+        else zLog = false;
       }
 
       //XRANGE and YRANGE overrides all that, but  Start/End should be recomputed accordingly

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -1161,4 +1161,18 @@ bool isAxonometricRotation(DDoubleGDL* Matrix, DDouble &alt, DDouble &az, DDoubl
       GDLDelete(mat);
     }
   }
+  
+void get3DMatrixParametersFor2DPosition(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement) {
+  DFloat* position=gdlGetRegion();
+  DFloat xrange=position[1]-position[0];
+  DFloat yrange=position[3]-position[2];
+  DFloat zrange=position[5]-position[4];
+  xratio=1.0*xrange;
+  yratio=1.0*yrange;
+  zratio=1.0*zrange;
+ displacement[0]=position[0];
+ displacement[1]=position[2];
+ displacement[2]=position[4];
+ std::cerr<<xratio<<","<<yratio<<","<<zratio<<","<<displacement[0]<<","<<displacement[1]<<","<<displacement[2]<<","<<std::endl;
+}
 } // namespace

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -724,16 +724,26 @@ DDoubleGDL* gdlDoAsScale3(DDouble az, DDouble alt, DDouble *scalex, DDouble *sca
   void gdlMakeSubpageRotationMatrix3d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans) {
 	DDouble newscale[3]={ xratio, yratio, zratio};
     SelfTranspose3d(me);
+    DDouble mytrans1[3] = {-0.5, -0.5, -0.5};
+    DDouble mytrans2[3] = {0.5, 0.5, 0.5};
+    SelfTranslate3d(me, mytrans1);
 	SelfScale3d(me,newscale);
 	SelfTranslate3d(me,trans);
+    SelfTranslate3d(me, mytrans2);
     SelfTranspose3d(me);
   }
   //this displaces 2D elements (images, already reprojected 3d) made in NoSubpage mode to a particluar subpage
-  void gdlMakeSubpageRotationMatrix2d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans) {
+  void gdlMakeSubpageRotationMatrix2d(DDoubleGDL* me, PLFLT xratio, PLFLT yratio, PLFLT zratio, PLFLT* trans, PLFLT shift, bool invert) {
 	DDouble newscale[3]={ xratio, yratio, zratio};
 	SelfReset3d(me);
+    (*me)[5] = invert?-1:1; //see gdlFlipYPlotDirection() above 
+    DDouble mytrans1[3] = {-0.5, -0.5, -0.5};
+    DDouble mytrans2[3] = {0.5, 0.5, 0.5};
+	mytrans2[1]+=shift; //additional 2D shift in Y for compensate plplot 'bug' for shade_surf
+    SelfTranslate3d(me, mytrans1);
 	SelfScale3d(me,newscale);
 	SelfTranslate3d(me,trans);
+    SelfTranslate3d(me, mytrans2);
     SelfTranspose3d(me);
   } 
  //converts 3D values according to COORDSYS towards NORMAL coordinates and , logically, unset xLog,yLo,zLog and define code as NORMAL.
@@ -1163,16 +1173,15 @@ bool isAxonometricRotation(DDoubleGDL* Matrix, DDouble &alt, DDouble &az, DDoubl
   }
   
 void get3DMatrixParametersFor2DPosition(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement) {
-  DFloat* position=gdlGetRegion();
-  DFloat xrange=position[1]-position[0];
-  DFloat yrange=position[3]-position[2];
-  DFloat zrange=position[5]-position[4];
-  xratio=1.0*xrange;
-  yratio=1.0*yrange;
-  zratio=1.0*zrange;
- displacement[0]=position[0];
- displacement[1]=position[2];
- displacement[2]=position[4];
- std::cerr<<xratio<<","<<yratio<<","<<zratio<<","<<displacement[0]<<","<<displacement[1]<<","<<displacement[2]<<","<<std::endl;
+  PLFLT* position=gdlGetRegion();
+  PLFLT xrange=position[1]-position[0];
+  PLFLT yrange=position[3]-position[2];
+  PLFLT zrange=position[5]-position[4];
+  xratio=xrange;
+  yratio=yrange;
+  zratio=zrange;
+ displacement[0]=position[0]-0.5+xrange/2;
+ displacement[1]=position[2]-0.5+yrange/2;
+ displacement[2]=position[4]-0.5+zrange/2;
 }
 } // namespace

--- a/src/plotting_convert_coord.cpp
+++ b/src/plotting_convert_coord.cpp
@@ -1174,14 +1174,14 @@ bool isAxonometricRotation(DDoubleGDL* Matrix, DDouble &alt, DDouble &az, DDoubl
   
 void get3DMatrixParametersFor2DPosition(PLFLT &xratio, PLFLT &yratio, PLFLT &zratio, PLFLT* displacement) {
   PLFLT* position=gdlGetRegion();
-  PLFLT xrange=position[1]-position[0];
-  PLFLT yrange=position[3]-position[2];
+  PLFLT xrange=position[2]-position[0];
+  PLFLT yrange=position[3]-position[1];
   PLFLT zrange=position[5]-position[4];
   xratio=xrange;
   yratio=yrange;
   zratio=zrange;
  displacement[0]=position[0]-0.5+xrange/2;
- displacement[1]=position[2]-0.5+yrange/2;
+ displacement[1]=position[1]-0.5+yrange/2;
  displacement[2]=position[4]-0.5+zrange/2;
 }
 } // namespace

--- a/src/plotting_plots.cpp
+++ b/src/plotting_plots.cpp
@@ -37,7 +37,7 @@ namespace lib {
 
     bool handle_args(EnvT* e) {
       //for cases where 3D is enabled, but z is not defined (since zVal is not an argument of PLOTS() )
-      DFloat * position = gdlGetRegion();
+      DFloat * position = gdlGetWindow();
       DDoubleGDL* zInit = new DDoubleGDL(position[4]);
       Guard<BaseGDL> zinit_guard(zInit);
 

--- a/src/plotting_polyfill.cpp
+++ b/src/plotting_polyfill.cpp
@@ -39,7 +39,7 @@ namespace lib {
 
     bool handle_args(EnvT* e) {
       //for cases where 3D is enabled, but z is not defined (since zVal is not an argument of PLOTS() )
-      DFloat * position = gdlGetRegion();
+      DFloat * position = gdlGetWindow();
       DDoubleGDL* zInit = new DDoubleGDL(position[4]);
       Guard<BaseGDL> zinit_guard(zInit);
 

--- a/src/plotting_surface.cpp
+++ b/src/plotting_surface.cpp
@@ -248,11 +248,17 @@ namespace lib
       //start a plot
       gdlNextPlotHandlingNoEraseOption(e, actStream);     //NOERASE
 
+	  //save region info
+	  PLFLT* save_region = gdlGetRegion();
+	  bool nosub=false;
+	  
       // viewport and world coordinates
       // set the PLOT charsize before setting viewport (margin depend on charsize)
       gdlSetPlotCharsize(e, actStream);
       zValue=gdlSetViewPortAndWorldCoordinates(e, actStream, xStart, xEnd, xLog, yStart, yEnd, yLog, zStart, zEnd, zLog, zValue);
       
+
+		
       // Deal with T3D options -- either present and we have to deduce az and alt contained in it,
       // or absent and we have to compute !P.T from az and alt.
 
@@ -278,12 +284,13 @@ namespace lib
           alt=-(360.-alt);
 		}
 		//Compute special transformation matrix for the BOX and give it to the driver. Subpage info is important
-        gdlBox3d=gdlDefinePlplotRotationMatrix( az, alt, scale, saveT3d);
-		actStream->getCurrentSubpageInfo(xratio, yratio, zratio, trans);
-		gdlMakeSubpageRotationMatrix3d(gdlBox3d, xratio, yratio, zratio,trans);
-		//now that 3D matrix is OK, we pass in 'No Sub'
+		gdlBox3d = gdlDefinePlplotRotationMatrix(az, alt, scale, saveT3d);
+		//now that 3D matrix is OK, we pass in 'No Sub'. The plot will be scaled ans offsetted to the size of the actual subpage or position
+		get3DMatrixParametersFor2DPosition(xratio, yratio, zratio, trans);
 		actStream->NoSub();
+		//recompute viewport etc now that ratio and offests will permit to displace the NoSub() plot at the correct position and scale:
 		zValue=gdlSetViewPortAndWorldCoordinates(e, actStream, xStart, xEnd, xLog, yStart, yEnd, yLog, zStart, zEnd, zLog, zValue);
+		gdlMakeSubpageRotationMatrix3d(gdlBox3d, xratio, yratio, zratio,trans);
 
         GDL_3DTRANSFORMDEVICE T3DForAXes;
         for (int i = 0; i < 16; ++i)T3DForAXes.T[i] =(*gdlBox3d)[i];
@@ -341,6 +348,38 @@ namespace lib
         //This is the good version for surface without the shade argument.
         actStream->vpor(0, 1, 0, 1);
         actStream->wind(-0.5/scale[0],0.5/scale[0],-0.5/scale[1],0.5/scale[1]); //mandatory: to center in (0,0,0) for 3D Matrix rotation.
+	  if (below) {
+		actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0.5, 1.5, -alt, az);
+		gdlFlipYPlotDirection(actStream); //special trick, not possible with plplot
+	  } else {
+		actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0.5, 1.5, alt, az);
+	  // shade //      } else {
+	  // shade //        //This is the good version for shade_surf and surface with shade option
+	  // shade //        // (needs shifting the plplot plot by some amount in the 3DDriverTransform of the driver.)     
+	  // shade //        actStream->vpor(0, 1, 0, 1);
+	  // shade //        actStream->wind(-0.5 / scale[0], 0.5 / scale[0], -0.5 / scale[1], 0.5 / scale[1]); //mandatory: to center in (0,0,0) for 3D Matrix rotation.
+	  // shade //        if (below) {
+	  // shade //          actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0, 1, -alt, az);
+	  // shade //          DDouble xp = 0;
+	  // shade //          DDouble yp1 = 0;
+	  // shade //          DDouble yp2 = 0;
+	  // shade //          Matrix3DTransformXYZval(0, 0, 0, &xp, &yp1,Current3DMatrix);
+	  // shade //          Matrix3DTransformXYZval(0, 0, 0.5, &xp, &yp2,Current3DMatrix);
+	  // shade //          gdlShiftYaxisUsing3DDriverTransform(actStream, 1 - (yp1 - yp2), true);
+	  // shade //        } else {
+	  // shade //          actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0, 1, alt, az); //mandatory: in order to have shades plotted correctly, z must go from 0 to 1, not -0.5 to 0.5
+	  // shade //          //as the code in plplot prevents negative "normalized" values.
+	  // shade //          // To insure this (and shade_surf) to work in all cases, we must rely on the 3DDriverTransform, once again, to shift the [0,1] plot in [-0.5, 0.5]
+	  // shade //          // 
+	  // shade //          //compute vertical displacement of point [0,0,0] in projected coordinates between zv=0 and zv=0.5
+	  // shade //          DDouble xp = 0;
+	  // shade //          DDouble yp1 = 0;
+	  // shade //          DDouble yp2 = 0;
+	  // shade //          Matrix3DTransformXYZval(0, 0, 0, &xp, &yp1,Current3DMatrix);
+	  // shade //          Matrix3DTransformXYZval(0, 0, 0.5, &xp, &yp2,Current3DMatrix);
+	  // shade //          gdlShiftYaxisUsing3DDriverTransform(actStream, yp1 - yp2, false);
+	  // shade //        }
+	  }
 		if (!doT3d) { //use a special matrix to shift and scale into current subpage
 		  gdlMakeSubpageRotationMatrix2d(gdlBox3d, xratio, yratio, zratio,trans);
 		  GDL_3DTRANSFORMDEVICE T3DForAXes;
@@ -348,38 +387,10 @@ namespace lib
 		  T3DForAXes.zValue = (std::isfinite(zValue)) ? zValue : 0;
 		  gdlStartSpecial3DDriverTransform(actStream, T3DForAXes);
           Guard<BaseGDL> g(gdlBox3d);
+		//restore region info
+		gdlStoreXAxisRegion(actStream, save_region);
+		gdlStoreYAxisRegion(actStream, save_region);
 		}
-		if (below) {
-		  actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0.5, 1.5, -alt, az);
-		  gdlFlipYPlotDirection(actStream); //special trick, not possible with plplot
-		} else actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0.5, 1.5, alt, az);
-// shade //      } else {
-// shade //        //This is the good version for shade_surf and surface with shade option
-// shade //        // (needs shifting the plplot plot by some amount in the 3DDriverTransform of the driver.)     
-// shade //        actStream->vpor(0, 1, 0, 1);
-// shade //        actStream->wind(-0.5 / scale[0], 0.5 / scale[0], -0.5 / scale[1], 0.5 / scale[1]); //mandatory: to center in (0,0,0) for 3D Matrix rotation.
-// shade //        if (below) {
-// shade //          actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0, 1, -alt, az);
-// shade //          DDouble xp = 0;
-// shade //          DDouble yp1 = 0;
-// shade //          DDouble yp2 = 0;
-// shade //          Matrix3DTransformXYZval(0, 0, 0, &xp, &yp1,Current3DMatrix);
-// shade //          Matrix3DTransformXYZval(0, 0, 0.5, &xp, &yp2,Current3DMatrix);
-// shade //          gdlShiftYaxisUsing3DDriverTransform(actStream, 1 - (yp1 - yp2), true);
-// shade //        } else {
-// shade //          actStream->w3d(1, 1, 1, 0, 1, 0, 1, 0, 1, alt, az); //mandatory: in order to have shades plotted correctly, z must go from 0 to 1, not -0.5 to 0.5
-// shade //          //as the code in plplot prevents negative "normalized" values.
-// shade //          // To insure this (and shade_surf) to work in all cases, we must rely on the 3DDriverTransform, once again, to shift the [0,1] plot in [-0.5, 0.5]
-// shade //          // 
-// shade //          //compute vertical displacement of point [0,0,0] in projected coordinates between zv=0 and zv=0.5
-// shade //          DDouble xp = 0;
-// shade //          DDouble yp1 = 0;
-// shade //          DDouble yp2 = 0;
-// shade //          Matrix3DTransformXYZval(0, 0, 0, &xp, &yp1,Current3DMatrix);
-// shade //          Matrix3DTransformXYZval(0, 0, 0.5, &xp, &yp2,Current3DMatrix);
-// shade //          gdlShiftYaxisUsing3DDriverTransform(actStream, yp1 - yp2, false);
-// shade //        }
-// shade //      }
       return false;
     }
     

--- a/src/plotting_surface.cpp
+++ b/src/plotting_surface.cpp
@@ -248,16 +248,16 @@ namespace lib
       //start a plot
       gdlNextPlotHandlingNoEraseOption(e, actStream);     //NOERASE
 
-	  //save region info
-	  PLFLT* save_region = gdlGetRegion();
+
 	  bool nosub=false;
 	  
       // viewport and world coordinates
       // set the PLOT charsize before setting viewport (margin depend on charsize)
       gdlSetPlotCharsize(e, actStream);
       zValue=gdlSetViewPortAndWorldCoordinates(e, actStream, xStart, xEnd, xLog, yStart, yEnd, yLog, zStart, zEnd, zLog, zValue);
-      
 
+	  //save region info
+	  PLFLT* save_region = gdlGetRegion();
 		
       // Deal with T3D options -- either present and we have to deduce az and alt contained in it,
       // or absent and we have to compute !P.T from az and alt.


### PR DESCRIPTION
Found a way to get correct 3D plots in !P.MULTI mode. Also changed a few other inconsitencies, in particular the ![XYZ].REGION was not correctly filled  Only problem left: with POSITION keyword set (or !P.POSITION) the 3D plot is not at the same size as its IDL counterpart. 
Also, corrected axis() function to work ok in some special cases when used by AXIS procedure as exemplified by the ADDITIONAL_AXES_PLOT example in coyote examples.