### PR TITLE
Closes #1981

### DIFF
--- a/src/basic_fun_jmg.cpp
+++ b/src/basic_fun_jmg.cpp
@@ -711,7 +711,8 @@ namespace lib {
 	  return fileStatus; // OPEN tag is init to zero (SpDByte::GetInstance())
 
 	struct stat buffer;
-	int status = fstat(lun, &buffer);
+    // int status = //status will be bad on the units used by SPAWN, UNIT=XXX; Do not check status
+    stat(actUnit.Name().c_str(), &buffer); 
 
 	fileStatus->InitTag("NAME", DStringGDL( actUnit.Name()));
 	fileStatus->InitTag("OPEN", DByteGDL( 1)); 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -202,6 +202,7 @@ void AnyStream::Close() {
       std::basic_streambuf<char> *current=ifStream->std::ios::rdbuf();
       ifStream->std::ios::rdbuf(old_rdbuf_in);
       old_rdbuf_in=nullptr;
+      ispipe = false;
     }
     ifStream->close();
     ifStream->clear();
@@ -211,6 +212,7 @@ void AnyStream::Close() {
       std::basic_streambuf<char> *current=ofStream->std::ios::rdbuf();
       ifStream->std::ios::rdbuf(old_rdbuf_out);
       old_rdbuf_out=nullptr;
+      ispipe = false;
     }
     ofStream->close();
     ofStream->clear();
@@ -243,6 +245,7 @@ void AnyStream::OpenAsPipes(const std::string& name_, const std::ios_base::openm
     }
     old_rdbuf_in = ifStream->std::ios::rdbuf();
     ifStream->std::ios::rdbuf(in);
+    ispipe=true;
   }
   if (mode_ & std::ios_base::out) {
     stdio_filebuf<char> * out = fileBufFromFD(pipeOutFd, std::ios_base::out);
@@ -256,6 +259,7 @@ void AnyStream::OpenAsPipes(const std::string& name_, const std::ios_base::openm
       }
       old_rdbuf_out = ofStream->std::ios::rdbuf();
       ofStream->std::ios::rdbuf(out);
+      ispipe=true;
     }
   }
 #else
@@ -403,9 +407,11 @@ bool AnyStream::Eof() {
   if (ifStream != NULL) {
     ifStream->clear(); // clear old EOF	
 
-    ifStream->peek(); // trigger EOF if at EOF
-
-    return ifStream->eof();
+    if (ispipe) return true;
+    else {
+      ifStream->peek(); // trigger EOF if at EOF
+      return ifStream->eof();
+    }
   }
   if (igzStream != NULL) {
     igzStream->clear(); // clear old EOF	

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -55,6 +55,7 @@ class AnyStream
 {
 // GGH made all these public
 public:
+  bool ispipe;
   std::fstream* ifStream;
   std::fstream* ofStream;
   igzstream* igzStream; // for gzip compressed input
@@ -63,7 +64,8 @@ public:
   std::basic_streambuf<char> *old_rdbuf_out;
  //public:
   AnyStream()
-    : ifStream(NULL) 
+    : ispipe(false)
+    , ifStream(NULL) 
     , ofStream(NULL) 
     , igzStream(NULL) 
     , ogzStream(NULL)

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -72,7 +72,7 @@ namespace lib {
       //
       //check lun is disguized tty as in scrn = filepath(/TERMINAL) & openw,lun,scrn,/more,/get_lun
       struct stat buffer;
-      int status = fstat(lun, &buffer);
+      int status = stat((fileUnits[ lun - 1].Name()).c_str(), &buffer);
       if (status == 0) 
         is_a_tty = isatty(lun);
     }


### PR DESCRIPTION
Due to an uncorrect diagnostic of why fstat() would halt if the LUN was a pipe (only case at the moment: SPAWN, unit=xxx), the FSTAT function was rendered incorrect. This patch solves all.