### PR TITLE
better widget user experience,  on OSX in particular. And a few bugs cured.

### DIFF
--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -66,12 +66,6 @@
 //initialize wxWidgets system:  create an instance of wxAppGDL
 #ifdef HAVE_LIBWXWIDGETS
 #include "gdlwidget.hpp"
-//displaced in gdlwidget.cpp to make wxGetApp() available under Python (in GDL.so)
-//#ifndef __WXMAC__ 
-//wxIMPLEMENT_APP_NO_MAIN( wxAppGDL);
-//#else
-//wxIMPLEMENT_APP_NO_MAIN( wxApp);
-//#endif
 #endif
 
 #include "version.hpp"

--- a/src/gdleventhandler.cpp
+++ b/src/gdleventhandler.cpp
@@ -46,18 +46,10 @@ int GDLEventHandler()
 #endif
   GraphicsDevice::HandleEvents();
 
-  const long OS_X_DELAY_NS = 20000000; // 20ms
-//ONLY APPLE? or WIN? Why? (GD)
-#ifdef __APPLE__
-  // under OS X the event loop burns to much CPU time
-  struct timespec delay;
-  delay.tv_sec=0;
-  delay.tv_nsec = OS_X_DELAY_NS; // 20ms
-  nanosleep(&delay,NULL);
-#endif
 #ifdef _WIN32 
   Sleep(10);  // this just to quiet down the character input from readline. 2 was not enough. 20 was ok.
 #endif
+  
   return 0;
 }
 

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1264,21 +1264,10 @@ void GDLWidget::HandleUnblockedWidgetEvents()
     DStructGDL* ev = NULL;
     while( (ev = GDLWidget::InteractiveEventQueue.Pop()) != NULL)
     {
-//        static int idIx = ev->Desc( )->TagIndex( "ID" ); // 0
-//        static int topIx = ev->Desc( )->TagIndex( "TOP" ); // 1
-//        static int handlerIx = ev->Desc( )->TagIndex( "HANDLER" ); // 2
-//        assert( idIx == 0 );
-//        assert( topIx == 1 );
-//        assert( handlerIx == 2 );
-
       ev = CallEventHandler( ev );
 
       if( ev != NULL)
       {
-        int idIx = ev->Desc( )->TagIndex( "ID" );
-        assert( idIx == 0 );
-        WidgetIDT id = (*static_cast<DLongGDL*> (ev->GetTag( idIx, 0 )))[0];
-        Warning( "Unhandled event. ID: " + i2s( id ) );
         GDLDelete( ev );
         ev = NULL;
       }

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -646,15 +646,15 @@ extern "C" { void CPSEnableForegroundOperation( ProcessSerialNumber* psn ); }
 #endif
 
   //initialize wxWidgets system:  create an instance of wxAppGDL here, not at Main (
-//#ifndef __WXMAC__ 
-//    wxAppGDL& wxGetApp() { return *static_cast<wxAppGDL*>(wxApp::GetInstance()); }   
-//    wxAppConsole *wxCreateApp() 
-//    { 
-//        wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE,"GDL");
-//        return new wxAppGDL;
-//    }
-//    wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
-//#else
+#ifndef __WXMAC__ 
+    wxAppGDL& wxGetApp() { return *static_cast<wxAppGDL*>(wxApp::GetInstance()); }   
+    wxAppConsole *wxCreateApp() 
+    { 
+        wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE,"GDL");
+        return new wxAppGDL;
+    }
+    wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
+#else
     wxApp& wxGetApp() { return *static_cast<wxApp*>(wxApp::GetInstance()); }   
     wxAppConsole *wxCreateApp() 
     { 
@@ -662,7 +662,7 @@ extern "C" { void CPSEnableForegroundOperation( ProcessSerialNumber* psn ); }
         return new wxApp;
     }
     wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
-//#endif
+#endif
 
 void GDLEventQueue::Purge()
 {
@@ -7832,20 +7832,20 @@ void GDLWidgetDraw::SetWidgetScreenSize(DLong sizex, DLong sizey) {
 // for MacOS /COCOA port, the following code does not work and the application is hung (!) Help!
 // So we rely only on doing nothing and call Yield() , that works, fingers crossed.
 // Really strange but wxWidgets is not well documented (who is?)
-//#ifndef __WXMAC__ 
-//int wxAppGDL::MyLoop() {
-//    if (loop.IsOk()) {
-////      std::cerr<<&loop<<std::endl;
-//      loop.SetActive(&loop);
-//      if (loop.IsRunning()) {
-//        while (loop.Pending()) // Unprocessed events in queue
-//        {
-//          loop.Dispatch(); // Dispatch next event in queue
-//        }
-//      }
-//    }
-//  return 0;
-//}
-//#endif
+#ifndef __WXMAC__ 
+int wxAppGDL::MyLoop() {
+    if (loop.IsOk()) {
+//      std::cerr<<&loop<<std::endl;
+      loop.SetActive(&loop);
+      if (loop.IsRunning()) {
+        while (loop.Pending()) // Unprocessed events in queue
+        {
+          loop.Dispatch(); // Dispatch next event in queue
+        }
+      }
+    }
+  return 0;
+}
+#endif
 
 #endif

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -640,16 +640,21 @@ bool GDLWidget::handlersOk=false;
 wxFont GDLWidget::defaultFont=wxNullFont; //the font defined by widget_control,default_font.
 wxFont GDLWidget::systemFont=wxNullFont;  //the initial system font. This to behave as IDL
 
+#ifdef __WXMAC__
+        #include <Carbon/Carbon.h>
+extern "C" { void CPSEnableForegroundOperation( ProcessSerialNumber* psn ); }
+#endif
+
   //initialize wxWidgets system:  create an instance of wxAppGDL here, not at Main (
-#ifndef __WXMAC__ 
-    wxAppGDL& wxGetApp() { return *static_cast<wxAppGDL*>(wxApp::GetInstance()); }   
-    wxAppConsole *wxCreateApp() 
-    { 
-        wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE,"GDL");
-        return new wxAppGDL;
-    }
-    wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
-#else
+//#ifndef __WXMAC__ 
+//    wxAppGDL& wxGetApp() { return *static_cast<wxAppGDL*>(wxApp::GetInstance()); }   
+//    wxAppConsole *wxCreateApp() 
+//    { 
+//        wxAppConsole::CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE,"GDL");
+//        return new wxAppGDL;
+//    }
+//    wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
+//#else
     wxApp& wxGetApp() { return *static_cast<wxApp*>(wxApp::GetInstance()); }   
     wxAppConsole *wxCreateApp() 
     { 
@@ -657,7 +662,7 @@ wxFont GDLWidget::systemFont=wxNullFont;  //the initial system font. This to beh
         return new wxApp;
     }
     wxAppInitializer  wxTheAppInitializer((wxAppInitializerFunction) wxCreateApp);
-#endif
+//#endif
 
 void GDLEventQueue::Purge()
 {
@@ -1229,9 +1234,9 @@ void GDLWidget::RefreshDynamicWidget() {
     }
 }
 
-void GDLWidget::SendWidgetTimerEvent(DDouble secs) {
+void GDLWidget::SendWidgetTimerEvent(int millisecs) {
+  if (millisecs < 1) millisecs=1;  //otherwise 0 hangs on OSX
   WidgetIDT* id = new WidgetIDT(widgetID);
-  int millisecs = floor(secs * 1000.0);
   if (theWxWidget) { //we nee a handle on a wxWindow object...
     wxWindow* w = dynamic_cast<wxWindow*> (theWxWidget);
     assert(w != NULL);
@@ -1279,6 +1284,7 @@ void GDLWidget::HandleUnblockedWidgetEvents()
       }
     }
     if (wxIsBusy()) wxEndBusyCursor( );
+  CallWXEventLoop(); // eneble results of above in the widgets
   }
 
 void GDLWidget::PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev) {
@@ -1412,22 +1418,11 @@ DLongGDL* GDLWidget::GetAllHeirs(){
   for (SizeT i = 0; i < currentVectorSize ; ++i) (*result)[i] = widgetIDList[i];
   return result;
 }
-#ifdef __WXMAC__
-        #include <Carbon/Carbon.h>
-extern "C" { void CPSEnableForegroundOperation( ProcessSerialNumber* psn ); }
-#endif
 
 //
 bool GDLWidget::InitWx() {
   // this hack enables to have a GUI on Mac OSX even if the
   // program was called from the command line (and isn't a bundle)
-  #ifdef __WXMAC__
-          ProcessSerialNumber psn;
-  
-          GetCurrentProcess( &psn );
-          CPSEnableForegroundOperation( &psn );
-          SetFrontProcess( &psn );
-  #endif
   try{
      wxInitialize();
   } catch (...) {return false;}
@@ -2455,19 +2450,11 @@ long style = (wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxRESIZE_BORDER | wxCAPTION | wx
   }
   topFrame = new gdlwxFrame(NULL, this, widgetID, titleWxString, wOffset, wxDefaultSize, style, modal);
 
-#ifdef __wxMAC__
+#ifdef __WXMAC__
 //does not work.
-//#include <ApplicationServices/ApplicationServices.h>
-//
-//ProcessSerialNumber PSN;
-//GetCurrentProcess(&PSN);
-//TransformProcessType(&PSN,kProcessTransformToForegroundApplication);
-
-  //the following is not really working either, except that a 'gdl' mac menubar is present an that's sufficient to get keyboard focus correctly
-wxMenu* macmenu[1];
-  WXMenubar* macBar=new wxMenubar();
-  macBar->Append(OSXGetAppleMenu (), titleWxString)
-  topFrame->SetMenuBar(macBar);
+  ProcessSerialNumber psn = {0, kCurrentProcess};
+  ProcessApplicationTransformState state = kProcessTransformToForegroundApplication;
+  OSStatus osxErr = TransformProcessType(&psn, state);
 #endif
 
 #ifdef GDL_DEBUG_WIDGETS_COLORIZE
@@ -2479,22 +2466,34 @@ wxMenu* macmenu[1];
   //add icon
   topFrame->SetIcon(wxgdlicon);
 
+  wxSizer* tfSizer=new wxBoxSizer(wxVERTICAL);
+  topFrame->SetSizer(tfSizer);
   if (mbarID != 0) {
 #if PREFERS_MENUBAR
     GDLWidgetMenuBar* mBar = new GDLWidgetMenuBar(widgetID, e);
     mbarID = mBar->GetWidgetID();
     mBarIDInOut = mbarID;
     wxMenuBar* me = dynamic_cast<wxMenuBar*> (mBar->GetWxWidget());
+#ifdef __WXMAC__
+//  me->Append(me->OSXGetAppleMenu(), "Apple");
+//    if (!osxErr) me->Append(new wxMenu("does not work\n"));
+#endif
     if (me) topFrame->SetMenuBar(me);
     else cerr << "Warning: GDLWidgetBase::GDLWidgetBase: Non-existent menubar widget!\n";
 #else    
+
+#ifdef __WXMAC__
+    wxPanel* p = new wxPanel(topFrame, wxID_ANY);
+    GDLWidgetMenuBar* mBar = new GDLWidgetMenuBar(p, widgetID, e);
+	wxBoxSizer* mbs=new wxBoxSizer(wxHORIZONTAL);
+	tfSizer->Add(p);
+#else
     GDLWidgetMenuBar* mBar = new GDLWidgetMenuBar(topFrame, widgetID, e);
+#endif
     mbarID = mBar->GetWidgetID();
     mBarIDInOut = mbarID;
 #endif
   }
-  wxSizer* tfSizer=new wxBoxSizer(wxVERTICAL);
-  topFrame->SetSizer(tfSizer);
   CreateBase(topFrame); //define widgetPanel, widgetSizer, theWxWidget and theWxContainer.
   //it is the FRAME that manage all events. Here we dedicate particularly the tlb_* events:
   // note that we have the choice for Size Event Handler for Frames, but need to change also is widgets.cpp
@@ -4841,7 +4840,7 @@ BaseGDL* GDLWidgetTable::GetDisjointSelectionValuesForStructs(DLongGDL* selectio
  	  ix = (*selection)[l++];
 	  t = (*selection)[l++];
 	}
-	sprintf(tagbuf, "%12d", outTag);
+	snprintf(tagbuf, 12, "%12d", outTag);
 	//convert ' ' to '_'
 	for (auto z = 0; z < 12; ++z) if (tagbuf[z] == 32) tagbuf[z] = 95;
 	std::string outTagName(const_cast<char *>(tagbuf));
@@ -7843,20 +7842,20 @@ void GDLWidgetDraw::SetWidgetScreenSize(DLong sizex, DLong sizey) {
 // for MacOS /COCOA port, the following code does not work and the application is hung (!) Help!
 // So we rely only on doing nothing and call Yield() , that works, fingers crossed.
 // Really strange but wxWidgets is not well documented (who is?)
-#ifndef __WXMAC__ 
-int wxAppGDL::MyLoop() {
-    if (loop.IsOk()) {
-//      std::cerr<<&loop<<std::endl;
-      loop.SetActive(&loop);
-      if (loop.IsRunning()) {
-        while (loop.Pending()) // Unprocessed events in queue
-        {
-          loop.Dispatch(); // Dispatch next event in queue
-        }
-      }
-    }
-  return 0;
-}
-#endif
+//#ifndef __WXMAC__ 
+//int wxAppGDL::MyLoop() {
+//    if (loop.IsOk()) {
+////      std::cerr<<&loop<<std::endl;
+//      loop.SetActive(&loop);
+//      if (loop.IsRunning()) {
+//        while (loop.Pending()) // Unprocessed events in queue
+//        {
+//          loop.Dispatch(); // Dispatch next event in queue
+//        }
+//      }
+//    }
+//  return 0;
+//}
+//#endif
 
 #endif

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1282,9 +1282,9 @@ void GDLWidget::HandleUnblockedWidgetEvents()
         GDLDelete( ev );
         ev = NULL;
       }
+	  CallWXEventLoop(); // eneble results of above in the widgets
     }
     if (wxIsBusy()) wxEndBusyCursor( );
-  CallWXEventLoop(); // eneble results of above in the widgets
   }
 
 void GDLWidget::PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev) {

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -5632,12 +5632,13 @@ GDLWidgetTree::GDLWidgetTree( WidgetIDT p, EnvT* e, BaseGDL* value_, DULong even
     } //else throw GDLException("Parent tree widget is not a folder."); //IDL just forgets.
   }
 void GDLWidgetTree::OnRealize(){
-   GDLWidgetTree* root=this->GetMyRootGDLWidgetTree();
-   if (this==root) {
-     wxTreeCtrlGDL* ctrl=static_cast<wxTreeCtrlGDL*>(this->GetWxWidget());
-     wxTreeItemId id=ctrl->GetFirstVisibleItem 	( 		) 	;
-     if (id) ctrl->SetFocusedItem(id);
-   }
+// not useful? root node does not seem selected at creation with *DL.
+//   GDLWidgetTree* root=this->GetMyRootGDLWidgetTree();
+//   if (this==root) {
+//     wxTreeCtrlGDL* ctrl=static_cast<wxTreeCtrlGDL*>(this->GetWxWidget());
+//     wxTreeItemId id=ctrl->GetFirstVisibleItem 	( 		) 	;
+//     if (id) ctrl->SetFocusedItem(id);
+//   }
 }
 DInt GDLWidgetTree::GetTreeIndex()
 {

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -27,7 +27,7 @@
 // on OSX. So we choose normally to undefine this 
 #ifndef __WXMAC__ 
 //warning MAC should not have prefer_menubar=1 unless you solve the mac manubar problem.
-#define PREFERS_MENUBAR 1
+//#define PREFERS_MENUBAR 1
 #endif
 // For compilers that support precompilation, includes "wx/wx.h".
 // HAVE_LARGEFILE_SUPPORT, SIZEOF_VOID_P, SIZEOF_SIZE_T,  may be set by Python, creates unnecessary warnings
@@ -252,19 +252,19 @@ public:
  WidgetEventInfo(wxEventType t_, wxObjectEventFunction f_, wxWindow* w_) : t(t_), f(f_), w(w_) {
  }
 };
-#ifndef __WXMAC__
-// main App class
- #include "wx/evtloop.h"
- 
-class wxAppGDL: public wxApp
-{
- wxGUIEventLoop loop;
- public:
- int MyLoop();
-};
-
-wxDECLARE_APP(wxAppGDL); //wxAppGDL is equivalent to wxGetApp()
-#endif
+//#ifndef __WXMAC__
+//// main App class
+// #include "wx/evtloop.h"
+// 
+//class wxAppGDL: public wxApp
+//{
+// wxGUIEventLoop loop;
+// public:
+// int MyLoop();
+//};
+//
+//wxDECLARE_APP(wxAppGDL); //wxAppGDL is equivalent to wxGetApp()
+//#endif
 
 // GDL versions of wxWidgets controls =======================================
 DECLARE_LOCAL_EVENT_TYPE(wxEVT_SHOW_REQUEST, -1)
@@ -442,11 +442,12 @@ public:
   }
   static BaseGDL * getSystemColours();
   static void CallWXEventLoop(){
-#ifdef __WXMAC__
+//#ifdef __WXMAC__
+//    wxTheApp->Yield();
+//#else
     wxTheApp->Yield();
-#else
-    wxGetApp().MyLoop(); //central loop for wxEvents!
-#endif
+//    wxGetApp().MyLoop(); //central loop for wxEvents!
+//#endif
   }
 protected:
   
@@ -793,7 +794,7 @@ public:
   bool DisableSizeEvents(gdlwxFrame* &tlbFrame,WidgetIDT &id);
   static void EnableSizeEvents(gdlwxFrame* &tlbFrame,WidgetIDT &id);
 
-  void SendWidgetTimerEvent(DDouble secs);
+  void SendWidgetTimerEvent(int millisecs);
   virtual void SetButtonWidget( bool onOff){}
   void ClearEvents();
 };
@@ -1529,11 +1530,20 @@ protected:
   std::deque<WidgetIDT> children;
   ~GDLWidgetMenuBar();
 public:
+#ifdef __WXMAC__
+  GDLWidgetMenuBar( wxWindow* frame, WidgetIDT p, EnvT* e):
+#else
   GDLWidgetMenuBar( wxFrame* frame, WidgetIDT p, EnvT* e): 
+#endif  
   GDLWidget( p, NULL) //NULL because MBar must not re-read env Values of e
   { 
-   long style=wxTB_HORIZONTAL|wxTB_DOCKABLE|wxTB_FLAT;
+   long style=wxHORIZONTAL|wxTB_DOCKABLE|wxTB_FLAT;
+//Do not ask me why this works on mac and not other way.
+#ifdef __WXMAC__
+   wxToolBar* t= new wxToolBar(frame, wxID_ANY);
+#else
    wxToolBar* t= frame->CreateToolBar(style, wxID_ANY);
+#endif   
     theWxWidget = theWxContainer = t;
 //    widgetSizer=new wxBoxSizer(wxHORIZONTAL);
 //    t->SetSizer(widgetSizer);

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -252,19 +252,19 @@ public:
  WidgetEventInfo(wxEventType t_, wxObjectEventFunction f_, wxWindow* w_) : t(t_), f(f_), w(w_) {
  }
 };
-//#ifndef __WXMAC__
-//// main App class
-// #include "wx/evtloop.h"
-// 
-//class wxAppGDL: public wxApp
-//{
-// wxGUIEventLoop loop;
-// public:
-// int MyLoop();
-//};
-//
-//wxDECLARE_APP(wxAppGDL); //wxAppGDL is equivalent to wxGetApp()
-//#endif
+#ifndef __WXMAC__
+// main App class
+ #include "wx/evtloop.h"
+
+class wxAppGDL: public wxApp
+{
+ wxGUIEventLoop loop;
+ public:
+ int MyLoop();
+};
+
+wxDECLARE_APP(wxAppGDL); //wxAppGDL is equivalent to wxGetApp()
+#endif
 
 // GDL versions of wxWidgets controls =======================================
 DECLARE_LOCAL_EVENT_TYPE(wxEVT_SHOW_REQUEST, -1)
@@ -442,12 +442,11 @@ public:
   }
   static BaseGDL * getSystemColours();
   static void CallWXEventLoop(){
-//#ifdef __WXMAC__
-//    wxTheApp->Yield();
-//#else
+#ifdef __WXMAC__
     wxTheApp->Yield();
-//    wxGetApp().MyLoop(); //central loop for wxEvents!
-//#endif
+#else
+    wxGetApp().MyLoop(); //central loop for wxEvents!
+#endif
   }
 protected:
   

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -1086,7 +1086,7 @@ public:
       this->SetFont(font);
       popupMenu=new wxMenu();
       position=this->GetClientRect().GetBottomLeft();
-      Connect(id, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(wxButtonGDL::OnButton));
+//      Connect(id, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(wxButtonGDL::OnButton));
       Connect(id, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(wxButtonGDL::OnButton));
     }
   wxMenu* GetPopupMenu(){return popupMenu;}
@@ -1098,6 +1098,7 @@ private:
 class wxBitmapButtonGDL: public wxBitmapButton
 {
   wxMenu* popupMenu;
+  wxPoint position;
 public: 
   wxBitmapButtonGDL(wxWindow *parent, 
           wxWindowID id, 
@@ -1109,7 +1110,8 @@ public:
           const wxString &name=wxButtonNameStr):
       wxBitmapButton(parent,id,bitmap_,pos,size,style,validator,name){
       popupMenu=new wxMenu();
-      Connect(id, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(wxBitmapButtonGDL::OnButton));
+      position=this->GetClientRect().GetBottomLeft();
+//      Connect(id, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(wxBitmapButtonGDL::OnButton));
       Connect(id, wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(wxBitmapButtonGDL::OnButton));
   }
   wxMenu* GetPopupMenu(){return popupMenu;}

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -139,7 +139,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
       widg = new DStructGDL( "WIDGET_TEXT_CH" );
       widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
       widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-      widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//      widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
       widg->InitTag( "TYPE", DIntGDL( 0 ) ); // selection
       widg->InitTag( "OFFSET", DLongGDL( this->GetInsertionPoint() ) );
       widg->InitTag( "CH", DByteGDL( 10 ) );
@@ -171,7 +171,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
         widg = new DStructGDL( "WIDGET_TEXT_SEL" );
         widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
         widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
         widg->InitTag( "TYPE", DIntGDL( 3 ) ); // selection
         widg->InitTag( "OFFSET", DLongGDL( this->GetInsertionPoint( ) ) );
         widg->InitTag( "LENGTH", DLongGDL( 0 ) );
@@ -191,7 +191,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
           widg = new DStructGDL( "WIDGET_TEXT_DEL" );
           widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
           widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-          widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//          widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
           widg->InitTag( "TYPE", DIntGDL( 2 ) ); // selection
           widg->InitTag( "OFFSET", DLongGDL( from - 1 ) );
           widg->InitTag( "LENGTH", DLongGDL( to - from + 1 ) );
@@ -204,7 +204,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
         widg = new DStructGDL( "WIDGET_TEXT_CH" );
         widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
         widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
         widg->InitTag( "TYPE", DIntGDL( 0 ) ); // selection
         widg->InitTag( "OFFSET", DLongGDL( from ) );
         widg->InitTag( "CH", DByteGDL( 9 ) );
@@ -217,7 +217,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
         widg = new DStructGDL( "WIDGET_TEXT_CH" );
         widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
         widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//        widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
         widg->InitTag( "TYPE", DIntGDL( 0 ) ); // selection
         widg->InitTag( "OFFSET", DLongGDL( from ) );
         widg->InitTag( "CH", DByteGDL( 10 ) );
@@ -234,7 +234,7 @@ void wxTextCtrlGDL::OnChar(wxKeyEvent& event ) {
     widg = new DStructGDL( "WIDGET_TEXT_CH" );
     widg->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widg->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widg->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widg->InitTag( "TYPE", DIntGDL( 0 ) ); // single char
     widg->InitTag( "OFFSET", DLongGDL( this->GetInsertionPoint( ) ) );
     widg->InitTag( "CH", DByteGDL( event.GetKeyCode( ) ) );
@@ -349,7 +349,7 @@ void gdlwxFrame::OnButton( wxCommandEvent& event)
   DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");
   widgbut->InitTag("ID", DLongGDL( event.GetId()));
   widgbut->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgbut->InitTag("SELECT", DLongGDL( 1));
 
   GDLWidget::PushEvent( baseWidgetID, widgbut);
@@ -367,7 +367,7 @@ void gdlwxFrame::OnMenu( wxCommandEvent& event)
   DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");
   widgbut->InitTag("ID", DLongGDL( event.GetId()));
   widgbut->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgbut->InitTag("SELECT", DLongGDL( 1));
 
   GDLWidget::PushEvent( baseWidgetID, widgbut);
@@ -394,7 +394,7 @@ void gdlwxFrame::OnRadioButton( wxCommandEvent& event)
     DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");
     widgbut->InitTag("ID", DLongGDL( lastSelection));
     widgbut->InitTag("TOP", DLongGDL( baseWidgetID));
-    widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widgbut->InitTag("SELECT", DLongGDL( 0));
 
     GDLWidgetButton* widget = dynamic_cast<GDLWidgetButton*>(GDLWidget::GetWidget( lastSelection));
@@ -407,7 +407,7 @@ void gdlwxFrame::OnRadioButton( wxCommandEvent& event)
   DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");
   widgbut->InitTag("ID", DLongGDL( event.GetId()));
   widgbut->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
 //   widgbut->InitTag("SELECT", DLongGDL( selectValue ? 1 : 0));
   widgbut->InitTag("SELECT", DLongGDL( 1));
 
@@ -436,7 +436,7 @@ void gdlwxFrame::OnCheckBox( wxCommandEvent& event)
   DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");
   widgbut->InitTag("ID", DLongGDL( event.GetId()));
   widgbut->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgbut->InitTag("SELECT", DLongGDL( selectValue ? 1 : 0));
 
   GDLWidget::PushEvent( baseWidgetID, widgbut);
@@ -458,7 +458,7 @@ void gdlwxFrame::OnComboBox( wxCommandEvent& event)
   widgcbox = new DStructGDL( "WIDGET_COMBOBOX");
   widgcbox->InitTag("ID", DLongGDL( event.GetId()));
   widgcbox->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgcbox->InitTag("INDEX", DLongGDL( selectValue));
   widgcbox->InitTag("STR", DStringGDL( std::string(strValue.mb_str(wxConvUTF8)) ));
 
@@ -480,7 +480,7 @@ void gdlwxFrame::OnComboBoxTextEnter( wxCommandEvent& event)
   widgcbox = new DStructGDL( "WIDGET_COMBOBOX");
   widgcbox->InitTag("ID", DLongGDL( event.GetId()));
   widgcbox->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgcbox->InitTag("INDEX", DLongGDL( selectValue));
   widgcbox->InitTag("STR", DStringGDL( std::string(strValue.mb_str(wxConvUTF8)) ));
 
@@ -499,7 +499,7 @@ void gdlwxFrame::OnDropList( wxCommandEvent& event)
   widdrplst = new DStructGDL( "WIDGET_DROPLIST");
   widdrplst->InitTag("ID", DLongGDL( event.GetId()));
   widdrplst->InitTag("TOP", DLongGDL( baseWidgetID));
-  widdrplst->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widdrplst->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widdrplst->InitTag("INDEX", DLongGDL( selectValue));   
 
   GDLWidget::PushEvent( baseWidgetID, widdrplst);
@@ -520,7 +520,7 @@ void gdlwxFrame::OnListBoxDo( wxCommandEvent& event, DLong clicks)
   widgcbox = new DStructGDL( "WIDGET_LIST");
   widgcbox->InitTag("ID", DLongGDL( event.GetId()));
   widgcbox->InitTag("TOP", DLongGDL( baseWidgetID));
-  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widgcbox->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widgcbox->InitTag("INDEX", DLongGDL( selectValue));
   widgcbox->InitTag("CLICKS", DLongGDL( clicks));
 
@@ -589,7 +589,7 @@ void gdlwxFrame::OnTextMouseEvents( wxMouseEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_SEL");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 3)); // selection
       textCtrl->GetSelection(&from,&to);
       widg->InitTag("OFFSET", DLongGDL( from ));
@@ -641,7 +641,7 @@ void gdlwxFrame::OnTextPaste( wxClipboardTextEvent& event)
     widg = new DStructGDL( "WIDGET_TEXT_STR");
     widg->InitTag("ID", DLongGDL( event.GetId()));
     widg->InitTag("TOP", DLongGDL( baseWidgetID));
-    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widg->InitTag("TYPE", DIntGDL( 1)); // multiple char
     widg->InitTag("OFFSET", DLongGDL( pos+s.length() ));
     widg->InitTag("STR", DStringGDL(std::string(s.c_str())));
@@ -759,7 +759,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
     widg = new DStructGDL( "WIDGET_TEXT_SEL");
     widg->InitTag("ID", DLongGDL( event.GetId()));
     widg->InitTag("TOP", DLongGDL( baseWidgetID));
-    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widg->InitTag("TYPE", DIntGDL( 3)); // selection
     widg->InitTag("OFFSET", DLongGDL( offset));
     widg->InitTag("LENGTH", DLongGDL( selEnd-selStart));
@@ -772,7 +772,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_DEL");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 2)); // delete
       widg->InitTag("OFFSET", DLongGDL( offset-1));
       widg->InitTag("LENGTH", DLongGDL( -lengthDiff));
@@ -783,7 +783,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_DEL");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 2)); // delete
       widg->InitTag("OFFSET", DLongGDL( 0));
       widg->InitTag("LENGTH", DLongGDL( lastValue.length()));
@@ -794,7 +794,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_STR");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 1)); // multiple char
       widg->InitTag("OFFSET", DLongGDL( 0));
       widg->InitTag("STR", DStringGDL( newValue));
@@ -804,7 +804,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_CH");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 0)); // single char
       widg->InitTag("OFFSET", DLongGDL( offset+1));
       widg->InitTag("CH", DByteGDL( newValue[offset<newValue.length()?offset:newValue.length()-1]));
@@ -821,7 +821,7 @@ void gdlwxFrame::OnText( wxCommandEvent& event)
       widg = new DStructGDL( "WIDGET_TEXT_STR");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("TYPE", DIntGDL( 1)); // multiple char
       widg->InitTag("OFFSET", DLongGDL( offset));
       widg->InitTag("STR", DStringGDL( str));
@@ -922,7 +922,7 @@ void gdlwxFrame::OnPageChanged( wxNotebookEvent& event)
   widg = new DStructGDL( "WIDGET_TAB");
   widg->InitTag("ID", DLongGDL( event.GetId()));
   widg->InitTag("TOP", DLongGDL( baseWidgetID));
-  widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//  widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
   widg->InitTag("TAB", DLongGDL( event.GetSelection()));
   
   GDLWidget::PushEvent( baseWidgetID, widg);
@@ -1035,7 +1035,7 @@ void gdlwxFrame::OnTimerResize(wxTimerEvent& event)
     DStructGDL* widgbase = new DStructGDL("WIDGET_BASE");
     widgbase->InitTag("ID", DLongGDL(owner->GetWidgetID()));
     widgbase->InitTag("TOP", DLongGDL(baseWidgetID));
-    widgbase->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//    widgbase->InitTag("HANDLER", DLongGDL(baseWidgetID));
     widgbase->InitTag("X", DLongGDL(frameSize.x));
     widgbase->InitTag("Y", DLongGDL(frameSize.y));
     GDLWidget::PushEvent(baseWidgetID, widgbase);
@@ -1097,7 +1097,7 @@ void gdlwxFrame::OnSizeWithTimer(wxSizeEvent& event)
     DStructGDL* widgbase = new DStructGDL("WIDGET_BASE");
     widgbase->InitTag("ID", DLongGDL(event.GetId()));
     widgbase->InitTag("TOP", DLongGDL(baseWidgetID));
-    widgbase->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//    widgbase->InitTag("HANDLER", DLongGDL(baseWidgetID));
     widgbase->InitTag("X", DLongGDL(frameSize.x));
     widgbase->InitTag("Y", DLongGDL(frameSize.y));
     GDLWidget::PushEvent(baseWidgetID, widgbase);
@@ -1131,7 +1131,7 @@ void gdlwxFrame::OnThumbTrack( wxScrollEvent& event)
       widg = new DStructGDL( "WIDGET_SLIDER");
       widg->InitTag("ID", DLongGDL( event.GetId()));
       widg->InitTag("TOP", DLongGDL( baseWidgetID));
-      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//      widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
       widg->InitTag("VALUE", DLongGDL( newSelection));
       widg->InitTag("DRAG", DIntGDL( 1)); // dragging events from here
       
@@ -1163,7 +1163,7 @@ void gdlwxFrame::OnThumbRelease( wxScrollEvent& event)
     widg = new DStructGDL( "WIDGET_SLIDER");
     widg->InitTag("ID", DLongGDL( event.GetId()));
     widg->InitTag("TOP", DLongGDL( baseWidgetID));
-    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widg->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widg->InitTag("VALUE", DLongGDL( newSelection));
     widg->InitTag("DRAG", DIntGDL( 0)); // set events from here
     
@@ -1187,7 +1187,7 @@ void gdlwxFrame::OnEnterWindow( wxMouseEvent &event ) {
     DStructGDL* widgtracking = new DStructGDL( "WIDGET_TRACKING" );
     widgtracking->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widgtracking->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgtracking->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgtracking->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgtracking->InitTag( "ENTER", DIntGDL( 1 ) ); 
     GDLWidget::PushEvent( baseWidgetID, widgtracking );
   }
@@ -1208,7 +1208,7 @@ void gdlwxFrame::OnLeaveWindow( wxMouseEvent &event ) {
     DStructGDL* widgtracking = new DStructGDL( "WIDGET_TRACKING" );
     widgtracking->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widgtracking->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgtracking->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgtracking->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgtracking->InitTag( "ENTER", DIntGDL( 0 ) ); 
     GDLWidget::PushEvent( baseWidgetID, widgtracking );
   }
@@ -1226,7 +1226,7 @@ void gdlwxFrame::OnKBRDFocusChange( wxFocusEvent &event ) {
     DStructGDL* widgkbrdfocus = new DStructGDL( "WIDGET_KBRD_FOCUS" );
     widgkbrdfocus->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widgkbrdfocus->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgkbrdfocus->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgkbrdfocus->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     int enter=(event.GetEventType()==wxEVT_SET_FOCUS);
     widgkbrdfocus->InitTag( "ENTER", DIntGDL( enter ) ); 
     GDLWidget::PushEvent( baseWidgetID, widgkbrdfocus );
@@ -1261,7 +1261,7 @@ void gdlwxFrame::OnContextEvent( wxContextMenuEvent& event) {
     DStructGDL* widgcontext = new DStructGDL( "WIDGET_CONTEXT" );
     widgcontext->InitTag( "ID", DLongGDL( eventID ) );
     widgcontext->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgcontext->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgcontext->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     wxPoint position=event.GetPosition( );
     if (position==wxDefaultPosition) { //issued from keyboard
       position=wxGetMousePosition();
@@ -1296,7 +1296,7 @@ void gdlwxFrame::OnIconize( wxIconizeEvent & event)
     DStructGDL* widgtlb_iconify_events = new DStructGDL( "WIDGET_TLB_ICONIFY" );
     widgtlb_iconify_events->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widgtlb_iconify_events->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgtlb_iconify_events->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgtlb_iconify_events->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgtlb_iconify_events->InitTag( "ICONIFIED", DIntGDL( event.IsIconized() ) ); 
     GDLWidget::PushEvent( baseWidgetID, widgtlb_iconify_events );
   } else event.Skip();
@@ -1319,7 +1319,7 @@ void gdlwxFrame::OnMove( wxMoveEvent & event)
     DStructGDL* widgtlb_move_events = new DStructGDL( "WIDGET_TLB_MOVE" );
     widgtlb_move_events->InitTag( "ID", DLongGDL( event.GetId( ) ) );
     widgtlb_move_events->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgtlb_move_events->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgtlb_move_events->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgtlb_move_events->InitTag( "X", DLongGDL( event.GetPosition().x ) );
     widgtlb_move_events->InitTag( "Y", DLongGDL( event.GetPosition().y ) );
     GDLWidget::PushEvent( baseWidgetID, widgtlb_move_events );
@@ -1343,7 +1343,7 @@ void gdlwxFrame::OnCloseFrame( wxCloseEvent & event) {
   DStructGDL* widgtlb_kill_request_events = new DStructGDL("WIDGET_KILL_REQUEST");
   widgtlb_kill_request_events->InitTag("ID", DLongGDL(event.GetId()));
   widgtlb_kill_request_events->InitTag("TOP", DLongGDL(baseWidgetID));
-  widgtlb_kill_request_events->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//  widgtlb_kill_request_events->InitTag("HANDLER", DLongGDL(baseWidgetID));
   GDLWidget::PushEvent(baseWidgetID, widgtlb_kill_request_events);
 }
 
@@ -1472,7 +1472,7 @@ void gdlwxDrawPanel::OnFakeDropFileEvent(wxDropFilesEvent& event){
     DStructGDL* drawdrop = new DStructGDL("WIDGET_DROP");
     drawdrop->InitTag("ID", DLongGDL( myWidgetDraw->GetWidgetID() )); //ID of the destination
     drawdrop->InitTag("TOP", DLongGDL(baseWidgetID));
-    drawdrop->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//    drawdrop->InitTag("HANDLER", DLongGDL(baseWidgetID));
     drawdrop->InitTag("DRAG_ID", DLongGDL(droppedID)); // ID of the source
     drawdrop->InitTag("POSITION", DIntGDL(1)); //   1 above 2 on 4 below destination widget
     wxPoint where=CalcUnscrolledPosition(event.GetPosition());
@@ -1492,7 +1492,7 @@ void gdlwxDrawPanel::OnMouseMove( wxMouseEvent &event ) {
     DStructGDL* widgdraw = new DStructGDL( "WIDGET_DRAW" );
     widgdraw->InitTag( "ID", DLongGDL( myWidgetDraw->GetWidgetID() ) );
     widgdraw->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgdraw->InitTag( "TYPE", DIntGDL( 2 ) ); //motion
     wxPoint where=WhereIsMouse(event);
     widgdraw->InitTag( "X", DLongGDL( where.x ) );
@@ -1516,7 +1516,7 @@ void gdlwxDrawPanel::OnMouseDown( wxMouseEvent &event ) {
     DStructGDL* widgdraw = new DStructGDL( "WIDGET_DRAW" );
     widgdraw->InitTag( "ID", DLongGDL( myWidgetDraw->GetWidgetID() ) );
     widgdraw->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgdraw->InitTag( "TYPE", DIntGDL( 0 ) ); //button Press
     wxPoint where=WhereIsMouse(event);
     widgdraw->InitTag( "X", DLongGDL( where.x ) );
@@ -1544,7 +1544,7 @@ void gdlwxDrawPanel::OnMouseDownDble(wxMouseEvent &event) {
 	DStructGDL* widgdraw = new DStructGDL("WIDGET_DRAW");
 	widgdraw->InitTag("ID", DLongGDL(myWidgetDraw->GetWidgetID()));
 	widgdraw->InitTag("TOP", DLongGDL(baseWidgetID));
-	widgdraw->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	widgdraw->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	widgdraw->InitTag("TYPE", DIntGDL(0)); //button Press
 	wxPoint where = WhereIsMouse(event);
 	widgdraw->InitTag("X", DLongGDL(where.x));
@@ -1571,7 +1571,7 @@ void gdlwxDrawPanel::OnMouseUp( wxMouseEvent &event ) {
     DStructGDL* widgdraw = new DStructGDL( "WIDGET_DRAW" );
     widgdraw->InitTag( "ID", DLongGDL( myWidgetDraw->GetWidgetID() ) );
     widgdraw->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgdraw->InitTag( "TYPE", DIntGDL( 1 ) ); //button Release
     wxPoint where=WhereIsMouse(event);
     widgdraw->InitTag( "X", DLongGDL( where.x ) );
@@ -1598,7 +1598,7 @@ void gdlwxDrawPanel::OnMouseWheel( wxMouseEvent &event ) {
     DStructGDL* widgdraw = new DStructGDL( "WIDGET_DRAW" );
     widgdraw->InitTag( "ID", DLongGDL( myWidgetDraw->GetWidgetID()  ) );
     widgdraw->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     widgdraw->InitTag( "TYPE", DIntGDL( 7 ) ); //wheel event
     wxPoint where=WhereIsMouse(event);
     widgdraw->InitTag( "X", DLongGDL( where.x ) );
@@ -1627,7 +1627,7 @@ void gdlwxDrawPanel::OnKey( wxKeyEvent &event ) {
     DStructGDL* widgdraw = new DStructGDL( "WIDGET_DRAW" );
     widgdraw->InitTag( "ID", DLongGDL( myWidgetDraw->GetWidgetID() ) );
     widgdraw->InitTag( "TOP", DLongGDL( baseWidgetID ) );
-    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
+//    widgdraw->InitTag( "HANDLER", DLongGDL( baseWidgetID ) );
     wxPoint where=WhereIsMouse(event);
     widgdraw->InitTag( "X", DLongGDL( where.x ) );
     widgdraw->InitTag( "Y", DLongGDL( drawSize.y-where.y  ) );
@@ -1692,7 +1692,7 @@ void wxGridGDL::OnTableRowResizing(wxGridSizeEvent & event){
     DStructGDL* widgtablerowheight = new DStructGDL( "WIDGET_TABLE_ROW_HEIGHT");
     widgtablerowheight->InitTag("ID", DLongGDL( event.GetId( ) ));
     widgtablerowheight->InitTag("TOP", DLongGDL( baseWidgetID));
-    widgtablerowheight->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widgtablerowheight->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widgtablerowheight->InitTag("TYPE", DIntGDL(6)); // 6
     widgtablerowheight->InitTag("ROW", DLongGDL( event.GetRowOrCol() ));
     widgtablerowheight->InitTag("HEIGHT",DLongGDL( this->GetRowSize(event.GetRowOrCol())));
@@ -1712,7 +1712,7 @@ void wxGridGDL::OnTableColResizing(wxGridSizeEvent & event){
     DStructGDL* widgtablerowheight = new DStructGDL( "WIDGET_TABLE_COL_WIDTH");
     widgtablerowheight->InitTag("ID", DLongGDL( event.GetId( ) ));
     widgtablerowheight->InitTag("TOP", DLongGDL( baseWidgetID));
-    widgtablerowheight->InitTag("HANDLER", DLongGDL( baseWidgetID ));
+//    widgtablerowheight->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widgtablerowheight->InitTag("TYPE", DIntGDL(7)); // 7
     widgtablerowheight->InitTag("COL", DLongGDL( event.GetRowOrCol() ));
     widgtablerowheight->InitTag("WIDTH",DLongGDL( this->GetColSize(event.GetRowOrCol())));
@@ -1743,7 +1743,7 @@ void wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event) {
 	  DStructGDL* widgtablecelsel2 = new DStructGDL("WIDGET_TABLE_CELL_SEL"); //sel 
 	  widgtablecelsel2->InitTag("ID", DLongGDL(event.GetId()));
 	  widgtablecelsel2->InitTag("TOP", DLongGDL(baseWidgetID));
-	  widgtablecelsel2->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	  widgtablecelsel2->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	  widgtablecelsel2->InitTag("TYPE", DIntGDL(4)); // 4 or 9
 	  widgtablecelsel2->InitTag("SEL_LEFT", DLongGDL(lc));
 	  widgtablecelsel2->InitTag("SEL_TOP", DLongGDL(tr));
@@ -1757,7 +1757,7 @@ void wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event) {
 		DStructGDL* widgtablecelsel = new DStructGDL("WIDGET_TABLE_CELL_DESEL");
 		widgtablecelsel->InitTag("ID", DLongGDL(event.GetId()));
 		widgtablecelsel->InitTag("TOP", DLongGDL(baseWidgetID));
-		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
 		widgtablecelsel->InitTag("TYPE", DIntGDL(9)); // 9
 		widgtablecelsel->InitTag("SEL_LEFT", DLongGDL(lc));
 		widgtablecelsel->InitTag("SEL_TOP", DLongGDL(tr));
@@ -1770,7 +1770,7 @@ void wxGridGDL::OnTableRangeSelection(wxGridRangeSelectEvent & event) {
 		DStructGDL* widgtablecelsel = new DStructGDL("WIDGET_TABLE_CELL_SEL");
 		widgtablecelsel->InitTag("ID", DLongGDL(event.GetId()));
 		widgtablecelsel->InitTag("TOP", DLongGDL(baseWidgetID));
-		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//		widgtablecelsel->InitTag("HANDLER", DLongGDL(baseWidgetID));
 		widgtablecelsel->InitTag("TYPE", DIntGDL(4)); // 
 		widgtablecelsel->InitTag("SEL_LEFT", DLongGDL(-1));
 		widgtablecelsel->InitTag("SEL_TOP", DLongGDL(-1));
@@ -1839,7 +1839,7 @@ void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 	widg = new DStructGDL("WIDGET_TABLE_DEL");
 	widg->InitTag("ID", DLongGDL(GDLWidgetTableID));
 	widg->InitTag("TOP", DLongGDL(baseWidgetID));
-	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	widg->InitTag("TYPE", DIntGDL(2)); // delete
 	widg->InitTag("OFFSET", DLongGDL(offset));
 	widg->InitTag("LENGTH", DLongGDL(-lengthDiff));
@@ -1852,7 +1852,7 @@ void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 	widg = new DStructGDL("WIDGET_TABLE_CH");
 	widg->InitTag("ID", DLongGDL(GDLWidgetTableID));
 	widg->InitTag("TOP", DLongGDL(baseWidgetID));
-	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	widg->InitTag("TYPE", DIntGDL(0)); // single char
 	widg->InitTag("OFFSET", DLongGDL(offset));
 	widg->InitTag("CH", DByteGDL(10)); //newline
@@ -1865,7 +1865,7 @@ void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 	widg = new DStructGDL("WIDGET_TABLE_CH");
 	widg->InitTag("ID", DLongGDL(GDLWidgetTableID));
 	widg->InitTag("TOP", DLongGDL(baseWidgetID));
-	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	widg->InitTag("TYPE", DIntGDL(0)); // single char
 	widg->InitTag("OFFSET", DLongGDL(offset));
 	widg->InitTag("CH", DByteGDL((newValue.substr(offset, offset).c_str())[0]));
@@ -1880,7 +1880,7 @@ void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 	  widg = new DStructGDL("WIDGET_TABLE_DEL");
 	  widg->InitTag("ID", DLongGDL(GDLWidgetTableID));
 	  widg->InitTag("TOP", DLongGDL(baseWidgetID));
-	  widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	  widg->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	  widg->InitTag("TYPE", DIntGDL(2)); // delete
 	  widg->InitTag("OFFSET", DLongGDL(offset));
 	  widg->InitTag("LENGTH", DLongGDL(previousValue.length() - offset));
@@ -1894,7 +1894,7 @@ void wxGridGDL::OnTextChanged(wxGridEvent & event) {
 	widg2 = new DStructGDL("WIDGET_TABLE_STR");
 	widg2->InitTag("ID", DLongGDL(GDLWidgetTableID));
 	widg2->InitTag("TOP", DLongGDL(baseWidgetID));
-	widg2->InitTag("HANDLER", DLongGDL(baseWidgetID));
+//	widg2->InitTag("HANDLER", DLongGDL(baseWidgetID));
 	widg2->InitTag("TYPE", DIntGDL(1)); // multiple char
 	widg2->InitTag("OFFSET", DLongGDL(offset));
 	widg2->InitTag("STR", DStringGDL(newValue.substr(offset)));

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -597,7 +597,8 @@ void gdlwxFrame::OnTextMouseEvents( wxMouseEvent& event)
       GDLWidget::PushEvent( baseWidgetID, widg);
       // NOTE: "Process a wxEVT_LEFT_DOWN event. The handler of this event should normally call event.Skip()
       // to allow the default processing to take place as otherwise the window under mouse wouldn't get the focus. "
-      if (event.ButtonDown(wxMOUSE_BTN_LEFT)) event.Skip( );
+//      if (event.ButtonDown(wxMOUSE_BTN_LEFT)) 
+		event.Skip( );
     }
     return;
     //middle button (paste) should be filtered. Here we just avoid the paste pollutes a not-edit widget (without creating a GDL event).
@@ -1229,7 +1230,8 @@ void gdlwxFrame::OnKBRDFocusChange( wxFocusEvent &event ) {
     int enter=(event.GetEventType()==wxEVT_SET_FOCUS);
     widgkbrdfocus->InitTag( "ENTER", DIntGDL( enter ) ); 
     GDLWidget::PushEvent( baseWidgetID, widgkbrdfocus );
-  } else event.Skip(); //"The focus event handlers should almost invariably call wxEvent::Skip() on their event argument to allow the default handling to take place. Failure to do this may result in incorrect behaviour of the native controls."
+  } 
+  event.Skip(); //"The focus event handlers should almost invariably call wxEvent::Skip() on their event argument to allow the default handling to take place. Failure to do this may result in incorrect behaviour of the native controls."
 }
 
 void gdlwxFrame::OnContextEvent( wxContextMenuEvent& event) {

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -333,7 +333,7 @@ void wxBitmapButtonGDL::OnButton( wxCommandEvent& event)
 #if (GDL_DEBUG_ALL_EVENTS || GDL_DEBUG_BUTTON_EVENTS)
   wxMessageOutputStderr().Printf(_T("in gdlMenuButtonBitmap::OnButton: %d\n"),event.GetId());
 #endif
- this->PopupMenu(static_cast<wxMenu*>(popupMenu));
+ this->PopupMenu(static_cast<wxMenu*>(popupMenu),position);
  event.Skip();
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3920,7 +3920,7 @@ void widget_control( EnvT* e ) {
       }
     }
   // last line and ONLY RETURN: make the wxWidgets respond
-  wxTheApp->Yield();
+  GDLWidget::CallWXEventLoop();
 #endif
 }
 #ifdef HAVE_WXWIDGETS_PROPERTYGRID

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2508,8 +2508,10 @@ BaseGDL* widget_info( EnvT* e ) {
     DStructGDL* ev;
 
     do { // outer while loop, will run once if NOWAIT
-   while (1) { //inner loop, catch controlC, default return if no event trapped in nowait mode
-   GDLWidget::CallWXEventLoop();
+
+	  GDLWidget::CallWXEventLoop();
+
+	  while (1) { //inner loop, catch controlC, default return if no event trapped in nowait mode
        if (!all) {
           //specific widget(s)
           // we cannot check only readlineEventQueue thinking our XMANAGER in blocking state looks to ALL widgets.
@@ -2539,6 +2541,7 @@ BaseGDL* widget_info( EnvT* e ) {
         }
         if (nowait) return defaultRes;
         if (sigControlC) return defaultRes;
+		GDLWidget::CallWXEventLoop();
       } //end inner loop
       //here we got a real event, process it, walking back the hierachy (in CallEventHandler()) for modified ev in case of function handlers.
     endwait:
@@ -2548,6 +2551,7 @@ BaseGDL* widget_info( EnvT* e ) {
         return defaultRes;
       }
       ev = CallEventHandler(ev); //process it recursively (going up hierarchy) in eventHandler. Should block waiting for xmanager.
+	  GDLWidget::CallWXEventLoop();
       // examine return:
       if (ev == NULL) { //swallowed by a procedure or non-event-stucture returning function 
         if (nowait) return defaultRes; //else will loop again

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -282,6 +282,7 @@ pro handle_Event,ev
         end
         
      endcase
+     return
   endif
   print, "(unhandled event: ok)"
 end

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -123,6 +123,18 @@ function draw2_event,ev
   print,"draw2 event"
   return,ev
 end
+function test_func_button,ev
+  print, "fancy button pressed! (catched in button widget itself)"
+  parent=widget_info(ev.id,/parent)
+  ev.handler=parent ; pass to parent
+  return, ev
+end
+function catch_passed_event_example,ev
+  print, "button "+strtrim(ev.id,2)+" was pressed! (catched in parent's event_func routine)"
+;  parent=widget_info(ev.id,/parent)
+;  ev.handler=parent ; pass to parent
+  return, ev
+end
 
 pro draw1_event,ev
 widget_id=ev.id
@@ -474,7 +486,7 @@ endif
     button_base00 = widget_base( tabbed_base, TITLE="BUTTONs", COL=2, $
        SPACE=10, XPAD=10, YPAD=10) & offy=10
 
-    button_base01 = widget_base(button_base00, TITLE="BUTTONs",/COL) & offy=10
+    button_base01 = widget_base(button_base00, TITLE="BUTTONs",/COL, event_func='catch_passed_event_example') & offy=10
     button_base02 = widget_base(button_base00, TITLE="BUTTONs",/COL) & offy=10
 ; BUTTONs
     tmp=widget_label(yoff=offy,button_base01,value="Simple ON/OFF Button") & offy+=10           ;
@@ -486,7 +498,7 @@ endif
     tmp=widget_label(yoff=offy,button_base01,value="Bitmap Simple Button") & offy+=10           ;
     tmp=widget_button(yoff=offy,button_base01,value=myBitmap()) & offy+=10 ;
     tmp=widget_label(yoff=offy,button_base01,value="Fancy Simple Button") & offy+=10           ;
-    tmp=widget_button(yoff=offy,button_base01,value="Fancy Button",font=fontname) & offy+=10 ;
+    tmp=widget_button(yoff=offy,button_base01,value="Fancy Button",font=fontname, event_func='test_func_button') & offy+=10 ;
     tmp=widget_label(yoff=offy,button_base01,value="Exclusive base, framed 30") & offy+=10  ;
     radio=widget_base(yoff=offy,button_base01,/EXCLUSIVE,COL=1,frame=30) & offy+=150         ;
     rb1=widget_button(radio,VALUE="button in EXCLUSIVE base 1",uvalue={vEv,'rb1',[8,0]}, font=fontname)
@@ -736,7 +748,16 @@ print,"Draw widgets:",draw,draw2
  print,"window indexes",index,index2
  image=dist(128)
  WSET,index
- n=100 & x=randomu(seed,n)& y=randomu(seed,n) &p=randomu(seed,10)*n & x[p]=x[3] &y[p]=y[22]& TRIANGULATE, x, y, tr,b,rep=r,conn=conn &myplot,tr,x,y,b,conn,1
+
+  catch, error
+  if error ne 0 then begin
+     save,x,y,p,file="problemwithtriangulate.sav"
+     message,/inf,"CONGRATULATIONS YOU FOUND (INVOLUNTARILY!) A PROBLEM WITH THE FAST TRIANGULATION ALGORITHM"
+     message,"Please contribute to GDL by saving the file 'problemwithtriangulate.sav' and make an issue on github: https://github.com/gnudatalanguage/gdl , thanks in advance" 
+     catch,/cancel
+  endif
+
+  n=100 & x=randomu(seed,n)& y=randomu(seed,n) &p=randomu(seed,10)*n & x[p]=x[3] &y[p]=y[22]& TRIANGULATE, x, y, tr,b,rep=r,conn=conn &myplot,tr,x,y,b,conn,1
 
     ;;
  WSET, index2 


### PR DESCRIPTION
Removed the 2 different codes between OSX and other platforms (with a small exception for the MenuBar), Menubars now are the same in unix, windows and OSX, and permit teh same button functionality as IDL (fancy fonts, images).

Yield() is still the unique way to have widgets going on OSX, the standard way of creating a wxApp does not work there. Conversely, using only Yield() instead of having mgGDlApp run a loop, is not working on Windows. Go figure.

widget responsiveness was extremely slow on OSX when an action here (ex: cursor on ATV) generates a change in another wxWindow, and more so if that window is in another topFrame ( OSX focus changes!)!! 
This PR greatly improves things but is not 100% satisfactory. Probably sign that Yield() is not the good way to handle our wxwidgets inner loop, should make the step and use threads? 

WIDGET_EVENT was found wrong in the sense that it used the same eventloop treatment as the 'always active' eventloop. But WIDGET_EVENT should just report the event, not call event handlers. Hopefully this new version is better. At least it satisfactorily solves #1685 without ugly #1716 patch