### PR TITLE
closes #1905 and #1929 all at once

### DIFF
--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -5987,8 +5987,9 @@ GDLWidgetButton::~GDLWidgetButton() {
 
 //a normal button.
 GDLWidgetNormalButton::GDLWidgetNormalButton(WidgetIDT p, EnvT* e,
-  DStringGDL* value, DULong eventflags,  wxBitmap* bitmap_, DStringGDL* buttonToolTip)
-: GDLWidgetButton(p, e, value, eventflags, bitmap_)
+  DStringGDL* value, DULong eventflags, bool norelease,  wxBitmap* bitmap_, DStringGDL* buttonToolTip)
+: GDLWidgetButton(p, e, value, eventflags, bitmap_),
+  noRelease(false)
 {
   GDLWidget* gdlParent = GetWidget(parentID);
   widgetPanel = GetParentPanel();
@@ -6012,6 +6013,7 @@ GDLWidgetNormalButton::GDLWidgetNormalButton(WidgetIDT p, EnvT* e,
     }
   } else if (gdlParent->GetExclusiveMode() == BGEXCLUSIVE1ST) {
     wxRadioButton *radioButton = new wxRadioButton(widgetPanel, widgetID, valueWxString,  wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+	noRelease=norelease;
     gdlParent->SetExclusiveMode(1);
     GDLWidgetBase* b = static_cast<GDLWidgetBase*> (gdlParent);
     if (b) b->SetLastRadioSelection(widgetID);
@@ -6022,11 +6024,13 @@ GDLWidgetNormalButton::GDLWidgetNormalButton(WidgetIDT p, EnvT* e,
     buttonType = RADIO;
   } else if (gdlParent->GetExclusiveMode() == BGEXCLUSIVE) {
     wxRadioButton *radioButton = new wxRadioButton(widgetPanel, widgetID, valueWxString, wxDefaultPosition, wxDefaultSize);
+	noRelease=norelease;
     theWxContainer = theWxWidget = radioButton;
     this->AddToDesiredEvents(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(gdlwxFrame::OnRadioButton), radioButton);
     buttonType = RADIO;
   } else if (gdlParent->GetExclusiveMode() == BGNONEXCLUSIVE) {
     wxCheckBox *checkBox = new wxCheckBox(widgetPanel, widgetID, valueWxString,  wxDefaultPosition, wxDefaultSize);
+	noRelease=norelease;
     theWxContainer = theWxWidget = checkBox;
     this->AddToDesiredEvents(wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(gdlwxFrame::OnCheckBox), checkBox);
     buttonType = CHECKBOX;

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -1264,9 +1264,11 @@ public:
 class GDLWidgetNormalButton: public GDLWidgetButton
 { 
 public:
- GDLWidgetNormalButton( WidgetIDT parentID, EnvT* e, DStringGDL* value, DULong eventflags, wxBitmap* bitmap=NULL, DStringGDL* buttonTooltip=NULL);
+  bool noRelease; //option checked only for radiobuttons
+ GDLWidgetNormalButton( WidgetIDT parentID, EnvT* e, DStringGDL* value, DULong eventflags, bool norelease, wxBitmap* bitmap=NULL, DStringGDL* buttonTooltip=NULL);
  ~GDLWidgetNormalButton();
  void SetButtonWidgetLabelText( const DString& value_ );
+ bool getNoReleaseOption(){return noRelease;}
 };
 
 class GDLWidgetMenuEntry: public GDLWidgetButton

--- a/src/gdlwidgeteventhandler.cpp
+++ b/src/gdlwidgeteventhandler.cpp
@@ -397,10 +397,11 @@ void gdlwxFrame::OnRadioButton( wxCommandEvent& event)
 //    widgbut->InitTag("HANDLER", DLongGDL( baseWidgetID ));
     widgbut->InitTag("SELECT", DLongGDL( 0));
 
-    GDLWidgetButton* widget = dynamic_cast<GDLWidgetButton*>(GDLWidget::GetWidget( lastSelection));
+    GDLWidgetNormalButton* widget = dynamic_cast<GDLWidgetNormalButton*>(GDLWidget::GetWidget( lastSelection));
     assert(widget!=NULL);
     widget->SetRadioButton( false);
-    GDLWidget::PushEvent( baseWidgetID, widgbut);
+
+    if (widget->getNoReleaseOption()==false) GDLWidget::PushEvent( baseWidgetID, widgbut);
   }
     
   // create GDL event struct
@@ -415,7 +416,7 @@ void gdlwxFrame::OnRadioButton( wxCommandEvent& event)
 
   GDLWidget* widget = GDLWidget::GetWidget( event.GetId());
   assert(widget->IsButton());
-  static_cast<GDLWidgetButton*>(widget)->SetRadioButton( true);
+  static_cast<GDLWidgetNormalButton*>(widget)->SetRadioButton( true);
   GDLWidget::PushEvent( baseWidgetID, widgbut);
 }
 
@@ -428,9 +429,12 @@ void gdlwxFrame::OnCheckBox( wxCommandEvent& event)
   bool selectValue = event.IsChecked();
   
   WidgetIDT baseWidgetID = GDLWidget::GetIdOfTopLevelBase( event.GetId());
-  GDLWidget* widget = GDLWidget::GetWidget( event.GetId());
-  assert(widget->IsButton());
-  static_cast<GDLWidgetButton*>(widget)->SetRadioButton( selectValue);
+  GDLWidgetNormalButton* widget = dynamic_cast<GDLWidgetNormalButton*>(GDLWidget::GetWidget(event.GetId()));
+  assert(widget!=NULL);
+  widget->SetRadioButton( selectValue);
+  
+  //do not report an unchecked event if /NO_RELEASE is set for this widget
+  if (selectValue==false && widget->getNoReleaseOption()==true) return;
   
   // create GDL event struct
   DStructGDL*  widgbut = new DStructGDL( "WIDGET_BUTTON");

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -146,12 +146,14 @@ namespace lib
 #undef UNDEF_RANGE_VALUE
 	if (warn) Warning("Infinite plot range.");
   }
+  
+  // freeRange serves only for gdlAdjustAxisRange() when axis style is not 'fixed', to get reasonable intervals.
   DDouble AutoTickIntv(DDouble x, bool freeRange) {
-	static const double s2 = sqrt(2) / 2.;
+	static const double s2 = 0.707107; //sqrt(2) / 2.;
 	static const double s3 = sqrt(2) / 2.5;
-	static const double s4 = sqrt(2) / 4.;
+	static const double s4 = 0.3535534; //sqrt(2) / 4.;
 	static const double s5 = sqrt(2) / 5;
-	static const double s9 = 0.15811390; //not sqrt(2) / 9.;
+	static const double s9 = 0.1581139; //not sqrt(2) / 9.; //could be not sqrt(2) / 9.?;
 	static const double s10 = s9/1.25; //not sqrt(2) / 9.;
 	static const double recompute = 0.1;
 
@@ -472,34 +474,34 @@ namespace lib
 	} else {
 	  if (log) { //no "leak factor" as below for the linear case: the axis range in the case xstyle=0 MUST cover an integer
 		// number of powers of ten, i.e., of AutoLogTickIntv(). As the intv depends on the range, it is necessary to converge towards a 'stable' value
-		PLFLT intvold = AutoLogTickIntv(pow(10, min), pow(10, max));
-		PLFLT intv = 0;
-		//find the "good" intv
-		PLFLT start=min;
-		PLFLT end=max;
-		while (intv != intvold) {
-			intv = intvold;
-			start= floor(start / intv) * intv;
-			end = ceil(end / intv) * intv;
-			intvold = AutoLogTickIntv(pow(10, start), pow(10, end));
-		  }
+		PLFLT intv = AutoLogTickIntv(pow(10, min), pow(10, max));
+//		PLFLT intv = 0;
+//		//find the "good" intv
+//		PLFLT start=min;
+//		PLFLT end=max;
+//		while (intv != intvold) {
+//			intv = intvold;
+//			start= floor(start / intv) * intv;
+//			end = ceil(end / intv) * intv;
+//			intvold = AutoLogTickIntv(pow(10, start), pow(10, end));
+//		  }
 		//intv is OK, find nearest value for max and min
 		  if ( abs ( (floor(max / intv) * intv ) - max ) > intv/1000) max =  ceil(max / intv) * intv;
 		  if ( abs ( (ceil(min / intv) * intv ) - min ) > intv/1000)  min = floor(min / intv) * intv;
 	  } else {
-		PLFLT intvold = AutoTickIntv(range,true);
-		PLFLT intv = 0;
-		//find the "good" intv
-		PLFLT start=min;
-		PLFLT end=max;
-//		while (intv != intvold) {
-			intv = intvold;
-			start= floor(start / intv) * intv;
-			end = ceil(end / intv) * intv;
-			range=end-start;
-			intvold = AutoTickIntv(range,true);
-//		  }
-			intv = intvold;
+		PLFLT intv = AutoTickIntv(range,true);
+//		PLFLT intv = 0;
+//		//find the "good" intv
+//		PLFLT start=min;
+//		PLFLT end=max;
+////		while (intv != intvold) {
+//			intv = intvold;
+//			start= floor(start / intv) * intv;
+//			end = ceil(end / intv) * intv;
+//			range=end-start;
+//			intvold = AutoTickIntv(range,true);
+////		  }
+//			intv = intvold;
 		//intv is OK, find nearest value for max and min, do not jump to next tick if the difference is invisible:
 		  if ( abs ( (floor(max / intv) * intv ) - max ) > intv/1000) max =  ceil(max / intv) * intv;
 		  if ( abs ( (ceil(min / intv) * intv ) - min ) > intv/1000)  min = floor(min / intv) * intv;
@@ -3099,12 +3101,12 @@ void SelfNormLonLat(DDoubleGDL *lonlat) {
 	  if (nint > 0) {
 		if (isLog) {
 		  DDouble first = ceil(min / TickInterval) * TickInterval;
-		  DDoubleGDL* val = new DDoubleGDL(dimension(nint+1), BaseGDL::NOZERO);
+		  DDoubleGDL* val = new DDoubleGDL(dimension(nint), BaseGDL::NOZERO); //IDL does not return the terminal tick (box limit)
 		  for (auto i = 0; i < val->N_Elements(); ++i) (*val)[i] = pow(10,first + i * sign* TickInterval);
 		  e->SetKW(choosenIx, val);
 		} else {
 		  DDouble first = ceil(min / TickInterval)*TickInterval;
-		  DDoubleGDL* val = new DDoubleGDL(dimension(nint+1), BaseGDL::NOZERO);
+		  DDoubleGDL* val = new DDoubleGDL(dimension(nint), BaseGDL::NOZERO); //IDL does not return the terminal tick (box limit)
 		  for (auto i = 0; i < val->N_Elements(); ++i) (*val)[i] = first + i * sign * TickInterval;
 		  e->SetKW(choosenIx, val);
 		}
@@ -3683,7 +3685,7 @@ NoTitlesAccepted:
 	DLong AxisStyle;
 	gdlGetDesiredAxisStyle(e, axisId, AxisStyle);
 	if (TickInterval == 0 && !hasTickv) {
-	  if (Ticks <= 0) TickInterval = gdlComputeAxisTickInterval(e, axisId, Start, End, Log, 0, (axisId==ZAXIS && ((AxisStyle & 1) == 0)));
+	  if (Ticks <= 0) TickInterval = gdlComputeAxisTickInterval(e, axisId, Start, End, Log, 0, ((AxisStyle & 1) == 0));
 	  else if (Ticks > 1) TickInterval = (End - Start) / Ticks;
 	  else TickInterval = (End - Start);
 	} else {
@@ -3930,7 +3932,7 @@ NoTitlesAccepted:
 
 	for (auto i = 0; i < tickdata.nTickUnits; ++i) //loop on TICKUNITS axis
 	{
-	  if (i > 0 || TickInterval == 0) TickInterval = gdlComputeAxisTickInterval(e, axisId, Start, End, Log, i/*, (AxisStyle & 1) == 0*/);
+	  if (i > 0 || TickInterval == 0) TickInterval = gdlComputeAxisTickInterval(e, axisId, Start, End, Log, i, false); //fixed range by 1st axis written
 	  //protect against (plplot) bug #1893
       if (TickInterval+tickdata.Start == tickdata.Start) continue;
 	  tickdata.nchars = 0; //set nchars to 0, at the end nchars will be the maximum size.

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1123,7 +1123,9 @@ BaseGDL* widget_draw( EnvT* e ) {
   if (parent->IsMenu() && !isMenu) {
     checked=(e->KeywordSet(checkIx));
   }
-// TBD:  "HELP", "INPUT_FOCUS", "X_BITMAP_EXTRA", "FLAT", "NO_RELEASE", "ACCELERATOR","TAB_MODE" 
+  static int NO_RELEASE = e->KeywordIx( "NO_RELEASE" );
+  bool norelease=e->KeywordSet( NO_RELEASE);
+// TBD:  "HELP", "INPUT_FOCUS", "X_BITMAP_EXTRA", "FLAT", "ACCELERATOR","TAB_MODE" 
   
   
 //  To get the equivalent of pushbutton_events (push and release) with wxWidgets and have a better coverage, use ToggleButtons (wx 2.9 and after)
@@ -1182,7 +1184,7 @@ BaseGDL* widget_draw( EnvT* e ) {
   //Separate Button Types depending on parent container type:
   if (parent->IsBase()) {
   if (isMenu) button = new GDLWidgetMenuButton( parentID, e, value, eventFlags, bitmap, tooltipgdl);
-    else button = new GDLWidgetNormalButton( parentID, e, value, eventFlags, bitmap, tooltipgdl);
+  else button = new GDLWidgetNormalButton( parentID, e, value, eventFlags, norelease, bitmap, tooltipgdl);
   } else if (parent->IsMenuBar()) {
 #ifdef PREFERS_MENUBAR
     button = new GDLWidgetMenuBarButton( parentID, e, value, eventFlags, tooltipgdl);

--- a/testsuite/interactive_tests/test_widgets.pro
+++ b/testsuite/interactive_tests/test_widgets.pro
@@ -181,7 +181,12 @@ pro handle_Event,ev
   common forprogressbar,progressbar,pbarid,pbarpos
 
   ; avoid to report timer events
-  if tag_names(ev, /structure_name) ne 'WIDGET_TIMER' then  help,ev,/str
+  if tag_names(ev, /structure_name) ne 'WIDGET_TIMER' then begin
+     print, 'event: ',count++
+     help,ev,/str
+     print
+  endif
+  
   
   if tag_names(ev, /structure_name) eq 'WIDGET_KILL_REQUEST' then begin
      acceptance=dialog_message(dialog_parent=ev.id,"I Do want to close the window", /CANCEL, /DEFAULT_NO,/QUESTION) ; +strtrim(ev.id,2))
@@ -524,12 +529,14 @@ endif
     radio=widget_base(yoff=offy,button_base01,/EXCLUSIVE,COL=1,frame=30) & offy+=150         ;
     rb1=widget_button(radio,VALUE="button in EXCLUSIVE base 1",uvalue={vEv,'rb1',[8,0]}, font=fontname)
     rb2=widget_button(radio,VALUE="button in EXCLUSIVE base 2",uvalue={vEv,'rb2',[9,0]})
+    rb2=widget_button(radio,VALUE="button with NO_RELASE option",/NO_RELEASE,uvalue={vEv,'rb2',[9,0]})
     
     tmp=widget_label(yoff=offy,button_base01,value="Non-Exclusive base,simple look") & offy+=10 ;
     
     check=widget_base(yoff=offy,button_base01,/NONEXCLUSIVE,COL=1) & offy+=100 ;
     cb1=widget_button(check,VALUE="button in NONEXCLUSIVE base 1",uvalue={vEv,'cb1',[81,0]}, font=fontname)
     cb2=widget_button(check,VALUE="button in NONEXCLUSIVE base 2",uvalue={vEv,'cb2',[12,0]})
+    cb2=widget_button(check,VALUE="button with NO_RELEASE option",/NO_RELEASE,uvalue={vEv,'cb2',[12,0]})
     
     tmp=widget_label(yoff=offy,button_base01,value='2 CW_BGROUP /COL in a framed base') & offy+=10 ;
     


### PR DESCRIPTION
#1905 : tickinterval was wrongly recomputed with different criteria when the plot interval was not fixed by the [XYZ]STYLE option (and yes, the display/tick interval changes of number and value are not the same when the axis range is free or fixed).
#1929 : NO_RELEASE option  for radiobuttons introduced.