### PR TITLE
Correct bad handling of the various thickness options and patch cursor (closes #1901)

### DIFF
--- a/src/gdlgstream.hpp
+++ b/src/gdlgstream.hpp
@@ -108,24 +108,24 @@ static std::string internalFontCodes[] = {
 
   typedef struct GDL_BOX {
     bool initialized;
-    PLFLT wx1; //world coord of x min
-    PLFLT wx2;
-    PLFLT wy1;
-    PLFLT wy2;
-    PLFLT nx1; //normalized position in subpage
-    PLFLT nx2;
-    PLFLT ny1;
-    PLFLT ny2;
-    PLFLT ndx1; //normalized device position
-    PLFLT ndx2;
-    PLFLT ndy1;
-    PLFLT ndy2;
+    PLFLT wx1 = 0; //world coord of x min
+    PLFLT wx2 = 1;
+    PLFLT wy1 = 0;
+    PLFLT wy2 = 1;
+    PLFLT nx1= 0; //normalized position in subpage
+    PLFLT nx2= 1;
+    PLFLT ny1= 0;
+    PLFLT ny2= 1;
+    PLFLT ndx1= 0; //normalized device position
+    PLFLT ndx2= 1;
+    PLFLT ndy1= 0;
+    PLFLT ndy2= 1;
     PLFLT nxsize; //size of box, x , normed
     PLFLT nysize;
-    PLFLT dx1; //position in device coords (e.g. pixels)
-    PLFLT dx2;
-    PLFLT dy1;
-    PLFLT dy2;
+    PLFLT dx1= 0; //position in device coords (e.g. pixels)
+    PLFLT dx2= 1;
+    PLFLT dy1= 0;
+    PLFLT dy2= 1;
     PLFLT dxsize; //size of box, x , normed
     PLFLT dysize;
     PLFLT pageWorldCoordinates[4];

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -1278,7 +1278,23 @@ namespace lib
     position[5]=(*static_cast<DFloatGDL*>(SysVar::Z()->GetTag(WINDOWTAG, 0)))[1];
     return position;
 }
- //Get [XYZ].REGION
+  PLFLT gdlGetBoxNXSize() {
+    DStructGDL* Struct=SysVar::X(); 
+    static unsigned WINDOWTAG=Struct->Desc()->TagIndex("WINDOW");
+    DFloat end,start;
+    start=(*static_cast<DFloatGDL*>(Struct->GetTag(WINDOWTAG, 0)))[0];
+    end=(*static_cast<DFloatGDL*>(Struct->GetTag(WINDOWTAG, 0)))[1];
+    return end-start;
+}
+PLFLT gdlGetBoxNYSize() {
+    DStructGDL* Struct=SysVar::Y(); 
+    static unsigned WINDOWTAG=Struct->Desc()->TagIndex("WINDOW");
+    DFloat end,start;
+    start=(*static_cast<DFloatGDL*>(Struct->GetTag(WINDOWTAG, 0)))[0];
+    end=(*static_cast<DFloatGDL*>(Struct->GetTag(WINDOWTAG, 0)))[1];
+    return end-start;
+}
+    //Get [XYZ].REGION
   PLFLT* gdlGetRegion() {
     DStructGDL* Struct=SysVar::X(); //same for all
     static unsigned REGIONTAG=Struct->Desc()->TagIndex("REGION");
@@ -3742,9 +3758,10 @@ NoTitlesAccepted:
 	  inverted_ticks = true;
 	  TickLen = -TickLen;
 	}
-	//ticklen in a percentage of box x or y size, to be expressed in mm 
-	if (axisId == XAXIS) ticklen_in_mm = a->mmyPageSize()*(a->boxnYSize()) * ticklen_in_mm;
-	else ticklen_in_mm = a->mmxPageSize()*(a->boxnXSize()) * ticklen_in_mm;
+	//ticklen in a percentage of box x or y size, to be expressed in mm. Since AXis is also called by the AXIS command that internally redefines vpor()
+	// the ticklen must be defined from current !X and !Y values, so:
+	if (axisId == XAXIS) ticklen_in_mm = a->mmyPageSize() * gdlGetBoxNYSize() * ticklen_in_mm;
+	else ticklen_in_mm = a->mmxPageSize()* gdlGetBoxNXSize() * ticklen_in_mm;
 	//    if (ticklen_in_mm > 100.) ticklen_in_mm = 0; //PATCH to avoid PS and MEM device problem. Check why gspa() returns silly values. TBC 
 	DFloat ticklen_as_norm = (axisId == XAXIS) ? a->mm2ndy(ticklen_in_mm) : a->mm2ndx(ticklen_in_mm); //in normed coord
 	//eventually, each succesive X or Y axis is separated from previous by interligne + ticklen in adequate units. 

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -528,7 +528,7 @@ namespace lib
 	}
   }
 
-  void plotting_routine_call::restoreDrawArea(GDLGStream *a) {
+  void restoreDrawArea(GDLGStream *a) {
 	//retrieve and reset plplot to the last setup for vpor() and wind() made by position-scaling commands like PLOT or CONTOUR
 	DDouble *sx, *sy;
 	DDouble wx[2], wy[2];

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -3637,13 +3637,14 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
 	  
 	  a->plstream::vpor(refboxxmin, refboxxmax, refboxymin, refboxymax);
 	  a->wind(owboxxmin, owboxxmax, owboxymin, owboxymax); //restore old values
-	  gdlSetPlotCharthick(e, a);
 	  if (!subTitle.empty()) {
+		gdlSetPlotCharthick(e, a);
 		gdlSetPlotCharsize(e, a);
 		PLFLT title_disp = 4 * interligne_as_char - 0.5; //in chars
 		a->mtex("b", title_disp, 0.5, 0.5, subTitle.c_str()); //position is in units of current char height. baseline at half-height
 	  }
 	  if (!title.empty()) {
+		gdlSetPlotCharthick(e, a);
 		gdlSetPlotCharsize(e, a, 1.25);
 		PLFLT disp = interligne_as_char / 2;
 		a->mtex("t", disp + 0.5, 0.5, 0.5, title.c_str()); //position is in units of current char height. baseline at half-height
@@ -3704,8 +3705,8 @@ NoTitlesAccepted:
 	gdlGetDesiredAxisGridStyle(e, axisId, GridStyle);
 	DLong Minor;
 	gdlGetDesiredAxisMinor(e, axisId, Minor);
-	DFloat Thick;
-	gdlGetDesiredAxisThick(e, axisId, Thick);
+	DFloat AxisThick;
+	gdlGetDesiredAxisThick(e, axisId, AxisThick);
 	DStringGDL* TickFormat;
 	gdlGetDesiredAxisTickFormat(e, axisId, TickFormat);
 	DLong TickLayout;
@@ -3906,8 +3907,7 @@ NoTitlesAccepted:
 	a->plstream::vpor(refboxxmin, refboxxmax, refboxymin, refboxymax);
 	a->plstream::gvpd(boxxmin, boxxmax, boxymin, boxymax);
 	a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
-	//      thick for box and ticks.
-	a->Thick(Thick);
+
 	a->smaj(ticklen_in_mm, 1.0);
 	if (TickLen < 0.3 || inverted_ticks) a->smin(ticklen_in_mm / 2.0, 1.0); //IDL behaviour.
 
@@ -3925,6 +3925,8 @@ NoTitlesAccepted:
 	  else a->plstream::wind(Start, End, owboxymin, owboxymax);
 //		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
 		if (doplot) {
+		  //   Set thick for this axis line and ticks.
+		  a->Thick(AxisThick);
 		  bool isTickv = (hasTickv && i == 0);
 		  if (isTickv) {
 			gdlDrawAxisTicks(a, axisId, Tickv, Log, Ticks, TickLen, tickOpt, where, TickLayout, &tickdata, doplot);
@@ -3933,6 +3935,8 @@ NoTitlesAccepted:
 			a->box(tickOpt.c_str(), TickInterval, Minor, "", 0.0, 0); //ticks
 			a->box(Opt.c_str(), TickInterval, Minor, "", 0.0, 0); //no labels, just get ticks positions
 		  }	
+		  // Labels: replace PenThickness with character desired thickness (otherwise drawing of characters inherits the /[XYZ]THICK option )
+		  gdlSetPlotCharthick(e, a);
 		  DDoubleGDL* values = getLabelingValues(axisId);	
 		  gdlDrawOurLabels(a, axisId, values, Log, isTickv, adddisplacement, Opt, where, TickLayout, (i == 0) ? gdlSimpleAxisTickFunc : gdlMultiAxisTickFunc, &tickdata, otheraxis, doplot);
 		  GDLDelete(values);
@@ -3945,6 +3949,8 @@ NoTitlesAccepted:
 	  else a->plstream::wind(owboxxmin, owboxxmax, Start, End);
 //		a->plstream::wind(wboxxmin, wboxxmax, wboxymin, wboxymax);
 		if (doplot) {
+		  //   Set thick for this axis line and ticks.
+		  a->Thick(AxisThick);
 		  bool isTickv = (hasTickv && i == 0);
 		  if (isTickv) {
 			gdlDrawAxisTicks(a, axisId, Tickv, Log, Ticks, TickLen, tickOpt, where, TickLayout, &tickdata, doplot);
@@ -3953,6 +3959,8 @@ NoTitlesAccepted:
 			a->box("", 0.0, 0.0, tickOpt.c_str(), TickInterval, Minor); //write ticks
 			a->box("", 0.0, 0.0, Opt.c_str(), TickInterval, Minor); //write blank labels and get ticks positions
 		  }
+		  // Labels: replace PenThickness with character desired thickness (otherwise drawing of characters inherits the /[XYZ]THICK option )
+		  gdlSetPlotCharthick(e, a);
 		  DDoubleGDL* values = getLabelingValues(axisId);
 		  //write labels our way, with any centering , even on multiline etc. We need the length of the 
 		  nchars[i] = gdlDrawOurLabels(a, axisId, values, Log, isTickv, adddisplacement, Opt, where, TickLayout, (i == 0) ? gdlSimpleAxisTickFunc : gdlMultiAxisTickFunc, &tickdata, otheraxis, doplot);

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -324,8 +324,6 @@ namespace lib {
     virtual void applyGraphics(EnvT*, GDLGStream*) = 0;
     virtual void post_call(EnvT*, GDLGStream*) = 0;
 
-    void restoreDrawArea(GDLGStream *a);
-
     // all steps combined (virtual methods cannot be called from ctor)
   public:
     void call(EnvT* e, SizeT n_params_required);
@@ -335,6 +333,7 @@ namespace lib {
   //This because static pointers to options indexes are needed to speed up process, but these indexes vary between
   //the definition of the caller functions (e.g. "CHARSIZE" is 1 for CONTOUR but 7 for XYOUTS). So they need to be kept
   //static (for speed) but private for each graphic command.
+  void restoreDrawArea(GDLGStream *a);
 
   void gdlSetGraphicsBackgroundColorFromKw(EnvT *e, GDLGStream *a, bool kw = true);
 

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -256,6 +256,8 @@ namespace lib {
   void gdlSetGraphicsPenColorToBackground(GDLGStream *a);
   void gdlLineStyle(GDLGStream *a, DLong style);
   PLFLT* gdlGetRegion();
+  PLFLT gdlGetBoxNXSize(); // what !X thinks the current PLOT box size is, in normalised coordinates. To be used instead of the boxnXSize() gdlgstream function whenever possible.
+  PLFLT gdlGetBoxNYSize(); // what !Y thinks the current PLOT box size is, in normalised coordinates. To be used instead of the boxnYSize() gdlgstream function whenever possible.
   DFloat* gdlGetWindow();
   void gdlStoreXAxisRegion(GDLGStream* actStream, PLFLT* r);
   void gdlStoreYAxisRegion(GDLGStream* actStream, PLFLT* r);

--- a/src/plotting_cursor.cpp
+++ b/src/plotting_cursor.cpp
@@ -180,6 +180,8 @@ void cursor(EnvT* e){
     actStream->vpor(0, 1, 0, 1);
     actStream->wind(0, 1, 0, 1);
 
+  } else {
+	restoreDrawArea(actStream);
   }
   // mimic idl logic:
   DLong wait = WAIT;

--- a/src/plotting_xyouts.cpp
+++ b/src/plotting_xyouts.cpp
@@ -218,7 +218,7 @@ namespace lib {
       // *** start drawing by defalut values
       gdlSetGraphicsForegroundColorFromKw(e, actStream);
       if (!docharthick) gdlSetPlotCharthick(e, actStream);
-      if (!docharsize) gdlSetPlotCharsize(e, actStream, true); //accept SIZE kw!
+      if (!docharsize) gdlSetPlotCharsize(e, actStream, 1.0, true); //accept SIZE kw!
 
       // Get decomposed value for colors
       DLong decomposed = GraphicsDevice::GetDevice()->GetDecomposed();


### PR DESCRIPTION
XYOUTS was not recognizing the SIZE keyword after a change in the call of an internal routine.
[XYZ]THICK and CHARTHICK were sometimes mangled due to the fact that there is only one thickness for all lines in plplot, including drawing Hershey fonts.
TICKSIZE of AXIS was, if not precised, dependent on the position in the plot (code was using internal plplot coordinates).
#1901 bug cured.