### PR TITLE
Revert commit ebfa961 and close #1849

### DIFF
--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -35,9 +35,6 @@
       extern bool posixpaths;
     }
 #endif
-    
-#define MAX_LOOPS_NUMBER 32
-    
   typedef struct _SCC_STRUCT_ { //semicompiled code, small memory imprint (instead of a copy of the DNodes)
 	u_int nodeType = 0;
 	u_int ligne = 0;
@@ -595,8 +592,8 @@ class DPro: public DSubUD
 {
 public:
   // for main function, not inserted into proList
-  // should be fine (way too much): MAX_LOOPS_NUMBER (32?) NESTED loops in $MAIN$ (elswhere: unlimited)
-  DPro(): DSubUD("$MAIN$","","") { this->nForLoops = MAX_LOOPS_NUMBER;}
+  // should be fine (way too much): 32 NESTED loops in $MAIN$ (elswhere: unlimited)
+  DPro(): DSubUD("$MAIN$","","") { this->nForLoops = 32;}
 
   DPro(const std::string& n,const std::string& o="",const std::string& f=""): 
     DSubUD(n,o,f)

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -208,7 +208,7 @@ EnvUDT::EnvUDT( ProgNodeP cN, BaseGDL* self,
 
   DSubUD* proUD=static_cast<DSubUD*>(pro);
 
-  forLoopInfo.InitSize(proUD->NForLoops());
+  forLoopInfo.InitSize( proUD->NForLoops());
 
   SizeT envSize;
   //   SizeT keySize;
@@ -264,7 +264,7 @@ EnvUDT::EnvUDT( BaseGDL* self, ProgNodeP cN, const string& parent, CallContext l
 
   DSubUD* proUD=static_cast<DSubUD*>(pro);
 
-  forLoopInfo.InitSize(proUD->NForLoops());
+  forLoopInfo.InitSize( proUD->NForLoops());
 
   SizeT envSize=proUD->var.size();
   parIx=proUD->key.size();
@@ -318,7 +318,7 @@ EnvUDT::EnvUDT( ProgNodeP callingNode_, DSubUD* newPro, DObjGDL** self):
 
   DSubUD* proUD= newPro; //static_cast<DSubUD*>(pro);
   
-  forLoopInfo.InitSize(proUD->NForLoops());
+  forLoopInfo.InitSize( proUD->NForLoops());
 
   SizeT envSize;
   //   SizeT keySize;


### PR DESCRIPTION
#1849 arised after #1778 was introduced following #1766.
Although the motivation of #1766  still helds, the #1788 solution creates a problem with "EXECUTE" (that uses the caller environment). Until the situation is clearer, best is to revert to the 'old' code that is perhaps less optimized but works in all known cases.

This reverts commit ebfa961be944ba83bd654bc4bd9e50a40e0fd408.