### PR TITLE
Remove all warnings in -Wall  compile mode

### DIFF
--- a/src/deviceps.hpp
+++ b/src/deviceps.hpp
@@ -41,18 +41,18 @@
 
 class DevicePS: public GraphicsDevice
 {
-  std::string      fileName;
-  GDLPSStream*     actStream;
-  float            XPageSize;
-  float            YPageSize;
-  float            XOffset;
-  float            YOffset;
-  int              color;
-  int              decomposed; // false -> use color table
-  bool	           orient_portrait; 
-  bool             encapsulated;
-  int              bitsPerPix;
-  float	           scale;
+  std::string fileName;
+  GDLPSStream* actStream;
+  float XPageSize;
+  float YPageSize;
+  float XOffset;
+  float YOffset;
+  int color;
+  int decomposed; // false -> use color table
+  bool orient_portrait;
+  bool encapsulated;
+  int bitsPerPix;
+  float scale;
 
   GDLStream  *psUnit;
 
@@ -147,9 +147,21 @@ class DevicePS: public GraphicsDevice
   }
     
 public:
-  DevicePS(): GraphicsDevice(), fileName( "gdl.ps"), actStream( NULL),
-    XPageSize(17.78), YPageSize(12.7), XOffset(1.905),YOffset(12.7),  //IDL default for offsets: 54 pts /X and 360 pts/Y
-    color(0), decomposed( 0), encapsulated(false), scale(1.), orient_portrait(true), bitsPerPix(8)
+  DevicePS(): 
+  GraphicsDevice()
+  , fileName( "gdl.ps")
+  , actStream( NULL)
+  , XPageSize(17.78)
+  , YPageSize(12.7)
+  , XOffset(1.905)
+  , YOffset(12.7)
+   //IDL default for offsets: 54 pts /X and 360 pts/Y
+  , color(0)
+  , decomposed( 0)
+  , orient_portrait(true)
+  , encapsulated(false)
+  , bitsPerPix(8)
+  , scale(1.)
   {
     name = "PS";
 

--- a/src/dnode.hpp
+++ b/src/dnode.hpp
@@ -296,6 +296,9 @@ private:
   ArrayIndexListT* arrIxListNoAssoc; // ptr to array index list
 //  ArrayIndexT*     arrIx;     // ptr to array index (1-dim)
 
+  int labelStart; // for loops to determine if to bail out
+  int labelEnd; // for loops to determine if to bail out
+
   union {
     int        initInt;    // for c-i not actually used
     
@@ -316,8 +319,6 @@ private:
     int        compileOpt; // for PRO and FUNCTION nodes
   };
 
-  int labelStart; // for loops to determine if to bail out
-  int labelEnd; // for loops to determine if to bail out
 
   friend class ProgNode;
   friend class DCompiler;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -2229,7 +2229,7 @@ BaseGDL* file_info( EnvT* e)
                        p0S->Rank() == 0 ? dimension(1) : p0S->Dim()
                        ); 
 
-    static int tName = tName = res->Desc()->TagIndex("NAME");
+    static int tName = res->Desc()->TagIndex("NAME");
     static int tExists, tRead, tWrite, tExecute, tRegular, tDirectory, tBlockSpecial, 
     tCharacterSpecial, tNamedPipe, tSetuid, tSetgid, tSocket, tStickyBit, 
     tSymlink, tDanglingSymlink, tMode, tAtime, tCtime, tMtime, tSize;

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
 #endif
   for( SizeT a=1; a< argc; ++a)
     {
-      if( string( argv[a]) == "--help" | string( argv[a]) == "-h") {
+      if( string( argv[a]) == "--help" || string( argv[a]) == "-h") {
       cerr << "Usage: gdl [ OPTIONS ] [ batch_file ... ]" << endl;
       cerr << "Start the GDL interpreter (incremental compiler)" << endl;
       cerr << endl;
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
       cerr << "Homepage: https://gnudatalanguage.github.io" << endl;
       return 0;
     }
-      else if (string(argv[a])=="--version" | string(argv[a])=="-v" | string(argv[a])=="-V")
+      else if (string(argv[a])=="--version" || string(argv[a])=="-v" || string(argv[a])=="-V")
 	{
 	  cerr << "GDL - GNU Data Language, Version " << VERSION << endl;
 	  return 0;
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
         for (int i = a + 1; i < argc; i++) lib::command_line_args.push_back(string(argv[i]));
         break;
       }
-      else if (string(argv[a])=="-quiet" | string(argv[a])=="--quiet" | string(argv[a])=="-q") 
+      else if (string(argv[a])=="-quiet" || string(argv[a])=="--quiet" || string(argv[a])=="-q") 
 	{
 	  quiet = true;
 	}
@@ -428,7 +428,7 @@ int main(int argc, char *argv[])
       {
          usePlatformDeviceName = true;
       }
-      else if (string(argv[a]) == "--no-use-wx" |  string(argv[a]) == "-X")
+      else if (string(argv[a]) == "--no-use-wx" ||  string(argv[a]) == "-X")
       {
          force_no_wxgraphics = true;
       }

--- a/src/gdlfpexceptions.cpp
+++ b/src/gdlfpexceptions.cpp
@@ -65,7 +65,8 @@ std::unique_ptr<ReportFPExceptionsGuard> GDLStartAutoStopRegisteringFPExceptions
   // just clear existing fpe exceptions
     std::feclearexcept(FE_ALL_EXCEPT);
 	std::unique_ptr<ReportFPExceptionsGuard> p(new ReportFPExceptionsGuard()) ;
-	return std::move( p ); 
+	std::unique_ptr<ReportFPExceptionsGuard> pp=std::move( p );
+	return pp;
 }
 //normal !EXCEPT=1 reporting
 void GDLCheckFPExceptionsAtLineLevel() {

--- a/src/gdlwidget.hpp
+++ b/src/gdlwidget.hpp
@@ -486,21 +486,21 @@ protected:
   bool         valid; //if not, is in the process of being destroyed (prevent reentrance).
   long  alignment; //alignment of the widget
   int dynamicResize; //for some widgets, will enable resizing: -1: not resizable, 0/1 resizable
+  DString      notifyRealize;
+
   std::vector<WidgetIDT> followers; //all the widgets that use me as group_leader
   std::vector<WidgetEventInfo*> desiredEventsList; //list of all the events (and handlers) this widget must obey.
-  DString      notifyRealize;
-  
   wxTimer * m_windowTimer;
 //  bool delay_destroy;
   
 private:  
 
-  DString      uName;
   DString      proValue;
   DString      funcValue;
   DString      eventPro; // event handler PRO
   DString      eventFun; // event handler FUN
   DString      killNotify;
+  DString      uName;
   
   void GetCommonKeywords( EnvT* e);
   void DefaultValuesInAbsenceofEnv();

--- a/src/graphicsdevice.cpp
+++ b/src/graphicsdevice.cpp
@@ -126,7 +126,7 @@ GraphicsDevice::~GraphicsDevice()
   if( actDevice != this) delete dStruct;
 } // v-table instatiation
 
-GraphicsDevice::GraphicsDevice(): dStruct( NULL), CopyBufferSize(0)
+GraphicsDevice::GraphicsDevice(): CopyBufferSize(0), dStruct( NULL)
 {
 }
 

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1525,14 +1525,10 @@ void list_leftinsertion( EnvUDT* e, BaseGDL* theref, int iprm  );
       DLong leftIx = -1;
       DLong rightIx = -1;
       // advance both to 1st
-      if( nCountL > 0)
-    while( (*static_cast<DPtrGDL*>(hashTableL->GetTag( pKeyTag, ++leftIx)))[0] == 0);
-      if( leftIx == -1)
-    leftIx = nSizeL;
-      if( nCountR > 0)
-    while( (*static_cast<DPtrGDL*>(hashTableR->GetTag( pKeyTag, ++rightIx)))[0] == 0);
-      if( rightIx == -1)
-    rightIx = nSizeR;
+      if( nCountL > 0)     while( (*static_cast<DPtrGDL*>(hashTableL->GetTag( pKeyTag, ++leftIx)))[0] == 0);
+      if( leftIx == -1)    leftIx = nSizeL;
+      if( nCountR > 0)    while( (*static_cast<DPtrGDL*>(hashTableR->GetTag( pKeyTag, ++rightIx)))[0] == 0);
+      if( rightIx == -1)    rightIx = nSizeR;
       
       DLong nCount = nCountMax;
       for( SizeT el=0; el<nCount; ++el)

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -775,11 +775,8 @@ BaseGDL* LIST___OverloadEQOp( EnvUDT* e)
       Guard<BaseGDL> eqResGuard( eqRes);
       DByteGDL* eqResByte = static_cast<DByteGDL*>(eqRes);
       SizeT c = 0;
-      for( c=0; c<eqResByte->N_Elements(); ++c)
-        if( !((*eqResByte)[ c]))
-          break;
-      if( c == eqResByte->N_Elements())
-        (*result)[ i] = 1;    
+      for( c=0; c<eqResByte->N_Elements(); ++c) if( !((*eqResByte)[ c])) break;
+      if( c == eqResByte->N_Elements()) (*result)[ i] = 1;    
         eqResGuard.Release();
     }
       }
@@ -3207,8 +3204,7 @@ void list__swap( EnvUDT* e)
 
   BaseGDL* value = NULL;
     DType valType;
-  if( nParam >= 2)
-    value = e->GetTheKW(kwVALUEIx);
+  if( nParam >= 2)  value = e->GetTheKW(kwVALUEIx);
     bool isvalscalar = false;
     if( value == NULL || value == NullGDL::GetSingleInstance()) 
         isvalscalar = true;

--- a/src/math_fun.cpp
+++ b/src/math_fun.cpp
@@ -1449,7 +1449,7 @@ namespace lib {
     if (p0->Type() == GDL_COMPLEXDBL) {
       DComplexDblGDL* res;
       if (isReference) res = static_cast<DComplexDblGDL*> (p0)->NewResult();
-      else res = res = static_cast<DComplexDblGDL*> (p0);
+      else res = static_cast<DComplexDblGDL*> (p0);
       DComplexDblGDL* p0C = static_cast<DComplexDblGDL*> (p0);
       if ((GDL_NTHREADS=parallelize( nEl))==1) {
         for (SizeT i = 0; i < nEl; ++i) (*res)[i] = std::conj((*p0C)[i]);

--- a/src/math_fun_ac.cpp
+++ b/src/math_fun_ac.cpp
@@ -92,14 +92,6 @@
 									\
   const double dzero = 0.0000000000000000000 ;				\
 
-  //  cout << "helo " << t1 << " " << (*p1_float)[0] << " " << nElp1 << endl; \
-  //									\
-  //    throw GDLException(e->CallingNode(), "Variable is undefined: "+e->GetParString(1)); 
-  									
-  //  DType t1 = e->GetParDefined(1)->Type();				\
-  //  if (t1 == GDL_COMPLEX || t1 == GDL_COMPLEXDBL)			\
-  // e->Throw("Complex not implemented (GSL limitation). ");
-
 
 // change by Alain C., June 1st 2015 : IDL 8.4 behavior
 #define GM_DF2()							\

--- a/src/matrix_invert.cpp
+++ b/src/matrix_invert.cpp
@@ -278,6 +278,7 @@ namespace lib {
 	  f32_2[0] = (float) f64_2[0];
 	  f32_2[1] = (float) f64_2[1];
 
+// attention: « void* memcpy(void*, const void*, size_t) » copie un objet du type non trivial « Data_<SpDComplex>::Ty » {aka « struct std::complex<float> »} depuis un tableau de « float » [-Wclass-memaccess]
 	  memcpy(&(*res)[i], &f32_2[0], szflt*2);
 	}
 
@@ -313,7 +314,7 @@ namespace lib {
 	  if (abs(det) * LOG10E < 1e-5) singular = 2;
 	}
 	else singular = 1;
-
+//attention: « void* memcpy(void*, const void*, size_t) » copie un objet du type non trivial « Data_<SpDComplexDbl>::Ty » {aka « struct std::complex<double> »} depuis un tableau de « double » [-Wclass-memaccess]
 	memcpy(&(*res)[0], inverse->data, nEl*szdbl*2);
 
 	// 	gsl_permutation_free(perm);

--- a/src/plotting_surface.cpp
+++ b/src/plotting_surface.cpp
@@ -384,7 +384,8 @@ void applyGraphics(EnvT* e, GDLGStream * actStream) {
       }
 	  // doShade will work correctly only if decomposed=0 --- same as IDL.
       // Get decomposed value for shades
-      DLong decomposed;
+      DLong decomposed= GraphicsDevice::GetDevice()->GetDecomposed();
+
 	  if (doShade) actStream->ForceColorMap1Ramp(0.0); else actStream->ForceColorMap1Ramp(0.33);
       static int UPPER_ONLYIx = e->KeywordIx( "UPPER_ONLY");
       static int LOWER_ONLYIx = e->KeywordIx( "LOWER_ONLY");

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2511,9 +2511,7 @@ BaseGDL* widget_info( EnvT* e ) {
 			id = (*static_cast<DLongGDL*> (ev->GetTag(idIx, 0)))[0]; // get its id
 			for (SizeT i = 0; i < widgetIDList.size(); i++) { //is ID corresponding to any widget in list?
 			  if (widgetIDList.at(i) == id) { //if yes
-				//IMPORTANT: return ev immediately. This is what permits #1685: an event trapped by WIDGET_EVENT does not behave
-				//like the same event processed in the evenloop.
-				return ev;
+				goto endwait;
 			  }
 			}
 			GDLWidget::widgetEventQueue.PushBack(ev);


### PR DESCRIPTION
removing all warnings obtained when compiling with `CMAKE_CXX_FLAGS='-g -Wall -Wno-unused -Wno-sign-compare -Wno-char-subscripts -Wno-misleading-indentation -Wno-comment -Wno-class-memaccess'`
`sign-compare` and `char-subscripts` should be examined more closely.
