### PR TITLE
remove blocking eventloop.

### DIFF
--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -396,7 +396,7 @@ public:
   static wxFont defaultFont;
   static wxFont systemFont;
   static GDLEventQueue BlockingEventQueue;
-  static GDLEventQueue InteractiveEventQueue;
+  static GDLEventQueue widgetEventQueue;
   static void PushEvent( WidgetIDT baseWidgetID, DStructGDL* ev);
   static void InformAuthorities(const std::string& message);
   


### PR DESCRIPTION
As widget_event , handleevent() and xmanager are written now, there should be only one eventlist, not two (this old feature always worried me). xmanager simply blocks on widget_event by default and the loop does not give back the line command until the blocking widgest is closed. A progressbar using a timer has been introduced in test_widgets: its behaviour is now 100% compatible with IDL ( try to create 2 test_widgets, one non blocking and the next blocking: same behaviour, even the error returned when the blocking widget is closed before the non-blocking one is also observed in IDL)