### PR TITLE
Cmakefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ gdlde/
 gdlde*.zip
 .vscode
 .idea/
+2020.2.zip
+qhull-2020.2

--- a/CMakeModules/FindImageMagick.cmake
+++ b/CMakeModules/FindImageMagick.cmake
@@ -88,7 +88,7 @@ function(FIND_IMAGEMAGICK_API component header)
       ${ImageMagick_INCLUDE_DIRS}
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\ImageMagick\\Current;BinPath]/include"
     PATH_SUFFIXES
-      ImageMagick ImageMagick-6
+      ImageMagick ImageMagick-6 ImageMagic-7
     DOC "Path to the ImageMagick include dir."
     )
 
@@ -165,17 +165,17 @@ foreach(component ${ImageMagick_FIND_COMPONENTS}
     )
   if(component STREQUAL "Magick++")
     FIND_IMAGEMAGICK_API(Magick++ Magick++.h
-      Magick++ CORE_RL_Magick++_ Magick++-6.Q16 Magick++-Q16 Magick++-6.Q8 Magick++-Q8 Magick++-6.Q16HDRI Magick++-Q16HDRI Magick++-6.Q8HDRI Magick++-Q8HDRI
+      Magick++ CORE_RL_Magick++_ Magick++-6.Q16 Magick++-Q16 Magick++-6.Q8 Magick++-Q8 Magick++-6.Q16HDRI Magick++-Q16HDRI Magick++-6.Q8HDRI Magick++-Q8HDRI Magick++-7.Q16HDRI
       )
     list(APPEND ImageMagick_REQUIRED_VARS ImageMagick_Magick++_LIBRARY)
   elseif(component STREQUAL "MagickWand")
     FIND_IMAGEMAGICK_API(MagickWand wand/MagickWand.h
-      Wand MagickWand CORE_RL_wand_ MagickWand-6.Q16 MagickWand-Q16 MagickWand-6.Q8 MagickWand-Q8 MagickWand-6.Q16HDRI MagickWand-Q16HDRI MagickWand-6.Q8HDRI MagickWand-Q8HDRI
+      Wand MagickWand CORE_RL_wand_ MagickWand-6.Q16 MagickWand-Q16 MagickWand-6.Q8 MagickWand-Q8 MagickWand-6.Q16HDRI MagickWand-Q16HDRI MagickWand-6.Q8HDRI MagickWand-Q8HDRI MagickWand-7.Q16HDRI
       )
     list(APPEND ImageMagick_REQUIRED_VARS ImageMagick_MagickWand_LIBRARY)
   elseif(component STREQUAL "MagickCore")
     FIND_IMAGEMAGICK_API(MagickCore magick/MagickCore.h
-      Magick MagickCore CORE_RL_magick_ MagickCore-6.Q16 MagickCore-Q16 MagickCore-6.Q8 MagickCore-Q8 MagickCore-6.Q16HDRI MagickCore-Q16HDRI MagickCore-6.Q8HDRI MagickCore-Q8HDRI
+      Magick MagickCore CORE_RL_magick_ MagickCore-6.Q16 MagickCore-Q16 MagickCore-6.Q8 MagickCore-Q8 MagickCore-6.Q16HDRI MagickCore-Q16HDRI MagickCore-6.Q8HDRI MagickCore-Q8HDRI MagickCore-7.Q16HDRI
       )
     list(APPEND ImageMagick_REQUIRED_VARS ImageMagick_MagickCore_LIBRARY)
   else()

--- a/CMakeModules/FindImageMagick.cmake
+++ b/CMakeModules/FindImageMagick.cmake
@@ -88,7 +88,7 @@ function(FIND_IMAGEMAGICK_API component header)
       ${ImageMagick_INCLUDE_DIRS}
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\ImageMagick\\Current;BinPath]/include"
     PATH_SUFFIXES
-      ImageMagick ImageMagick-6 ImageMagic-7
+      ImageMagick ImageMagick-6 ImageMagick-7
     DOC "Path to the ImageMagick include dir."
     )
 

--- a/testsuite/test_dynamic_drivers.pro
+++ b/testsuite/test_dynamic_drivers.pro
@@ -10,7 +10,7 @@ pro test_dynamic_drivers
   surfr                         ; set up default 3D
   !P.T3D=1
   set_plot,'z'
-  device,set_resolu=[100,100]
+  device,set_resolution=[100,100]
   ; plot a box passing at pixel [0,0] if unprojected,
   ; which would be the case if the driver is not 'ours'.
   ; this trick works only with axes, as the other drawings use normal


### PR DESCRIPTION
I found a couple of errors while compiling I saw that this project uses imagemagick-7 not imagemagick-6 as shown here #https://github.com/gnudatalanguage/gdl/issues/1578#issuecomment-1519117266 and I think the reason it is not automatically looking for the correct version. I have added it into the the FindImageMagick. Also a slight note that debian 12 has only imagemagick-6 and cmake recommends that you install it. 

test_dynamic_drivers.pro had an error that would prevent the test from setting the resolution which I think was not exiting correctly I now have a few plotting tests failing now but I think this is a personal dependency issue I would like to personally resolve before discussing further. 

For the git ignore these files were added to the working directory by the setup script you can choose whether to keep this change or not.