### PR TITLE
Operators completeness (again)

### DIFF
--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -1976,6 +1976,14 @@ template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOpInv.incpp"
 }
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvCplx.incpp"
+}
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvCplx.incpp"
+}
 // invalid types
 
 template<>
@@ -2275,20 +2283,18 @@ Data_<Sp>* Data_<Sp>::LtMark(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
 
 template<>
 Data_<SpDString>* Data_<SpDString>::LtMark(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
   return this;
 }
 
 template<>
 Data_<SpDComplex>* Data_<SpDComplex>::LtMark(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_LtMarkCplx.incpp"
 }
 
 template<>
 Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMark(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_LtMarkCplx.incpp"
 }
 
 template<>
@@ -2334,14 +2340,12 @@ Data_<SpDString>* Data_<SpDString>::LtMarkS(BaseGDL* r) {
 
 template<>
 Data_<SpDComplex>* Data_<SpDComplex>::LtMarkS(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_LtMarkSCplx.incpp"
 }
 
 template<>
 Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::LtMarkS(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_LtMarkSCplx.incpp"
 }
 
 template<>
@@ -2389,14 +2393,12 @@ Data_<SpDString>* Data_<SpDString>::GtMark(BaseGDL* r) {
 
 template<>
 Data_<SpDComplex>* Data_<SpDComplex>::GtMark(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_GtMarkCplx.incpp"
 }
 
 template<>
 Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMark(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_GtMarkCplx.incpp"
 }
 
 template<>
@@ -2443,14 +2445,12 @@ Data_<SpDString>* Data_<SpDString>::GtMarkS(BaseGDL* r) {
 
 template<>
 Data_<SpDComplex>* Data_<SpDComplex>::GtMarkS(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_GtMarkSCplx.incpp"
 }
 
 template<>
 Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::GtMarkS(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+#include "snippets/basic_op_GtMarkSCplx.incpp"
 }
 
 template<>

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -1958,87 +1958,23 @@ Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FIL
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  if (nEl == 1) {
-    if ((*this)[0] == zero) (*this)[0] = (*right)[0];
-    return this;
-  }
-
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
-  }
-  return this;
+#include "snippets/basic_op_OrOp.incpp"
 }
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  if (nEl == 1) {
-    if ((*right)[0] != zero) (*this)[0] = (*right)[0];
-    return this;
-  }
-
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
-  }
-  return this;
+#include "snippets/basic_op_OrOpInv.incpp"
 }
 // for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  if (nEl == 1) {
-    if ((*this)[0] == zero) (*this)[0] = (*right)[0];
-    return this;
-  }
-
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
-  }
-  return this;
+#include "snippets/basic_op_OrOp.incpp"
 }
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  if (nEl == 1) {
-    if ((*right)[0] != zero) (*this)[0] = (*right)[0];
-    return this;
-  }
-
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*this)[i] = (*right)[i];
-  }
-  return this;
+#include "snippets/basic_op_OrOpInv.incpp"
 }
 // invalid types
 
@@ -2145,27 +2081,23 @@ Data_<Sp>* Data_<Sp>::OrOpInvS(BaseGDL* right) {
 
 // different for floats
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvS(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSCplx.incpp"
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSCplx.incpp"
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvS(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSCplx.incpp"
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvS(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvS(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSCplx.incpp"
 }
 
 

--- a/src/basic_op.cpp
+++ b/src/basic_op.cpp
@@ -1751,9 +1751,8 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOp(BaseGDL* r) {
 }
 
 template<>
-Data_<SpDString>* Data_<SpDString>::AndOp(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype " + str + ".", true, false);
-  return this;
+Data_<SpDString>* Data_<SpDString>::AndOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_AndOpCplx.incpp"
 }
 
 template<>
@@ -1762,34 +1761,23 @@ Data_<SpDPtr>* Data_<SpDPtr>::AndOp(BaseGDL* r) {
   return this;
 }
 
-// template<>
-// Data_<SpDPtr>* Data_<SpDPtr>::AndOpInv( BaseGDL* r)
-// { 
-//  throw GDLException("Cannot apply operation to datatype PTR.",true,false);
-//  return this;
-// }
-
 template<>
 Data_<SpDObj>* Data_<SpDObj>::AndOp(BaseGDL* r) {
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
 
-//AndOpInv
-
 template<class Sp>
 Data_<Sp>* Data_<Sp>::AndOpInv(BaseGDL* right) {
   TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
   return AndOp(right);
 }
-// different for floats
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpInv(BaseGDL* r) {
 #include "snippets/basic_op_AndOpInv.incpp"
 }
 
-// for doubles
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpInv(BaseGDL* r) {
 #include "snippets/basic_op_AndOpInv.incpp"
@@ -1806,6 +1794,10 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInv(BaseGDL* r) {
 #include "snippets/basic_op_AndOpInv.incpp"
 }
 
+template<>
+Data_<SpDString>* Data_<SpDString>::AndOpInv(BaseGDL* r) {
+#include "snippets/basic_op_AndOpInv.incpp"
+}
 
 template<class Sp>
 Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
@@ -1830,8 +1822,6 @@ Data_<Sp>* Data_<Sp>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
   }
   return this;
 }
-// different for floats
-
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
@@ -1848,7 +1838,6 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpS(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION_
   }
   return this;
 }
-// for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpS(BaseGDL* r) {
@@ -1878,11 +1867,19 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpS(BaseGDL* r) {
 #include "snippets/basic_op_AndOpSCplx.incpp"
 }
 
-// invalid types
-
 template<>
 Data_<SpDString>* Data_<SpDString>::AndOpS(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Ty s = (*right)[0];
+  // right->Scalar(s);
+  if (s == zero) {
+    {
+      for (SizeT i = 0; i < nEl; ++i) (*this)[i] = zero;
+    }
+  }
   return this;
 }
 
@@ -1902,13 +1899,11 @@ template<class Sp>
 Data_<Sp>* Data_<Sp>::AndOpInvS(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   return AndOpS(right);
 }
-// for floats
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvS(BaseGDL* r) {
 #include "snippets/basic_op_AndOpInvS.incpp"
 }
-
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvS(BaseGDL* r) { 
@@ -1923,6 +1918,12 @@ template<>
 Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInvS(BaseGDL* r) { 
 #include "snippets/basic_op_AndOpInvS.incpp"
 }
+
+template<>
+Data_<SpDString>* Data_<SpDString>::AndOpInvS(BaseGDL* r) {
+#include "snippets/basic_op_AndOpInvS.incpp"
+}
+
 // OrOp
 // Ors right to itself, //C deletes right
 // right must always have more or same number of elements
@@ -1950,46 +1951,14 @@ Data_<Sp>* Data_<Sp>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__L
 }
 // different for floats
 
-template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  return OrOp(right);
-}
-// for floats
-
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOp.incpp"
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInv.incpp"
-}
-// for doubles
-
-template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOp.incpp"
-}
-
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInv.incpp"
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvCplx.incpp"
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvCplx.incpp"
-}
-// invalid types
-
-template<>
-Data_<SpDString>* Data_<SpDString>::OrOp(BaseGDL* r) { 
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return this;
 }
 
 template<>
@@ -2003,6 +1972,11 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOp(BaseGDL* r) {  TRACE_ROUTINE(__
 }
 
 template<>
+Data_<SpDString>* Data_<SpDString>::OrOp(BaseGDL* r) { 
+#include "snippets/basic_op_OrOp.incpp"
+}
+
+template<>
 Data_<SpDPtr>* Data_<SpDPtr>::OrOp(BaseGDL* r) { 
   throw GDLException("Cannot apply operation to datatype PTR.", true, false);
   return this;
@@ -2013,6 +1987,37 @@ Data_<SpDObj>* Data_<SpDObj>::OrOp(BaseGDL* r) {
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return this;
 }
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::OrOpInv(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  return OrOp(right);
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInv.incpp"
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInv.incpp"
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvCplx.incpp"
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvCplx.incpp"
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::OrOpInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInv.incpp"
+}
+
 // OrOp
 // Ors right to itself, //C deletes right
 // right must always have more or same number of elements
@@ -2045,6 +2050,7 @@ template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOpS(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOpSCplx.incpp"
 }
+
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpS(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOpSCplx.incpp"
@@ -2060,12 +2066,9 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpS(BaseGDL* r) { TRACE_ROUTINE(__
 #include "snippets/basic_op_OrOpSCplx.incpp"
 }
 
-// invalid types
-
 template<>
-Data_<SpDString>* Data_<SpDString>::OrOpS(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return this;
+Data_<SpDString>* Data_<SpDString>::OrOpS(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpSCplx.incpp"
 }
 
 template<>
@@ -2108,6 +2111,10 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvS(BaseGDL* r) {  TRACE_ROUTIN
 #include "snippets/basic_op_OrOpInvSCplx.incpp"
 }
 
+template<>
+Data_<SpDString>* Data_<SpDString>::OrOpInvS(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSCplx.incpp"
+}
 
 template<class Sp>
 Data_<Sp>* Data_<Sp>::XorOp(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)

--- a/src/basic_op_div.cpp
+++ b/src/basic_op_div.cpp
@@ -54,55 +54,21 @@ Data_<Sp>* Data_<Sp>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LI
 }
 
 template<> // Float
-Data_<SpDFloat>* Data_<SpDFloat>::Div(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  SizeT i = 0;
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-    (*this)[0] /= (*right)[0];
-	GDLStopRegisteringFPExceptions();
-	return this;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return this;
+Data_<SpDFloat>* Data_<SpDFloat>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_Div.incpp"
 }
 
 template<> // Double
-Data_<SpDDouble>* Data_<SpDDouble>::Div(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  SizeT i = 0;
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-    (*this)[0] /= (*right)[0];
-	GDLStopRegisteringFPExceptions();
-	return this;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return this;
+Data_<SpDDouble>* Data_<SpDDouble>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_Div.incpp"
+}
+template<> // Double
+Data_<SpDComplex>* Data_<SpDComplex>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_Div.incpp"
+}
+template<> // Double
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::Div(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_Div.incpp"
 }
 
 
@@ -141,55 +107,21 @@ Data_<Sp>* Data_<Sp>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
 }
 
 template<> 
-Data_<SpDFloat>* Data_<SpDFloat>::DivInv(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-	(*this)[0] = (*right)[0] / (*this)[0];
-	GDLStopRegisteringFPExceptions();
-	return this;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	  for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return this;
+Data_<SpDFloat>* Data_<SpDFloat>::DivInv(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInv.incpp"
 }
 
 template<> 
-Data_<SpDDouble>* Data_<SpDDouble>::DivInv(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-	(*this)[0] = (*right)[0] / (*this)[0];
-	GDLStopRegisteringFPExceptions();
-	return this;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	  for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return this;
+Data_<SpDDouble>* Data_<SpDDouble>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInv.incpp"
+}
+template<> 
+Data_<SpDComplex>* Data_<SpDComplex>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvCplx.incpp"
+}
+template<> 
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivInv(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvCplx.incpp"
 }
 // invalid types
 

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -71,23 +71,10 @@ Data_<Sp>* Data_<Sp>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__
 }
 // different for floats
 
-template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  return AndOpNew(right);
-}
-// for floats
-
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 # include "snippets/basic_op_AndOpNew.incpp"
 }
-
-//b=(a and a)
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-# include "snippets/basic_op_AndOpInvNew.incpp"
-}
-// for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
@@ -95,23 +82,8 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCT
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-# include "snippets/basic_op_AndOpInvNew.incpp"
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-# include "snippets/basic_op_AndOpInvNewCplx.incpp"
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-# include "snippets/basic_op_AndOpInvNewCplx.incpp"
-}
-// invalid types
-
-template<>
 Data_<SpDString>* Data_<SpDString>::AndOpNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return NULL;
+# include "snippets/basic_op_AndOpNew.incpp"
 }
 
 template<>
@@ -136,7 +108,34 @@ Data_<SpDObj>* Data_<SpDObj>::AndOpNew(BaseGDL* r) {
   return NULL;
 }
 
-// scalar versions
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  return AndOpNew(right);
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNew.incpp"
+}
+
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNew.incpp"
+}
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNewCplx.incpp"
+}
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNewCplx.incpp"
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNew.incpp"
+}
 
 template<class Sp>
 Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
@@ -162,13 +161,6 @@ Data_<Sp>* Data_<Sp>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
   return res;
 }
 // different for floats
-
-template<class Sp>
-Data_<Sp>* Data_<Sp>::AndOpInvSNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  return AndOpSNew(right);
-}
-// for floats
-
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
@@ -178,7 +170,59 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
   return this->Dup();
 }
 
-//b=(a and 1)
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
+  return this->Dup();
+}
+
+template<>
+Data_<SpDString>* Data_<SpDString>::AndOpSNew(BaseGDL* r) {
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
+  return this->Dup();
+}
+
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
+  return this->Dup();
+}
+
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  Data_* right = static_cast<Data_*> (r);
+  if ((*right)[0] == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  }
+  return this->Dup();
+}
+
+template<>
+Data_<SpDPtr>* Data_<SpDPtr>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
+  return NULL;
+}
+
+template<>
+Data_<SpDObj>* Data_<SpDObj>::AndOpSNew(BaseGDL* r) {
+  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
+  return NULL;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::AndOpInvSNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  return AndOpSNew(right);
+}
+
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
   Data_* right = static_cast<Data_*> (r);
@@ -206,16 +250,6 @@ Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUN
     }
     return res;
   }
-}
-// for doubles
-
-template<>
-Data_<SpDDouble>* Data_<SpDDouble>::AndOpSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  if ((*right)[0] == zero) {
-    return New(this->dim, BaseGDL::ZERO);
-  }
-  return this->Dup();
 }
 
 template<>
@@ -246,31 +280,7 @@ Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__F
     return res;
   }
 }
-// invalid types
 
-template<>
-Data_<SpDString>* Data_<SpDString>::AndOpSNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return NULL;
-}
-
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::AndOpSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  if ((*right)[0] == zero) {
-    return New(this->dim, BaseGDL::ZERO);
-  }
-  return this->Dup();
-}
-
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  if ((*right)[0] == zero) {
-    return New(this->dim, BaseGDL::ZERO);
-  }
-  return this->Dup();
-}
 template<>
 Data_<SpDComplex>* Data_<SpDComplex>::AndOpInvSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_AndOpInvSNewCplx.incpp"
@@ -281,25 +291,34 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInvSNew(BaseGDL* r) {TRACE_ROUT
 #include "snippets/basic_op_AndOpInvSNewCplx.incpp"
 }
 
-// template<>
-// Data_<SpDString>* Data_<SpDString>::AndOpInvSNew( BaseGDL* r)
-// { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-//  throw GDLException("Cannot apply operation to datatype STRING.",true,false);
-//  return res;
-// }
-
 template<>
-Data_<SpDPtr>* Data_<SpDPtr>::AndOpSNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype PTR.", true, false);
-  return NULL;
-}
+Data_<SpDString>* Data_<SpDString>::AndOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  Data_* right = static_cast<Data_*> (r);
 
-template<>
-Data_<SpDObj>* Data_<SpDObj>::AndOpSNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
-  return NULL;
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Ty s = (*right)[0];
+  if (s == zero) {
+    return New(this->dim, BaseGDL::ZERO);
+  } else {
+    Data_* res = NewResult();
+    if (nEl == 1) {
+      if ((*this)[0] != zero) (*res)[0] = s;
+      else (*res)[0] = zero;
+      return res;
+    }
+    if ((GDL_NTHREADS=parallelize( nEl))==1) {
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    } else {
+      TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+        for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = s;
+        else (*res)[i] = zero;
+    }
+    return res;
+  }
 }
-
 
 
 // OrOp ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -331,25 +350,11 @@ Data_<Sp>* Data_<Sp>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
   //C delete right;
   return res;
 }
-// different for floats
-
-template<class Sp>
-Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  return OrOpNew(right);
-}
-// for floats
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOpNew.incpp"
 }
-
-// b=(a or a)
-template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvNew.incpp"
-}
-// for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
@@ -357,24 +362,8 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvNew.incpp"
-}
-template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvNewCplx.incpp"
-}
-template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-#include "snippets/basic_op_OrOpInvNewCplx.incpp"
-}
-
-// invalid types
-
-template<>
 Data_<SpDString>* Data_<SpDString>::OrOpNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return NULL;
+#include "snippets/basic_op_OrOpNew.incpp"
 }
 
 template<>
@@ -397,6 +386,32 @@ template<>
 Data_<SpDObj>* Data_<SpDObj>::OrOpNew(BaseGDL* r) {
   throw GDLException("Cannot apply operation to datatype OBJECT.", true, false);
   return NULL;
+}
+
+template<class Sp>
+Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+  return OrOpNew(right);
+}
+
+template<>
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNew.incpp"
+}
+template<>
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNew.incpp"
+}
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNewCplx.incpp"
+}
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNewCplx.incpp"
+}
+template<>
+Data_<SpDString>* Data_<SpDString>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNew.incpp"
 }
 
 
@@ -449,8 +464,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvSNew(BaseGDL* r) {  TRACE_ROU
 
 template<>
 Data_<SpDString>* Data_<SpDString>::OrOpInvSNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return NULL;
+#include "snippets/basic_op_OrOpInvSNewCplx.incpp"
 }
 
 template<>
@@ -551,8 +565,7 @@ Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpSNew(BaseGDL* r) {TRACE_ROUTINE(
 
 template<>
 Data_<SpDString>* Data_<SpDString>::OrOpSNew(BaseGDL* r) {
-  throw GDLException("Cannot apply operation to datatype STRING.", true, false);
-  return NULL;
+#include "snippets/basic_op_OrOpSNewCplx.incpp"
 }
 
 template<>

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -418,113 +418,26 @@ Data_<Sp>* Data_<Sp>::OrOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,__
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  // ULong rEl=right->N_Elements();
-  ULong nEl = N_Elements();
-  Data_* res = NewResult();
-  // assert( rEl);
-  assert(nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if (nEl == 1) {
-    if ((*this)[0] == zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } //C delete right;
-  return res;
+#include "snippets/basic_op_OrOpNew.incpp"
 }
 
 // b=(a or a)
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  // ULong rEl=right->N_Elements();
-  ULong nEl = N_Elements();
-  Data_* res = NewResult();
-  // assert( rEl);
-  assert(nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if (nEl == 1) {
-    if ((*right)[0] != zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } //C delete right;
-  return res;
+#include "snippets/basic_op_OrOpInvNew.incpp"
 }
 // for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  // ULong rEl=right->N_Elements();
-  ULong nEl = N_Elements();
-  Data_* res = NewResult();
-  // assert( rEl);
-  assert(nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if (nEl == 1) {
-    if ((*this)[0] == zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } //C delete right;
-  return res;
+#include "snippets/basic_op_OrOpNew.incpp"
 }
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  // ULong rEl=right->N_Elements();
-  ULong nEl = N_Elements();
-  Data_* res = NewResult();
-  // assert( rEl);
-  assert(nEl);
-  //  if( !rEl || !nEl) throw GDLException("Variable is undefined.");
-  if (nEl == 1) {
-    if ((*right)[0] != zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = (*this)[i];
-  } //C delete right;
-  return res;
+#include "snippets/basic_op_OrOpInvNew.incpp"
 }
+
 // invalid types
 
 template<>
@@ -582,27 +495,23 @@ Data_<Sp>* Data_<Sp>::OrOpInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FIL
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDFloat>* Data_<SpDFloat>::OrOpInvSNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSNewCplx.incpp"
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvSNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSNewCplx.incpp"
 }
 
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvSNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvSNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSNewCplx.incpp"
 }
 
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvSNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-return this->Dup();
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvSNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_OrOpInvSNewCplx.incpp"
 }
 
 // invalid types

--- a/src/basic_op_new.cpp
+++ b/src/basic_op_new.cpp
@@ -79,109 +79,32 @@ Data_<Sp>* Data_<Sp>::AndOpInvNew(BaseGDL* right) { TRACE_ROUTINE(__FUNCTION__,_
 
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  // ULong rEl=right->N_Elements();
-  ULong nEl = N_Elements();
-  Data_* res = NewResult();
-
-  // assert( rEl);
-  assert(nEl);
-  if (nEl == 1) {
-    if ((*right)[0] == zero) (*res)[0] = zero;
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
-      else (*res)[i] = (*this)[i];
-  }
-  return res;
+# include "snippets/basic_op_AndOpNew.incpp"
 }
 
 //b=(a and a)
 template<>
 Data_<SpDFloat>* Data_<SpDFloat>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  assert(right->N_Elements());
-
-  Data_* res = NewResult();
-  if (nEl == 1) {
-    if ((*this)[0] != zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = zero;
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = zero;
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = zero;
-  }
-  return res;
+# include "snippets/basic_op_AndOpInvNew.incpp"
 }
 // for doubles
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  assert(right->N_Elements());
-
-  Data_* res = NewResult();
-  if (nEl == 1) {
-    if ((*right)[0] == zero) (*res)[0] = zero;
-    else (*res)[0] = (*this)[0];
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
-      else (*res)[i] = (*this)[i];
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero;
-      else (*res)[i] = (*this)[i];
-  }
-  return res;
+# include "snippets/basic_op_AndOpNew.incpp"
 }
 
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
-  Data_* right = static_cast<Data_*> (r);
-
-  ULong nEl = N_Elements();
-  assert(nEl);
-  assert(right->N_Elements());
-
-  Data_* res = NewResult();
-  if (nEl == 1) {
-    if ((*this)[0] != zero) (*res)[0] = (*right)[0];
-    else (*res)[0] = zero;
-    return res;
-  }
-  if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = zero;
-  } else {
-    TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-      else (*res)[i] = zero;
-  }
-  return res;
+# include "snippets/basic_op_AndOpInvNew.incpp"
+}
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNewCplx.incpp"
+}
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::AndOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+# include "snippets/basic_op_AndOpInvNewCplx.incpp"
 }
 // invalid types
 
@@ -436,6 +359,14 @@ Data_<SpDDouble>* Data_<SpDDouble>::OrOpNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTI
 template<>
 Data_<SpDDouble>* Data_<SpDDouble>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 #include "snippets/basic_op_OrOpInvNew.incpp"
+}
+template<>
+Data_<SpDComplex>* Data_<SpDComplex>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNewCplx.incpp"
+}
+template<>
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::OrOpInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
+#include "snippets/basic_op_OrOpInvNewCplx.incpp"
 }
 
 // invalid types
@@ -1570,60 +1501,23 @@ Data_<Sp>* Data_<Sp>::DivNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,_
 }
 
 template<> // Float
-Data_<SpDFloat>* Data_<SpDFloat>::DivNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  Data_* res = NewResult();
-  SizeT i = 0;
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-    (*res)[0] = (*this)[0] / (*right)[0];
-	GDLStopRegisteringFPExceptions();
-	return res;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return res;
+Data_<SpDFloat>* Data_<SpDFloat>::DivNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivNew.incpp"
 }
 
 template<> // Double
-Data_<SpDDouble>* Data_<SpDDouble>::DivNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  Data_* res = NewResult();
-  SizeT i = 0;
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-    (*this)[0] /= (*right)[0];
-	GDLStopRegisteringFPExceptions();
-	return res;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
-
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return res;
+Data_<SpDDouble>* Data_<SpDDouble>::DivNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivNew.incpp"
 }
 
+template<> // Double
+Data_<SpDComplex>* Data_<SpDComplex>::DivNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivNew.incpp"
+}
+template<> // Double
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivNew(BaseGDL* r) {  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivNew.incpp"
+}
 
 // inverse division: left=right/left
 
@@ -1660,57 +1554,22 @@ Data_<Sp>* Data_<Sp>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE_
 }
 
 template<> 
-Data_<SpDFloat>* Data_<SpDFloat>::DivInvNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  Data_* res = NewResult();
-
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-	(*res)[0] = (*right)[0] / (*this)[0];
-	GDLStopRegisteringFPExceptions();
-	return res;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	  for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return res;
+Data_<SpDFloat>* Data_<SpDFloat>::DivInvNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvNewCplx.incpp"
 }
 
 template<> 
-Data_<SpDDouble>* Data_<SpDDouble>::DivInvNew(BaseGDL* r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  Data_* right = static_cast<Data_*> (r);
-  ULong nEl = N_Elements();
-  assert(nEl);
-  Data_* res = NewResult();
+Data_<SpDDouble>* Data_<SpDDouble>::DivInvNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvNewCplx.incpp"
+}
 
-  GDLStartRegisteringFPExceptions();
-  if (nEl == 1) {
-	(*res)[0] = (*right)[0] / (*this)[0];
-	GDLStopRegisteringFPExceptions();
-	return res;
-  }
-  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-	for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
-  } else {
-	TRACEOMP(__FILE__, __LINE__)
-#pragma omp parallel for num_threads(GDL_NTHREADS)
-	  for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
-  }
-
-  GDLStopRegisteringFPExceptions();
-  
-  return res;
+template<> 
+Data_<SpDComplex>* Data_<SpDComplex>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvNewCplx.incpp"
+}
+template<> 
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivInvNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+#include "snippets/basic_op_DivInvNewCplx.incpp"
 }
 // invalid types
 
@@ -1782,22 +1641,22 @@ Data_<Sp>* Data_<Sp>::DivSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE__,
 }
 // float version: gives Inf for division by zero
 template<> 
-Data_<SpDFloat>* Data_<SpDFloat>::DivSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::DivSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivSNew.incpp"
 }
 // double version: gives Inf for division by zero
 template<>  //no need to differentiate Sp Types, as the FP exception is produced only by s
-Data_<SpDDouble>* Data_<SpDDouble>::DivSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::DivSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivSNew.incpp"
 }
 // double version: gives -NaN for division by zero to copy IDL.
 template<>  //no need to differentiate Sp Types, as the FP exception is produced only by s
-Data_<SpDComplex>* Data_<SpDComplex>::DivSNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::DivSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivSNewCplx.incpp"
 }
 // double version: gives -NaN for division by zero to copy IDL.
 template<>  //no need to differentiate Sp Types, as the FP exception is produced only by s
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivSNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivSNewCplxDbl.incpp"
 }
 
@@ -1974,20 +1833,20 @@ Data_<Sp>* Data_<Sp>::DivInvSNew(BaseGDL* r) { TRACE_ROUTINE(__FUNCTION__,__FILE
 }
 
 template<>
-Data_<SpDFloat>* Data_<SpDFloat>::DivInvSNew(BaseGDL* r) {
+Data_<SpDFloat>* Data_<SpDFloat>::DivInvSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivInvSNew.incpp"
 }
 
 template<>
-Data_<SpDDouble>* Data_<SpDDouble>::DivInvSNew(BaseGDL* r) {
+Data_<SpDDouble>* Data_<SpDDouble>::DivInvSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivInvSNew.incpp"
 }
 template<>
-Data_<SpDComplex>* Data_<SpDComplex>::DivInvSNew(BaseGDL* r) {
+Data_<SpDComplex>* Data_<SpDComplex>::DivInvSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivInvSNew.incpp"
 }
 template<>
-Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivInvSNew(BaseGDL* r) {
+Data_<SpDComplexDbl>* Data_<SpDComplexDbl>::DivInvSNew(BaseGDL* r) {TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 #include "snippets/basic_op_DivInvSNew.incpp"
 }
 // invalid types

--- a/src/snippets/basic_op_AndOpInvNew.incpp
+++ b/src/snippets/basic_op_AndOpInvNew.incpp
@@ -1,0 +1,22 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
+
+  Data_* res = NewResult();
+  if (nEl == 1) {
+    if ((*this)[0] != zero) (*res)[0] = (*right)[0];
+    else (*res)[0] = zero;
+    return res;
+  }
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  }
+  return res;

--- a/src/snippets/basic_op_AndOpInvNewCplx.incpp
+++ b/src/snippets/basic_op_AndOpInvNewCplx.incpp
@@ -1,0 +1,22 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  assert(right->N_Elements());
+
+  Data_* res = NewResult();
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) != 0) (*res)[0] = (*right)[0];
+    else (*res)[0] = zero;
+    return res;
+  }
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) != 0) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) != 0) (*res)[i] = (*right)[i];
+      else (*res)[i] = zero;
+  }
+  return res;

--- a/src/snippets/basic_op_AndOpNew.incpp
+++ b/src/snippets/basic_op_AndOpNew.incpp
@@ -1,0 +1,19 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*right)[0] == zero) (*res)[0] = zero;
+    else (*res)[0] = (*this)[0];
+    return res;
+  }
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero; else (*res)[i] = (*this)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if ((*right)[i] == zero) (*res)[i] = zero; else (*res)[i] = (*this)[i];
+  }
+  return res;
+ 

--- a/src/snippets/basic_op_AndOpNewCplx.incpp
+++ b/src/snippets/basic_op_AndOpNewCplx.incpp
@@ -2,21 +2,17 @@ Data_* right = static_cast<Data_*> (r);
 
 ULong nEl = N_Elements();
 assert(nEl);
-assert(right->N_Elements());
-
 Data_* res = NewResult();
 if (nEl == 1) {
-  if ((*this)[0] != zero) (*res)[0] = (*right)[0];
-  else (*res)[0] = zero;
+    if (std::norm((*right)[0]) == 0) (*res)[0] = zero;
+    else (*res)[0] = (*this)[0];
   return res;
 }
 if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
-  for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-    else (*res)[i] = zero;
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*right)[i]) == 0) (*res)[i] = zero;  else (*res)[i] = (*this)[i];
 } else {
   TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] != zero) (*res)[i] = (*right)[i];
-    else (*res)[i] = zero;
+    for (OMPInt i = 0; i < nEl; ++i)  if (std::norm((*right)[i]) == 0) (*res)[i] = zero;  else (*res)[i] = (*this)[i];
 }
 return res;

--- a/src/snippets/basic_op_Div.incpp
+++ b/src/snippets/basic_op_Div.incpp
@@ -1,0 +1,21 @@
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+  SizeT i = 0;
+  GDLStartRegisteringFPExceptions();
+  if (nEl == 1) {
+    (*this)[0] /= (*right)[0];
+	GDLStopRegisteringFPExceptions();
+	return this;
+  }
+  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
+  } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+	for (OMPInt ix = i; ix < nEl; ++ix) (*this)[ix] /= (*right)[ix];
+  }
+
+  GDLStopRegisteringFPExceptions();
+  
+  return this;

--- a/src/snippets/basic_op_DivInv.incpp
+++ b/src/snippets/basic_op_DivInv.incpp
@@ -1,0 +1,21 @@
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  GDLStartRegisteringFPExceptions();
+  if (nEl == 1) {
+	(*this)[0] = (*right)[0] / (*this)[0];
+	GDLStopRegisteringFPExceptions();
+	return this;
+  }
+  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+	for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
+  } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+	  for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
+  }
+
+  GDLStopRegisteringFPExceptions();
+  
+  return this;

--- a/src/snippets/basic_op_DivInvCplx.incpp
+++ b/src/snippets/basic_op_DivInvCplx.incpp
@@ -1,0 +1,21 @@
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+
+  GDLStartRegisteringFPExceptions();
+  if (nEl == 1) {
+	(*this)[0] = (*right)[0] / (*this)[0];
+	GDLStopRegisteringFPExceptions();
+	return this;
+  }
+  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+	for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
+  } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+	  for (OMPInt ix = 0; ix < nEl; ++ix) (*this)[ix] = (*right)[ix] / (*this)[ix];
+  }
+
+  GDLStopRegisteringFPExceptions();
+  
+  return this;

--- a/src/snippets/basic_op_DivInvNewCplx.incpp
+++ b/src/snippets/basic_op_DivInvNewCplx.incpp
@@ -1,0 +1,22 @@
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Data_* res = NewResult();
+
+  GDLStartRegisteringFPExceptions();
+  if (nEl == 1) {
+	(*res)[0] = (*right)[0] / (*this)[0];
+	GDLStopRegisteringFPExceptions();
+	return res;
+  }
+  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+	for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
+  } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+	  for (OMPInt ix = 0; ix < nEl; ++ix) (*res)[ix] = (*right)[ix] / (*this)[ix];
+  }
+
+  GDLStopRegisteringFPExceptions();
+  
+  return res;

--- a/src/snippets/basic_op_DivNew.incpp
+++ b/src/snippets/basic_op_DivNew.incpp
@@ -1,0 +1,23 @@
+  Data_* right = static_cast<Data_*> (r);
+  ULong nEl = N_Elements();
+  assert(nEl);
+  Data_* res = NewResult();
+  SizeT i = 0;
+  GDLStartRegisteringFPExceptions();
+  if (nEl == 1) {
+    (*this)[0] /= (*right)[0];
+	GDLStopRegisteringFPExceptions();
+	return res;
+  }
+  if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
+
+  } else {
+	TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+	for (OMPInt ix = i; ix < nEl; ++ix) (*res)[ix] = (*this)[ix] / (*right)[ix];
+  }
+
+  GDLStopRegisteringFPExceptions();
+  
+  return res;

--- a/src/snippets/basic_op_GtMarkCplx.incpp
+++ b/src/snippets/basic_op_GtMarkCplx.incpp
@@ -1,0 +1,17 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) < std::norm((*right)[0])) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) < std::norm((*right)[i])) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) < std::norm((*right)[i])) (*this)[i] = (*right)[i];
+  }
+  return this;

--- a/src/snippets/basic_op_GtMarkSCplx.incpp
+++ b/src/snippets/basic_op_GtMarkSCplx.incpp
@@ -1,0 +1,19 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) < std::norm((*right)[0])) (*this)[0] = (*right)[0];
+    return this;
+  }
+  Ty s = (*right)[0];
+  double snorm=std::norm(s);
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) < snorm) (*this)[i] = s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) < snorm) (*this)[i] = s;
+  }
+  return this;

--- a/src/snippets/basic_op_LtMarkCplx.incpp
+++ b/src/snippets/basic_op_LtMarkCplx.incpp
@@ -1,0 +1,17 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) > std::norm((*right)[0])) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) > std::norm((*right)[i])) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) > std::norm((*right)[i])) (*this)[i] = (*right)[i];
+  }
+  return this;

--- a/src/snippets/basic_op_LtMarkSCplx.incpp
+++ b/src/snippets/basic_op_LtMarkSCplx.incpp
@@ -1,0 +1,19 @@
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) > std::norm((*right)[0])) (*this)[0] = (*right)[0];
+    return this;
+  }
+  Ty s = (*right)[0];
+  double snorm=std::norm(s);
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) > snorm) (*this)[i] = s;
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) > snorm) (*this)[i] = s;
+  }
+  return this;

--- a/src/snippets/basic_op_OrOp.incpp
+++ b/src/snippets/basic_op_OrOp.incpp
@@ -1,22 +1,22 @@
-// e1->N_Elements() > e2->N_Elements() -> e2->OrOp(e1) : this (e2) =e1 unless e1==0 
+// e1->N_Elements() > e2->N_Elements() -> e2->OrOp(e1) : this (e2) =e1 unless e1=right==0 
 Data_* right = static_cast<Data_*> (r);
 
 ULong nEl = N_Elements();
 assert(nEl);
 if (nEl == 1) {
-  if (std::norm((*this)[0]) == 0) (*this)[0] = (*right)[0];
+  if ((*right)[0] != zero) (*this)[0] = (*right)[0];
   return this;
 }
 
 if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
   for (OMPInt i = 0; i < nEl; ++i) {
-    if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+    if ((*right)[i] != zero ) (*this)[i] = (*right)[i];
   }
 } else {
   TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
     for (OMPInt i = 0; i < nEl; ++i) {
-          if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+          if ((*right)[i] != zero) (*this)[i] = (*right)[i];
     }
 }
 return this;

--- a/src/snippets/basic_op_OrOpCplx.incpp
+++ b/src/snippets/basic_op_OrOpCplx.incpp
@@ -4,19 +4,19 @@ Data_* right = static_cast<Data_*> (r);
 ULong nEl = N_Elements();
 assert(nEl);
 if (nEl == 1) {
-  if (std::norm((*this)[0]) == 0) (*this)[0] = (*right)[0];
+  if (std::norm((*right)[0]) != 0) (*this)[0] = (*right)[0];
   return this;
 }
 
 if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
   for (OMPInt i = 0; i < nEl; ++i) {
-    if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+    if (std::norm((*right)[i]) != 0 ) (*this)[i] = (*right)[i];
   }
 } else {
   TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
     for (OMPInt i = 0; i < nEl; ++i) {
-          if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+    if (std::norm((*right)[i]) != 0 ) (*this)[i] = (*right)[i];
     }
 }
 return this;

--- a/src/snippets/basic_op_OrOpInv.incpp
+++ b/src/snippets/basic_op_OrOpInv.incpp
@@ -1,0 +1,18 @@
+// e1->N_Elements() < e2->N_Elements() -> e1->OrOpInv(e2) : this (e1) unless e1==0 
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if ((*this)[0] == zero) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+      for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i] == zero) (*this)[i] = (*right)[i];
+  }
+  return this;

--- a/src/snippets/basic_op_OrOpInvCplx.incpp
+++ b/src/snippets/basic_op_OrOpInvCplx.incpp
@@ -1,0 +1,18 @@
+// e1->N_Elements() < e2->N_Elements() -> e1->OrOpInv(e2) : this (e1) unless e1==0 
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  assert(nEl);
+  if (nEl == 1) {
+    if (std::norm((*this)[0]) == 0) (*this)[0] = (*right)[0];
+    return this;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*this)[i]) == 0) (*this)[i] = (*right)[i];
+  }
+  return this;

--- a/src/snippets/basic_op_OrOpInvNew.incpp
+++ b/src/snippets/basic_op_OrOpInvNew.incpp
@@ -1,0 +1,24 @@
+// e1->N_Elements() < e2->N_Elements() -> e1->OrOpInv(e2) : this (e1) unless e1==0 
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0];
+    if ((*res)[0] == zero) (*res)[0] = (*right)[0];
+    return res;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+    for (OMPInt i = 0; i < nEl; ++i) if ((*res)[i] == zero) (*res)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if ((*res)[i] == zero) (*res)[i] = (*right)[i];
+  }
+  return res;

--- a/src/snippets/basic_op_OrOpInvNewCplx.incpp
+++ b/src/snippets/basic_op_OrOpInvNewCplx.incpp
@@ -1,0 +1,24 @@
+// e1->N_Elements() < e2->N_Elements() -> e1->OrOpInv(e2) : this (e1) unless e1==0 
+  Data_* right = static_cast<Data_*> (r);
+
+  ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  
+  assert(nEl);
+  if (nEl == 1) {
+    (*res)[0] = (*this)[0];
+    if (std::norm((*res)[0]) == 0 ) (*res)[0] = (*right)[0];
+    return res;
+  }
+
+  if ((GDL_NTHREADS=parallelize( nEl))==1) {
+    for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*res)[i]) == 0 ) (*res)[i] = (*right)[i];
+  } else {
+    TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+     for (OMPInt i = 0; i < nEl; ++i) (*res)[i] = (*this)[i];
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if (std::norm((*res)[i]) == 0 ) (*res)[i] = (*right)[i];
+  }
+  return res;

--- a/src/snippets/basic_op_OrOpInvSCplx.incpp
+++ b/src/snippets/basic_op_OrOpInvSCplx.incpp
@@ -1,0 +1,19 @@
+//  e1 Or e2=StrictScalar() : e1 everywhere except if e1==0 
+Data_* right = static_cast<Data_*> (r);
+
+ULong nEl = N_Elements();
+assert(nEl);
+Ty s = (*right)[0];
+if (nEl == 1) {
+  if ((*this)[0]==zero) (*this)[0]=s;
+  return this;
+}
+
+if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+  for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i]==zero) (*this)[i] = s;
+} else {
+  TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i]==zero) (*this)[i] = s;
+}
+return this;

--- a/src/snippets/basic_op_OrOpInvSNewCplx.incpp
+++ b/src/snippets/basic_op_OrOpInvSNewCplx.incpp
@@ -1,0 +1,20 @@
+//  e1 Or e2=StrictScalar() : e1 everywhere except if e1==0 
+Data_* right = static_cast<Data_*> (r);
+
+ULong nEl = N_Elements();
+Data_* res = this->Dup();
+assert(nEl);
+Ty s = (*right)[0];
+if (nEl == 1) {
+  if ((*this)[0]==zero) (*res)[0]=s;
+  return res;
+}
+
+if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+  for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i]==zero) (*res)[i] = s;
+} else {
+  TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+    for (OMPInt i = 0; i < nEl; ++i) if ((*this)[i]==zero) (*res)[i] = s;
+}
+return res;

--- a/src/snippets/basic_op_OrOpNew.incpp
+++ b/src/snippets/basic_op_OrOpNew.incpp
@@ -1,0 +1,21 @@
+// e1->N_Elements() > e2->N_Elements() -> e2->OrOp(e1) :ret =e1 unless e1=right==0 
+Data_* right = static_cast<Data_*> (r);
+
+ULong nEl = N_Elements();
+  Data_* res = NewResult();
+  // assert( rEl);
+assert(nEl);
+if (nEl == 1) {
+    (*res)[0] = (*right)[0];
+    if ((*res)[0] == zero) (*res)[0] = (*this)[0];
+  return res;
+}
+if ((GDL_NTHREADS = parallelize(nEl)) == 1) {
+    for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  ((*right)[i] != zero )?(*right)[i] : (*this)[i];
+
+} else {
+  TRACEOMP(__FILE__, __LINE__)
+#pragma omp parallel for num_threads(GDL_NTHREADS)
+     for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  ((*right)[i] != zero )?(*right)[i] : (*this)[i];
+}
+return res;

--- a/src/snippets/basic_op_OrOpNewCplx.incpp
+++ b/src/snippets/basic_op_OrOpNewCplx.incpp
@@ -1,22 +1,21 @@
+// e1->N_Elements() > e2->N_Elements() -> e2->OrOp(e1) :ret =e1 unless e1=right==0 
   Data_* right = static_cast<Data_*> (r);
 
-  // ULong rEl=right->N_Elements();
   ULong nEl = N_Elements();
   Data_* res = NewResult();
   // assert( rEl);
   assert(nEl);
-  //if( !rEl || !nEl) throw GDLException("Variable is undefined.");
   if (nEl == 1) {   
-    (*res)[0] =  (std::norm((*this)[0]) > 0)?(*this)[0] : (*right)[0]; // | Ty(1);
+    (*res)[0] = (*right)[0];
+    if (std::norm((*res)[0]) == 0) (*res)[0] = (*this)[0];
     return res;
   }
   if ((GDL_NTHREADS=parallelize( nEl))==1) {
-    for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  (std::norm((*this)[i]) > 0)?(*this)[i] : (*right)[i]; // | Ty(1);
+    for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  (std::norm((*right)[i]) != 0 )?(*right)[i] : (*this)[i];
 
   } else {
     TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
-      for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  (std::norm((*this)[i]) > 0)?(*this)[i] : (*right)[i]; // | Ty(1);
+     for (OMPInt i = 0; i < nEl; ++i)  (*res)[i] =  (std::norm((*right)[i]) != 0 )?(*right)[i] : (*this)[i];
   }
-  //C delete right;
   return res;

--- a/src/snippets/basic_op_OrOpSCplx.incpp
+++ b/src/snippets/basic_op_OrOpSCplx.incpp
@@ -1,3 +1,4 @@
+//  e1=StrictScalar() OR e2 -> e2 <- e1 : e1 everywhere except if e1==0 
 Data_* right = static_cast<Data_*> (r);
 
 ULong nEl = N_Elements();

--- a/src/snippets/basic_op_OrOpSNewCplx.incpp
+++ b/src/snippets/basic_op_OrOpSNewCplx.incpp
@@ -1,3 +1,4 @@
+//  e1=StrictScalar() OR e2 -> e2 <- e1 : e1 everywhere except if e1==0 
 Data_* right = static_cast<Data_*> (r);
 
 ULong nEl = N_Elements();

--- a/testsuite/test_indepth_basic_functions.pro
+++ b/testsuite/test_indepth_basic_functions.pro
@@ -229,7 +229,7 @@ intent="z="+what+"array"
   for i=0,n_elements(what)-1 do z=execute(calls[i])
 end
 
-pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, include_complex=include_complex
+pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, string=string, include_complex=include_complex
   if (n_elements(include_complex) eq 0 ) then include_complex=0
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   lun=given_lun
@@ -238,6 +238,8 @@ pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, i
   typenames_all=["BYTE","INT","LONG","UINT","ULONG","LONG64","ULONG64","FLOAT","DOUBLE","COMPLEX","DCOMPLEX"]
   typecodes_float=[4,5]
   typenames_float=["FLOAT","DOUBLE"]
+  typecodes_string=[7]
+  typenames_string=["STRING"]
   typecodes_complex=[6,9]
   typenames_complex=["COMPLEX","DCOMPLEX"]
   typecodes=typecodes_all & typenames=typenames_all ; default
@@ -261,18 +263,26 @@ pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, i
      integers_only=1
      not_complex=1
   endif
+  if (keyword_set(string)) then begin
+     typecodes=typecodes_string
+     typenames=typenames_string
+     include_complex=0
+     all_numeric=0
+     integers_only=0
+     not_complex=0
+  endif
   
 
   a=dindgen(size)+1.0d & a[2]=0d ; insures test on some AND or OR codes 
-  onedimarray=[7.0d]
+  onedimarray=[777.0d]
   smallarray=dindgen(4)+1.0d & smallarray[2]=0d;
   big=ptrarr(11,/allo)
-  forbig=a+1.555 & forbig[3]=0 
+  forbig=a+3333 & forbig[3]=0 
   k=0 & foreach i,typecodes do begin & *big[k]=fix(forbig,type=i) & k++ &end
   zero=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *zero[k]=fix(0,type=i) & k++ &end
   scalar=ptrarr(11,/allo)
-  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(9,type=i) & k++ &end
+  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(99999,type=i) & k++ &end
   onedim=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *onedim[k]=fix(onedimarray,type=i) & k++ &end
   small=ptrarr(11,/allo)
@@ -286,8 +296,7 @@ pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, i
 
 ; operators 1
 ; Some of these operators have 4 flavors, depending on size, ex AndOP, AndOpS, AndOpInv, AndOpInvS, and 3 cases: new, new but one var is Guarded, or operating on same operand
-;what=[" + "," - " ," * "," / "," ^ "]
-what=[" ^ "]
+what=[" + "," - " ," * "," / "," ^ "]
 process_new, what, all_numeric
 process_temporary_right, what, all_numeric
 process_temporary_left, what, all_numeric
@@ -324,7 +333,7 @@ process_temporary_right, what, not_complex
 process_temporary_left, what, not_complex
 ; after this, no need to use process_temporary_xxxx, already done.
 ; operators 6
-what=[" ^= "]; , " *= " , " EQ= " , " GE= " ,  " GT= " , " LE= " ,  " LT= " ,  " -= " ,  " NE= " , " OR= " , " += " , " /= ", " AND= ", " MOD= ", " >= ", " <= "]
+what=[" ^= " , " *= " , " EQ= " , " GE= " ,  " GT= " , " LE= " ,  " LT= " ,  " -= " ,  " NE= " , " OR= " , " += " , " /= ", " AND= ", " MOD= ", " >= ", " <= "]
 process_new_self,what, all_numeric
 ; operators 7:  complex not supported (GDL error)
 what=[" MOD= " , " >= " ," <= " ]
@@ -332,7 +341,7 @@ process_new_self,what, not_complex
 end
 ;; trace_routine can only be used and useful if GDL is compiled with option TRACE_OPCALLS.
 ;; it gives on the terminal the nama and file of the exact function used
-pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_cpu=test_cpu, include_complex=include_complex, float=float, complex=complex
+pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_cpu=test_cpu, include_complex=include_complex, float=float, complex=complex, string=string
   if (n_elements(size) eq 0 ) then size=10
   if keyword_set(trace_routine) then begin
      test_indepth_operators_sub, size, -1, include_complex=include_complex, float=float, complex=complex

--- a/testsuite/test_indepth_basic_functions.pro
+++ b/testsuite/test_indepth_basic_functions.pro
@@ -253,18 +253,26 @@ pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, i
      integers_only=1
      not_complex=1
   endif
+  if (keyword_set(complex)) then begin
+     typecodes=typecodes_complex
+     typenames=typenames_complex
+     include_complex=0
+     all_numeric=1
+     integers_only=1
+     not_complex=1
+  endif
   
 
   a=dindgen(size)+1.0d & a[2]=0d ; insures test on some AND or OR codes 
-  onedimarray=[777.0d]
+  onedimarray=[7.0d]
   smallarray=dindgen(4)+1.0d & smallarray[2]=0d;
   big=ptrarr(11,/allo)
-  forbig=a+3333 & forbig[3]=0 
+  forbig=a+1.555 & forbig[3]=0 
   k=0 & foreach i,typecodes do begin & *big[k]=fix(forbig,type=i) & k++ &end
   zero=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *zero[k]=fix(0,type=i) & k++ &end
   scalar=ptrarr(11,/allo)
-  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(99999,type=i) & k++ &end
+  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(9,type=i) & k++ &end
   onedim=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *onedim[k]=fix(onedimarray,type=i) & k++ &end
   small=ptrarr(11,/allo)
@@ -278,7 +286,8 @@ pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, i
 
 ; operators 1
 ; Some of these operators have 4 flavors, depending on size, ex AndOP, AndOpS, AndOpInv, AndOpInvS, and 3 cases: new, new but one var is Guarded, or operating on same operand
-what=[" + "," - " ," * "," / "," ^ "]
+;what=[" + "," - " ," * "," / "," ^ "]
+what=[" ^ "]
 process_new, what, all_numeric
 process_temporary_right, what, all_numeric
 process_temporary_left, what, all_numeric
@@ -315,7 +324,7 @@ process_temporary_right, what, not_complex
 process_temporary_left, what, not_complex
 ; after this, no need to use process_temporary_xxxx, already done.
 ; operators 6
-what=[" ^= " , " *= " , " EQ= " , " GE= " ,  " GT= " , " LE= " ,  " LT= " ,  " -= " ,  " NE= " , " OR= " , " += " , " /= ", " AND= ", " MOD= ", " >= ", " <= "]
+what=[" ^= "]; , " *= " , " EQ= " , " GE= " ,  " GT= " , " LE= " ,  " LT= " ,  " -= " ,  " NE= " , " OR= " , " += " , " /= ", " AND= ", " MOD= ", " >= ", " <= "]
 process_new_self,what, all_numeric
 ; operators 7:  complex not supported (GDL error)
 what=[" MOD= " , " >= " ," <= " ]

--- a/testsuite/test_indepth_basic_functions.pro
+++ b/testsuite/test_indepth_basic_functions.pro
@@ -9,6 +9,7 @@ end
 pro process_new,what,limit
   format='("{",a,"} ",a)'
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
 intent="zero right: z=scalar"+what+'0'
   calls="printf,lun,what[i],intent[i],format=format & for k=0,limit do  begin & ret=(*scalar[k]"+what+"*zero[k]) & printf,lun,typenames[k] & printf,lun,ret & end"
   for i=0,n_elements(what)-1 do z=execute(calls[i])
@@ -51,6 +52,7 @@ intent="big big: z=big"+what+"big"
 end
 ; helper for repetitive test with guarded variable (after "AdjustTypesXXX", in prognodeexpr.cpp) operators like in "z= a and temporary(b) " )
 pro process_temporary_right,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   format='("{",a,"} ",a)'
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
 intent="*Guarded*,zero right: z=scalar"+what+"temporary(0)"
@@ -95,6 +97,7 @@ intent="*Guarded*,big big: z=big"+what+"temporary(big"
 end
 ; helper for repetitive test with guarded variable (after "AdjustTypesXXX", in prognodeexpr.cpp) operators like in "z= temporary(a) and b " )
 pro process_temporary_left,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   format='("{",a,"} ",a)'
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
 intent="*Guarded*,zero right: z=temporary(scalar)"+what+"zero"
@@ -140,6 +143,7 @@ end
 
 ; helper for repetitive test with self variable (operator like in "a and= b" )
 pro process_new_self,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   format='("{",a,"} ",a)'
 ; need to copy first operands, they will be modified
@@ -179,6 +183,7 @@ intent="big big: z=big"+what+"big"
 end
 ; helper for repetitive test with self left (operator like in "a++" )
 pro process_onevar_left_self,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   format='("{",a,"} ",a)'
 ; need to copy first operands, they will be modified
@@ -194,6 +199,7 @@ intent="array left: a=array & a"+what
 end
 ; helper for repetitive test with self left (operator like in "a++" )
 pro process_onevar_left,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   format='("{",a,"} ",a)'
 intent="zero left: ret=0"+what
@@ -208,6 +214,7 @@ intent="array left: ret=array"+what
 end
 ; helper for repetitive test with self right (operator like in "a = NOT a" )
 pro process_onevar_right,what,limit
+  for i=0,n_elements(what)-1 do z=execute( " printf,lun,'------------------------------------------------------------------------'" )
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   format='("{",a,"} ",a)'
 ; need to copy first operands, they will be modified
@@ -222,24 +229,42 @@ intent="z="+what+"array"
   for i=0,n_elements(what)-1 do z=execute(calls[i])
 end
 
-pro test_indepth_operators_sub, size, given_lun
+pro test_indepth_operators_sub, size, given_lun, float=float, complex=complex, include_complex=include_complex
+  if (n_elements(include_complex) eq 0 ) then include_complex=0
   common test_all_basic_function_common, lun, typecodes, typenames, zero, scalar, onedim, small, big
   lun=given_lun
 ; initialisations: floats at end, since some commands do not accept floats/doubles/complex
-  typecodes=[1,2,3,12,13,14,15,4,5,6,9]
-  typenames=["BYTE","INT","LONG","UINT","ULONG","LONG64","ULONG64","FLOAT","DOUBLE","COMPLEX","DCOMPLEX"]
-  all_numeric=10
+  typecodes_all=[1,2,3,12,13,14,15,4,5,6,9]
+  typenames_all=["BYTE","INT","LONG","UINT","ULONG","LONG64","ULONG64","FLOAT","DOUBLE","COMPLEX","DCOMPLEX"]
+  typecodes_float=[4,5]
+  typenames_float=["FLOAT","DOUBLE"]
+  typecodes_complex=[6,9]
+  typenames_complex=["COMPLEX","DCOMPLEX"]
+  typecodes=typecodes_all & typenames=typenames_all ; default
+  all_numeric=(include_complex gt 0)?10:8 ; 10 but complex values can valuably return NaNs and Infs because this is what teh C++ runtime library returns for complex. We do not use the same algorithm as IDL.
   integers_only=6
   not_complex=8
-  a=dindgen(size)+1.0d
-  onedimarray=[7.0d]
-  smallarray=a[0:4]
+
+  if (keyword_set(float)) then begin
+     typecodes=typecodes_float
+     typenames=typenames_float
+     include_complex=0
+     all_numeric=1
+     integers_only=1
+     not_complex=1
+  endif
+  
+
+  a=dindgen(size)+1.0d & a[2]=0d ; insures test on some AND or OR codes 
+  onedimarray=[777.0d]
+  smallarray=dindgen(4)+1.0d & smallarray[2]=0d;
   big=ptrarr(11,/allo)
-  k=0 & foreach i,typecodes do begin & *big[k]=fix(a,type=i) & k++ &end
+  forbig=a+3333 & forbig[3]=0 
+  k=0 & foreach i,typecodes do begin & *big[k]=fix(forbig,type=i) & k++ &end
   zero=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *zero[k]=fix(0,type=i) & k++ &end
   scalar=ptrarr(11,/allo)
-  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(2,type=i) & k++ &end
+  k=0 & foreach i,typecodes do begin & *scalar[k]=fix(99999,type=i) & k++ &end
   onedim=ptrarr(11,/allo)
   k=0 & foreach i,typecodes do begin & *onedim[k]=fix(onedimarray,type=i) & k++ &end
   small=ptrarr(11,/allo)
@@ -298,10 +323,10 @@ process_new_self,what, not_complex
 end
 ;; trace_routine can only be used and useful if GDL is compiled with option TRACE_OPCALLS.
 ;; it gives on the terminal the nama and file of the exact function used
-pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_cpu=test_cpu
+pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_cpu=test_cpu, include_complex=include_complex, float=float, complex=complex
   if (n_elements(size) eq 0 ) then size=10
   if keyword_set(trace_routine) then begin
-     test_indepth_operators_sub, size, -1
+     test_indepth_operators_sub, size, -1, include_complex=include_complex, float=float, complex=complex
      return
   endif
   DEFSYSV,"!GDL",exists=isgdl
@@ -313,7 +338,7 @@ pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_c
   old_ncpu=!cpu.tpool_nthreads
   old_nmin=!cpu.tpool_min_elts
   cpu,tpool_nthreads=1
-  test_indepth_operators_sub, size, lun
+  test_indepth_operators_sub, size, lun, include_complex=include_complex, float=float, complex=complex
   print,"test done for 1 cpu. If possible, compare '"+outfile1+"' and 'IDL_oneCPU_test_operators.txt'."
   if keyword_set(test_cpu) and isgdl then begin
      ; enable test for multiple cpu if old_ncpu is > 4
@@ -324,7 +349,7 @@ pro test_indepth_basic_functions, size=size, trace_routine=trace_routine, test_c
         openw,lun,outfile2
         cpu,tpool_nthreads=4
         cpu,tpool_min_elts=2
-        test_indepth_operators_sub, size, lun
+        test_indepth_operators_sub, size, lun, include_complex=include_complex, float=float, complex=complex
         cpu,tpool_nthreads=old_ncpu
         cpu,tpool_min_elts=old_nmin
         print,"test done for multiple cpu. Compare '"+outfile2+"' and '"+outfile1+"'."


### PR DESCRIPTION
closes #1845 + found problems with OR  and several COMPLEX operators.
Now discrepancy is **only** for complex values and  " ^ " operator in the extremely rare cases where NaNs ans Infs are computed: the sign of the Inf may differ from IDL as the result from the used of the stdlib complex pow() function.