### PR TITLE
added 2 lines to remove deprecated declaration warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -213,7 +213,8 @@ ${SOURCES}
 ${WX_RC}
 )
 endif(HAVE_LIBWXWIDGETS AND WIN32)
-
+set_source_files_properties(magick_cl.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+set_source_files_properties(libinit_cl.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
 #whereami
 add_library(whereami STATIC ${CMAKE_SOURCE_DIR}/src/whereami/src/whereami.c)
 add_subdirectory(antlr)


### PR DESCRIPTION
GraphicsMagick refuses to obey a depreciation warning, this is to remove the annoying log clutter.
(note: patch does not check if GM is used instead of IM)