### PR TITLE
Prompted by issue #1972 (closes #1792 and close #830) 

### DIFF
--- a/src/FMTLexer.cpp
+++ b/src/FMTLexer.cpp
@@ -371,11 +371,11 @@ void FMTLexer::mSTRING(bool _createToken) {
 				}
 			}
 			else {
-				goto _loop59;
+				goto _loop61;
 			}
 			
 		}
-		_loop59:;
+		_loop61:;
 		} // ( ... )*
 		_saveIndex = text.length();
 		match('\"' /* charlit */ );
@@ -401,11 +401,11 @@ void FMTLexer::mSTRING(bool _createToken) {
 				}
 			}
 			else {
-				goto _loop62;
+				goto _loop64;
 			}
 			
 		}
-		_loop62:;
+		_loop64:;
 		} // ( ... )*
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
@@ -1552,18 +1552,18 @@ void FMTLexer::mWHITESPACE(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt158=0;
+	int _cnt160=0;
 	for (;;) {
 		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0x20 /* ' ' */ )) {
 			mW(false);
 		}
 		else {
-			if ( _cnt158>=1 ) { goto _loop158; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt160>=1 ) { goto _loop160; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt158++;
+		_cnt160++;
 	}
-	_loop158:;
+	_loop160:;
 	}  // ( ... )+
 	_ttype=antlr::Token::SKIP;
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
@@ -1580,18 +1580,18 @@ void FMTLexer::mDIGITS(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt161=0;
+	int _cnt163=0;
 	for (;;) {
 		if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 			matchRange('0','9');
 		}
 		else {
-			if ( _cnt161>=1 ) { goto _loop161; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt163>=1 ) { goto _loop163; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt161++;
+		_cnt163++;
 	}
-	_loop161:;
+	_loop163:;
 	}  // ( ... )+
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1643,7 +1643,7 @@ void FMTLexer::mNUMBER(bool _createToken) {
 			mH(false);
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt168=0;
+			int _cnt170=0;
 			for (;;) {
 				// init action gets executed even in guessing mode
 				if( i == n )
@@ -1654,12 +1654,12 @@ void FMTLexer::mNUMBER(bool _createToken) {
 					mCHAR(false);
 				}
 				else {
-					if ( _cnt168>=1 ) { goto _loop168; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt170>=1 ) { goto _loop170; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt168++;
+				_cnt170++;
 			}
-			_loop168:;
+			_loop170:;
 			}  // ( ... )+
 		}
 		else {

--- a/src/FMTParser.cpp
+++ b/src/FMTParser.cpp
@@ -39,46 +39,6 @@ void FMTParser::format(
 	RefFMTNode format_AST = RefFMTNode(antlr::nullAST);
 	
 	match(LBRACE);
-	qfq();
-	astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-	{ // ( ... )*
-	for (;;) {
-		if ((LA(1) == COMMA)) {
-			match(COMMA);
-			qfq();
-			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-		}
-		else {
-			goto _loop3;
-		}
-		
-	}
-	_loop3:;
-	} // ( ... )*
-	match(RBRACE);
-	format_AST = RefFMTNode(currentAST.root);
-	
-	format_AST = RefFMTNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FORMAT,"FORMAT")))->add(antlr::RefAST(format_AST))));
-	format_AST->setRep( repeat);
-	
-	currentAST.root = format_AST;
-	if ( format_AST!=RefFMTNode(antlr::nullAST) &&
-		format_AST->getFirstChild() != RefFMTNode(antlr::nullAST) )
-		  currentAST.child = format_AST->getFirstChild();
-	else
-		currentAST.child = format_AST;
-	currentAST.advanceChildToEnd();
-	format_AST = RefFMTNode(currentAST.root);
-	returnAST = format_AST;
-}
-
-void FMTParser::qfq() {
-	returnAST = RefFMTNode(antlr::nullAST);
-	antlr::ASTPair currentAST;
-	RefFMTNode qfq_AST = RefFMTNode(antlr::nullAST);
-	
-	q();
-	astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 	{
 	switch ( LA(1)) {
 	case CSTR:
@@ -126,13 +86,73 @@ void FMTParser::qfq() {
 	{
 		f();
 		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-		q();
-		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 		break;
 	}
-	case COMMA:
-	case RBRACE:
+	case SLASH:
 	{
+		q();
+		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+		{
+		switch ( LA(1)) {
+		case CSTR:
+		case CD:
+		case CSE:
+		case CE:
+		case CI:
+		case CF:
+		case CSG:
+		case CG:
+		case CO:
+		case CB:
+		case CS:
+		case CX:
+		case CZ:
+		case PM:
+		case MP:
+		case PLUS:
+		case MOINS:
+		case CNUMBER:
+		case LBRACE:
+		case STRING:
+		case TERM:
+		case NONL:
+		case Q:
+		case CSTRING:
+		case TL:
+		case TR:
+		case T:
+		case X:
+		case A:
+		case F:
+		case D:
+		case E:
+		case SE:
+		case G:
+		case SG:
+		case I:
+		case O:
+		case B:
+		case Z:
+		case ZZ:
+		case C:
+		case NUMBER:
+		{
+			f();
+			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+			break;
+		}
+		case COMMA:
+		case RBRACE:
+		case SLASH:
+		{
+			break;
+		}
+		default:
+		{
+			throw antlr::NoViableAltException(LT(1), getFilename());
+		}
+		}
+		}
 		break;
 	}
 	default:
@@ -141,49 +161,226 @@ void FMTParser::qfq() {
 	}
 	}
 	}
-	qfq_AST = RefFMTNode(currentAST.root);
-	returnAST = qfq_AST;
-}
-
-void FMTParser::q() {
-	returnAST = RefFMTNode(antlr::nullAST);
-	antlr::ASTPair currentAST;
-	RefFMTNode q_AST = RefFMTNode(antlr::nullAST);
-	
-	int n1 = 0;
-	
-	
 	{ // ( ... )*
 	for (;;) {
-		if ((LA(1) == SLASH)) {
-			RefFMTNode tmp4_AST = RefFMTNode(antlr::nullAST);
-			tmp4_AST = astFactory->create(LT(1));
-			match(SLASH);
-			n1++;
+		switch ( LA(1)) {
+		case SLASH:
+		{
+			q();
+			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+			{
+			switch ( LA(1)) {
+			case CSTR:
+			case CD:
+			case CSE:
+			case CE:
+			case CI:
+			case CF:
+			case CSG:
+			case CG:
+			case CO:
+			case CB:
+			case CS:
+			case CX:
+			case CZ:
+			case PM:
+			case MP:
+			case PLUS:
+			case MOINS:
+			case CNUMBER:
+			case LBRACE:
+			case STRING:
+			case TERM:
+			case NONL:
+			case Q:
+			case CSTRING:
+			case TL:
+			case TR:
+			case T:
+			case X:
+			case A:
+			case F:
+			case D:
+			case E:
+			case SE:
+			case G:
+			case SG:
+			case I:
+			case O:
+			case B:
+			case Z:
+			case ZZ:
+			case C:
+			case NUMBER:
+			{
+				f();
+				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+				break;
+			}
+			case COMMA:
+			case RBRACE:
+			case SLASH:
+			{
+				break;
+			}
+			default:
+			{
+				throw antlr::NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			break;
 		}
-		else {
+		case COMMA:
+		{
+			match(COMMA);
+			{
+			switch ( LA(1)) {
+			case CSTR:
+			case CD:
+			case CSE:
+			case CE:
+			case CI:
+			case CF:
+			case CSG:
+			case CG:
+			case CO:
+			case CB:
+			case CS:
+			case CX:
+			case CZ:
+			case PM:
+			case MP:
+			case PLUS:
+			case MOINS:
+			case CNUMBER:
+			case LBRACE:
+			case STRING:
+			case TERM:
+			case NONL:
+			case Q:
+			case CSTRING:
+			case TL:
+			case TR:
+			case T:
+			case X:
+			case A:
+			case F:
+			case D:
+			case E:
+			case SE:
+			case G:
+			case SG:
+			case I:
+			case O:
+			case B:
+			case Z:
+			case ZZ:
+			case C:
+			case NUMBER:
+			{
+				f();
+				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+				break;
+			}
+			case SLASH:
+			{
+				q();
+				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+				{
+				switch ( LA(1)) {
+				case CSTR:
+				case CD:
+				case CSE:
+				case CE:
+				case CI:
+				case CF:
+				case CSG:
+				case CG:
+				case CO:
+				case CB:
+				case CS:
+				case CX:
+				case CZ:
+				case PM:
+				case MP:
+				case PLUS:
+				case MOINS:
+				case CNUMBER:
+				case LBRACE:
+				case STRING:
+				case TERM:
+				case NONL:
+				case Q:
+				case CSTRING:
+				case TL:
+				case TR:
+				case T:
+				case X:
+				case A:
+				case F:
+				case D:
+				case E:
+				case SE:
+				case G:
+				case SG:
+				case I:
+				case O:
+				case B:
+				case Z:
+				case ZZ:
+				case C:
+				case NUMBER:
+				{
+					f();
+					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+					break;
+				}
+				case COMMA:
+				case RBRACE:
+				case SLASH:
+				{
+					break;
+				}
+				default:
+				{
+					throw antlr::NoViableAltException(LT(1), getFilename());
+				}
+				}
+				}
+				break;
+			}
+			default:
+			{
+				throw antlr::NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			break;
+		}
+		default:
+		{
 			goto _loop8;
 		}
-		
+		}
 	}
 	_loop8:;
 	} // ( ... )*
-	q_AST = RefFMTNode(currentAST.root);
+	match(RBRACE);
+	format_AST = RefFMTNode(currentAST.root);
 	
-	if( n1 > 0) 
-	{
-	q_AST = RefFMTNode(astFactory->make((new antlr::ASTArray(1))->add(antlr::RefAST(astFactory->create(SLASH,"/")))));
-	q_AST->setRep( n1);
-	}           
+	format_AST = RefFMTNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FORMAT,"FORMAT")))->add(antlr::RefAST(format_AST))));
+	format_AST->setRep( repeat);
 	
-	currentAST.root = q_AST;
-	if ( q_AST!=RefFMTNode(antlr::nullAST) &&
-		q_AST->getFirstChild() != RefFMTNode(antlr::nullAST) )
-		  currentAST.child = q_AST->getFirstChild();
+	currentAST.root = format_AST;
+	if ( format_AST!=RefFMTNode(antlr::nullAST) &&
+		format_AST->getFirstChild() != RefFMTNode(antlr::nullAST) )
+		  currentAST.child = format_AST->getFirstChild();
 	else
-		currentAST.child = q_AST;
+		currentAST.child = format_AST;
 	currentAST.advanceChildToEnd();
-	returnAST = q_AST;
+	format_AST = RefFMTNode(currentAST.root);
+	returnAST = format_AST;
 }
 
 void FMTParser::f() {
@@ -207,36 +404,36 @@ void FMTParser::f() {
 	switch ( LA(1)) {
 	case TERM:
 	{
-		RefFMTNode tmp5_AST = RefFMTNode(antlr::nullAST);
-		tmp5_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp5_AST));
+		RefFMTNode tmp4_AST = RefFMTNode(antlr::nullAST);
+		tmp4_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp4_AST));
 		match(TERM);
 		f_AST = RefFMTNode(currentAST.root);
 		break;
 	}
 	case NONL:
 	{
-		RefFMTNode tmp6_AST = RefFMTNode(antlr::nullAST);
-		tmp6_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp6_AST));
+		RefFMTNode tmp5_AST = RefFMTNode(antlr::nullAST);
+		tmp5_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp5_AST));
 		match(NONL);
 		f_AST = RefFMTNode(currentAST.root);
 		break;
 	}
 	case Q:
 	{
-		RefFMTNode tmp7_AST = RefFMTNode(antlr::nullAST);
-		tmp7_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp7_AST));
+		RefFMTNode tmp6_AST = RefFMTNode(antlr::nullAST);
+		tmp6_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp6_AST));
 		match(Q);
 		f_AST = RefFMTNode(currentAST.root);
 		break;
 	}
 	case CSTRING:
 	{
-		RefFMTNode tmp8_AST = RefFMTNode(antlr::nullAST);
-		tmp8_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp8_AST));
+		RefFMTNode tmp7_AST = RefFMTNode(antlr::nullAST);
+		tmp7_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp7_AST));
 		match(CSTRING);
 		f_AST = RefFMTNode(currentAST.root);
 		break;
@@ -383,6 +580,38 @@ void FMTParser::f() {
 	returnAST = f_AST;
 }
 
+void FMTParser::q() {
+	returnAST = RefFMTNode(antlr::nullAST);
+	antlr::ASTPair currentAST;
+	RefFMTNode q_AST = RefFMTNode(antlr::nullAST);
+	
+	int n1 = 0;
+	
+	
+	{
+	RefFMTNode tmp8_AST = RefFMTNode(antlr::nullAST);
+	tmp8_AST = astFactory->create(LT(1));
+	match(SLASH);
+	n1++;
+	}
+	q_AST = RefFMTNode(currentAST.root);
+	
+	if( n1 > 0) 
+	{
+	q_AST = RefFMTNode(astFactory->make((new antlr::ASTArray(1))->add(antlr::RefAST(astFactory->create(SLASH,"/")))));
+	q_AST->setRep( n1);
+	}           
+	
+	currentAST.root = q_AST;
+	if ( q_AST!=RefFMTNode(antlr::nullAST) &&
+		q_AST->getFirstChild() != RefFMTNode(antlr::nullAST) )
+		  currentAST.child = q_AST->getFirstChild();
+	else
+		currentAST.child = q_AST;
+	currentAST.advanceChildToEnd();
+	returnAST = q_AST;
+}
+
 void FMTParser::f_csubcode() {
 	returnAST = RefFMTNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
@@ -441,7 +670,7 @@ void FMTParser::cstring() {
 	RefFMTNode s_AST = RefFMTNode(antlr::nullAST);
 	
 	{ // ( ... )+
-	int _cnt12=0;
+	int _cnt14=0;
 	for (;;) {
 		switch ( LA(1)) {
 		case CSTR:
@@ -477,12 +706,12 @@ void FMTParser::cstring() {
 		}
 		default:
 		{
-			if ( _cnt12>=1 ) { goto _loop12; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+			if ( _cnt14>=1 ) { goto _loop14; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 		}
 		}
-		_cnt12++;
+		_cnt14++;
 	}
-	_loop12:;
+	_loop14:;
 	}  // ( ... )+
 	cstring_AST = RefFMTNode(currentAST.root);
 	returnAST = cstring_AST;
@@ -1341,11 +1570,11 @@ void FMTParser::calendar_string() {
 				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 			}
 			else {
-				goto _loop31;
+				goto _loop33;
 			}
 			
 		}
-		_loop31:;
+		_loop33:;
 		} // ( ... )*
 		}
 		break;

--- a/src/FMTParser.hpp
+++ b/src/FMTParser.hpp
@@ -52,9 +52,8 @@ public:
 	public: void format(
 		 int repeat
 	);
-	public: void qfq();
-	public: void q();
 	public: void f();
+	public: void q();
 	public: void f_csubcode();
 	public: void cstring();
 	public: void cformat();

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -206,12 +206,6 @@ antlr::RefToken GDLLexer::nextToken()
 				theRetToken=_returnToken;
 				break;
 			}
-			case 0x3b /* ';' */ :
-			{
-				mCOMMENT(true);
-				theRetToken=_returnToken;
-				break;
-			}
 			case 0x9 /* '\t' */ :
 			case 0xc /* '\14' */ :
 			case 0x20 /* ' ' */ :
@@ -220,16 +214,22 @@ antlr::RefToken GDLLexer::nextToken()
 				theRetToken=_returnToken;
 				break;
 			}
-			case 0x24 /* '$' */ :
-			{
-				mCONT_STATEMENT(true);
-				theRetToken=_returnToken;
-				break;
-			}
 			case 0xa /* '\n' */ :
 			case 0xd /* '\r' */ :
 			{
 				mEND_OF_LINE(true);
+				theRetToken=_returnToken;
+				break;
+			}
+			case 0x3b /* ';' */ :
+			{
+				mCOMMENT(true);
+				theRetToken=_returnToken;
+				break;
+			}
+			case 0x24 /* '$' */ :
+			{
+				mCONT_STATEMENT(true);
 				theRetToken=_returnToken;
 				break;
 			}
@@ -378,12 +378,12 @@ antlr::RefToken GDLLexer::nextToken()
 					mLTMARK(true);
 					theRetToken=_returnToken;
 				}
-				else if ((_tokenSet_1.member(LA(1))) && (true) && (true)) {
-					mIDENTIFIER(true);
-					theRetToken=_returnToken;
-				}
 				else if ((LA(1) == 0x26 /* '&' */ ) && (true)) {
 					mEND_MARKER(true);
+					theRetToken=_returnToken;
+				}
+				else if ((_tokenSet_1.member(LA(1))) && (true) && (true)) {
+					mIDENTIFIER(true);
 					theRetToken=_returnToken;
 				}
 			else {
@@ -2654,24 +2654,49 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								match('s' /* charlit */ );
 								break;
 							}
-							case 0x6c /* 'l' */ :
+							case 0x9 /* '\t' */ :
+							case 0xc /* '\14' */ :
+							case 0x20 /* ' ' */ :
 							{
-								match('l' /* charlit */ );
+								mWHITESPACE(false);
 								break;
 							}
-							case 0x75 /* 'u' */ :
+							case 0x26 /* '&' */ :
 							{
-								match('u' /* charlit */ );
+								mEND_MARKER(false);
 								break;
 							}
-							case 0x22 /* '\"' */ :
+							case 0xa /* '\n' */ :
+							case 0xd /* '\r' */ :
 							{
-								match("\"");
+								mEND_OF_LINE(false);
 								break;
 							}
 							default:
-								{
+								if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
+									match("ull");
 								}
+								else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
+									match("us");
+								}
+								else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
+									match("ub");
+								}
+								else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
+									match("ll");
+								}
+								else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
+									match("ul");
+								}
+								else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
+									match('l' /* charlit */ );
+								}
+								else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
+									match('u' /* charlit */ );
+								}
+							else {
+								throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
+							}
 							}
 							}
 							}
@@ -2701,9 +2726,6 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 						_loop395:;
 						}  // ( ... )+
-						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_I;
-						}
 						{
 						switch ( LA(1)) {
 						case 0x73 /* 's' */ :
@@ -2723,16 +2745,6 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							text.erase(_saveIndex);
 							if ( inputState->guessing==0 ) {
 								_ttype=CONSTANT_OCT_BYTE;
-							}
-							break;
-						}
-						case 0x22 /* '\"' */ :
-						{
-							_saveIndex = text.length();
-							match("\"");
-							text.erase(_saveIndex);
-							if ( inputState->guessing==0 ) {
-								_ttype=STRING_LITERAL;
 							}
 							break;
 						}
@@ -2794,6 +2806,9 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							else {
+								if ( inputState->guessing==0 ) {
+									_ttype=CONSTANT_OCT_I;
+								}
 							}
 						}
 						}
@@ -3423,6 +3438,71 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_saveIndex=0;
 }
 
+void GDLLexer::mWHITESPACE(bool _createToken) {
+	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
+	_ttype = WHITESPACE;
+	std::string::size_type _saveIndex;
+	
+	{ // ( ... )+
+	int _cnt497=0;
+	for (;;) {
+		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
+			mW(false);
+		}
+		else {
+			if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+		}
+		
+		_cnt497++;
+	}
+	_loop497:;
+	}  // ( ... )+
+	if ( inputState->guessing==0 ) {
+		_ttype=antlr::Token::SKIP;
+	}
+	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
+	   _token = makeToken(_ttype);
+	   _token->setText(text.substr(_begin, text.length()-_begin));
+	}
+	_returnToken = _token;
+	_saveIndex=0;
+}
+
+void GDLLexer::mEND_MARKER(bool _createToken) {
+	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
+	_ttype = END_MARKER;
+	std::string::size_type _saveIndex;
+	
+	match('&' /* charlit */ );
+	if ( inputState->guessing==0 ) {
+		_ttype=END_U;
+	}
+	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
+	   _token = makeToken(_ttype);
+	   _token->setText(text.substr(_begin, text.length()-_begin));
+	}
+	_returnToken = _token;
+	_saveIndex=0;
+}
+
+void GDLLexer::mEND_OF_LINE(bool _createToken) {
+	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
+	_ttype = END_OF_LINE;
+	std::string::size_type _saveIndex;
+	
+	mEOL(false);
+	mSKIP_LINES(false);
+	if ( inputState->guessing==0 ) {
+		_ttype=END_U;
+	}
+	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
+	   _token = makeToken(_ttype);
+	   _token->setText(text.substr(_begin, text.length()-_begin));
+	}
+	_returnToken = _token;
+	_saveIndex=0;
+}
+
 void GDLLexer::mCOMMENT(bool _createToken) {
 	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
 	_ttype = COMMENT;
@@ -3623,53 +3703,6 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 	_saveIndex=0;
 }
 
-void GDLLexer::mEND_MARKER(bool _createToken) {
-	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
-	_ttype = END_MARKER;
-	std::string::size_type _saveIndex;
-	
-	match('&' /* charlit */ );
-	if ( inputState->guessing==0 ) {
-		_ttype=END_U;
-	}
-	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
-	   _token = makeToken(_ttype);
-	   _token->setText(text.substr(_begin, text.length()-_begin));
-	}
-	_returnToken = _token;
-	_saveIndex=0;
-}
-
-void GDLLexer::mWHITESPACE(bool _createToken) {
-	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
-	_ttype = WHITESPACE;
-	std::string::size_type _saveIndex;
-	
-	{ // ( ... )+
-	int _cnt497=0;
-	for (;;) {
-		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
-			mW(false);
-		}
-		else {
-			if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
-		}
-		
-		_cnt497++;
-	}
-	_loop497:;
-	}  // ( ... )+
-	if ( inputState->guessing==0 ) {
-		_ttype=antlr::Token::SKIP;
-	}
-	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
-	   _token = makeToken(_ttype);
-	   _token->setText(text.substr(_begin, text.length()-_begin));
-	}
-	_returnToken = _token;
-	_saveIndex=0;
-}
-
 void GDLLexer::mSKIP_LINES(bool _createToken) {
 	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
 	_ttype = SKIP_LINES;
@@ -3739,24 +3772,6 @@ void GDLLexer::mCONT_STATEMENT(bool _createToken) {
 		++lineContinuation;
 		_ttype=antlr::Token::SKIP; 
 		
-	}
-	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
-	   _token = makeToken(_ttype);
-	   _token->setText(text.substr(_begin, text.length()-_begin));
-	}
-	_returnToken = _token;
-	_saveIndex=0;
-}
-
-void GDLLexer::mEND_OF_LINE(bool _createToken) {
-	int _ttype; antlr::RefToken _token; std::string::size_type _begin = text.length();
-	_ttype = END_OF_LINE;
-	std::string::size_type _saveIndex;
-	
-	mEOL(false);
-	mSKIP_LINES(false);
-	if ( inputState->guessing==0 ) {
-		_ttype=END_U;
 	}
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);

--- a/src/GDLLexer.hpp
+++ b/src/GDLLexer.hpp
@@ -248,14 +248,14 @@ public:
 	protected: void mSTRING_LITERAL(bool _createToken);
 	protected: void mDOT(bool _createToken);
 	public: void mCONSTANT_OR_STRING_LITERAL(bool _createToken);
+	public: void mWHITESPACE(bool _createToken);
+	public: void mEND_MARKER(bool _createToken);
+	public: void mEND_OF_LINE(bool _createToken);
 	public: void mCOMMENT(bool _createToken);
 	public: void mIDENTIFIER(bool _createToken);
 	public: void mSYSVARNAME(bool _createToken);
-	public: void mEND_MARKER(bool _createToken);
-	public: void mWHITESPACE(bool _createToken);
 	protected: void mSKIP_LINES(bool _createToken);
 	public: void mCONT_STATEMENT(bool _createToken);
-	public: void mEND_OF_LINE(bool _createToken);
 	protected: void mMAX_TOKEN_NUMBER(bool _createToken);
 private:
 	

--- a/src/format.g
+++ b/src/format.g
@@ -60,24 +60,20 @@ tokens {
 {
 // class extensions
 }
-
-format [ int repeat] // mark last format for format reversion 
-    : LBRACE! qfq (COMMA! qfq)* RBRACE!
+// original work by Marc was missing things as print,"a","b","c",format='(/a/,a,/,a/)'
+//based on https://www.antlr3.org/grammar/1183077163756/f77-antlr2.g GD changed to this:
+format  [ int repeat] // mark last format for format reversion
+    : LBRACE! (f | q (f)?)  ( q (f)? | 	COMMA! (f | q (f)?) )* RBRACE!
         {
             #format = #( [FORMAT,"FORMAT"], #format);
             #format->setRep( repeat);
-        }
-    ;
-
-qfq
-    : q (f q) ? // q (f q)* produces nondeterminism 
-    ;
+        } ;
 
 q!
 {
     int n1 = 0;
 }
-    : (SLASH { n1++;})*
+    : (SLASH { n1++;})
         {
             if( n1 > 0) 
             {

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -2261,7 +2261,7 @@ CONSTANT_OR_STRING_LITERAL
     // could be a string, but octals have priority
     // but "012345" is a string because of ending \"
     :
-        ("0x"(H)+ ( 's' | 'l' | 'u' )?) =>  //NOT 'b' as B is part of (H) : ex: 0x3BAFB 
+      ("0x"(H)+ ( 's' | 'l' | 'u' )?) =>  //NOT 'b' as B is part of (H) : ex: 0x3BAFB 
       ("0x"! (H)+          { _ttype=CONSTANT_HEX_I; } // DEFINT32
             ( 's'!        { _ttype=CONSTANT_HEX_INT; }
         | 'u'!        { _ttype=CONSTANT_HEX_UI; }   // DEFINT32
@@ -2272,19 +2272,37 @@ CONSTANT_OR_STRING_LITERAL
         | "ul"!           { _ttype=CONSTANT_HEX_ULONG; }
         | "ull"!    { _ttype=CONSTANT_HEX_ULONG64; }
             )?)
-    |('\"'(O)+ ( 'b' | 's' | 'l' | 'u' | "\"")?) => 
-        ('\"'! (O)+        { _ttype=CONSTANT_OCT_I; }  // DEFINT32
-            ( 's'!        { _ttype=CONSTANT_OCT_INT; }
-            | 'b'!        { _ttype=CONSTANT_OCT_BYTE; }
-            | 'u'!         { _ttype=CONSTANT_OCT_UI; }   // DEFINT32
-            | "us"!        { _ttype=CONSTANT_OCT_UINT; } 
-            | "ub"!        { _ttype=CONSTANT_OCT_BYTE; }
-            | 'l'!         { _ttype=CONSTANT_OCT_LONG; }
-            | "ll"!        { _ttype=CONSTANT_OCT_LONG64; }
-            | "ul"!        { _ttype=CONSTANT_OCT_ULONG; }
-            | "ull"!    { _ttype=CONSTANT_OCT_ULONG64; }
-            | "\""!            { _ttype=STRING_LITERAL; }
-            )?)
+	    
+  |('\"'(O)+ ( "ull"  | "us" | "ub" | "ll" | "ul" | 'b' | 's' | 'l' | 'u' | WHITESPACE |END_MARKER| END_OF_LINE )) => 
+      ('\"'! (O)+ //       { _ttype=CONSTANT_OCT_I; }  // DEFINT32
+          ( 's'!        { _ttype=CONSTANT_OCT_INT; }
+          | 'b'!        { _ttype=CONSTANT_OCT_BYTE; }
+          | 'u'!         { _ttype=CONSTANT_OCT_UI; }   // DEFINT32
+          | "us"!        { _ttype=CONSTANT_OCT_UINT; } 
+          | "ub"!        { _ttype=CONSTANT_OCT_BYTE; }
+          | 'l'!         { _ttype=CONSTANT_OCT_LONG; }
+          | "ll"!        { _ttype=CONSTANT_OCT_LONG64; }
+          | "ul"!        { _ttype=CONSTANT_OCT_ULONG; }
+          | "ull"!    { _ttype=CONSTANT_OCT_ULONG64; }
+	  |  { _ttype=CONSTANT_OCT_I; }
+          )
+	  )
+//  | '\"'! (L|D)+  '\"'!   { _ttype=STRING_LITERAL; } 
+
+
+//    |('\"'(O)+ ( 'b' | 's' | 'l' | 'u' | "\"")?) => 
+//        ('\"'! (O)+        { _ttype=CONSTANT_OCT_I; }  // DEFINT32
+//            ( 's'!        { _ttype=CONSTANT_OCT_INT; }
+//            | 'b'!        { _ttype=CONSTANT_OCT_BYTE; }
+//            | 'u'!         { _ttype=CONSTANT_OCT_UI; }   // DEFINT32
+//            | "us"!        { _ttype=CONSTANT_OCT_UINT; } 
+//            | "ub"!        { _ttype=CONSTANT_OCT_BYTE; }
+//            | 'l'!         { _ttype=CONSTANT_OCT_LONG; }
+//            | "ll"!        { _ttype=CONSTANT_OCT_LONG64; }
+//            | "ul"!        { _ttype=CONSTANT_OCT_ULONG; }
+//            | "ull"!    { _ttype=CONSTANT_OCT_ULONG64; }
+//            | "." (O)* "\""!            { _ttype=STRING_LITERAL; }
+//            )?)
     | ('\''(H)+'\'' ( 'x' | "xs" | "xb" | "xl" | "xu" | "xus" | "xub" | "xul" )) =>
         ('\''! (H)+ '\''! 'x'!
           (                  { _ttype=CONSTANT_HEX_I; } // DEFINT32


### PR DESCRIPTION
 see issue #1972 
- strings and octals correctly defined in accordance with IDL8.8 +:
  -   `a="8ull & print,a` produces a STRING  containing "8ull & print,a"
  -   `a="7ull & print,a` prints `7`,  as `"7ull` is an octal.
  - etc, see issue for examples.
- close also #830 the SLASH is now correctly supported in formats.