### PR TITLE
Device NULL now is really existing, so that coordinate …

### DIFF
--- a/src/devicenull.hpp
+++ b/src/devicenull.hpp
@@ -17,13 +17,45 @@
 
 #ifndef DEVICENULL_HPP_
 #define DEVICENULL_HPP_
-
+#include "gdlnullstream.hpp"
 class DeviceNULL : public GraphicsDevice
 {
-  //  std::string      fileName;
-  //  GDLNULLStream*     actStream;
-  // void InitStream()  {  }
+   GDLNULLStream*   actStream;
+  void DeleteStream()
+  {
+    delete actStream; actStream = NULL;
+  }
 
+  void InitStream()
+  {
+    DeleteStream();
+
+    // always allocate the buffer with creating a new stream
+    actStream = new GDLNULLStream( 100, 100);
+    actStream->Init();
+    // need to be called initially. permit to fix things
+    actStream->plstream::ssub(1, 1); // plstream below stays with ONLY ONE page
+    actStream->plstream::adv(0); //-->this one is the 1st and only pladv
+    // load font
+    actStream->plstream::font(1);
+    actStream->plstream::vpor(0, 1, 0, 1);
+    actStream->plstream::wind(0, 1, 0, 1);
+
+    actStream->ssub(1, 1);
+    actStream->SetPageDPMM();
+    actStream->DefaultCharSize();
+    actStream->adv(0); //this is for us (counters) //needs DefaultCharSize
+  }
+  
+  GDLGStream* GetStream( bool open=true)
+  {
+    if( actStream == NULL) 
+      {
+	InitStream();
+      }
+    return actStream;
+  }
+  
 public:
   //  DeviceNULL(): GraphicsDevice(), fileName( "gdl.null"), actStream( NULL)
   DeviceNULL(): GraphicsDevice()
@@ -54,8 +86,11 @@ public:
     dStruct->InitTag("ORIGIN",     origin); 
     dStruct->InitTag("ZOOM",       zoom); 
   }
-  
-  ~DeviceNULL() {}
+  ~DeviceNULL()
+  {
+    DeleteStream();
+  }
+
  
 };
 

--- a/src/gdlnullstream.hpp
+++ b/src/gdlnullstream.hpp
@@ -1,0 +1,42 @@
+/* *************************************************************************
+                          gdlnullstream.hpp  -  graphic stream z-buffer
+                             -------------------
+    begin                : July 22 2002
+    copyright            : (C) 2025 by G. Duvert
+    email                : see github
+ ***************************************************************************/
+
+/* *************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GDLNULLSTREAM_HPP_
+#define GDLNULLSTREAM_HPP_
+
+#include <iostream>
+
+#include "graphicsdevice.hpp"
+#include "gdlgstream.hpp"
+
+class GDLNULLStream: public GDLGStream
+{
+public:
+  GDLNULLStream( int nx, int ny): GDLGStream( nx, ny, "null")
+  {
+  }
+
+  ~GDLNULLStream()
+  {
+  }
+//No graphic commands 
+ void Init()
+{
+   this->plstream::init();
+}
+};
+#endif

--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -547,7 +547,6 @@ namespace lib
     void plotting_routine_call::call(EnvT* e, SizeT n_params_required) {
       // when !d.name == Null  we do nothing !
       DString name = (*static_cast<DStringGDL*> (SysVar::D()->GetTag(SysVar::D()->Desc()->TagIndex("NAME"), 0)))[0];
-      if (name == "NULL") return;
 
       _nParam = e->NParam(n_params_required);
 
@@ -573,7 +572,10 @@ namespace lib
         return;
       }
 
-      applyGraphics(e, actStream);
+// NULL Device exists, but better NOT TO SEND graphics commands to it
+// If a 'save' command (like saving modified !X.CRANGE values) is present in the 'applyGraphics()' code (it should not!)
+// then this command will not be saved, and this will be a bug. NO 'save' commands should appear in applyGraphics()
+      if (name!="NULL") applyGraphics(e, actStream);
 
 //      restoreDrawArea(actStream); //doing this would mess the /NOERASE logic when MULTI
 

--- a/src/plotting.hpp
+++ b/src/plotting.hpp
@@ -321,7 +321,7 @@ namespace lib {
   private:
     virtual bool handle_args(EnvT*) = 0; // return value = overplot
     virtual bool prepareDrawArea(EnvT*, GDLGStream*) = 0;
-    virtual void applyGraphics(EnvT*, GDLGStream*) = 0;
+    virtual void applyGraphics(EnvT*, GDLGStream*) = 0;  //Should *NOT* contain any 'save' commands able to change !X,!Y,!Z,!P,!D values !!!! 
     virtual void post_call(EnvT*, GDLGStream*) = 0;
 
     // all steps combined (virtual methods cannot be called from ctor)


### PR DESCRIPTION
… transformations and other changes in graphic system variables (!X,!Y,!Z ...) are eventually computed when this device is used. Device NULL does not however call any 'real' graphic computation nor responds to all DEVICE commands, as in IDL.

closes #2004 