### PR TITLE
changes in shmmap

### DIFF
--- a/src/shm.cpp
+++ b/src/shm.cpp
@@ -34,7 +34,7 @@ enum { BYTE=0,COMPLEX,DCOMPLEX,DOUBLE,FLOAT,INTEGER,L64,LONG,UINT,UL64,ULONG, DI
 static const std::string atomName[16]={"UNDEFINED","BYTE","INT","LONG","FLOAT","DOUBLE","COMPLEX","STRING","STRUCT","DCOMPLEX","POINTER","OBJREF","UINT","ULONG","LONG64","ULONG64"};
 static const int atomSize[16]={0,1,2,4,4,8,8,0,0,16,0,0,2,4,8,8};
 namespace lib {
-
+  
   bool get_shm_common_keywords(EnvT* e, std::string &segmentName, dimension & dim, int & type) {
 	SizeT np = e->NParam(0);
 	if (np != 0) e->AssureStringScalarPar(0, segmentName);
@@ -145,12 +145,10 @@ namespace lib {
 	  //reinterpret OS_HANDLE
 	  DLong sysv_handle=0;
 	  if (doOsHandle) { //must exist and be useable
-		e->AssureLongScalarKW(OS_HANDLE,sysv_handle);
-		int shmflg=all_perms;
-		key_t handle=sysv_handle;
-		sysv_hdle=shmget(handle,total_length,shmflg);
-		if (sysv_hdle ==-1) e->Throw("SYSV Shared Memory Segment " + i2s(sysv_handle) + " attach failed, reason: " + std::string(strerror(errno)) + ".");
-	  } else {
+		e->AssureLongScalarKW(OS_HANDLE,sysv_hdle); //handle must be sysv_hdle
+		destroy_segment = false;
+	  } else { // a creation 
+		destroy_segment = true;
 		int shmflg=IPC_CREAT|all_perms;
 		key_t handle=0;
 		sysv_hdle=shmget(handle,total_length,shmflg);
@@ -190,9 +188,13 @@ namespace lib {
 		if (status != 0) e->Throw("Shared Memory Segment " + segmentName + " creation failed (size), reason: " + std::string(strerror(errno)) + ".");
 		//segment is destroyable on exit unless 'destroy_segment' is set to 0
 		destroy_segment = true;
-		if (e->KeywordPresentAndDefined(DESTROY_SEGMENT)) destroy_segment = e->KeywordSet(DESTROY_SEGMENT);
+	  } else { //exist: 
+		destroy_segment = false;
 	  }
 	}
+	//DESTROY_SEGMENT modifies default behaviour  
+	if (e->KeywordPresentAndDefined(DESTROY_SEGMENT)) destroy_segment = e->KeywordSet(DESTROY_SEGMENT);
+	if (destroy_segment) atexit(TidySharedAtGDLExit);
 	//now, exist or not, we define only the requested memory mapping size "length".
 	void* mapAddress=NULL;
 	if (sysv) {
@@ -247,7 +249,12 @@ namespace lib {
 	  if (((*i).second.flags & USE_SYSV) == USE_SYSV) {
 		int result=shmdt((*i).second.mapped_address);
 		if (result ==-1) e->Throw("SYSV Shared Memory Segment " + segmentName + " Unmapping unsucessfull, reason: "+ std::string(strerror(errno))+".");
+		if (((*i).second.flags & DESTROY_SEGMENT_ON_UNMAP)==DESTROY_SEGMENT_ON_UNMAP) {
+		  int shmid=0;
+		  if (sscanf((*i).second.osHandle.c_str(),"%i",&shmid)==1) shmctl(shmid, IPC_RMID, NULL);
+		}
 	  } else {
+		msync((*i).second.mapped_address,(*i).second.length, MS_ASYNC); //msync is recommended even if probably overkill on linux since 2.6.19
 		int result=munmap((*i).second.mapped_address,(*i).second.length); //unmap
 		if (result !=0) e->Throw("Shared Memory Segment " + segmentName + " Unmapping unsucessfull, reason: "+ std::string(strerror(errno))+".");
 		if (((*i).second.flags & DESTROY_SEGMENT_ON_UNMAP)==DESTROY_SEGMENT_ON_UNMAP)  shm_unlink((*i).second.osHandle.c_str());
@@ -386,12 +393,13 @@ namespace lib {
 	}
 	return;
   }
-  //called from system when deleting a mapped variable
+  //called from system when deleting a mapped variable. If called with NULL, delete all possible mapped areas (to be done on exit)
   void shm_unreference(BaseGDL* var){
-	void* pointer=var->DataAddr(); //the mapped address
+	void* pointer;
+	if (var==NULL) pointer=NULL; else pointer=var->DataAddr(); //the mapped address
 	for (shmListIter i=shmList.begin(); i!=shmList.end(); ++i) {
 	  void* pointed=(*i).second.mapped_address;
-	  if (pointer == pointed) {
+	  if (pointer==NULL || pointer == pointed) {
 		(*i).second.refcount--;
 		if ((((*i).second.flags & DELETE_PENDING)==DELETE_PENDING) && (*i).second.refcount<1) {
 		  //no more reference, if shmap is pending delete, delete it.
@@ -399,7 +407,12 @@ namespace lib {
 		  if (((*i).second.flags & USE_SYSV) == USE_SYSV) {
 			int result = shmdt((*i).second.mapped_address);
 			if (result == -1) Warning("SYSV Shared Memory Segment " + (*i).first  + " Unmapping unsucessfull after deleting last mapped variable, reason: " + std::string(strerror(errno)) + ".");
+			if (((*i).second.flags & DESTROY_SEGMENT_ON_UNMAP) == DESTROY_SEGMENT_ON_UNMAP) {
+			  int shmid = 0;
+			  if (sscanf((*i).second.osHandle.c_str(), "%i", &shmid) == 1) shmctl(shmid, IPC_RMID, NULL);
+			}
 		  } else {
+	        msync((*i).second.mapped_address,(*i).second.length, MS_ASYNC); //msync is recommended even if probably overkill on linux since 2.6.19
 			int result = munmap((*i).second.mapped_address, (*i).second.length); //unmap
 			if (result != 0) Warning("Shared Memory Segment " + (*i).first  + " Unmapping unsucessfull after deleting last mapped variable, reason: " + std::string(strerror(errno)) + ".");
 			if (((*i).second.flags & DESTROY_SEGMENT_ON_UNMAP) == DESTROY_SEGMENT_ON_UNMAP) shm_unlink((*i).second.osHandle.c_str());
@@ -410,5 +423,14 @@ namespace lib {
 	  }
 	}
   }
+  
+  void TidySharedAtGDLExit()
+{
+  //remove shared mem mappings that need to be removed according to permissions etc.
+#ifndef _WIN32
+  shm_unreference(NULL);
+#endif
+}
+
 } // namespace
 #endif

--- a/src/shm.hpp
+++ b/src/shm.hpp
@@ -49,7 +49,7 @@ namespace lib {
   void shmunmap_pro(EnvT* e);
   BaseGDL* shmvar_fun(EnvT* e);
   BaseGDL* shmdebug_fun(EnvT* e);
-
+  void TidySharedAtGDLExit();
 } // namespace
 
 #endif


### PR DESCRIPTION
- insured correct behaviour with SYSV shmmap (connect to an existing SYSV mapping via the OS_HANDLE, which is a number)
- mappings are now destroyed correctly on exit or with shmunmap, when permitted by defaults or positioning of the DESTROY_ON_EXIT keyword. 
- tidying the shared mapping is performed on gdl exit, even if not specifically asked for using shmunmap. 
- synchronisation of shared memory file contents should be better.