### PR TITLE
Speedup lexer

### DIFF
--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -118,12 +118,16 @@ elif [ ${BUILD_OS} == "Linux" ]; then
     ) # JP 2021 Mar 21: SuSE lacks eccodes
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
-        llvm@18 libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
+        libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
+        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
+	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
+	  # "For compilers to find libomp you may need to set:"
+	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
+	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -433,15 +437,12 @@ function configure_gdl {
     
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
-            export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
+	# suggested by homebrew
+	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
-            export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
+	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp I/usr/local/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -448,7 +448,7 @@ function configure_gdl {
         fi
         CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF"
 								"-DREADLINEDIR=${READLINE_DIR}"
-								"-DOpenMP_CXX_FLAGS=${OMP_PREPROC}")
+								'-DOpenMP_CXX_FLAGS=\"${OMP_PREPROC}\"') #avoid blank expansion
    fi
 
 #    if [[ ${BUILD_OS} != "macOS" ]]; then

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -119,7 +119,7 @@ elif [ ${BUILD_OS} == "Linux" ]; then
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
         llvm libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
+        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -58,7 +58,6 @@ WITH_PYTHONVERSION=${WITH_PYTHONVERSION:-ON}
 WITH_FFTW=${WITH_FFTW:-ON}
 WITH_UDUNITS2=${WITH_UDUNITS2:-ON}
 WITH_GLPK=${WITH_GLPK:-ON}
-WITH_OPENMP=${WITH_OPENMP:-ON}
 if [[ ${BUILD_OS} == "macOS" ]]; then
     WITH_HDF4=${WITH_HDF4:-OFF}
     WITH_GRIB=${WITH_GRIB:-ON}
@@ -436,7 +435,8 @@ function configure_gdl {
     fi
     
     if [[ ${BUILD_OS} == "macOS" ]]; then
-        if [[ ${Platform} == "arm64" ]]; then
+       export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+       if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
 			OMP_PREPROC='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include'

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,10 +439,10 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp I/usr/local/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -119,7 +119,7 @@ elif [ ${BUILD_OS} == "Linux" ]; then
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
         llvm libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
+        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -30,10 +30,6 @@ if [[ ${BUILD_OS} == *"MSYS"* ]] || [[ ${BUILD_OS} == *"MINGW"* ]]; then
 elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
-	# suggested by homebrew
-    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
-	export LDFLAGS="-L/usr/local/opt/libomp/lib"
-	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi
 
 # Build flags
@@ -122,16 +118,12 @@ elif [ ${BUILD_OS} == "Linux" ]; then
     ) # JP 2021 Mar 21: SuSE lacks eccodes
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
-        llvm libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
+        llvm@18 libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
+        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
-	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
-	  # "For compilers to find libomp you may need to set:"
-	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
-	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -442,10 +434,14 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,7 +439,7 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=\"-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include\" -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
             CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,10 +439,10 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp I/usr/local/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -118,16 +118,12 @@ elif [ ${BUILD_OS} == "Linux" ]; then
     ) # JP 2021 Mar 21: SuSE lacks eccodes
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
-        libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
+        llvm@18 libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
+        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
-	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
-	  # "For compilers to find libomp you may need to set:"
-	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
-	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -437,12 +433,15 @@ function configure_gdl {
     
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
-	# suggested by homebrew
-	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+            export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
         else
-	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp I/usr/local/opt/libomp/include -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
+            export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -434,14 +434,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -448,7 +448,7 @@ function configure_gdl {
         fi
         CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF"
 								"-DREADLINEDIR=${READLINE_DIR}"
-								'-DOpenMP_CXX_FLAGS=\"${OMP_PREPROC}\"') #avoid blank expansion
+								"-DOpenMP_CXX_FLAGS=${OMP_PREPROC}")
    fi
 
 #    if [[ ${BUILD_OS} != "macOS" ]]; then

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -30,6 +30,9 @@ if [[ ${BUILD_OS} == *"MSYS"* ]] || [[ ${BUILD_OS} == *"MINGW"* ]]; then
 elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
+	# suggested by homebrew
+	export LDFLAGS="-L/usr/local/opt/libomp/lib"
+	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi
 
 # Build flags
@@ -124,6 +127,10 @@ elif [ ${BUILD_OS} == "macOS" ]; then
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
+	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
+	  # "For compilers to find libomp you may need to set:"
+	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
+	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -434,10 +441,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -30,9 +30,6 @@ if [[ ${BUILD_OS} == *"MSYS"* ]] || [[ ${BUILD_OS} == *"MINGW"* ]]; then
 elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
-	# suggested by homebrew
-	export LDFLAGS="-L/usr/local/opt/libomp/lib"
-	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi
 
 # Build flags
@@ -127,10 +124,6 @@ elif [ ${BUILD_OS} == "macOS" ]; then
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
-	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
-	  # "For compilers to find libomp you may need to set:"
-	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
-	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -441,10 +434,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,17 +439,12 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-			OMP_PREPROC='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include'
-			READLINE_DIR='/opt/homebrew/opt/readline'
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=\"-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include\" -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
-			OMP_PREPROC='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include'
-			READLINE_DIR='/usr/local/opt/readline'
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
         fi
-        CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF"
-								"-DREADLINEDIR=${READLINE_DIR}"
-								"-DOpenMP_CXX_FLAGS=${OMP_PREPROC}")
-   fi
+    fi
 
 #    if [[ ${BUILD_OS} != "macOS" ]]; then
 #        CMAKE_QHULLDIR_OPT="-DQHULLDIR="${ROOT_DIR}"/qhull-2020.2"
@@ -465,7 +460,7 @@ function configure_gdl {
     cmake ${GDL_DIR} -G"${GENERATOR}" \
         -DCMAKE_BUILD_TYPE=${Configuration} \
         -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
-        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DOPENMP=${WITH_OPENMP} \
         -DWXWIDGETS=${WITH_WXWIDGETS} -DX11={WITH_X11} -DGRAPHICSMAGICK=${WITH_GRAPHICSMAGICK} \
         -DNETCDF=${WITH_NETCDF} -DHDF=${WITH_HDF4} -DHDF5=${WITH_HDF5} \
         -DMPI=${WITH_MPI} -DTIFF=${WITH_TIFF} -DGEOTIFF=${WITH_GEOTIFF} \

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -58,6 +58,7 @@ WITH_PYTHONVERSION=${WITH_PYTHONVERSION:-ON}
 WITH_FFTW=${WITH_FFTW:-ON}
 WITH_UDUNITS2=${WITH_UDUNITS2:-ON}
 WITH_GLPK=${WITH_GLPK:-ON}
+WITH_OPENMP=${WITH_OPENMP:-ON}
 if [[ ${BUILD_OS} == "macOS" ]]; then
     WITH_HDF4=${WITH_HDF4:-OFF}
     WITH_GRIB=${WITH_GRIB:-ON}
@@ -435,8 +436,7 @@ function configure_gdl {
     fi
     
     if [[ ${BUILD_OS} == "macOS" ]]; then
-       export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-       if [[ ${Platform} == "arm64" ]]; then
+        if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
 			OMP_PREPROC='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include'

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -31,7 +31,6 @@ elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
 	# suggested by homebrew
-    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
 	export LDFLAGS="-L/usr/local/opt/libomp/lib"
 	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -31,6 +31,7 @@ elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
 	# suggested by homebrew
+    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
 	export LDFLAGS="-L/usr/local/opt/libomp/lib"
 	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -434,10 +434,14 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
+                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
+                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -434,10 +434,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -434,10 +434,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=OFF -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -30,6 +30,10 @@ if [[ ${BUILD_OS} == *"MSYS"* ]] || [[ ${BUILD_OS} == *"MINGW"* ]]; then
 elif [[ ${BUILD_OS} == "Darwin" ]]; then
     BUILD_OS="macOS"
     Platform=${Platform:-$(arch)}
+	# suggested by homebrew
+    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
+	export LDFLAGS="-L/usr/local/opt/libomp/lib"
+	export CPPFLAGS="-I/usr/local/opt/libomp/include"
 fi
 
 # Build flags
@@ -118,12 +122,16 @@ elif [ ${BUILD_OS} == "Linux" ]; then
     ) # JP 2021 Mar 21: SuSE lacks eccodes
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
-        llvm@18 libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
+        llvm libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
+        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
       # GD added dylibbundler that simplify building correct apps.
+	  # GD 25/04/2025 do not use this gcc for compilation. Do as mantioned by homebrew for libomp 
+	  # "For compilers to find libomp you may need to set:"
+	  # "  export LDFLAGS="-L/usr/local/opt/libomp/lib"  "
+	  # " export CPPFLAGS="-I/usr/local/opt/libomp/include"  "
 else
     log "Fatal error! Unknown OS: ${BUILD_OS}. This script only supports one of: Windows, Linux, macOS."
     exit 1
@@ -434,14 +442,10 @@ function configure_gdl {
     if [[ ${BUILD_OS} == "macOS" ]]; then
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline" )
         else
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
-            CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
-                                    "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"
-                                    "-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang" )
+            CMAKE_ADDITIONAL_ARGS=( "-DOPENMP=ON -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline" )
         fi
     fi
 

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,12 +439,17 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=\"-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include\" -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+			OMP_PREPROC='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include'
+			READLINE_DIR='/opt/homebrew/opt/readline'
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")
+			OMP_PREPROC='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include'
+			READLINE_DIR='/usr/local/opt/readline'
         fi
-    fi
+        CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF"
+								"-DREADLINEDIR=${READLINE_DIR}"
+								"-DOpenMP_CXX_FLAGS=${OMP_PREPROC}")
+   fi
 
 #    if [[ ${BUILD_OS} != "macOS" ]]; then
 #        CMAKE_QHULLDIR_OPT="-DQHULLDIR="${ROOT_DIR}"/qhull-2020.2"
@@ -460,7 +465,7 @@ function configure_gdl {
     cmake ${GDL_DIR} -G"${GENERATOR}" \
         -DCMAKE_BUILD_TYPE=${Configuration} \
         -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
-        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DOPENMP=${WITH_OPENMP} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
         -DWXWIDGETS=${WITH_WXWIDGETS} -DX11={WITH_X11} -DGRAPHICSMAGICK=${WITH_GRAPHICSMAGICK} \
         -DNETCDF=${WITH_NETCDF} -DHDF=${WITH_HDF4} -DHDF5=${WITH_HDF5} \
         -DMPI=${WITH_MPI} -DTIFF=${WITH_TIFF} -DGEOTIFF=${WITH_GEOTIFF} \

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -439,7 +439,7 @@ function configure_gdl {
         if [[ ${Platform} == "arm64" ]]; then
 	# suggested by homebrew
 	        LDFLAGS="-L/opt/homebrew/opt/libomp/lib -lomp"
-            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS=\"-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include\" -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
+            CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline") 
         else
 	        LDFLAGS="-L/usr/local/opt/libomp/lib -lomp"
             CMAKE_ADDITIONAL_ARGS=( "-DOpenMP_CXX_FLAGS='-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include' -DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline")

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -428,11 +428,11 @@ void GDLLexer::mSTRING(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop309;
+			goto _loop324;
 		}
 		
 	}
-	_loop309:;
+	_loop324:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1174,10 +1174,10 @@ void GDLLexer::mEOL(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{
-	bool synPredMatched361 = false;
+	bool synPredMatched376 = false;
 	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true) && (true))) {
-		int _m361 = mark();
-		synPredMatched361 = true;
+		int _m376 = mark();
+		synPredMatched376 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -1185,12 +1185,12 @@ void GDLLexer::mEOL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched361 = false;
+			synPredMatched376 = false;
 		}
-		rewind(_m361);
+		rewind(_m376);
 		inputState->guessing--;
 	}
-	if ( synPredMatched361 ) {
+	if ( synPredMatched376 ) {
 		match("\r\n");
 	}
 	else if ((LA(1) == 0xa /* '\n' */ )) {
@@ -1441,18 +1441,18 @@ void GDLLexer::mEXP(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt379=0;
+		int _cnt394=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt379>=1 ) { goto _loop379; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt394>=1 ) { goto _loop394; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt379++;
+			_cnt394++;
 		}
-		_loop379:;
+		_loop394:;
 		}  // ( ... )+
 	}
 	else {
@@ -1526,18 +1526,18 @@ void GDLLexer::mDBL(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt386=0;
+		int _cnt401=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt386>=1 ) { goto _loop386; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt401>=1 ) { goto _loop401; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt386++;
+			_cnt401++;
 		}
-		_loop386:;
+		_loop401:;
 		}  // ( ... )+
 	}
 	else {
@@ -1987,27 +1987,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_ttype = CONSTANT_OR_STRING_LITERAL;
 	std::string::size_type _saveIndex;
 	
-	bool synPredMatched461 = false;
+	bool synPredMatched476 = false;
 	if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))) && (_tokenSet_6.member(LA(4))))) {
-		int _m461 = mark();
-		synPredMatched461 = true;
+		int _m476 = mark();
+		synPredMatched476 = true;
 		inputState->guessing++;
 		try {
 			{
 			match('\'' /* charlit */ );
 			{ // ( ... )+
-			int _cnt459=0;
+			int _cnt474=0;
 			for (;;) {
 				if ((_tokenSet_4.member(LA(1)))) {
 					mH(false);
 				}
 				else {
-					if ( _cnt459>=1 ) { goto _loop459; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt474>=1 ) { goto _loop474; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt459++;
+				_cnt474++;
 			}
-			_loop459:;
+			_loop474:;
 			}  // ( ... )+
 			match('\'' /* charlit */ );
 			{
@@ -2043,29 +2043,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched461 = false;
+			synPredMatched476 = false;
 		}
-		rewind(_m461);
+		rewind(_m476);
 		inputState->guessing--;
 	}
-	if ( synPredMatched461 ) {
+	if ( synPredMatched476 ) {
 		{
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
 		text.erase(_saveIndex);
 		{ // ( ... )+
-		int _cnt464=0;
+		int _cnt479=0;
 		for (;;) {
 			if ((_tokenSet_4.member(LA(1)))) {
 				mH(false);
 			}
 			else {
-				if ( _cnt464>=1 ) { goto _loop464; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt479>=1 ) { goto _loop479; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt464++;
+			_cnt479++;
 		}
-		_loop464:;
+		_loop479:;
 		}  // ( ... )+
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
@@ -2162,27 +2162,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 		}
 	}
 	else {
-		bool synPredMatched470 = false;
+		bool synPredMatched485 = false;
 		if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_7.member(LA(3))) && (_tokenSet_8.member(LA(4))))) {
-			int _m470 = mark();
-			synPredMatched470 = true;
+			int _m485 = mark();
+			synPredMatched485 = true;
 			inputState->guessing++;
 			try {
 				{
 				match('\'' /* charlit */ );
 				{ // ( ... )+
-				int _cnt468=0;
+				int _cnt483=0;
 				for (;;) {
 					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 						mO(false);
 					}
 					else {
-						if ( _cnt468>=1 ) { goto _loop468; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt483>=1 ) { goto _loop483; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt468++;
+					_cnt483++;
 				}
-				_loop468:;
+				_loop483:;
 				}  // ( ... )+
 				match('\'' /* charlit */ );
 				{
@@ -2209,29 +2209,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched470 = false;
+				synPredMatched485 = false;
 			}
-			rewind(_m470);
+			rewind(_m485);
 			inputState->guessing--;
 		}
-		if ( synPredMatched470 ) {
+		if ( synPredMatched485 ) {
 			{
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt473=0;
+			int _cnt488=0;
 			for (;;) {
 				if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 					mO(false);
 				}
 				else {
-					if ( _cnt473>=1 ) { goto _loop473; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt488>=1 ) { goto _loop488; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt473++;
+				_cnt488++;
 			}
-			_loop473:;
+			_loop488:;
 			}  // ( ... )+
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
@@ -2328,27 +2328,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		else {
-			bool synPredMatched479 = false;
+			bool synPredMatched494 = false;
 			if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (_tokenSet_9.member(LA(4))))) {
-				int _m479 = mark();
-				synPredMatched479 = true;
+				int _m494 = mark();
+				synPredMatched494 = true;
 				inputState->guessing++;
 				try {
 					{
 					match('\'' /* charlit */ );
 					{ // ( ... )+
-					int _cnt477=0;
+					int _cnt492=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt477>=1 ) { goto _loop477; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt492>=1 ) { goto _loop492; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt477++;
+						_cnt492++;
 					}
-					_loop477:;
+					_loop492:;
 					}  // ( ... )+
 					match('\'' /* charlit */ );
 					{
@@ -2375,29 +2375,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched479 = false;
+					synPredMatched494 = false;
 				}
-				rewind(_m479);
+				rewind(_m494);
 				inputState->guessing--;
 			}
-			if ( synPredMatched479 ) {
+			if ( synPredMatched494 ) {
 				{
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				{ // ( ... )+
-				int _cnt482=0;
+				int _cnt497=0;
 				for (;;) {
 					if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 						mB(false);
 					}
 					else {
-						if ( _cnt482>=1 ) { goto _loop482; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt482++;
+					_cnt497++;
 				}
-				_loop482:;
+				_loop497:;
 				}  // ( ... )+
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
@@ -2494,27 +2494,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			else {
-				bool synPredMatched443 = false;
+				bool synPredMatched458 = false;
 				if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (true))) {
-					int _m443 = mark();
-					synPredMatched443 = true;
+					int _m458 = mark();
+					synPredMatched458 = true;
 					inputState->guessing++;
 					try {
 						{
 						match("0b");
 						{ // ( ... )+
-						int _cnt441=0;
+						int _cnt456=0;
 						for (;;) {
 							if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 								mB(false);
 							}
 							else {
-								if ( _cnt441>=1 ) { goto _loop441; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt456>=1 ) { goto _loop456; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt441++;
+							_cnt456++;
 						}
-						_loop441:;
+						_loop456:;
 						}  // ( ... )+
 						{
 						switch ( LA(1)) {
@@ -2557,29 +2557,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched443 = false;
+						synPredMatched458 = false;
 					}
-					rewind(_m443);
+					rewind(_m458);
 					inputState->guessing--;
 				}
-				if ( synPredMatched443 ) {
+				if ( synPredMatched458 ) {
 					{
 					_saveIndex = text.length();
 					match("0b");
 					text.erase(_saveIndex);
 					{ // ( ... )+
-					int _cnt446=0;
+					int _cnt461=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt446>=1 ) { goto _loop446; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt461>=1 ) { goto _loop461; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt446++;
+						_cnt461++;
 					}
-					_loop446:;
+					_loop461:;
 					}  // ( ... )+
 					if ( inputState->guessing==0 ) {
 						_ttype=CONSTANT_BIN_I;
@@ -2670,27 +2670,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				else {
-					bool synPredMatched425 = false;
+					bool synPredMatched440 = false;
 					if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x78 /* 'x' */ ))) {
-						int _m425 = mark();
-						synPredMatched425 = true;
+						int _m440 = mark();
+						synPredMatched440 = true;
 						inputState->guessing++;
 						try {
 							{
 							match("0x");
 							{ // ( ... )+
-							int _cnt423=0;
+							int _cnt438=0;
 							for (;;) {
 								if ((_tokenSet_4.member(LA(1)))) {
 									mH(false);
 								}
 								else {
-									if ( _cnt423>=1 ) { goto _loop423; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt438>=1 ) { goto _loop438; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt423++;
+								_cnt438++;
 							}
-							_loop423:;
+							_loop438:;
 							}  // ( ... )+
 							{
 							switch ( LA(1)) {
@@ -2717,29 +2717,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched425 = false;
+							synPredMatched440 = false;
 						}
-						rewind(_m425);
+						rewind(_m440);
 						inputState->guessing--;
 					}
-					if ( synPredMatched425 ) {
+					if ( synPredMatched440 ) {
 						{
 						_saveIndex = text.length();
 						match("0x");
 						text.erase(_saveIndex);
 						{ // ( ... )+
-						int _cnt428=0;
+						int _cnt443=0;
 						for (;;) {
 							if ((_tokenSet_4.member(LA(1)))) {
 								mH(false);
 							}
 							else {
-								if ( _cnt428>=1 ) { goto _loop428; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt443>=1 ) { goto _loop443; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt428++;
+							_cnt443++;
 						}
-						_loop428:;
+						_loop443:;
 						}  // ( ... )+
 						if ( inputState->guessing==0 ) {
 							_ttype=CONSTANT_HEX_I;
@@ -2816,27 +2816,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					else {
-						bool synPredMatched434 = false;
+						bool synPredMatched449 = false;
 						if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x6f /* 'o' */ ))) {
-							int _m434 = mark();
-							synPredMatched434 = true;
+							int _m449 = mark();
+							synPredMatched449 = true;
 							inputState->guessing++;
 							try {
 								{
 								match("0o");
 								{ // ( ... )+
-								int _cnt432=0;
+								int _cnt447=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt432>=1 ) { goto _loop432; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt447>=1 ) { goto _loop447; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt432++;
+									_cnt447++;
 								}
-								_loop432:;
+								_loop447:;
 								}  // ( ... )+
 								{
 								switch ( LA(1)) {
@@ -2879,29 +2879,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched434 = false;
+								synPredMatched449 = false;
 							}
-							rewind(_m434);
+							rewind(_m449);
 							inputState->guessing--;
 						}
-						if ( synPredMatched434 ) {
+						if ( synPredMatched449 ) {
 							{
 							_saveIndex = text.length();
 							match("0o");
 							text.erase(_saveIndex);
 							{ // ( ... )+
-							int _cnt437=0;
+							int _cnt452=0;
 							for (;;) {
 								if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 									mO(false);
 								}
 								else {
-									if ( _cnt437>=1 ) { goto _loop437; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt452>=1 ) { goto _loop452; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt437++;
+								_cnt452++;
 							}
-							_loop437:;
+							_loop452:;
 							}  // ( ... )+
 							if ( inputState->guessing==0 ) {
 								_ttype=CONSTANT_OCT_I;
@@ -2992,27 +2992,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						else {
-							bool synPredMatched452 = false;
+							bool synPredMatched467 = false;
 							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true) && (true))) {
-								int _m452 = mark();
-								synPredMatched452 = true;
+								int _m467 = mark();
+								synPredMatched467 = true;
 								inputState->guessing++;
 								try {
 									{
 									match('\"' /* charlit */ );
 									{ // ( ... )+
-									int _cnt450=0;
+									int _cnt465=0;
 									for (;;) {
 										if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 											mO(false);
 										}
 										else {
-											if ( _cnt450>=1 ) { goto _loop450; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+											if ( _cnt465>=1 ) { goto _loop465; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 										}
 										
-										_cnt450++;
+										_cnt465++;
 									}
-									_loop450:;
+									_loop465:;
 									}  // ( ... )+
 									{
 									switch ( LA(1)) {
@@ -3060,29 +3060,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched452 = false;
+									synPredMatched467 = false;
 								}
-								rewind(_m452);
+								rewind(_m467);
 								inputState->guessing--;
 							}
-							if ( synPredMatched452 ) {
+							if ( synPredMatched467 ) {
 								{
 								_saveIndex = text.length();
 								match('\"' /* charlit */ );
 								text.erase(_saveIndex);
 								{ // ( ... )+
-								int _cnt455=0;
+								int _cnt470=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt455>=1 ) { goto _loop455; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt470>=1 ) { goto _loop470; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt455++;
+									_cnt470++;
 								}
-								_loop455:;
+								_loop470:;
 								}  // ( ... )+
 								if ( inputState->guessing==0 ) {
 									_ttype=CONSTANT_OCT_I;
@@ -3183,10 +3183,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							else {
-								bool synPredMatched503 = false;
+								bool synPredMatched518 = false;
 								if (((_tokenSet_10.member(LA(1))) && (_tokenSet_11.member(LA(2))) && (true) && (true))) {
-									int _m503 = mark();
-									synPredMatched503 = true;
+									int _m518 = mark();
+									synPredMatched518 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -3204,18 +3204,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt495=0;
+											int _cnt510=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt495>=1 ) { goto _loop495; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt510>=1 ) { goto _loop510; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt495++;
+												_cnt510++;
 											}
-											_loop495:;
+											_loop510:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3233,11 +3233,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop498;
+														goto _loop513;
 													}
 													
 												}
-												_loop498:;
+												_loop513:;
 												} // ( ... )*
 												{
 												mDBL(false);
@@ -3257,18 +3257,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt501=0;
+											int _cnt516=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt501>=1 ) { goto _loop501; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt516>=1 ) { goto _loop516; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt501++;
+												_cnt516++;
 											}
-											_loop501:;
+											_loop516:;
 											}  // ( ... )+
 											{
 											mDBL(false);
@@ -3283,12 +3283,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched503 = false;
+										synPredMatched518 = false;
 									}
-									rewind(_m503);
+									rewind(_m518);
 									inputState->guessing--;
 								}
-								if ( synPredMatched503 ) {
+								if ( synPredMatched518 ) {
 									{
 									switch ( LA(1)) {
 									case 0x30 /* '0' */ :
@@ -3304,18 +3304,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										{
 										{ // ( ... )+
-										int _cnt507=0;
+										int _cnt522=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt507>=1 ) { goto _loop507; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt522>=1 ) { goto _loop522; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt507++;
+											_cnt522++;
 										}
-										_loop507:;
+										_loop522:;
 										}  // ( ... )+
 										{
 										switch ( LA(1)) {
@@ -3333,11 +3333,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 													mD(false);
 												}
 												else {
-													goto _loop510;
+													goto _loop525;
 												}
 												
 											}
-											_loop510:;
+											_loop525:;
 											} // ( ... )*
 											{
 											mDBL(false);
@@ -3357,18 +3357,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										match('.' /* charlit */ );
 										{ // ( ... )+
-										int _cnt513=0;
+										int _cnt528=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt513>=1 ) { goto _loop513; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt528>=1 ) { goto _loop528; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt513++;
+											_cnt528++;
 										}
-										_loop513:;
+										_loop528:;
 										}  // ( ... )+
 										{
 										mDBL(false);
@@ -3414,10 +3414,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								else {
-									bool synPredMatched528 = false;
+									bool synPredMatched543 = false;
 									if (((_tokenSet_10.member(LA(1))) && (_tokenSet_12.member(LA(2))) && (true) && (true))) {
-										int _m528 = mark();
-										synPredMatched528 = true;
+										int _m543 = mark();
+										synPredMatched543 = true;
 										inputState->guessing++;
 										try {
 											{
@@ -3435,18 +3435,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												{
 												{ // ( ... )+
-												int _cnt520=0;
+												int _cnt535=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt520>=1 ) { goto _loop520; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt535>=1 ) { goto _loop535; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt520++;
+													_cnt535++;
 												}
-												_loop520:;
+												_loop535:;
 												}  // ( ... )+
 												{
 												switch ( LA(1)) {
@@ -3464,11 +3464,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 															mD(false);
 														}
 														else {
-															goto _loop523;
+															goto _loop538;
 														}
 														
 													}
-													_loop523:;
+													_loop538:;
 													} // ( ... )*
 													{
 													if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3493,18 +3493,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												match('.' /* charlit */ );
 												{ // ( ... )+
-												int _cnt526=0;
+												int _cnt541=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt526>=1 ) { goto _loop526; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt541>=1 ) { goto _loop541; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt526++;
+													_cnt541++;
 												}
-												_loop526:;
+												_loop541:;
 												}  // ( ... )+
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3524,12 +3524,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											}
 										}
 										catch (antlr::RecognitionException& pe) {
-											synPredMatched528 = false;
+											synPredMatched543 = false;
 										}
-										rewind(_m528);
+										rewind(_m543);
 										inputState->guessing--;
 									}
-									if ( synPredMatched528 ) {
+									if ( synPredMatched543 ) {
 										{
 										switch ( LA(1)) {
 										case 0x30 /* '0' */ :
@@ -3545,18 +3545,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt532=0;
+											int _cnt547=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt532>=1 ) { goto _loop532; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt547>=1 ) { goto _loop547; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt532++;
+												_cnt547++;
 											}
-											_loop532:;
+											_loop547:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3574,11 +3574,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop535;
+														goto _loop550;
 													}
 													
 												}
-												_loop535:;
+												_loop550:;
 												} // ( ... )*
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3603,18 +3603,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt538=0;
+											int _cnt553=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt538>=1 ) { goto _loop538; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt553>=1 ) { goto _loop553; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt538++;
+												_cnt553++;
 											}
-											_loop538:;
+											_loop553:;
 											}  // ( ... )+
 											{
 											if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3682,11 +3682,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop486;
+												goto _loop501;
 											}
 											
 										}
-										_loop486:;
+										_loop501:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x22 /* '\"' */ )) {
@@ -3720,11 +3720,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop490;
+												goto _loop505;
 											}
 											
 										}
-										_loop490:;
+										_loop505:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x27 /* '\'' */ )) {
@@ -3748,18 +3748,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true) && (true)) {
 										{ // ( ... )+
-										int _cnt543=0;
+										int _cnt558=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt543>=1 ) { goto _loop543; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt558>=1 ) { goto _loop558; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt543++;
+											_cnt558++;
 										}
-										_loop543:;
+										_loop558:;
 										}  // ( ... )+
 										if ( inputState->guessing==0 ) {
 											_ttype=CONSTANT_I;
@@ -3904,11 +3904,11 @@ void GDLLexer::mCOMMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop549;
+			goto _loop564;
 		}
 		
 	}
-	_loop549:;
+	_loop564:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -3984,11 +3984,11 @@ void GDLLexer::mIDENTIFIER(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop553;
+			goto _loop568;
 		}
 		}
 	}
-	_loop553:;
+	_loop568:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		
@@ -4014,7 +4014,7 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 	match('!' /* charlit */ );
 	}
 	{ // ( ... )+
-	int _cnt557=0;
+	int _cnt572=0;
 	for (;;) {
 		switch ( LA(1)) {
 		case 0x5f /* '_' */ :
@@ -4069,12 +4069,12 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 		}
 		default:
 		{
-			if ( _cnt557>=1 ) { goto _loop557; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt572>=1 ) { goto _loop572; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		}
-		_cnt557++;
+		_cnt572++;
 	}
-	_loop557:;
+	_loop572:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		
@@ -4113,18 +4113,18 @@ void GDLLexer::mWHITESPACE(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt561=0;
+	int _cnt576=0;
 	for (;;) {
 		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
 			mW(false);
 		}
 		else {
-			if ( _cnt561>=1 ) { goto _loop561; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt576>=1 ) { goto _loop576; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt561++;
+		_cnt576++;
 	}
-	_loop561:;
+	_loop576:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -4165,11 +4165,11 @@ void GDLLexer::mSKIP_LINES(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop564;
+			goto _loop579;
 		}
 		}
 	}
-	_loop564:;
+	_loop579:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -4193,11 +4193,11 @@ void GDLLexer::mCONT_STATEMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop568;
+			goto _loop583;
 		}
 		
 	}
-	_loop568:;
+	_loop583:;
 	} // ( ... )*
 	mEOL(false);
 	mSKIP_LINES(false);

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -428,11 +428,11 @@ void GDLLexer::mSTRING(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop327;
+			goto _loop329;
 		}
 		
 	}
-	_loop327:;
+	_loop329:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1174,10 +1174,10 @@ void GDLLexer::mEOL(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{
-	bool synPredMatched379 = false;
+	bool synPredMatched381 = false;
 	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true) && (true))) {
-		int _m379 = mark();
-		synPredMatched379 = true;
+		int _m381 = mark();
+		synPredMatched381 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -1185,12 +1185,12 @@ void GDLLexer::mEOL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched379 = false;
+			synPredMatched381 = false;
 		}
-		rewind(_m379);
+		rewind(_m381);
 		inputState->guessing--;
 	}
-	if ( synPredMatched379 ) {
+	if ( synPredMatched381 ) {
 		match("\r\n");
 	}
 	else if ((LA(1) == 0xa /* '\n' */ )) {
@@ -1441,18 +1441,18 @@ void GDLLexer::mEXP(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt397=0;
+		int _cnt399=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt397>=1 ) { goto _loop397; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt399>=1 ) { goto _loop399; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt397++;
+			_cnt399++;
 		}
-		_loop397:;
+		_loop399:;
 		}  // ( ... )+
 	}
 	else {
@@ -1526,18 +1526,18 @@ void GDLLexer::mDBL(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt404=0;
+		int _cnt406=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt404>=1 ) { goto _loop404; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt406>=1 ) { goto _loop406; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt404++;
+			_cnt406++;
 		}
-		_loop404:;
+		_loop406:;
 		}  // ( ... )+
 	}
 	else {
@@ -1987,27 +1987,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_ttype = CONSTANT_OR_STRING_LITERAL;
 	std::string::size_type _saveIndex;
 	
-	bool synPredMatched479 = false;
+	bool synPredMatched481 = false;
 	if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))) && (_tokenSet_6.member(LA(4))))) {
-		int _m479 = mark();
-		synPredMatched479 = true;
+		int _m481 = mark();
+		synPredMatched481 = true;
 		inputState->guessing++;
 		try {
 			{
 			match('\'' /* charlit */ );
 			{ // ( ... )+
-			int _cnt477=0;
+			int _cnt479=0;
 			for (;;) {
 				if ((_tokenSet_4.member(LA(1)))) {
 					mH(false);
 				}
 				else {
-					if ( _cnt477>=1 ) { goto _loop477; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt479>=1 ) { goto _loop479; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt477++;
+				_cnt479++;
 			}
-			_loop477:;
+			_loop479:;
 			}  // ( ... )+
 			match('\'' /* charlit */ );
 			{
@@ -2043,29 +2043,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched479 = false;
+			synPredMatched481 = false;
 		}
-		rewind(_m479);
+		rewind(_m481);
 		inputState->guessing--;
 	}
-	if ( synPredMatched479 ) {
+	if ( synPredMatched481 ) {
 		{
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
 		text.erase(_saveIndex);
 		{ // ( ... )+
-		int _cnt482=0;
+		int _cnt484=0;
 		for (;;) {
 			if ((_tokenSet_4.member(LA(1)))) {
 				mH(false);
 			}
 			else {
-				if ( _cnt482>=1 ) { goto _loop482; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt484>=1 ) { goto _loop484; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt482++;
+			_cnt484++;
 		}
-		_loop482:;
+		_loop484:;
 		}  // ( ... )+
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
@@ -2162,27 +2162,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 		}
 	}
 	else {
-		bool synPredMatched488 = false;
+		bool synPredMatched490 = false;
 		if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_7.member(LA(3))) && (_tokenSet_8.member(LA(4))))) {
-			int _m488 = mark();
-			synPredMatched488 = true;
+			int _m490 = mark();
+			synPredMatched490 = true;
 			inputState->guessing++;
 			try {
 				{
 				match('\'' /* charlit */ );
 				{ // ( ... )+
-				int _cnt486=0;
+				int _cnt488=0;
 				for (;;) {
 					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 						mO(false);
 					}
 					else {
-						if ( _cnt486>=1 ) { goto _loop486; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt488>=1 ) { goto _loop488; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt486++;
+					_cnt488++;
 				}
-				_loop486:;
+				_loop488:;
 				}  // ( ... )+
 				match('\'' /* charlit */ );
 				{
@@ -2209,29 +2209,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched488 = false;
+				synPredMatched490 = false;
 			}
-			rewind(_m488);
+			rewind(_m490);
 			inputState->guessing--;
 		}
-		if ( synPredMatched488 ) {
+		if ( synPredMatched490 ) {
 			{
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt491=0;
+			int _cnt493=0;
 			for (;;) {
 				if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 					mO(false);
 				}
 				else {
-					if ( _cnt491>=1 ) { goto _loop491; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt493>=1 ) { goto _loop493; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt491++;
+				_cnt493++;
 			}
-			_loop491:;
+			_loop493:;
 			}  // ( ... )+
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
@@ -2328,27 +2328,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		else {
-			bool synPredMatched497 = false;
+			bool synPredMatched499 = false;
 			if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (_tokenSet_9.member(LA(4))))) {
-				int _m497 = mark();
-				synPredMatched497 = true;
+				int _m499 = mark();
+				synPredMatched499 = true;
 				inputState->guessing++;
 				try {
 					{
 					match('\'' /* charlit */ );
 					{ // ( ... )+
-					int _cnt495=0;
+					int _cnt497=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt495>=1 ) { goto _loop495; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt495++;
+						_cnt497++;
 					}
-					_loop495:;
+					_loop497:;
 					}  // ( ... )+
 					match('\'' /* charlit */ );
 					{
@@ -2375,29 +2375,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched497 = false;
+					synPredMatched499 = false;
 				}
-				rewind(_m497);
+				rewind(_m499);
 				inputState->guessing--;
 			}
-			if ( synPredMatched497 ) {
+			if ( synPredMatched499 ) {
 				{
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				{ // ( ... )+
-				int _cnt500=0;
+				int _cnt502=0;
 				for (;;) {
 					if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 						mB(false);
 					}
 					else {
-						if ( _cnt500>=1 ) { goto _loop500; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt502>=1 ) { goto _loop502; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt500++;
+					_cnt502++;
 				}
-				_loop500:;
+				_loop502:;
 				}  // ( ... )+
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
@@ -2494,27 +2494,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			else {
-				bool synPredMatched461 = false;
+				bool synPredMatched463 = false;
 				if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (true))) {
-					int _m461 = mark();
-					synPredMatched461 = true;
+					int _m463 = mark();
+					synPredMatched463 = true;
 					inputState->guessing++;
 					try {
 						{
 						match("0b");
 						{ // ( ... )+
-						int _cnt459=0;
+						int _cnt461=0;
 						for (;;) {
 							if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 								mB(false);
 							}
 							else {
-								if ( _cnt459>=1 ) { goto _loop459; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt461>=1 ) { goto _loop461; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt459++;
+							_cnt461++;
 						}
-						_loop459:;
+						_loop461:;
 						}  // ( ... )+
 						{
 						switch ( LA(1)) {
@@ -2557,29 +2557,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched461 = false;
+						synPredMatched463 = false;
 					}
-					rewind(_m461);
+					rewind(_m463);
 					inputState->guessing--;
 				}
-				if ( synPredMatched461 ) {
+				if ( synPredMatched463 ) {
 					{
 					_saveIndex = text.length();
 					match("0b");
 					text.erase(_saveIndex);
 					{ // ( ... )+
-					int _cnt464=0;
+					int _cnt466=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt464>=1 ) { goto _loop464; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt466>=1 ) { goto _loop466; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt464++;
+						_cnt466++;
 					}
-					_loop464:;
+					_loop466:;
 					}  // ( ... )+
 					if ( inputState->guessing==0 ) {
 						_ttype=CONSTANT_BIN_I;
@@ -2670,27 +2670,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				else {
-					bool synPredMatched443 = false;
+					bool synPredMatched445 = false;
 					if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x78 /* 'x' */ ))) {
-						int _m443 = mark();
-						synPredMatched443 = true;
+						int _m445 = mark();
+						synPredMatched445 = true;
 						inputState->guessing++;
 						try {
 							{
 							match("0x");
 							{ // ( ... )+
-							int _cnt441=0;
+							int _cnt443=0;
 							for (;;) {
 								if ((_tokenSet_4.member(LA(1)))) {
 									mH(false);
 								}
 								else {
-									if ( _cnt441>=1 ) { goto _loop441; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt443>=1 ) { goto _loop443; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt441++;
+								_cnt443++;
 							}
-							_loop441:;
+							_loop443:;
 							}  // ( ... )+
 							{
 							switch ( LA(1)) {
@@ -2717,29 +2717,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched443 = false;
+							synPredMatched445 = false;
 						}
-						rewind(_m443);
+						rewind(_m445);
 						inputState->guessing--;
 					}
-					if ( synPredMatched443 ) {
+					if ( synPredMatched445 ) {
 						{
 						_saveIndex = text.length();
 						match("0x");
 						text.erase(_saveIndex);
 						{ // ( ... )+
-						int _cnt446=0;
+						int _cnt448=0;
 						for (;;) {
 							if ((_tokenSet_4.member(LA(1)))) {
 								mH(false);
 							}
 							else {
-								if ( _cnt446>=1 ) { goto _loop446; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt448>=1 ) { goto _loop448; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt446++;
+							_cnt448++;
 						}
-						_loop446:;
+						_loop448:;
 						}  // ( ... )+
 						if ( inputState->guessing==0 ) {
 							_ttype=CONSTANT_HEX_I;
@@ -2816,27 +2816,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					else {
-						bool synPredMatched452 = false;
+						bool synPredMatched454 = false;
 						if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x6f /* 'o' */ ))) {
-							int _m452 = mark();
-							synPredMatched452 = true;
+							int _m454 = mark();
+							synPredMatched454 = true;
 							inputState->guessing++;
 							try {
 								{
 								match("0o");
 								{ // ( ... )+
-								int _cnt450=0;
+								int _cnt452=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt450>=1 ) { goto _loop450; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt452>=1 ) { goto _loop452; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt450++;
+									_cnt452++;
 								}
-								_loop450:;
+								_loop452:;
 								}  // ( ... )+
 								{
 								switch ( LA(1)) {
@@ -2879,29 +2879,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched452 = false;
+								synPredMatched454 = false;
 							}
-							rewind(_m452);
+							rewind(_m454);
 							inputState->guessing--;
 						}
-						if ( synPredMatched452 ) {
+						if ( synPredMatched454 ) {
 							{
 							_saveIndex = text.length();
 							match("0o");
 							text.erase(_saveIndex);
 							{ // ( ... )+
-							int _cnt455=0;
+							int _cnt457=0;
 							for (;;) {
 								if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 									mO(false);
 								}
 								else {
-									if ( _cnt455>=1 ) { goto _loop455; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt457>=1 ) { goto _loop457; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt455++;
+								_cnt457++;
 							}
-							_loop455:;
+							_loop457:;
 							}  // ( ... )+
 							if ( inputState->guessing==0 ) {
 								_ttype=CONSTANT_OCT_I;
@@ -2992,27 +2992,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						else {
-							bool synPredMatched470 = false;
+							bool synPredMatched472 = false;
 							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true) && (true))) {
-								int _m470 = mark();
-								synPredMatched470 = true;
+								int _m472 = mark();
+								synPredMatched472 = true;
 								inputState->guessing++;
 								try {
 									{
 									match('\"' /* charlit */ );
 									{ // ( ... )+
-									int _cnt468=0;
+									int _cnt470=0;
 									for (;;) {
 										if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 											mO(false);
 										}
 										else {
-											if ( _cnt468>=1 ) { goto _loop468; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+											if ( _cnt470>=1 ) { goto _loop470; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 										}
 										
-										_cnt468++;
+										_cnt470++;
 									}
-									_loop468:;
+									_loop470:;
 									}  // ( ... )+
 									{
 									switch ( LA(1)) {
@@ -3060,29 +3060,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched470 = false;
+									synPredMatched472 = false;
 								}
-								rewind(_m470);
+								rewind(_m472);
 								inputState->guessing--;
 							}
-							if ( synPredMatched470 ) {
+							if ( synPredMatched472 ) {
 								{
 								_saveIndex = text.length();
 								match('\"' /* charlit */ );
 								text.erase(_saveIndex);
 								{ // ( ... )+
-								int _cnt473=0;
+								int _cnt475=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt473>=1 ) { goto _loop473; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt475>=1 ) { goto _loop475; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt473++;
+									_cnt475++;
 								}
-								_loop473:;
+								_loop475:;
 								}  // ( ... )+
 								if ( inputState->guessing==0 ) {
 									_ttype=CONSTANT_OCT_I;
@@ -3183,10 +3183,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							else {
-								bool synPredMatched521 = false;
+								bool synPredMatched523 = false;
 								if (((_tokenSet_10.member(LA(1))) && (_tokenSet_11.member(LA(2))) && (true) && (true))) {
-									int _m521 = mark();
-									synPredMatched521 = true;
+									int _m523 = mark();
+									synPredMatched523 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -3204,18 +3204,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt513=0;
+											int _cnt515=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt513>=1 ) { goto _loop513; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt515>=1 ) { goto _loop515; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt513++;
+												_cnt515++;
 											}
-											_loop513:;
+											_loop515:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3233,11 +3233,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop516;
+														goto _loop518;
 													}
 													
 												}
-												_loop516:;
+												_loop518:;
 												} // ( ... )*
 												{
 												mDBL(false);
@@ -3257,18 +3257,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt519=0;
+											int _cnt521=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt519>=1 ) { goto _loop519; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt521>=1 ) { goto _loop521; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt519++;
+												_cnt521++;
 											}
-											_loop519:;
+											_loop521:;
 											}  // ( ... )+
 											{
 											mDBL(false);
@@ -3283,12 +3283,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched521 = false;
+										synPredMatched523 = false;
 									}
-									rewind(_m521);
+									rewind(_m523);
 									inputState->guessing--;
 								}
-								if ( synPredMatched521 ) {
+								if ( synPredMatched523 ) {
 									{
 									switch ( LA(1)) {
 									case 0x30 /* '0' */ :
@@ -3304,18 +3304,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										{
 										{ // ( ... )+
-										int _cnt525=0;
+										int _cnt527=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt525>=1 ) { goto _loop525; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt527>=1 ) { goto _loop527; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt525++;
+											_cnt527++;
 										}
-										_loop525:;
+										_loop527:;
 										}  // ( ... )+
 										{
 										switch ( LA(1)) {
@@ -3333,11 +3333,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 													mD(false);
 												}
 												else {
-													goto _loop528;
+													goto _loop530;
 												}
 												
 											}
-											_loop528:;
+											_loop530:;
 											} // ( ... )*
 											{
 											mDBL(false);
@@ -3357,18 +3357,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										match('.' /* charlit */ );
 										{ // ( ... )+
-										int _cnt531=0;
+										int _cnt533=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt531>=1 ) { goto _loop531; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt533>=1 ) { goto _loop533; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt531++;
+											_cnt533++;
 										}
-										_loop531:;
+										_loop533:;
 										}  // ( ... )+
 										{
 										mDBL(false);
@@ -3414,10 +3414,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								else {
-									bool synPredMatched546 = false;
+									bool synPredMatched548 = false;
 									if (((_tokenSet_10.member(LA(1))) && (_tokenSet_12.member(LA(2))) && (true) && (true))) {
-										int _m546 = mark();
-										synPredMatched546 = true;
+										int _m548 = mark();
+										synPredMatched548 = true;
 										inputState->guessing++;
 										try {
 											{
@@ -3435,18 +3435,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												{
 												{ // ( ... )+
-												int _cnt538=0;
+												int _cnt540=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt538>=1 ) { goto _loop538; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt540>=1 ) { goto _loop540; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt538++;
+													_cnt540++;
 												}
-												_loop538:;
+												_loop540:;
 												}  // ( ... )+
 												{
 												switch ( LA(1)) {
@@ -3464,11 +3464,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 															mD(false);
 														}
 														else {
-															goto _loop541;
+															goto _loop543;
 														}
 														
 													}
-													_loop541:;
+													_loop543:;
 													} // ( ... )*
 													{
 													if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3493,18 +3493,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												match('.' /* charlit */ );
 												{ // ( ... )+
-												int _cnt544=0;
+												int _cnt546=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt544>=1 ) { goto _loop544; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt546>=1 ) { goto _loop546; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt544++;
+													_cnt546++;
 												}
-												_loop544:;
+												_loop546:;
 												}  // ( ... )+
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3524,12 +3524,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											}
 										}
 										catch (antlr::RecognitionException& pe) {
-											synPredMatched546 = false;
+											synPredMatched548 = false;
 										}
-										rewind(_m546);
+										rewind(_m548);
 										inputState->guessing--;
 									}
-									if ( synPredMatched546 ) {
+									if ( synPredMatched548 ) {
 										{
 										switch ( LA(1)) {
 										case 0x30 /* '0' */ :
@@ -3545,18 +3545,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt550=0;
+											int _cnt552=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt550>=1 ) { goto _loop550; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt552>=1 ) { goto _loop552; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt550++;
+												_cnt552++;
 											}
-											_loop550:;
+											_loop552:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3574,11 +3574,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop553;
+														goto _loop555;
 													}
 													
 												}
-												_loop553:;
+												_loop555:;
 												} // ( ... )*
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3603,18 +3603,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt556=0;
+											int _cnt558=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt556>=1 ) { goto _loop556; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt558>=1 ) { goto _loop558; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt556++;
+												_cnt558++;
 											}
-											_loop556:;
+											_loop558:;
 											}  // ( ... )+
 											{
 											if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3682,11 +3682,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop504;
+												goto _loop506;
 											}
 											
 										}
-										_loop504:;
+										_loop506:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x22 /* '\"' */ )) {
@@ -3720,11 +3720,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop508;
+												goto _loop510;
 											}
 											
 										}
-										_loop508:;
+										_loop510:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x27 /* '\'' */ )) {
@@ -3748,18 +3748,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true) && (true)) {
 										{ // ( ... )+
-										int _cnt561=0;
+										int _cnt563=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt561>=1 ) { goto _loop561; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt563>=1 ) { goto _loop563; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt561++;
+											_cnt563++;
 										}
-										_loop561:;
+										_loop563:;
 										}  // ( ... )+
 										if ( inputState->guessing==0 ) {
 											_ttype=CONSTANT_I;
@@ -3904,11 +3904,11 @@ void GDLLexer::mCOMMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop567;
+			goto _loop569;
 		}
 		
 	}
-	_loop567:;
+	_loop569:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -3984,11 +3984,11 @@ void GDLLexer::mIDENTIFIER(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop571;
+			goto _loop573;
 		}
 		}
 	}
-	_loop571:;
+	_loop573:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		
@@ -4014,7 +4014,7 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 	match('!' /* charlit */ );
 	}
 	{ // ( ... )+
-	int _cnt575=0;
+	int _cnt577=0;
 	for (;;) {
 		switch ( LA(1)) {
 		case 0x5f /* '_' */ :
@@ -4069,12 +4069,12 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 		}
 		default:
 		{
-			if ( _cnt575>=1 ) { goto _loop575; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt577>=1 ) { goto _loop577; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		}
-		_cnt575++;
+		_cnt577++;
 	}
-	_loop575:;
+	_loop577:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		
@@ -4113,18 +4113,18 @@ void GDLLexer::mWHITESPACE(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt579=0;
+	int _cnt581=0;
 	for (;;) {
 		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
 			mW(false);
 		}
 		else {
-			if ( _cnt579>=1 ) { goto _loop579; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt581>=1 ) { goto _loop581; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt579++;
+		_cnt581++;
 	}
-	_loop579:;
+	_loop581:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -4165,11 +4165,11 @@ void GDLLexer::mSKIP_LINES(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop582;
+			goto _loop584;
 		}
 		}
 	}
-	_loop582:;
+	_loop584:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -4193,11 +4193,11 @@ void GDLLexer::mCONT_STATEMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop586;
+			goto _loop588;
 		}
 		
 	}
-	_loop586:;
+	_loop588:;
 	} // ( ... )*
 	mEOL(false);
 	mSKIP_LINES(false);

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -428,11 +428,11 @@ void GDLLexer::mSTRING(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop324;
+			goto _loop327;
 		}
 		
 	}
-	_loop324:;
+	_loop327:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1174,10 +1174,10 @@ void GDLLexer::mEOL(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{
-	bool synPredMatched376 = false;
+	bool synPredMatched379 = false;
 	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true) && (true))) {
-		int _m376 = mark();
-		synPredMatched376 = true;
+		int _m379 = mark();
+		synPredMatched379 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -1185,12 +1185,12 @@ void GDLLexer::mEOL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched376 = false;
+			synPredMatched379 = false;
 		}
-		rewind(_m376);
+		rewind(_m379);
 		inputState->guessing--;
 	}
-	if ( synPredMatched376 ) {
+	if ( synPredMatched379 ) {
 		match("\r\n");
 	}
 	else if ((LA(1) == 0xa /* '\n' */ )) {
@@ -1441,18 +1441,18 @@ void GDLLexer::mEXP(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt394=0;
+		int _cnt397=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt394>=1 ) { goto _loop394; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt397>=1 ) { goto _loop397; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt394++;
+			_cnt397++;
 		}
-		_loop394:;
+		_loop397:;
 		}  // ( ... )+
 	}
 	else {
@@ -1526,18 +1526,18 @@ void GDLLexer::mDBL(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt401=0;
+		int _cnt404=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt401>=1 ) { goto _loop401; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt404>=1 ) { goto _loop404; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt401++;
+			_cnt404++;
 		}
-		_loop401:;
+		_loop404:;
 		}  // ( ... )+
 	}
 	else {
@@ -1987,27 +1987,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_ttype = CONSTANT_OR_STRING_LITERAL;
 	std::string::size_type _saveIndex;
 	
-	bool synPredMatched476 = false;
+	bool synPredMatched479 = false;
 	if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))) && (_tokenSet_6.member(LA(4))))) {
-		int _m476 = mark();
-		synPredMatched476 = true;
+		int _m479 = mark();
+		synPredMatched479 = true;
 		inputState->guessing++;
 		try {
 			{
 			match('\'' /* charlit */ );
 			{ // ( ... )+
-			int _cnt474=0;
+			int _cnt477=0;
 			for (;;) {
 				if ((_tokenSet_4.member(LA(1)))) {
 					mH(false);
 				}
 				else {
-					if ( _cnt474>=1 ) { goto _loop474; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt477>=1 ) { goto _loop477; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt474++;
+				_cnt477++;
 			}
-			_loop474:;
+			_loop477:;
 			}  // ( ... )+
 			match('\'' /* charlit */ );
 			{
@@ -2043,29 +2043,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched476 = false;
+			synPredMatched479 = false;
 		}
-		rewind(_m476);
+		rewind(_m479);
 		inputState->guessing--;
 	}
-	if ( synPredMatched476 ) {
+	if ( synPredMatched479 ) {
 		{
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
 		text.erase(_saveIndex);
 		{ // ( ... )+
-		int _cnt479=0;
+		int _cnt482=0;
 		for (;;) {
 			if ((_tokenSet_4.member(LA(1)))) {
 				mH(false);
 			}
 			else {
-				if ( _cnt479>=1 ) { goto _loop479; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt482>=1 ) { goto _loop482; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt479++;
+			_cnt482++;
 		}
-		_loop479:;
+		_loop482:;
 		}  // ( ... )+
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
@@ -2162,27 +2162,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 		}
 	}
 	else {
-		bool synPredMatched485 = false;
+		bool synPredMatched488 = false;
 		if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_7.member(LA(3))) && (_tokenSet_8.member(LA(4))))) {
-			int _m485 = mark();
-			synPredMatched485 = true;
+			int _m488 = mark();
+			synPredMatched488 = true;
 			inputState->guessing++;
 			try {
 				{
 				match('\'' /* charlit */ );
 				{ // ( ... )+
-				int _cnt483=0;
+				int _cnt486=0;
 				for (;;) {
 					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 						mO(false);
 					}
 					else {
-						if ( _cnt483>=1 ) { goto _loop483; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt486>=1 ) { goto _loop486; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt483++;
+					_cnt486++;
 				}
-				_loop483:;
+				_loop486:;
 				}  // ( ... )+
 				match('\'' /* charlit */ );
 				{
@@ -2209,29 +2209,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched485 = false;
+				synPredMatched488 = false;
 			}
-			rewind(_m485);
+			rewind(_m488);
 			inputState->guessing--;
 		}
-		if ( synPredMatched485 ) {
+		if ( synPredMatched488 ) {
 			{
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt488=0;
+			int _cnt491=0;
 			for (;;) {
 				if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 					mO(false);
 				}
 				else {
-					if ( _cnt488>=1 ) { goto _loop488; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt491>=1 ) { goto _loop491; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt488++;
+				_cnt491++;
 			}
-			_loop488:;
+			_loop491:;
 			}  // ( ... )+
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
@@ -2328,27 +2328,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		else {
-			bool synPredMatched494 = false;
+			bool synPredMatched497 = false;
 			if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (_tokenSet_9.member(LA(4))))) {
-				int _m494 = mark();
-				synPredMatched494 = true;
+				int _m497 = mark();
+				synPredMatched497 = true;
 				inputState->guessing++;
 				try {
 					{
 					match('\'' /* charlit */ );
 					{ // ( ... )+
-					int _cnt492=0;
+					int _cnt495=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt492>=1 ) { goto _loop492; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt495>=1 ) { goto _loop495; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt492++;
+						_cnt495++;
 					}
-					_loop492:;
+					_loop495:;
 					}  // ( ... )+
 					match('\'' /* charlit */ );
 					{
@@ -2375,29 +2375,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched494 = false;
+					synPredMatched497 = false;
 				}
-				rewind(_m494);
+				rewind(_m497);
 				inputState->guessing--;
 			}
-			if ( synPredMatched494 ) {
+			if ( synPredMatched497 ) {
 				{
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				{ // ( ... )+
-				int _cnt497=0;
+				int _cnt500=0;
 				for (;;) {
 					if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 						mB(false);
 					}
 					else {
-						if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt500>=1 ) { goto _loop500; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt497++;
+					_cnt500++;
 				}
-				_loop497:;
+				_loop500:;
 				}  // ( ... )+
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
@@ -2494,27 +2494,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			else {
-				bool synPredMatched458 = false;
+				bool synPredMatched461 = false;
 				if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (true))) {
-					int _m458 = mark();
-					synPredMatched458 = true;
+					int _m461 = mark();
+					synPredMatched461 = true;
 					inputState->guessing++;
 					try {
 						{
 						match("0b");
 						{ // ( ... )+
-						int _cnt456=0;
+						int _cnt459=0;
 						for (;;) {
 							if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 								mB(false);
 							}
 							else {
-								if ( _cnt456>=1 ) { goto _loop456; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt459>=1 ) { goto _loop459; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt456++;
+							_cnt459++;
 						}
-						_loop456:;
+						_loop459:;
 						}  // ( ... )+
 						{
 						switch ( LA(1)) {
@@ -2557,29 +2557,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched458 = false;
+						synPredMatched461 = false;
 					}
-					rewind(_m458);
+					rewind(_m461);
 					inputState->guessing--;
 				}
-				if ( synPredMatched458 ) {
+				if ( synPredMatched461 ) {
 					{
 					_saveIndex = text.length();
 					match("0b");
 					text.erase(_saveIndex);
 					{ // ( ... )+
-					int _cnt461=0;
+					int _cnt464=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt461>=1 ) { goto _loop461; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt464>=1 ) { goto _loop464; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt461++;
+						_cnt464++;
 					}
-					_loop461:;
+					_loop464:;
 					}  // ( ... )+
 					if ( inputState->guessing==0 ) {
 						_ttype=CONSTANT_BIN_I;
@@ -2670,27 +2670,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				else {
-					bool synPredMatched440 = false;
+					bool synPredMatched443 = false;
 					if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x78 /* 'x' */ ))) {
-						int _m440 = mark();
-						synPredMatched440 = true;
+						int _m443 = mark();
+						synPredMatched443 = true;
 						inputState->guessing++;
 						try {
 							{
 							match("0x");
 							{ // ( ... )+
-							int _cnt438=0;
+							int _cnt441=0;
 							for (;;) {
 								if ((_tokenSet_4.member(LA(1)))) {
 									mH(false);
 								}
 								else {
-									if ( _cnt438>=1 ) { goto _loop438; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt441>=1 ) { goto _loop441; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt438++;
+								_cnt441++;
 							}
-							_loop438:;
+							_loop441:;
 							}  // ( ... )+
 							{
 							switch ( LA(1)) {
@@ -2717,29 +2717,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched440 = false;
+							synPredMatched443 = false;
 						}
-						rewind(_m440);
+						rewind(_m443);
 						inputState->guessing--;
 					}
-					if ( synPredMatched440 ) {
+					if ( synPredMatched443 ) {
 						{
 						_saveIndex = text.length();
 						match("0x");
 						text.erase(_saveIndex);
 						{ // ( ... )+
-						int _cnt443=0;
+						int _cnt446=0;
 						for (;;) {
 							if ((_tokenSet_4.member(LA(1)))) {
 								mH(false);
 							}
 							else {
-								if ( _cnt443>=1 ) { goto _loop443; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt446>=1 ) { goto _loop446; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt443++;
+							_cnt446++;
 						}
-						_loop443:;
+						_loop446:;
 						}  // ( ... )+
 						if ( inputState->guessing==0 ) {
 							_ttype=CONSTANT_HEX_I;
@@ -2816,27 +2816,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					else {
-						bool synPredMatched449 = false;
+						bool synPredMatched452 = false;
 						if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x6f /* 'o' */ ))) {
-							int _m449 = mark();
-							synPredMatched449 = true;
+							int _m452 = mark();
+							synPredMatched452 = true;
 							inputState->guessing++;
 							try {
 								{
 								match("0o");
 								{ // ( ... )+
-								int _cnt447=0;
+								int _cnt450=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt447>=1 ) { goto _loop447; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt450>=1 ) { goto _loop450; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt447++;
+									_cnt450++;
 								}
-								_loop447:;
+								_loop450:;
 								}  // ( ... )+
 								{
 								switch ( LA(1)) {
@@ -2879,29 +2879,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched449 = false;
+								synPredMatched452 = false;
 							}
-							rewind(_m449);
+							rewind(_m452);
 							inputState->guessing--;
 						}
-						if ( synPredMatched449 ) {
+						if ( synPredMatched452 ) {
 							{
 							_saveIndex = text.length();
 							match("0o");
 							text.erase(_saveIndex);
 							{ // ( ... )+
-							int _cnt452=0;
+							int _cnt455=0;
 							for (;;) {
 								if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 									mO(false);
 								}
 								else {
-									if ( _cnt452>=1 ) { goto _loop452; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt455>=1 ) { goto _loop455; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt452++;
+								_cnt455++;
 							}
-							_loop452:;
+							_loop455:;
 							}  // ( ... )+
 							if ( inputState->guessing==0 ) {
 								_ttype=CONSTANT_OCT_I;
@@ -2992,27 +2992,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						else {
-							bool synPredMatched467 = false;
+							bool synPredMatched470 = false;
 							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true) && (true))) {
-								int _m467 = mark();
-								synPredMatched467 = true;
+								int _m470 = mark();
+								synPredMatched470 = true;
 								inputState->guessing++;
 								try {
 									{
 									match('\"' /* charlit */ );
 									{ // ( ... )+
-									int _cnt465=0;
+									int _cnt468=0;
 									for (;;) {
 										if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 											mO(false);
 										}
 										else {
-											if ( _cnt465>=1 ) { goto _loop465; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+											if ( _cnt468>=1 ) { goto _loop468; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 										}
 										
-										_cnt465++;
+										_cnt468++;
 									}
-									_loop465:;
+									_loop468:;
 									}  // ( ... )+
 									{
 									switch ( LA(1)) {
@@ -3060,29 +3060,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched467 = false;
+									synPredMatched470 = false;
 								}
-								rewind(_m467);
+								rewind(_m470);
 								inputState->guessing--;
 							}
-							if ( synPredMatched467 ) {
+							if ( synPredMatched470 ) {
 								{
 								_saveIndex = text.length();
 								match('\"' /* charlit */ );
 								text.erase(_saveIndex);
 								{ // ( ... )+
-								int _cnt470=0;
+								int _cnt473=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt470>=1 ) { goto _loop470; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt473>=1 ) { goto _loop473; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt470++;
+									_cnt473++;
 								}
-								_loop470:;
+								_loop473:;
 								}  // ( ... )+
 								if ( inputState->guessing==0 ) {
 									_ttype=CONSTANT_OCT_I;
@@ -3183,10 +3183,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							else {
-								bool synPredMatched518 = false;
+								bool synPredMatched521 = false;
 								if (((_tokenSet_10.member(LA(1))) && (_tokenSet_11.member(LA(2))) && (true) && (true))) {
-									int _m518 = mark();
-									synPredMatched518 = true;
+									int _m521 = mark();
+									synPredMatched521 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -3204,18 +3204,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt510=0;
+											int _cnt513=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt510>=1 ) { goto _loop510; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt513>=1 ) { goto _loop513; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt510++;
+												_cnt513++;
 											}
-											_loop510:;
+											_loop513:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3233,11 +3233,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop513;
+														goto _loop516;
 													}
 													
 												}
-												_loop513:;
+												_loop516:;
 												} // ( ... )*
 												{
 												mDBL(false);
@@ -3257,18 +3257,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt516=0;
+											int _cnt519=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt516>=1 ) { goto _loop516; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt519>=1 ) { goto _loop519; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt516++;
+												_cnt519++;
 											}
-											_loop516:;
+											_loop519:;
 											}  // ( ... )+
 											{
 											mDBL(false);
@@ -3283,12 +3283,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched518 = false;
+										synPredMatched521 = false;
 									}
-									rewind(_m518);
+									rewind(_m521);
 									inputState->guessing--;
 								}
-								if ( synPredMatched518 ) {
+								if ( synPredMatched521 ) {
 									{
 									switch ( LA(1)) {
 									case 0x30 /* '0' */ :
@@ -3304,18 +3304,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										{
 										{ // ( ... )+
-										int _cnt522=0;
+										int _cnt525=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt522>=1 ) { goto _loop522; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt525>=1 ) { goto _loop525; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt522++;
+											_cnt525++;
 										}
-										_loop522:;
+										_loop525:;
 										}  // ( ... )+
 										{
 										switch ( LA(1)) {
@@ -3333,11 +3333,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 													mD(false);
 												}
 												else {
-													goto _loop525;
+													goto _loop528;
 												}
 												
 											}
-											_loop525:;
+											_loop528:;
 											} // ( ... )*
 											{
 											mDBL(false);
@@ -3357,18 +3357,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										match('.' /* charlit */ );
 										{ // ( ... )+
-										int _cnt528=0;
+										int _cnt531=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt528>=1 ) { goto _loop528; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt531>=1 ) { goto _loop531; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt528++;
+											_cnt531++;
 										}
-										_loop528:;
+										_loop531:;
 										}  // ( ... )+
 										{
 										mDBL(false);
@@ -3414,10 +3414,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								else {
-									bool synPredMatched543 = false;
+									bool synPredMatched546 = false;
 									if (((_tokenSet_10.member(LA(1))) && (_tokenSet_12.member(LA(2))) && (true) && (true))) {
-										int _m543 = mark();
-										synPredMatched543 = true;
+										int _m546 = mark();
+										synPredMatched546 = true;
 										inputState->guessing++;
 										try {
 											{
@@ -3435,18 +3435,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												{
 												{ // ( ... )+
-												int _cnt535=0;
+												int _cnt538=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt535>=1 ) { goto _loop535; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt538>=1 ) { goto _loop538; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt535++;
+													_cnt538++;
 												}
-												_loop535:;
+												_loop538:;
 												}  // ( ... )+
 												{
 												switch ( LA(1)) {
@@ -3464,11 +3464,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 															mD(false);
 														}
 														else {
-															goto _loop538;
+															goto _loop541;
 														}
 														
 													}
-													_loop538:;
+													_loop541:;
 													} // ( ... )*
 													{
 													if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3493,18 +3493,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												match('.' /* charlit */ );
 												{ // ( ... )+
-												int _cnt541=0;
+												int _cnt544=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt541>=1 ) { goto _loop541; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt544>=1 ) { goto _loop544; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt541++;
+													_cnt544++;
 												}
-												_loop541:;
+												_loop544:;
 												}  // ( ... )+
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3524,12 +3524,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											}
 										}
 										catch (antlr::RecognitionException& pe) {
-											synPredMatched543 = false;
+											synPredMatched546 = false;
 										}
-										rewind(_m543);
+										rewind(_m546);
 										inputState->guessing--;
 									}
-									if ( synPredMatched543 ) {
+									if ( synPredMatched546 ) {
 										{
 										switch ( LA(1)) {
 										case 0x30 /* '0' */ :
@@ -3545,18 +3545,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt547=0;
+											int _cnt550=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt547>=1 ) { goto _loop547; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt550>=1 ) { goto _loop550; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt547++;
+												_cnt550++;
 											}
-											_loop547:;
+											_loop550:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3574,11 +3574,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop550;
+														goto _loop553;
 													}
 													
 												}
-												_loop550:;
+												_loop553:;
 												} // ( ... )*
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3603,18 +3603,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt553=0;
+											int _cnt556=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt553>=1 ) { goto _loop553; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt556>=1 ) { goto _loop556; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt553++;
+												_cnt556++;
 											}
-											_loop553:;
+											_loop556:;
 											}  // ( ... )+
 											{
 											if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3682,11 +3682,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop501;
+												goto _loop504;
 											}
 											
 										}
-										_loop501:;
+										_loop504:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x22 /* '\"' */ )) {
@@ -3720,11 +3720,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop505;
+												goto _loop508;
 											}
 											
 										}
-										_loop505:;
+										_loop508:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x27 /* '\'' */ )) {
@@ -3748,18 +3748,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true) && (true)) {
 										{ // ( ... )+
-										int _cnt558=0;
+										int _cnt561=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt558>=1 ) { goto _loop558; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt561>=1 ) { goto _loop561; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt558++;
+											_cnt561++;
 										}
-										_loop558:;
+										_loop561:;
 										}  // ( ... )+
 										if ( inputState->guessing==0 ) {
 											_ttype=CONSTANT_I;
@@ -3904,11 +3904,11 @@ void GDLLexer::mCOMMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop564;
+			goto _loop567;
 		}
 		
 	}
-	_loop564:;
+	_loop567:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -3984,11 +3984,11 @@ void GDLLexer::mIDENTIFIER(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop568;
+			goto _loop571;
 		}
 		}
 	}
-	_loop568:;
+	_loop571:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		
@@ -4014,7 +4014,7 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 	match('!' /* charlit */ );
 	}
 	{ // ( ... )+
-	int _cnt572=0;
+	int _cnt575=0;
 	for (;;) {
 		switch ( LA(1)) {
 		case 0x5f /* '_' */ :
@@ -4069,12 +4069,12 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 		}
 		default:
 		{
-			if ( _cnt572>=1 ) { goto _loop572; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt575>=1 ) { goto _loop575; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		}
-		_cnt572++;
+		_cnt575++;
 	}
-	_loop572:;
+	_loop575:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		
@@ -4113,18 +4113,18 @@ void GDLLexer::mWHITESPACE(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt576=0;
+	int _cnt579=0;
 	for (;;) {
 		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
 			mW(false);
 		}
 		else {
-			if ( _cnt576>=1 ) { goto _loop576; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt579>=1 ) { goto _loop579; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt576++;
+		_cnt579++;
 	}
-	_loop576:;
+	_loop579:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -4165,11 +4165,11 @@ void GDLLexer::mSKIP_LINES(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop579;
+			goto _loop582;
 		}
 		}
 	}
-	_loop579:;
+	_loop582:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -4193,11 +4193,11 @@ void GDLLexer::mCONT_STATEMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop583;
+			goto _loop586;
 		}
 		
 	}
-	_loop583:;
+	_loop586:;
 	} // ( ... )*
 	mEOL(false);
 	mSKIP_LINES(false);

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <string>
 
-static void printLineErrorHelper(std::string filename, int line, int col) {
+static void printLineErrorHelper(std::string filename, int line, int col, std::string msg="" ) {
   if (filename.size() > 0) {
 	std::ifstream ifs;
 	ifs.open(filename, std::ifstream::in);
@@ -39,7 +39,7 @@ static void printLineErrorHelper(std::string filename, int line, int col) {
   for (auto i = 0; i < col; ++i) std::cerr << ' ';
   std::cerr << '^';
   std::cerr << '\n';
-  std::cerr << "% Syntax error.\n";
+  if ( msg.size() > 0) std::cerr << msg << std::endl; else std::cerr << "% Syntax error.\n";
   if ( filename.size() > 0)   std::cerr <<"  At: "<<filename<<", Line "<<line<<std::endl;
   return;
 }

--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -234,8 +234,16 @@ antlr::RefToken GDLLexer::nextToken()
 				break;
 			}
 			default:
-				if (((LA(1) == 0x61 /* 'a' */ ) && (LA(2) == 0x6e /* 'n' */ ) && (LA(3) == 0x64 /* 'd' */ ))&&( LA(4) == '=')) {
+				if ((LA(1) == 0x61 /* 'a' */ ) && (LA(2) == 0x6e /* 'n' */ ) && (LA(3) == 0x64 /* 'd' */ ) && (LA(4) == 0x3d /* '=' */ )) {
 					mAND_OP_EQ(true);
+					theRetToken=_returnToken;
+				}
+				else if ((LA(1) == 0x6d /* 'm' */ ) && (LA(2) == 0x6f /* 'o' */ ) && (LA(3) == 0x64 /* 'd' */ ) && (LA(4) == 0x3d /* '=' */ )) {
+					mMOD_OP_EQ(true);
+					theRetToken=_returnToken;
+				}
+				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x6f /* 'o' */ ) && (LA(3) == 0x72 /* 'r' */ ) && (LA(4) == 0x3d /* '=' */ )) {
+					mXOR_OP_EQ(true);
 					theRetToken=_returnToken;
 				}
 				else if ((LA(1) == 0x65 /* 'e' */ ) && (LA(2) == 0x71 /* 'q' */ ) && (LA(3) == 0x3d /* '=' */ )) {
@@ -262,20 +270,12 @@ antlr::RefToken GDLLexer::nextToken()
 					mMATRIX_OP2_EQ(true);
 					theRetToken=_returnToken;
 				}
-				else if (((LA(1) == 0x6d /* 'm' */ ) && (LA(2) == 0x6f /* 'o' */ ) && (LA(3) == 0x64 /* 'd' */ ))&&( LA(4) == '=')) {
-					mMOD_OP_EQ(true);
-					theRetToken=_returnToken;
-				}
 				else if ((LA(1) == 0x6e /* 'n' */ ) && (LA(2) == 0x65 /* 'e' */ ) && (LA(3) == 0x3d /* '=' */ )) {
 					mNE_OP_EQ(true);
 					theRetToken=_returnToken;
 				}
 				else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x72 /* 'r' */ ) && (LA(3) == 0x3d /* '=' */ )) {
 					mOR_OP_EQ(true);
-					theRetToken=_returnToken;
-				}
-				else if (((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x6f /* 'o' */ ) && (LA(3) == 0x72 /* 'r' */ ))&&( LA(4) == '=')) {
-					mXOR_OP_EQ(true);
 					theRetToken=_returnToken;
 				}
 				else if ((LA(1) == 0x2a /* '*' */ ) && (LA(2) == 0x3d /* '=' */ )) {
@@ -378,7 +378,7 @@ antlr::RefToken GDLLexer::nextToken()
 					mLTMARK(true);
 					theRetToken=_returnToken;
 				}
-				else if ((_tokenSet_1.member(LA(1))) && (true) && (true)) {
+				else if ((_tokenSet_1.member(LA(1))) && (true) && (true) && (true)) {
 					mIDENTIFIER(true);
 					theRetToken=_returnToken;
 				}
@@ -516,8 +516,6 @@ void GDLLexer::mAND_OP_EQ(bool _createToken) {
 	_ttype = AND_OP_EQ;
 	std::string::size_type _saveIndex;
 	
-	if (!( LA(4) == '='))
-		throw antlr::SemanticException(" LA(4) == \'=\'");
 	match("and=");
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -686,8 +684,6 @@ void GDLLexer::mMOD_OP_EQ(bool _createToken) {
 	_ttype = MOD_OP_EQ;
 	std::string::size_type _saveIndex;
 	
-	if (!( LA(4) == '='))
-		throw antlr::SemanticException(" LA(4) == \'=\'");
 	match("mod=");
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -772,8 +768,6 @@ void GDLLexer::mXOR_OP_EQ(bool _createToken) {
 	_ttype = XOR_OP_EQ;
 	std::string::size_type _saveIndex;
 	
-	if (!( LA(4) == '='))
-		throw antlr::SemanticException(" LA(4) == \'=\'");
 	match("xor=");
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1181,7 +1175,7 @@ void GDLLexer::mEOL(bool _createToken) {
 	
 	{
 	bool synPredMatched361 = false;
-	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true))) {
+	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true) && (true))) {
 		int _m361 = mark();
 		synPredMatched361 = true;
 		inputState->guessing++;
@@ -1202,7 +1196,7 @@ void GDLLexer::mEOL(bool _createToken) {
 	else if ((LA(1) == 0xa /* '\n' */ )) {
 		match('\n' /* charlit */ );
 	}
-	else if ((LA(1) == 0xd /* '\r' */ ) && (true) && (true)) {
+	else if ((LA(1) == 0xd /* '\r' */ ) && (true) && (true) && (true)) {
 		match('\r' /* charlit */ );
 	}
 	else {
@@ -1993,96 +1987,92 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_ttype = CONSTANT_OR_STRING_LITERAL;
 	std::string::size_type _saveIndex;
 	
-	bool synPredMatched443 = false;
-	if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ))) {
-		int _m443 = mark();
-		synPredMatched443 = true;
+	bool synPredMatched461 = false;
+	if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))) && (_tokenSet_6.member(LA(4))))) {
+		int _m461 = mark();
+		synPredMatched461 = true;
 		inputState->guessing++;
 		try {
 			{
-			match("0b");
+			match('\'' /* charlit */ );
 			{ // ( ... )+
-			int _cnt441=0;
+			int _cnt459=0;
 			for (;;) {
-				if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
-					mB(false);
+				if ((_tokenSet_4.member(LA(1)))) {
+					mH(false);
 				}
 				else {
-					if ( _cnt441>=1 ) { goto _loop441; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt459>=1 ) { goto _loop459; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt441++;
+				_cnt459++;
 			}
-			_loop441:;
+			_loop459:;
 			}  // ( ... )+
+			match('\'' /* charlit */ );
 			{
-			switch ( LA(1)) {
-			case 0x62 /* 'b' */ :
-			{
-				match('b' /* charlit */ );
-				break;
+			if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x73 /* 's' */ )) {
+				match("xus");
 			}
-			case 0x73 /* 's' */ :
-			{
-				match('s' /* charlit */ );
-				break;
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x62 /* 'b' */ )) {
+				match("xub");
 			}
-			default:
-				if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
-					match("ull");
-				}
-				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
-					match("us");
-				}
-				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
-					match("ub");
-				}
-				else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
-					match("ll");
-				}
-				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
-					match("ul");
-				}
-				else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
-					match('l' /* charlit */ );
-				}
-				else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
-					match('u' /* charlit */ );
-				}
-				else {
-				}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
+				match("xul");
 			}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x73 /* 's' */ )) {
+				match("xs");
+			}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
+				match("xb");
+			}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
+				match("xl");
+			}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
+				match("xu");
+			}
+			else if ((LA(1) == 0x78 /* 'x' */ ) && (true)) {
+				match('x' /* charlit */ );
+			}
+			else {
+				throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
+			}
+			
 			}
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched443 = false;
+			synPredMatched461 = false;
 		}
-		rewind(_m443);
+		rewind(_m461);
 		inputState->guessing--;
 	}
-	if ( synPredMatched443 ) {
+	if ( synPredMatched461 ) {
 		{
 		_saveIndex = text.length();
-		match("0b");
+		match('\'' /* charlit */ );
 		text.erase(_saveIndex);
 		{ // ( ... )+
-		int _cnt446=0;
+		int _cnt464=0;
 		for (;;) {
-			if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
-				mB(false);
+			if ((_tokenSet_4.member(LA(1)))) {
+				mH(false);
 			}
 			else {
-				if ( _cnt446>=1 ) { goto _loop446; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt464>=1 ) { goto _loop464; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt446++;
+			_cnt464++;
 		}
-		_loop446:;
+		_loop464:;
 		}  // ( ... )+
-		if ( inputState->guessing==0 ) {
-			_ttype=CONSTANT_BIN_I;
-		}
+		_saveIndex = text.length();
+		match('\'' /* charlit */ );
+		text.erase(_saveIndex);
+		_saveIndex = text.length();
+		match('x' /* charlit */ );
+		text.erase(_saveIndex);
 		{
 		switch ( LA(1)) {
 		case 0x73 /* 's' */ :
@@ -2091,17 +2081,17 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			match('s' /* charlit */ );
 			text.erase(_saveIndex);
 			if ( inputState->guessing==0 ) {
-				_ttype=CONSTANT_BIN_INT;
+				_ttype=CONSTANT_HEX_INT;
 			}
 			break;
 		}
 		case 0x62 /* 'b' */ :
 		{
 			_saveIndex = text.length();
-			match("b");
+			match('b' /* charlit */ );
 			text.erase(_saveIndex);
 			if ( inputState->guessing==0 ) {
-				_ttype=CONSTANT_BIN_BYTE;
+				_ttype=CONSTANT_HEX_BYTE;
 			}
 			break;
 		}
@@ -2111,7 +2101,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match("ull");
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_ULONG64;
+					_ttype=CONSTANT_HEX_ULONG64;
 				}
 			}
 			else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
@@ -2119,7 +2109,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match("us");
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_UINT;
+					_ttype=CONSTANT_HEX_UINT;
 				}
 			}
 			else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
@@ -2127,7 +2117,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match("ub");
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_BYTE;
+					_ttype=CONSTANT_HEX_BYTE;
 				}
 			}
 			else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
@@ -2135,7 +2125,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match("ll");
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_LONG64;
+					_ttype=CONSTANT_HEX_LONG64;
 				}
 			}
 			else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
@@ -2143,7 +2133,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match("ul");
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_ULONG;
+					_ttype=CONSTANT_HEX_ULONG;
 				}
 			}
 			else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
@@ -2151,7 +2141,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match('u' /* charlit */ );
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_UI;
+					_ttype=CONSTANT_HEX_UI;
 				}
 			}
 			else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
@@ -2159,63 +2149,57 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match('l' /* charlit */ );
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_BIN_LONG;
+					_ttype=CONSTANT_HEX_LONG;
 				}
 			}
 			else {
+				if ( inputState->guessing==0 ) {
+					_ttype=CONSTANT_HEX_I;
+				}
 			}
 		}
 		}
 		}
 	}
 	else {
-		bool synPredMatched461 = false;
-		if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))))) {
-			int _m461 = mark();
-			synPredMatched461 = true;
+		bool synPredMatched470 = false;
+		if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_7.member(LA(3))) && (_tokenSet_8.member(LA(4))))) {
+			int _m470 = mark();
+			synPredMatched470 = true;
 			inputState->guessing++;
 			try {
 				{
 				match('\'' /* charlit */ );
 				{ // ( ... )+
-				int _cnt459=0;
+				int _cnt468=0;
 				for (;;) {
-					if ((_tokenSet_4.member(LA(1)))) {
-						mH(false);
+					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
+						mO(false);
 					}
 					else {
-						if ( _cnt459>=1 ) { goto _loop459; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt468>=1 ) { goto _loop468; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt459++;
+					_cnt468++;
 				}
-				_loop459:;
+				_loop468:;
 				}  // ( ... )+
 				match('\'' /* charlit */ );
 				{
-				if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x73 /* 's' */ )) {
-					match("xus");
+				if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
+					match("oul");
 				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x62 /* 'b' */ )) {
-					match("xub");
+				else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x73 /* 's' */ )) {
+					match("os");
 				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
-					match("xul");
+				else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
+					match("ol");
 				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x73 /* 's' */ )) {
-					match("xs");
+				else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
+					match("ou");
 				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
-					match("xb");
-				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
-					match("xl");
-				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
-					match("xu");
-				}
-				else if ((LA(1) == 0x78 /* 'x' */ ) && (true)) {
-					match('x' /* charlit */ );
+				else if ((LA(1) == 0x6f /* 'o' */ ) && (true)) {
+					match('o' /* charlit */ );
 				}
 				else {
 					throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
@@ -2225,35 +2209,35 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched461 = false;
+				synPredMatched470 = false;
 			}
-			rewind(_m461);
+			rewind(_m470);
 			inputState->guessing--;
 		}
-		if ( synPredMatched461 ) {
+		if ( synPredMatched470 ) {
 			{
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt464=0;
+			int _cnt473=0;
 			for (;;) {
-				if ((_tokenSet_4.member(LA(1)))) {
-					mH(false);
+				if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
+					mO(false);
 				}
 				else {
-					if ( _cnt464>=1 ) { goto _loop464; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt473>=1 ) { goto _loop473; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt464++;
+				_cnt473++;
 			}
-			_loop464:;
+			_loop473:;
 			}  // ( ... )+
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			_saveIndex = text.length();
-			match('x' /* charlit */ );
+			match('o' /* charlit */ );
 			text.erase(_saveIndex);
 			{
 			switch ( LA(1)) {
@@ -2263,7 +2247,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match('s' /* charlit */ );
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_HEX_INT;
+					_ttype=CONSTANT_OCT_INT;
 				}
 				break;
 			}
@@ -2273,7 +2257,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				match('b' /* charlit */ );
 				text.erase(_saveIndex);
 				if ( inputState->guessing==0 ) {
-					_ttype=CONSTANT_HEX_BYTE;
+					_ttype=CONSTANT_OCT_BYTE;
 				}
 				break;
 			}
@@ -2283,7 +2267,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match("ull");
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_ULONG64;
+						_ttype=CONSTANT_OCT_ULONG64;
 					}
 				}
 				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
@@ -2291,7 +2275,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match("us");
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_UINT;
+						_ttype=CONSTANT_OCT_UINT;
 					}
 				}
 				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
@@ -2299,7 +2283,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match("ub");
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_BYTE;
+						_ttype=CONSTANT_OCT_BYTE;
 					}
 				}
 				else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
@@ -2307,7 +2291,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match("ll");
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_LONG64;
+						_ttype=CONSTANT_OCT_LONG64;
 					}
 				}
 				else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
@@ -2315,7 +2299,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match("ul");
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_ULONG;
+						_ttype=CONSTANT_OCT_ULONG;
 					}
 				}
 				else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
@@ -2323,7 +2307,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match('u' /* charlit */ );
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_UI;
+						_ttype=CONSTANT_OCT_UI;
 					}
 				}
 				else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
@@ -2331,12 +2315,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match('l' /* charlit */ );
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_LONG;
+						_ttype=CONSTANT_OCT_LONG;
 					}
 				}
 				else {
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_HEX_I;
+						_ttype=CONSTANT_OCT_I;
 					}
 				}
 			}
@@ -2344,44 +2328,44 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		else {
-			bool synPredMatched470 = false;
-			if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_6.member(LA(3))))) {
-				int _m470 = mark();
-				synPredMatched470 = true;
+			bool synPredMatched479 = false;
+			if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (_tokenSet_9.member(LA(4))))) {
+				int _m479 = mark();
+				synPredMatched479 = true;
 				inputState->guessing++;
 				try {
 					{
 					match('\'' /* charlit */ );
 					{ // ( ... )+
-					int _cnt468=0;
+					int _cnt477=0;
 					for (;;) {
-						if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
-							mO(false);
+						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
+							mB(false);
 						}
 						else {
-							if ( _cnt468>=1 ) { goto _loop468; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt477>=1 ) { goto _loop477; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt468++;
+						_cnt477++;
 					}
-					_loop468:;
+					_loop477:;
 					}  // ( ... )+
 					match('\'' /* charlit */ );
 					{
-					if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
-						match("oul");
+					if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
+						match("bul");
 					}
-					else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x73 /* 's' */ )) {
-						match("os");
+					else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x73 /* 's' */ )) {
+						match("bs");
 					}
-					else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
-						match("ol");
+					else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
+						match("bl");
 					}
-					else if ((LA(1) == 0x6f /* 'o' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
-						match("ou");
+					else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
+						match("bu");
 					}
-					else if ((LA(1) == 0x6f /* 'o' */ ) && (true)) {
-						match('o' /* charlit */ );
+					else if ((LA(1) == 0x62 /* 'b' */ ) && (true)) {
+						match('b' /* charlit */ );
 					}
 					else {
 						throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
@@ -2391,35 +2375,35 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched470 = false;
+					synPredMatched479 = false;
 				}
-				rewind(_m470);
+				rewind(_m479);
 				inputState->guessing--;
 			}
-			if ( synPredMatched470 ) {
+			if ( synPredMatched479 ) {
 				{
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				{ // ( ... )+
-				int _cnt473=0;
+				int _cnt482=0;
 				for (;;) {
-					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
-						mO(false);
+					if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
+						mB(false);
 					}
 					else {
-						if ( _cnt473>=1 ) { goto _loop473; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt482>=1 ) { goto _loop482; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt473++;
+					_cnt482++;
 				}
-				_loop473:;
+				_loop482:;
 				}  // ( ... )+
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				_saveIndex = text.length();
-				match('o' /* charlit */ );
+				match('b' /* charlit */ );
 				text.erase(_saveIndex);
 				{
 				switch ( LA(1)) {
@@ -2429,7 +2413,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match('s' /* charlit */ );
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_OCT_INT;
+						_ttype=CONSTANT_BIN_INT;
 					}
 					break;
 				}
@@ -2439,7 +2423,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					match('b' /* charlit */ );
 					text.erase(_saveIndex);
 					if ( inputState->guessing==0 ) {
-						_ttype=CONSTANT_OCT_BYTE;
+						_ttype=CONSTANT_BIN_BYTE;
 					}
 					break;
 				}
@@ -2449,7 +2433,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match("ull");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_ULONG64;
+							_ttype=CONSTANT_BIN_ULONG64;
 						}
 					}
 					else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
@@ -2457,7 +2441,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match("us");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_UINT;
+							_ttype=CONSTANT_BIN_UINT;
 						}
 					}
 					else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
@@ -2465,7 +2449,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match("ub");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_BYTE;
+							_ttype=CONSTANT_BIN_BYTE;
 						}
 					}
 					else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
@@ -2473,7 +2457,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match("ll");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_LONG64;
+							_ttype=CONSTANT_BIN_LONG64;
 						}
 					}
 					else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
@@ -2481,7 +2465,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match("ul");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_ULONG;
+							_ttype=CONSTANT_BIN_ULONG;
 						}
 					}
 					else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
@@ -2489,7 +2473,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match('u' /* charlit */ );
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_UI;
+							_ttype=CONSTANT_BIN_UI;
 						}
 					}
 					else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
@@ -2497,12 +2481,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						match('l' /* charlit */ );
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_LONG;
+							_ttype=CONSTANT_BIN_LONG;
 						}
 					}
 					else {
 						if ( inputState->guessing==0 ) {
-							_ttype=CONSTANT_OCT_I;
+							_ttype=CONSTANT_BIN_I;
 						}
 					}
 				}
@@ -2510,83 +2494,96 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			else {
-				bool synPredMatched479 = false;
-				if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ))) {
-					int _m479 = mark();
-					synPredMatched479 = true;
+				bool synPredMatched443 = false;
+				if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (true))) {
+					int _m443 = mark();
+					synPredMatched443 = true;
 					inputState->guessing++;
 					try {
 						{
-						match('\'' /* charlit */ );
+						match("0b");
 						{ // ( ... )+
-						int _cnt477=0;
+						int _cnt441=0;
 						for (;;) {
 							if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 								mB(false);
 							}
 							else {
-								if ( _cnt477>=1 ) { goto _loop477; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt441>=1 ) { goto _loop441; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt477++;
+							_cnt441++;
 						}
-						_loop477:;
+						_loop441:;
 						}  // ( ... )+
-						match('\'' /* charlit */ );
 						{
-						if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
-							match("bul");
-						}
-						else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x73 /* 's' */ )) {
-							match("bs");
-						}
-						else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
-							match("bl");
-						}
-						else if ((LA(1) == 0x62 /* 'b' */ ) && (LA(2) == 0x75 /* 'u' */ ) && (true)) {
-							match("bu");
-						}
-						else if ((LA(1) == 0x62 /* 'b' */ ) && (true)) {
+						switch ( LA(1)) {
+						case 0x62 /* 'b' */ :
+						{
 							match('b' /* charlit */ );
+							break;
 						}
-						else {
-							throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
+						case 0x73 /* 's' */ :
+						{
+							match('s' /* charlit */ );
+							break;
 						}
-						
+						default:
+							if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (LA(3) == 0x6c /* 'l' */ )) {
+								match("ull");
+							}
+							else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x73 /* 's' */ )) {
+								match("us");
+							}
+							else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x62 /* 'b' */ )) {
+								match("ub");
+							}
+							else if ((LA(1) == 0x6c /* 'l' */ ) && (LA(2) == 0x6c /* 'l' */ )) {
+								match("ll");
+							}
+							else if ((LA(1) == 0x75 /* 'u' */ ) && (LA(2) == 0x6c /* 'l' */ ) && (true)) {
+								match("ul");
+							}
+							else if ((LA(1) == 0x6c /* 'l' */ ) && (true)) {
+								match('l' /* charlit */ );
+							}
+							else if ((LA(1) == 0x75 /* 'u' */ ) && (true)) {
+								match('u' /* charlit */ );
+							}
+							else {
+							}
+						}
 						}
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched479 = false;
+						synPredMatched443 = false;
 					}
-					rewind(_m479);
+					rewind(_m443);
 					inputState->guessing--;
 				}
-				if ( synPredMatched479 ) {
+				if ( synPredMatched443 ) {
 					{
 					_saveIndex = text.length();
-					match('\'' /* charlit */ );
+					match("0b");
 					text.erase(_saveIndex);
 					{ // ( ... )+
-					int _cnt482=0;
+					int _cnt446=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt482>=1 ) { goto _loop482; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt446>=1 ) { goto _loop446; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt482++;
+						_cnt446++;
 					}
-					_loop482:;
+					_loop446:;
 					}  // ( ... )+
-					_saveIndex = text.length();
-					match('\'' /* charlit */ );
-					text.erase(_saveIndex);
-					_saveIndex = text.length();
-					match('b' /* charlit */ );
-					text.erase(_saveIndex);
+					if ( inputState->guessing==0 ) {
+						_ttype=CONSTANT_BIN_I;
+					}
 					{
 					switch ( LA(1)) {
 					case 0x73 /* 's' */ :
@@ -2602,7 +2599,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					case 0x62 /* 'b' */ :
 					{
 						_saveIndex = text.length();
-						match('b' /* charlit */ );
+						match("b");
 						text.erase(_saveIndex);
 						if ( inputState->guessing==0 ) {
 							_ttype=CONSTANT_BIN_BYTE;
@@ -2667,9 +2664,6 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						else {
-							if ( inputState->guessing==0 ) {
-								_ttype=CONSTANT_BIN_I;
-							}
 						}
 					}
 					}
@@ -2999,7 +2993,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 						else {
 							bool synPredMatched452 = false;
-							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true))) {
+							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true) && (true))) {
 								int _m452 = mark();
 								synPredMatched452 = true;
 								inputState->guessing++;
@@ -3190,7 +3184,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 							else {
 								bool synPredMatched503 = false;
-								if (((_tokenSet_7.member(LA(1))) && (_tokenSet_8.member(LA(2))) && (true))) {
+								if (((_tokenSet_10.member(LA(1))) && (_tokenSet_11.member(LA(2))) && (true) && (true))) {
 									int _m503 = mark();
 									synPredMatched503 = true;
 									inputState->guessing++;
@@ -3421,7 +3415,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 								else {
 									bool synPredMatched528 = false;
-									if (((_tokenSet_7.member(LA(1))) && (_tokenSet_9.member(LA(2))) && (true))) {
+									if (((_tokenSet_10.member(LA(1))) && (_tokenSet_12.member(LA(2))) && (true) && (true))) {
 										int _m528 = mark();
 										synPredMatched528 = true;
 										inputState->guessing++;
@@ -3670,7 +3664,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										
 										}
 									}
-									else if ((LA(1) == 0x22 /* '\"' */ ) && (true) && (true)) {
+									else if ((LA(1) == 0x22 /* '\"' */ ) && (true) && (true) && (true)) {
 										_saveIndex = text.length();
 										match('\"' /* charlit */ );
 										text.erase(_saveIndex);
@@ -3682,9 +3676,9 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												match('\"' /* charlit */ );
 												text.erase(_saveIndex);
 											}
-											else if ((_tokenSet_10.member(LA(1)))) {
+											else if ((_tokenSet_13.member(LA(1)))) {
 												{
-												match(_tokenSet_10);
+												match(_tokenSet_13);
 												}
 											}
 											else {
@@ -3708,7 +3702,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											_ttype=STRING_LITERAL;
 										}
 									}
-									else if ((LA(1) == 0x27 /* '\'' */ ) && (true) && (true)) {
+									else if ((LA(1) == 0x27 /* '\'' */ ) && (true) && (true) && (true)) {
 										_saveIndex = text.length();
 										match('\'' /* charlit */ );
 										text.erase(_saveIndex);
@@ -3720,9 +3714,9 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												match('\'' /* charlit */ );
 												text.erase(_saveIndex);
 											}
-											else if ((_tokenSet_11.member(LA(1)))) {
+											else if ((_tokenSet_14.member(LA(1)))) {
 												{
-												match(_tokenSet_11);
+												match(_tokenSet_14);
 												}
 											}
 											else {
@@ -3752,7 +3746,7 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											_ttype=DOT;
 										}
 									}
-									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true)) {
+									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true) && (true)) {
 										{ // ( ... )+
 										int _cnt543=0;
 										for (;;) {
@@ -3904,7 +3898,7 @@ void GDLLexer::mCOMMENT(bool _createToken) {
 	match(';' /* charlit */ );
 	{ // ( ... )*
 	for (;;) {
-		if ((_tokenSet_2.member(LA(1))) && (true) && (true)) {
+		if ((_tokenSet_2.member(LA(1))) && (true) && (true) && (true)) {
 			{
 			match(_tokenSet_2);
 			}
@@ -4284,19 +4278,28 @@ const antlr::BitSet GDLLexer::_tokenSet_4(_tokenSet_4_data_,10);
 const unsigned long GDLLexer::_tokenSet_5_data_[] = { 0UL, 67043456UL, 0UL, 126UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // \' 0 1 2 3 4 5 6 7 8 9 a b c d e f 
 const antlr::BitSet GDLLexer::_tokenSet_5(_tokenSet_5_data_,10);
-const unsigned long GDLLexer::_tokenSet_6_data_[] = { 0UL, 16711808UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// \' 0 1 2 3 4 5 6 7 
+const unsigned long GDLLexer::_tokenSet_6_data_[] = { 0UL, 67043456UL, 0UL, 16777342UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// \' 0 1 2 3 4 5 6 7 8 9 a b c d e f x 
 const antlr::BitSet GDLLexer::_tokenSet_6(_tokenSet_6_data_,10);
-const unsigned long GDLLexer::_tokenSet_7_data_[] = { 0UL, 67059712UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// . 0 1 2 3 4 5 6 7 8 9 
+const unsigned long GDLLexer::_tokenSet_7_data_[] = { 0UL, 16711808UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// \' 0 1 2 3 4 5 6 7 
 const antlr::BitSet GDLLexer::_tokenSet_7(_tokenSet_7_data_,10);
-const unsigned long GDLLexer::_tokenSet_8_data_[] = { 0UL, 67059712UL, 0UL, 16UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// . 0 1 2 3 4 5 6 7 8 9 d 
+const unsigned long GDLLexer::_tokenSet_8_data_[] = { 0UL, 16711808UL, 0UL, 32768UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// \' 0 1 2 3 4 5 6 7 o 
 const antlr::BitSet GDLLexer::_tokenSet_8(_tokenSet_8_data_,10);
-const unsigned long GDLLexer::_tokenSet_9_data_[] = { 0UL, 67059712UL, 0UL, 32UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// . 0 1 2 3 4 5 6 7 8 9 e 
+const unsigned long GDLLexer::_tokenSet_9_data_[] = { 0UL, 196736UL, 0UL, 4UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// \' 0 1 b 
 const antlr::BitSet GDLLexer::_tokenSet_9(_tokenSet_9_data_,10);
-const unsigned long GDLLexer::_tokenSet_10_data_[] = { 4294958072UL, 4294967291UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLLexer::_tokenSet_10_data_[] = { 0UL, 67059712UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// . 0 1 2 3 4 5 6 7 8 9 
+const antlr::BitSet GDLLexer::_tokenSet_10(_tokenSet_10_data_,10);
+const unsigned long GDLLexer::_tokenSet_11_data_[] = { 0UL, 67059712UL, 0UL, 16UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// . 0 1 2 3 4 5 6 7 8 9 d 
+const antlr::BitSet GDLLexer::_tokenSet_11(_tokenSet_11_data_,10);
+const unsigned long GDLLexer::_tokenSet_12_data_[] = { 0UL, 67059712UL, 0UL, 32UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// . 0 1 2 3 4 5 6 7 8 9 e 
+const antlr::BitSet GDLLexer::_tokenSet_12(_tokenSet_12_data_,10);
+const unsigned long GDLLexer::_tokenSet_13_data_[] = { 4294958072UL, 4294967291UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xb 0xc 0xe 0xf 0x10 0x11 0x12 0x13 0x14 
 // 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f   ! # $ % & \' 
 // ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I 
@@ -4310,8 +4313,8 @@ const unsigned long GDLLexer::_tokenSet_10_data_[] = { 4294958072UL, 4294967291U
 // 0xcb 0xcc 0xcd 0xce 0xcf 0xd0 0xd1 0xd2 0xd3 0xd4 0xd5 0xd6 0xd7 0xd8 
 // 0xd9 0xda 0xdb 0xdc 0xdd 0xde 0xdf 0xe0 0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 
 // 0xe7 0xe8 0xe9 0xea 0xeb 0xec 0xed 0xee 0xef 
-const antlr::BitSet GDLLexer::_tokenSet_10(_tokenSet_10_data_,16);
-const unsigned long GDLLexer::_tokenSet_11_data_[] = { 4294958072UL, 4294967167UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const antlr::BitSet GDLLexer::_tokenSet_13(_tokenSet_13_data_,16);
+const unsigned long GDLLexer::_tokenSet_14_data_[] = { 4294958072UL, 4294967167UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xb 0xc 0xe 0xf 0x10 0x11 0x12 0x13 0x14 
 // 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f   ! \" # $ % 
 // & ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H 
@@ -4325,5 +4328,5 @@ const unsigned long GDLLexer::_tokenSet_11_data_[] = { 4294958072UL, 4294967167U
 // 0xcb 0xcc 0xcd 0xce 0xcf 0xd0 0xd1 0xd2 0xd3 0xd4 0xd5 0xd6 0xd7 0xd8 
 // 0xd9 0xda 0xdb 0xdc 0xdd 0xde 0xdf 0xe0 0xe1 0xe2 0xe3 0xe4 0xe5 0xe6 
 // 0xe7 0xe8 0xe9 0xea 0xeb 0xec 0xed 0xee 0xef 
-const antlr::BitSet GDLLexer::_tokenSet_11(_tokenSet_11_data_,16);
+const antlr::BitSet GDLLexer::_tokenSet_14(_tokenSet_14_data_,16);
 

--- a/src/GDLLexer.hpp
+++ b/src/GDLLexer.hpp
@@ -25,9 +25,6 @@
 #include <antlr/TokenStreamIOException.hpp>
 #include <antlr/CharInputBuffer.hpp>
 
-// GD: set to 1 to traceout what the Parser does.
-#define debugParser 0
-//#include "dinterpreter.hpp"
 
 // definition in dinterpreter.cpp
 void MemorizeCompileOptForMAINIfNeeded( unsigned int cOpt);

--- a/src/GDLLexer.hpp
+++ b/src/GDLLexer.hpp
@@ -285,6 +285,12 @@ private:
 	static const antlr::BitSet _tokenSet_10;
 	static const unsigned long _tokenSet_11_data_[];
 	static const antlr::BitSet _tokenSet_11;
+	static const unsigned long _tokenSet_12_data_[];
+	static const antlr::BitSet _tokenSet_12;
+	static const unsigned long _tokenSet_13_data_[];
+	static const antlr::BitSet _tokenSet_13;
+	static const unsigned long _tokenSet_14_data_[];
+	static const antlr::BitSet _tokenSet_14;
 };
 
 #endif /*INC_GDLLexer_hpp_*/

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -901,7 +901,7 @@ void GDLParser::translation_unit() {
 							recovery=false;
 			// HERE WE COULD COUNT THE ERRORS and replace "No parser output generated." in dinterpreter.cpp by something like
 			// "% XXX Compilation error(s) in module YYY."
-			//				throw;
+							throw; //seems necessary, for execute in particular. this patch is not very clever.
 					
 		} else {
 			throw;
@@ -1702,7 +1702,8 @@ void GDLParser::interactive() {
 	catch ( GDLException& e) {
 		if (inputState->guessing==0) {
 			
-							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn(), e.toString());
+			printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn(), e.toString());
+					  throw; //necessary for EXECUTE to get the error state. Alas.
 			
 		} else {
 			throw;

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <string>
 
-static void printLineErrorHelper(std::string filename, int line, int col) {
+static void printLineErrorHelper(std::string filename, int line, int col, std::string msg="" ) {
   if (filename.size() > 0) {
 	std::ifstream ifs;
 	ifs.open(filename, std::ifstream::in);
@@ -34,7 +34,7 @@ static void printLineErrorHelper(std::string filename, int line, int col) {
   for (auto i = 0; i < col; ++i) std::cerr << ' ';
   std::cerr << '^';
   std::cerr << '\n';
-  std::cerr << "% Syntax error.\n";
+  if ( msg.size() > 0) std::cerr << msg << std::endl; else std::cerr << "% Syntax error.\n";
   if ( filename.size() > 0)   std::cerr <<"  At: "<<filename<<", Line "<<line<<std::endl;
   return;
 }
@@ -897,8 +897,11 @@ void GDLParser::translation_unit() {
 	catch ( GDLException& e) {
 		if (inputState->guessing==0) {
 			
+							printLineErrorHelper(getFilename(), e.getLine(), e.getColumn(), e.getMessage());
 							recovery=false;
-							throw;
+			// HERE WE COULD COUNT THE ERRORS and replace "No parser output generated." in dinterpreter.cpp by something like
+			// "% XXX Compilation error(s) in module YYY."
+			//				throw;
 					
 		} else {
 			throw;
@@ -913,7 +916,7 @@ void GDLParser::translation_unit() {
 							// this partially solves #59 (no line number in '@'-included files
 							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
 							// PARSER SYNTAX ERROR
-							throw GDLException( e.getLine(), e.getColumn(), "Parser syntax error: "+e.getMessage(), e.getFilename() );
+			//				throw GDLException( e.getLine(), e.getColumn(), "Parser syntax error: "+e.getMessage(), e.getFilename() );
 						} else {
 							if (IsTracingSyntaxErrors()) {
 								std::cerr<<"old syntax at line "<<LT(1).get()->getLine()<<", column "<<LT(1).get()->getColumn()<<std::endl;
@@ -933,7 +936,7 @@ void GDLParser::translation_unit() {
 						// this partially solves #59 (no line number in '@'-included files
 						printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
 						// LEXER SYNTAX ERROR
-						throw GDLException( e.getLine(), e.getColumn(), "Lexer syntax error: "+e.getMessage(), e.getFilename() );
+			//			throw GDLException( e.getLine(), e.getColumn(), "Lexer syntax error: "+e.getMessage(), e.getFilename() );
 			
 		} else {
 			throw;
@@ -947,7 +950,7 @@ void GDLParser::translation_unit() {
 							// this partially solves #59 (no line number in '@'-included files
 							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
 							// PARSER SYNTAX ERROR
-							throw GDLException( e.getLine(), e.getColumn(), "Parser recognition exception error: "+e.getMessage(), e.getFilename() );
+			//				throw GDLException( e.getLine(), e.getColumn(), "Parser recognition exception error: "+e.getMessage(), e.getFilename() );
 						} else {
 							if (IsTracingSyntaxErrors()) {
 								std::cerr<<"old syntax at line "<<LT(1).get()->getLine()<<", column "<<LT(1).get()->getColumn()<<std::endl;
@@ -1699,7 +1702,7 @@ void GDLParser::interactive() {
 	catch ( GDLException& e) {
 		if (inputState->guessing==0) {
 			
-			throw;
+							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn(), e.toString());
 			
 		} else {
 			throw;
@@ -5651,8 +5654,8 @@ void GDLParser::parameter_def() {
 			parameter_def_AST = RefDNode(currentAST.root);
 			
 			RefDNode c=static_cast<RefDNode>( astFactory->create(CONSTANT,"1"));
-			c->Text2Int(10);
 			c->SetLine( id_AST->getLine());
+			c->Text2Int(10);
 			parameter_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(KEYDEF,"!=!")))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(c))));
 			
 			currentAST.root = parameter_def_AST;
@@ -6153,8 +6156,8 @@ void GDLParser::constant_hex_byte() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_byte_AST = RefDNode(currentAST.root);
 		constant_hex_byte_AST=astFactory->create(CONSTANT,c1->getText());
-		constant_hex_byte_AST->Text2Byte(16);    
 		constant_hex_byte_AST->SetLine( c1->getLine());    
+		constant_hex_byte_AST->Text2Byte(16);    
 		
 		currentAST.root = constant_hex_byte_AST;
 		if ( constant_hex_byte_AST!=RefDNode(antlr::nullAST) &&
@@ -6182,8 +6185,8 @@ void GDLParser::constant_hex_long() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_long_AST = RefDNode(currentAST.root);
 		constant_hex_long_AST=astFactory->create(CONSTANT,c2->getText());
-		constant_hex_long_AST->Text2Long(16);    
 		constant_hex_long_AST->SetLine( c2->getLine());    
+		constant_hex_long_AST->Text2Long(16);    
 		
 		currentAST.root = constant_hex_long_AST;
 		if ( constant_hex_long_AST!=RefDNode(antlr::nullAST) &&
@@ -6211,8 +6214,8 @@ void GDLParser::constant_hex_long64() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_long64_AST = RefDNode(currentAST.root);
 		constant_hex_long64_AST=astFactory->create(CONSTANT,c3->getText());
-		constant_hex_long64_AST->Text2Long64(16);    
 		constant_hex_long64_AST->SetLine( c3->getLine());    
+		constant_hex_long64_AST->Text2Long64(16);    
 		
 		currentAST.root = constant_hex_long64_AST;
 		if ( constant_hex_long64_AST!=RefDNode(antlr::nullAST) &&
@@ -6240,8 +6243,8 @@ void GDLParser::constant_hex_int() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_int_AST = RefDNode(currentAST.root);
 		constant_hex_int_AST=astFactory->create(CONSTANT,c4->getText());
-		constant_hex_int_AST->Text2Int(16);    
 		constant_hex_int_AST->SetLine( c4->getLine());    
+		constant_hex_int_AST->Text2Int(16);    
 		
 		currentAST.root = constant_hex_int_AST;
 		if ( constant_hex_int_AST!=RefDNode(antlr::nullAST) &&
@@ -6269,11 +6272,11 @@ void GDLParser::constant_hex_i() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_i_AST = RefDNode(currentAST.root);
 		constant_hex_i_AST=astFactory->create(CONSTANT,c44->getText());
+		constant_hex_i_AST->SetLine( c44->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_hex_i_AST->Text2Long(16,true);    
 		else
 		constant_hex_i_AST->Text2Int(16,true);    
-		constant_hex_i_AST->SetLine( c44->getLine());    
 		
 		currentAST.root = constant_hex_i_AST;
 		if ( constant_hex_i_AST!=RefDNode(antlr::nullAST) &&
@@ -6301,8 +6304,8 @@ void GDLParser::constant_hex_ulong() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_ulong_AST = RefDNode(currentAST.root);
 		constant_hex_ulong_AST=astFactory->create(CONSTANT,c5->getText());
-		constant_hex_ulong_AST->Text2ULong(16);    
 		constant_hex_ulong_AST->SetLine( c5->getLine());    
+		constant_hex_ulong_AST->Text2ULong(16);    
 		
 		currentAST.root = constant_hex_ulong_AST;
 		if ( constant_hex_ulong_AST!=RefDNode(antlr::nullAST) &&
@@ -6330,8 +6333,8 @@ void GDLParser::constant_hex_ulong64() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_ulong64_AST = RefDNode(currentAST.root);
 		constant_hex_ulong64_AST=astFactory->create(CONSTANT,c6->getText());
-		constant_hex_ulong64_AST->Text2ULong64(16);    
 		constant_hex_ulong64_AST->SetLine( c6->getLine());    
+		constant_hex_ulong64_AST->Text2ULong64(16);    
 		
 		currentAST.root = constant_hex_ulong64_AST;
 		if ( constant_hex_ulong64_AST!=RefDNode(antlr::nullAST) &&
@@ -6359,11 +6362,11 @@ void GDLParser::constant_hex_ui() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_ui_AST = RefDNode(currentAST.root);
 		constant_hex_ui_AST=astFactory->create(CONSTANT,c77->getText());
+		constant_hex_ui_AST->SetLine( c77->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_hex_ui_AST->Text2ULong(16,true);    
 		else
 		constant_hex_ui_AST->Text2UInt(16,true);    
-		constant_hex_ui_AST->SetLine( c77->getLine());    
 		
 		currentAST.root = constant_hex_ui_AST;
 		if ( constant_hex_ui_AST!=RefDNode(antlr::nullAST) &&
@@ -6391,8 +6394,8 @@ void GDLParser::constant_hex_uint() {
 	if ( inputState->guessing==0 ) {
 		constant_hex_uint_AST = RefDNode(currentAST.root);
 		constant_hex_uint_AST=astFactory->create(CONSTANT,c7->getText());
-		constant_hex_uint_AST->Text2UInt(16);    
 		constant_hex_uint_AST->SetLine( c7->getLine());    
+		constant_hex_uint_AST->Text2UInt(16);    
 		
 		currentAST.root = constant_hex_uint_AST;
 		if ( constant_hex_uint_AST!=RefDNode(antlr::nullAST) &&
@@ -6420,8 +6423,8 @@ void GDLParser::constant_byte() {
 	if ( inputState->guessing==0 ) {
 		constant_byte_AST = RefDNode(currentAST.root);
 		constant_byte_AST=astFactory->create(CONSTANT,c8->getText());
-		constant_byte_AST->Text2Byte(10);    
 		constant_byte_AST->SetLine( c8->getLine());    
+		constant_byte_AST->Text2Byte(10);    
 		
 		currentAST.root = constant_byte_AST;
 		if ( constant_byte_AST!=RefDNode(antlr::nullAST) &&
@@ -6449,8 +6452,8 @@ void GDLParser::constant_long() {
 	if ( inputState->guessing==0 ) {
 		constant_long_AST = RefDNode(currentAST.root);
 		constant_long_AST=astFactory->create(CONSTANT,c9->getText());
-		constant_long_AST->Text2Long(10);    
 		constant_long_AST->SetLine( c9->getLine());    
+		constant_long_AST->Text2Long(10);    
 		
 		currentAST.root = constant_long_AST;
 		if ( constant_long_AST!=RefDNode(antlr::nullAST) &&
@@ -6478,8 +6481,8 @@ void GDLParser::constant_long64() {
 	if ( inputState->guessing==0 ) {
 		constant_long64_AST = RefDNode(currentAST.root);
 		constant_long64_AST=astFactory->create(CONSTANT,c10->getText());
-		constant_long64_AST->Text2Long64(10);    
 		constant_long64_AST->SetLine( c10->getLine());    
+		constant_long64_AST->Text2Long64(10);    
 		
 		currentAST.root = constant_long64_AST;
 		if ( constant_long64_AST!=RefDNode(antlr::nullAST) &&
@@ -6507,8 +6510,8 @@ void GDLParser::constant_int() {
 	if ( inputState->guessing==0 ) {
 		constant_int_AST = RefDNode(currentAST.root);
 		constant_int_AST=astFactory->create(CONSTANT,c11->getText());
-		constant_int_AST->Text2Int(10);    
 		constant_int_AST->SetLine( c11->getLine());    
+		constant_int_AST->Text2Int(10);    
 		
 		currentAST.root = constant_int_AST;
 		if ( constant_int_AST!=RefDNode(antlr::nullAST) &&
@@ -6536,11 +6539,11 @@ void GDLParser::constant_i() {
 	if ( inputState->guessing==0 ) {
 		constant_i_AST = RefDNode(currentAST.root);
 		constant_i_AST=astFactory->create(CONSTANT,c111->getText());
+		constant_i_AST->SetLine( c111->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_i_AST->Text2Long(10,true);    
 		else
 		constant_i_AST->Text2Int(10,true);    
-		constant_i_AST->SetLine( c111->getLine());    
 		
 		currentAST.root = constant_i_AST;
 		if ( constant_i_AST!=RefDNode(antlr::nullAST) &&
@@ -6568,8 +6571,8 @@ void GDLParser::constant_ulong() {
 	if ( inputState->guessing==0 ) {
 		constant_ulong_AST = RefDNode(currentAST.root);
 		constant_ulong_AST=astFactory->create(CONSTANT,c12->getText());
-		constant_ulong_AST->Text2ULong(10);    
 		constant_ulong_AST->SetLine( c12->getLine());    
+		constant_ulong_AST->Text2ULong(10);    
 		
 		currentAST.root = constant_ulong_AST;
 		if ( constant_ulong_AST!=RefDNode(antlr::nullAST) &&
@@ -6597,8 +6600,8 @@ void GDLParser::constant_ulong64() {
 	if ( inputState->guessing==0 ) {
 		constant_ulong64_AST = RefDNode(currentAST.root);
 		constant_ulong64_AST=astFactory->create(CONSTANT,c13->getText());
-		constant_ulong64_AST->Text2ULong64(10);    
 		constant_ulong64_AST->SetLine( c13->getLine());    
+		constant_ulong64_AST->Text2ULong64(10);    
 		
 		currentAST.root = constant_ulong64_AST;
 		if ( constant_ulong64_AST!=RefDNode(antlr::nullAST) &&
@@ -6626,11 +6629,11 @@ void GDLParser::constant_ui() {
 	if ( inputState->guessing==0 ) {
 		constant_ui_AST = RefDNode(currentAST.root);
 		constant_ui_AST=astFactory->create(CONSTANT,c144->getText());
+		constant_ui_AST->SetLine( c144->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_ui_AST->Text2ULong(10,true);    
 		else
 		constant_ui_AST->Text2UInt(10,true);    
-		constant_ui_AST->SetLine( c144->getLine());    
 		
 		currentAST.root = constant_ui_AST;
 		if ( constant_ui_AST!=RefDNode(antlr::nullAST) &&
@@ -6658,8 +6661,8 @@ void GDLParser::constant_uint() {
 	if ( inputState->guessing==0 ) {
 		constant_uint_AST = RefDNode(currentAST.root);
 		constant_uint_AST=astFactory->create(CONSTANT,c14->getText());
-		constant_uint_AST->Text2UInt(10);    
 		constant_uint_AST->SetLine( c14->getLine());    
+		constant_uint_AST->Text2UInt(10);    
 		
 		currentAST.root = constant_uint_AST;
 		if ( constant_uint_AST!=RefDNode(antlr::nullAST) &&
@@ -6687,8 +6690,8 @@ void GDLParser::constant_oct_byte() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_byte_AST = RefDNode(currentAST.root);
 		constant_oct_byte_AST=astFactory->create(CONSTANT,c15->getText());
-		constant_oct_byte_AST->Text2Byte(8);    
 		constant_oct_byte_AST->SetLine( c15->getLine());    
+		constant_oct_byte_AST->Text2Byte(8);    
 		
 		currentAST.root = constant_oct_byte_AST;
 		if ( constant_oct_byte_AST!=RefDNode(antlr::nullAST) &&
@@ -6716,8 +6719,8 @@ void GDLParser::constant_oct_long() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_long_AST = RefDNode(currentAST.root);
 		constant_oct_long_AST=astFactory->create(CONSTANT,c16->getText());
-		constant_oct_long_AST->Text2Long(8);    
 		constant_oct_long_AST->SetLine( c16->getLine());    
+		constant_oct_long_AST->Text2Long(8);    
 		
 		currentAST.root = constant_oct_long_AST;
 		if ( constant_oct_long_AST!=RefDNode(antlr::nullAST) &&
@@ -6745,8 +6748,8 @@ void GDLParser::constant_oct_long64() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_long64_AST = RefDNode(currentAST.root);
 		constant_oct_long64_AST=astFactory->create(CONSTANT,c17->getText());
-		constant_oct_long64_AST->Text2Long64(8);    
 		constant_oct_long64_AST->SetLine( c17->getLine());    
+		constant_oct_long64_AST->Text2Long64(8);    
 		
 		currentAST.root = constant_oct_long64_AST;
 		if ( constant_oct_long64_AST!=RefDNode(antlr::nullAST) &&
@@ -6774,8 +6777,8 @@ void GDLParser::constant_oct_int() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_int_AST = RefDNode(currentAST.root);
 		constant_oct_int_AST=astFactory->create(CONSTANT,c18->getText());
-		constant_oct_int_AST->Text2Int(8);    
 		constant_oct_int_AST->SetLine( c18->getLine());    
+		constant_oct_int_AST->Text2Int(8);    
 		
 		currentAST.root = constant_oct_int_AST;
 		if ( constant_oct_int_AST!=RefDNode(antlr::nullAST) &&
@@ -6803,11 +6806,11 @@ void GDLParser::constant_oct_i() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_i_AST = RefDNode(currentAST.root);
 		constant_oct_i_AST=astFactory->create(CONSTANT,c188->getText());
+		constant_oct_i_AST->SetLine( c188->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_oct_i_AST->Text2Long(8,true);    
 		else
 		constant_oct_i_AST->Text2Int(8,true);    
-		constant_oct_i_AST->SetLine( c188->getLine());    
 		
 		currentAST.root = constant_oct_i_AST;
 		if ( constant_oct_i_AST!=RefDNode(antlr::nullAST) &&
@@ -6835,8 +6838,8 @@ void GDLParser::constant_oct_ulong() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_ulong_AST = RefDNode(currentAST.root);
 		constant_oct_ulong_AST=astFactory->create(CONSTANT,c19->getText());
-		constant_oct_ulong_AST->Text2ULong(8);    
 		constant_oct_ulong_AST->SetLine( c19->getLine());    
+		constant_oct_ulong_AST->Text2ULong(8);    
 		
 		currentAST.root = constant_oct_ulong_AST;
 		if ( constant_oct_ulong_AST!=RefDNode(antlr::nullAST) &&
@@ -6864,8 +6867,8 @@ void GDLParser::constant_oct_ulong64() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_ulong64_AST = RefDNode(currentAST.root);
 		constant_oct_ulong64_AST=astFactory->create(CONSTANT,c20->getText());
-		constant_oct_ulong64_AST->Text2ULong64(8);    
 		constant_oct_ulong64_AST->SetLine( c20->getLine());    
+		constant_oct_ulong64_AST->Text2ULong64(8);    
 		
 		currentAST.root = constant_oct_ulong64_AST;
 		if ( constant_oct_ulong64_AST!=RefDNode(antlr::nullAST) &&
@@ -6893,11 +6896,11 @@ void GDLParser::constant_oct_ui() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_ui_AST = RefDNode(currentAST.root);
 		constant_oct_ui_AST=astFactory->create(CONSTANT,c211->getText());
+		constant_oct_ui_AST->SetLine( c211->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_oct_ui_AST->Text2ULong(8,true);    
 		else
 		constant_oct_ui_AST->Text2UInt(8,true);    
-		constant_oct_ui_AST->SetLine( c211->getLine());    
 		
 		currentAST.root = constant_oct_ui_AST;
 		if ( constant_oct_ui_AST!=RefDNode(antlr::nullAST) &&
@@ -6925,8 +6928,8 @@ void GDLParser::constant_oct_uint() {
 	if ( inputState->guessing==0 ) {
 		constant_oct_uint_AST = RefDNode(currentAST.root);
 		constant_oct_uint_AST=astFactory->create(CONSTANT,c21->getText());
-		constant_oct_uint_AST->Text2UInt(8);    
 		constant_oct_uint_AST->SetLine( c21->getLine());    
+		constant_oct_uint_AST->Text2UInt(8);    
 		
 		currentAST.root = constant_oct_uint_AST;
 		if ( constant_oct_uint_AST!=RefDNode(antlr::nullAST) &&
@@ -6954,8 +6957,8 @@ void GDLParser::constant_float() {
 	if ( inputState->guessing==0 ) {
 		constant_float_AST = RefDNode(currentAST.root);
 		constant_float_AST=astFactory->create(CONSTANT,c22->getText());
-		constant_float_AST->Text2Float();    
 		constant_float_AST->SetLine( c22->getLine());    
+		constant_float_AST->Text2Float();    
 		
 		currentAST.root = constant_float_AST;
 		if ( constant_float_AST!=RefDNode(antlr::nullAST) &&
@@ -6983,8 +6986,8 @@ void GDLParser::constant_double() {
 	if ( inputState->guessing==0 ) {
 		constant_double_AST = RefDNode(currentAST.root);
 		constant_double_AST=astFactory->create(CONSTANT,c23->getText());
-		constant_double_AST->Text2Double();    
 		constant_double_AST->SetLine( c23->getLine());    
+		constant_double_AST->Text2Double();    
 		
 		currentAST.root = constant_double_AST;
 		if ( constant_double_AST!=RefDNode(antlr::nullAST) &&
@@ -7012,8 +7015,8 @@ void GDLParser::constant_bin_byte() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_byte_AST = RefDNode(currentAST.root);
 		constant_bin_byte_AST=astFactory->create(CONSTANT,c24->getText());
-		constant_bin_byte_AST->Text2Byte(2);    
 		constant_bin_byte_AST->SetLine( c24->getLine());    
+		constant_bin_byte_AST->Text2Byte(2);    
 		
 		currentAST.root = constant_bin_byte_AST;
 		if ( constant_bin_byte_AST!=RefDNode(antlr::nullAST) &&
@@ -7041,8 +7044,8 @@ void GDLParser::constant_bin_long() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_long_AST = RefDNode(currentAST.root);
 		constant_bin_long_AST=astFactory->create(CONSTANT,c25->getText());
-		constant_bin_long_AST->Text2Long(2);    
 		constant_bin_long_AST->SetLine( c25->getLine());    
+		constant_bin_long_AST->Text2Long(2);    
 		
 		currentAST.root = constant_bin_long_AST;
 		if ( constant_bin_long_AST!=RefDNode(antlr::nullAST) &&
@@ -7070,8 +7073,8 @@ void GDLParser::constant_bin_long64() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_long64_AST = RefDNode(currentAST.root);
 		constant_bin_long64_AST=astFactory->create(CONSTANT,c26->getText());
-		constant_bin_long64_AST->Text2Long64(2);    
 		constant_bin_long64_AST->SetLine( c26->getLine());    
+		constant_bin_long64_AST->Text2Long64(2);    
 		
 		currentAST.root = constant_bin_long64_AST;
 		if ( constant_bin_long64_AST!=RefDNode(antlr::nullAST) &&
@@ -7099,8 +7102,8 @@ void GDLParser::constant_bin_int() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_int_AST = RefDNode(currentAST.root);
 		constant_bin_int_AST=astFactory->create(CONSTANT,c27->getText());
-		constant_bin_int_AST->Text2Int(2);    
 		constant_bin_int_AST->SetLine( c27->getLine());    
+		constant_bin_int_AST->Text2Int(2);    
 		
 		currentAST.root = constant_bin_int_AST;
 		if ( constant_bin_int_AST!=RefDNode(antlr::nullAST) &&
@@ -7128,11 +7131,11 @@ void GDLParser::constant_bin_i() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_i_AST = RefDNode(currentAST.root);
 		constant_bin_i_AST=astFactory->create(CONSTANT,c277->getText());
+		constant_bin_i_AST->SetLine( c277->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_bin_i_AST->Text2Long(2,true);    
 		else
 		constant_bin_i_AST->Text2Int(2,true);    
-		constant_bin_i_AST->SetLine( c277->getLine());    
 		
 		currentAST.root = constant_bin_i_AST;
 		if ( constant_bin_i_AST!=RefDNode(antlr::nullAST) &&
@@ -7160,8 +7163,8 @@ void GDLParser::constant_bin_ulong() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_ulong_AST = RefDNode(currentAST.root);
 		constant_bin_ulong_AST=astFactory->create(CONSTANT,c28->getText());
-		constant_bin_ulong_AST->Text2ULong(2);    
 		constant_bin_ulong_AST->SetLine( c28->getLine());    
+		constant_bin_ulong_AST->Text2ULong(2);    
 		
 		currentAST.root = constant_bin_ulong_AST;
 		if ( constant_bin_ulong_AST!=RefDNode(antlr::nullAST) &&
@@ -7189,8 +7192,8 @@ void GDLParser::constant_bin_ulong64() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_ulong64_AST = RefDNode(currentAST.root);
 		constant_bin_ulong64_AST=astFactory->create(CONSTANT,c29->getText());
-		constant_bin_ulong64_AST->Text2ULong64(2);    
 		constant_bin_ulong64_AST->SetLine( c29->getLine());    
+		constant_bin_ulong64_AST->Text2ULong64(2);    
 		
 		currentAST.root = constant_bin_ulong64_AST;
 		if ( constant_bin_ulong64_AST!=RefDNode(antlr::nullAST) &&
@@ -7218,11 +7221,11 @@ void GDLParser::constant_bin_ui() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_ui_AST = RefDNode(currentAST.root);
 		constant_bin_ui_AST=astFactory->create(CONSTANT,c300->getText());
+		constant_bin_ui_AST->SetLine( c300->getLine());    
 		if( compileOpt & DEFINT32)
 		constant_bin_ui_AST->Text2ULong(2,true);    
 		else
 		constant_bin_ui_AST->Text2UInt(2,true);    
-		constant_bin_ui_AST->SetLine( c300->getLine());    
 		
 		currentAST.root = constant_bin_ui_AST;
 		if ( constant_bin_ui_AST!=RefDNode(antlr::nullAST) &&
@@ -7250,8 +7253,8 @@ void GDLParser::constant_bin_uint() {
 	if ( inputState->guessing==0 ) {
 		constant_bin_uint_AST = RefDNode(currentAST.root);
 		constant_bin_uint_AST=astFactory->create(CONSTANT,c30->getText());
-		constant_bin_uint_AST->Text2UInt(2);    
 		constant_bin_uint_AST->SetLine( c30->getLine());    
+		constant_bin_uint_AST->Text2UInt(2);    
 		
 		currentAST.root = constant_bin_uint_AST;
 		if ( constant_bin_uint_AST!=RefDNode(antlr::nullAST) &&
@@ -7279,8 +7282,8 @@ void GDLParser::constant_cmplx_i() {
 	if ( inputState->guessing==0 ) {
 		constant_cmplx_i_AST = RefDNode(currentAST.root);
 		constant_cmplx_i_AST=astFactory->create(CONSTANT,c31->getText());
-		constant_cmplx_i_AST->Text2ComplexI();    
 		constant_cmplx_i_AST->SetLine( c31->getLine());    
+		constant_cmplx_i_AST->Text2ComplexI();    
 		
 		currentAST.root = constant_cmplx_i_AST;
 		if ( constant_cmplx_i_AST!=RefDNode(antlr::nullAST) &&
@@ -7308,8 +7311,8 @@ void GDLParser::constant_cmplxdbl_i() {
 	if ( inputState->guessing==0 ) {
 		constant_cmplxdbl_i_AST = RefDNode(currentAST.root);
 		constant_cmplxdbl_i_AST=astFactory->create(CONSTANT,c32->getText());
-		constant_cmplxdbl_i_AST->Text2ComplexDblI();    
 		constant_cmplxdbl_i_AST->SetLine( c32->getLine());    
+		constant_cmplxdbl_i_AST->Text2ComplexDblI();    
 		
 		currentAST.root = constant_cmplxdbl_i_AST;
 		if ( constant_cmplxdbl_i_AST!=RefDNode(antlr::nullAST) &&

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -752,7 +752,6 @@ void GDLParser::translation_unit() {
 	
 	subReached=false;
 	compileOpt=NONE; // reset compileOpt    
-	if (debugParser) std::cout << " translation_unit" << std::endl;
 	
 	
 	try {      // for error handling
@@ -957,7 +956,6 @@ void GDLParser::end_unit() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode end_unit_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " end_unit!" << std::endl;
 	
 	{ // ( ... )+
 	int _cnt35=0;
@@ -984,7 +982,6 @@ void GDLParser::forward_function() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode forward_function_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " forward_function -> " /* << std::endl */;
 	
 	RefDNode tmp5_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -1010,7 +1007,6 @@ void GDLParser::procedure_def() {
 	RefDNode n_AST = RefDNode(antlr::nullAST);
 	
 	std::string name;
-	if (debugParser) std::cout  << " procedure_def -> " /* << std::endl */; 
 	
 	
 	p = LT(1);
@@ -1111,7 +1107,7 @@ void GDLParser::procedure_def() {
 	if ( inputState->guessing==0 ) {
 		
 		if( subName == name && searchForPro == true) subReached=true;
-		p_AST->SetCompileOpt( compileOpt); if (debugParser) std::cout<<std::endl;
+		p_AST->SetCompileOpt( compileOpt); 
 		
 	}
 	procedure_def_AST = RefDNode(currentAST.root);
@@ -1128,7 +1124,6 @@ void GDLParser::function_def() {
 	RefDNode n_AST = RefDNode(antlr::nullAST);
 	
 	std::string name;
-	if (debugParser) std::cout  << " function_def -> " /* << std::endl */; 
 	
 	
 	f = LT(1);
@@ -1229,7 +1224,7 @@ void GDLParser::function_def() {
 	if ( inputState->guessing==0 ) {
 		
 		if( subName == name && searchForPro == false) subReached=true;
-		f_AST->SetCompileOpt( compileOpt); if (debugParser) std::cout<<std::endl;
+		f_AST->SetCompileOpt( compileOpt); 
 		
 	}
 	function_def_AST = RefDNode(currentAST.root);
@@ -1240,7 +1235,6 @@ void GDLParser::common_block() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode common_block_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " common_block -> " /* << std::endl */;
 	
 	match(COMMON);
 	RefDNode tmp11_AST = RefDNode(antlr::nullAST);
@@ -1280,7 +1274,7 @@ void GDLParser::common_block() {
 	{
 		if ( inputState->guessing==0 ) {
 			common_block_AST = RefDNode(currentAST.root);
-			common_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(COMMONDECL,"commondecl")))->add(antlr::RefAST(common_block_AST)))); if (debugParser) std::cout<<std::endl;
+			common_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(COMMONDECL,"commondecl")))->add(antlr::RefAST(common_block_AST))));
 			currentAST.root = common_block_AST;
 			if ( common_block_AST!=RefDNode(antlr::nullAST) &&
 				common_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -1300,7 +1294,7 @@ void GDLParser::common_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			common_block_AST = RefDNode(currentAST.root);
-			common_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(COMMONDEF,"commondef")))->add(antlr::RefAST(common_block_AST)))); if (debugParser) std::cout<<std::endl;
+			common_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(COMMONDEF,"commondef")))->add(antlr::RefAST(common_block_AST))));
 			currentAST.root = common_block_AST;
 			if ( common_block_AST!=RefDNode(antlr::nullAST) &&
 				common_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -1325,7 +1319,6 @@ void GDLParser::statement_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode statement_list_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " statement_list -> " /* << std::endl */;
 	
 	{ // ( ... )+
 	int _cnt73=0;
@@ -1372,7 +1365,6 @@ void GDLParser::interactive_compile() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode interactive_compile_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " interactive_compile! " << std::endl;
 	
 	{
 	switch ( LA(1)) {
@@ -1468,7 +1460,6 @@ void GDLParser::parameter_declaration() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode parameter_declaration_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " parameter_declaration -> " /* << std::endl */;
 	
 	{
 	if ((LA(1) == IDENTIFIER) && (LA(2) == COMMA || LA(2) == END_U)) {
@@ -1525,7 +1516,7 @@ void GDLParser::parameter_declaration() {
 	if ( inputState->guessing==0 ) {
 		parameter_declaration_AST = RefDNode(currentAST.root);
 		parameter_declaration_AST = 
-		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(PARADECL,"paradecl")))->add(antlr::RefAST(parameter_declaration_AST)))); if (debugParser) std::cout<<std::endl;
+		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(PARADECL,"paradecl")))->add(antlr::RefAST(parameter_declaration_AST))));
 		currentAST.root = parameter_declaration_AST;
 		if ( parameter_declaration_AST!=RefDNode(antlr::nullAST) &&
 			parameter_declaration_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -1542,7 +1533,6 @@ void GDLParser::interactive() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode interactive_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " interactive " << std::endl;
 	
 	try {      // for error handling
 		{ // ( ... )+
@@ -1726,7 +1716,6 @@ void GDLParser::end_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode end_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " end_mark! -> " /* << std::endl */;
 	
 	switch ( LA(1)) {
 	case END:
@@ -1822,7 +1811,6 @@ void GDLParser::interactive_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode interactive_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " interactive_statement " << std::endl;
 	
 	{ // ( ... )*
 	for (;;) {
@@ -1861,7 +1849,6 @@ void GDLParser::statement() {
 	RefDNode d3_AST = RefDNode(antlr::nullAST);
 	
 	bool parent=false;
-	if (debugParser) std::cout << " statement -> " /* << std::endl */; 
 	
 	
 	switch ( LA(1)) {
@@ -2094,8 +2081,7 @@ void GDLParser::statement() {
 					statement_AST = RefDNode(currentAST.root);
 					
 					statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MPCALL,"mpcall")))->add(antlr::RefAST(statement_AST))));
-					statement_AST->SetLine( d1_AST->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
-					
+					statement_AST->SetLine( d1_AST->getLine());
 					
 					currentAST.root = statement_AST;
 					if ( statement_AST!=RefDNode(antlr::nullAST) &&
@@ -2143,7 +2129,7 @@ void GDLParser::statement() {
 						statement_AST = RefDNode(currentAST.root);
 						
 						statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MPCALL_PARENT,"mpcall::")))->add(antlr::RefAST(statement_AST))));
-						statement_AST->SetLine( d2_AST->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
+						statement_AST->SetLine( d2_AST->getLine());
 						
 						currentAST.root = statement_AST;
 						if ( statement_AST!=RefDNode(antlr::nullAST) &&
@@ -2311,7 +2297,7 @@ void GDLParser::statement() {
 							}
 							if ( inputState->guessing==0 ) {
 								statement_AST = RefDNode(currentAST.root);
-								statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(statement_AST)))); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
+								statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(statement_AST))));
 								currentAST.root = statement_AST;
 								if ( statement_AST!=RefDNode(antlr::nullAST) &&
 									statement_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -2610,7 +2596,6 @@ void GDLParser::statement() {
 								statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MPCALL_PARENT,"mpcall::")))->add(antlr::RefAST(statement_AST)))); 
 								else
 								statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MPCALL,"mpcall")))->add(antlr::RefAST(statement_AST))));
-										if (debugParser) std::cout<<"statement : \""<<LT(0)->getText()<<"\""<<std::endl;
 								
 								currentAST.root = statement_AST;
 								if ( statement_AST!=RefDNode(antlr::nullAST) &&
@@ -2644,7 +2629,7 @@ void GDLParser::statement() {
 							statement_AST = RefDNode(currentAST.root);
 							
 							statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MPCALL,"mpcall")))->add(antlr::RefAST(statement_AST))));
-							statement_AST->SetLine( d3_AST->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
+							statement_AST->SetLine( d3_AST->getLine());
 							
 							currentAST.root = statement_AST;
 							if ( statement_AST!=RefDNode(antlr::nullAST) &&
@@ -2676,7 +2661,6 @@ void GDLParser::switch_statement() {
 	RefDNode switch_statement_AST = RefDNode(antlr::nullAST);
 	
 	int numBranch=0;
-	if (debugParser) std::cout  << " switch_statement " << std::endl; 
 	
 	
 	RefDNode tmp61_AST = RefDNode(antlr::nullAST);
@@ -2803,7 +2787,6 @@ void GDLParser::expr() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode expr_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " expr-> ";
 	
 	logical_expr();
 	if (inputState->guessing==0) {
@@ -2859,7 +2842,6 @@ void GDLParser::switch_body() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode switch_body_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " switch_body " << std::endl;
 	
 	switch ( LA(1)) {
 	case IDENTIFIER:
@@ -2979,7 +2961,7 @@ void GDLParser::switch_body() {
 		}
 		if ( inputState->guessing==0 ) {
 			switch_body_AST = RefDNode(currentAST.root);
-			switch_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(switch_body_AST)))); if (debugParser) std::cout<<std::endl;
+			switch_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(switch_body_AST))));
 			currentAST.root = switch_body_AST;
 			if ( switch_body_AST!=RefDNode(antlr::nullAST) &&
 				switch_body_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3052,7 +3034,7 @@ void GDLParser::switch_body() {
 		}
 		if ( inputState->guessing==0 ) {
 			switch_body_AST = RefDNode(currentAST.root);
-			switch_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ELSEBLK,"elseblk")))->add(antlr::RefAST(switch_body_AST)))); if (debugParser) std::cout<<std::endl;
+			switch_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ELSEBLK,"elseblk")))->add(antlr::RefAST(switch_body_AST))));
 			currentAST.root = switch_body_AST;
 			if ( switch_body_AST!=RefDNode(antlr::nullAST) &&
 				switch_body_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3076,7 +3058,6 @@ void GDLParser::endswitch_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endswitch_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endswitch_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDSWITCH:
@@ -3109,7 +3090,6 @@ void GDLParser::endswitchelse_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endswitchelse_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endswitchelse_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case END:
@@ -3141,7 +3121,6 @@ void GDLParser::case_statement() {
 	RefDNode case_statement_AST = RefDNode(antlr::nullAST);
 	
 	int numBranch=0;
-	if (debugParser) std::cout  << " case_statement " << std::endl; 
 	
 	
 	RefDNode tmp73_AST = RefDNode(antlr::nullAST);
@@ -3257,7 +3236,7 @@ void GDLParser::case_statement() {
 	}
 	if ( inputState->guessing==0 ) {
 		
-		tmp73_AST->SetNumBranch(numBranch); if (debugParser) std::cout<<std::endl;
+		tmp73_AST->SetNumBranch(numBranch); 
 		
 	}
 	case_statement_AST = RefDNode(currentAST.root);
@@ -3268,7 +3247,6 @@ void GDLParser::case_body() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode case_body_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " case_body " << std::endl;
 	
 	switch ( LA(1)) {
 	case IDENTIFIER:
@@ -3388,7 +3366,7 @@ void GDLParser::case_body() {
 		}
 		if ( inputState->guessing==0 ) {
 			case_body_AST = RefDNode(currentAST.root);
-			case_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(case_body_AST)))); if (debugParser) std::cout<<std::endl;
+			case_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(case_body_AST))));
 			currentAST.root = case_body_AST;
 			if ( case_body_AST!=RefDNode(antlr::nullAST) &&
 				case_body_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3461,7 +3439,7 @@ void GDLParser::case_body() {
 		}
 		if ( inputState->guessing==0 ) {
 			case_body_AST = RefDNode(currentAST.root);
-			case_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ELSEBLK,"elseblk")))->add(antlr::RefAST(case_body_AST)))); if (debugParser) std::cout<<std::endl;
+			case_body_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ELSEBLK,"elseblk")))->add(antlr::RefAST(case_body_AST))));
 			currentAST.root = case_body_AST;
 			if ( case_body_AST!=RefDNode(antlr::nullAST) &&
 				case_body_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3485,7 +3463,6 @@ void GDLParser::endcase_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endcase_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endcase_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDCASE:
@@ -3518,7 +3495,6 @@ void GDLParser::endcaseelse_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endcaseelse_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endcaseelse_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case END:
@@ -3548,7 +3524,6 @@ void GDLParser::identifier_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode identifier_list_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " identifier_list -> " /* << std::endl */;
 	
 	RefDNode tmp83_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -3582,7 +3557,6 @@ void GDLParser::keyword_declaration() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode keyword_declaration_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " keyword_declaration -> " /* << std::endl */;
 	
 	RefDNode tmp86_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -3600,7 +3574,7 @@ void GDLParser::keyword_declaration() {
 	if ( inputState->guessing==0 ) {
 		keyword_declaration_AST = RefDNode(currentAST.root);
 		keyword_declaration_AST =
-		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(KEYDECL,"keydecl")))->add(antlr::RefAST(keyword_declaration_AST)))); if (debugParser) std::cout<<std::endl;
+		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(KEYDECL,"keydecl")))->add(antlr::RefAST(keyword_declaration_AST))));
 		currentAST.root = keyword_declaration_AST;
 		if ( keyword_declaration_AST!=RefDNode(antlr::nullAST) &&
 			keyword_declaration_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3624,7 +3598,6 @@ std::string  GDLParser::object_name() {
 	RefDNode m_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  i2 = antlr::nullToken;
 	RefDNode i2_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " object_name! -> " /* << std::endl */;
 	
 	i1 = LT(1);
 	if ( inputState->guessing == 0 ) {
@@ -3653,7 +3626,7 @@ std::string  GDLParser::object_name() {
 		}
 		
 		object_name_AST = RefDNode(astFactory->make((new antlr::ASTArray(4))->add(antlr::RefAST(NULL))->add(antlr::RefAST(i2_AST))->add(antlr::RefAST(m_AST))->add(antlr::RefAST(i1_AST)))); // NULL -> no root
-		name= std::string( i1->getText()+"__"+i2->getText()); if (debugParser) std::cout<<std::endl;
+		name= std::string( i1->getText()+"__"+i2->getText()); 
 		
 		currentAST.root = object_name_AST;
 		if ( object_name_AST!=RefDNode(antlr::nullAST) &&
@@ -3675,7 +3648,6 @@ void GDLParser::compile_opt() {
 	RefDNode i_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  ii = antlr::nullToken;
 	RefDNode ii_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " compile_opt! -> " /* << std::endl */;
 	
 	RefDNode tmp89_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -3725,7 +3697,6 @@ void GDLParser::endforeach_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endforeach_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endforeach_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDFOREACH:
@@ -3758,7 +3729,6 @@ void GDLParser::endfor_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endfor_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endfor_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDFOR:
@@ -3791,7 +3761,6 @@ void GDLParser::endrep_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endrep_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endrep_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDREP:
@@ -3824,7 +3793,6 @@ void GDLParser::endwhile_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endwhile_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endwhile_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDWHILE:
@@ -3857,7 +3825,6 @@ void GDLParser::endif_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endif_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endif_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDIF:
@@ -3890,7 +3857,6 @@ void GDLParser::endelse_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode endelse_mark_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " endelse_mark! " << std::endl;
 	
 	switch ( LA(1)) {
 	case ENDELSE:
@@ -3923,7 +3889,6 @@ void GDLParser::compound_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode compound_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " compound_statement -> " /* << std::endl */;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -3966,7 +3931,7 @@ void GDLParser::compound_statement() {
 		}
 		if ( inputState->guessing==0 ) {
 			compound_statement_AST = RefDNode(currentAST.root);
-			compound_statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(compound_statement_AST)))); if (debugParser) std::cout<<std::endl;
+			compound_statement_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(compound_statement_AST))));
 			currentAST.root = compound_statement_AST;
 			if ( compound_statement_AST!=RefDNode(antlr::nullAST) &&
 				compound_statement_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -3990,7 +3955,6 @@ void GDLParser::label_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode label_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " label_statement -> " /* << std::endl */;
 	
 	{ // ( ... )+
 	int _cnt77=0;
@@ -4056,7 +4020,6 @@ void GDLParser::label() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode label_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " label -> " /* << std::endl */;
 	
 	RefDNode tmp104_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4080,7 +4043,6 @@ void GDLParser::baseclass_method() {
 	RefDNode baseclass_method_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  s = antlr::nullToken;
 	RefDNode s_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout  << " baseclass_method -> " /* << std::endl */;
 	
 	s = LT(1);
 	if ( inputState->guessing == 0 ) {
@@ -4105,7 +4067,6 @@ void GDLParser::assign_expr() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode assign_expr_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " assign_expr -> " /* << std::endl */;
 	
 	match(LBRACE);
 	deref_expr();
@@ -4120,7 +4081,7 @@ void GDLParser::assign_expr() {
 	match(RBRACE);
 	if ( inputState->guessing==0 ) {
 		assign_expr_AST = RefDNode(currentAST.root);
-		assign_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(assign_expr_AST)))); if (debugParser) std::cout<<" assign_expr : \""<<LT(0)->getText()<<"\""<<std::endl;
+		assign_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(assign_expr_AST))));
 		currentAST.root = assign_expr_AST;
 		if ( assign_expr_AST!=RefDNode(antlr::nullAST) &&
 			assign_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4141,7 +4102,6 @@ void GDLParser::deref_dot_expr_keeplast() {
 	
 	RefDNode dot;
 	int nDot;
-	if (debugParser) std::cout << " deref_dot_expr_keeplast -> " /* << std::endl */; 
 	
 	
 	switch ( LA(1)) {
@@ -4168,7 +4128,7 @@ void GDLParser::deref_dot_expr_keeplast() {
 			dot=astFactory->create(DOT,".");
 			dot->SetNDot( nDot);    
 			dot->SetLine( a1_AST->getLine());
-			deref_dot_expr_keeplast_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_dot_expr_keeplast_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			deref_dot_expr_keeplast_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_dot_expr_keeplast_AST))));
 			}
 			
 			currentAST.root = deref_dot_expr_keeplast_AST;
@@ -4193,7 +4153,7 @@ void GDLParser::deref_dot_expr_keeplast() {
 		if ( inputState->guessing==0 ) {
 			deref_dot_expr_keeplast_AST = RefDNode(currentAST.root);
 			deref_dot_expr_keeplast_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_dot_expr_keeplast_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_dot_expr_keeplast_AST))));
 			currentAST.root = deref_dot_expr_keeplast_AST;
 			if ( deref_dot_expr_keeplast_AST!=RefDNode(antlr::nullAST) &&
 				deref_dot_expr_keeplast_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4217,7 +4177,6 @@ void GDLParser::formal_procedure_call() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode formal_procedure_call_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " formal_procedure_call -> " /* << std::endl */;
 	
 	RefDNode tmp111_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4260,7 +4219,6 @@ void GDLParser::deref_expr() {
 	
 	RefDNode dot;
 	SizeT nDot;
-	if (debugParser) std::cout << " deref_expr -> " /* << std::endl */; 
 	
 	
 	switch ( LA(1)) {
@@ -4290,7 +4248,7 @@ void GDLParser::deref_expr() {
 				dot->SetNDot( nDot);    
 				dot->SetLine( a1_AST->getLine());
 				
-				deref_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+				deref_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_expr_AST))));
 				
 				currentAST.root = deref_expr_AST;
 				if ( deref_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -4362,7 +4320,7 @@ void GDLParser::deref_expr() {
 		{
 			if ( inputState->guessing==0 ) {
 				deref_expr_AST = RefDNode(currentAST.root);
-				deref_expr_AST = a1_AST; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+				deref_expr_AST = a1_AST;
 				currentAST.root = deref_expr_AST;
 				if ( deref_expr_AST!=RefDNode(antlr::nullAST) &&
 					deref_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4392,7 +4350,7 @@ void GDLParser::deref_expr() {
 		if ( inputState->guessing==0 ) {
 			deref_expr_AST = RefDNode(currentAST.root);
 			deref_expr_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_expr_AST))));
 			currentAST.root = deref_expr_AST;
 			if ( deref_expr_AST!=RefDNode(antlr::nullAST) &&
 				deref_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4420,7 +4378,6 @@ void GDLParser::procedure_call() {
 	RefDNode id_AST = RefDNode(antlr::nullAST);
 	RefDNode e_AST = RefDNode(antlr::nullAST);
 	RefDNode pa_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " procedure_call! -> " /* << std::endl */;
 	
 	id = LT(1);
 	if ( inputState->guessing == 0 ) {
@@ -4457,7 +4414,7 @@ void GDLParser::procedure_call() {
 			
 			id_AST->setType(RETURN); // text is already "return"
 			procedure_call_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(e_AST)))); // make root
-			if (debugParser) std::cout<<" procedure_call : \""<<LT(0)->getText()<<"\""<<std::endl;
+			
 			currentAST.root = procedure_call_AST;
 			if ( procedure_call_AST!=RefDNode(antlr::nullAST) &&
 				procedure_call_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4472,7 +4429,7 @@ void GDLParser::procedure_call() {
 			procedure_call_AST = RefDNode(currentAST.root);
 			
 			id_AST->setType(BREAK); // text is already "break"
-			procedure_call_AST = id_AST; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			procedure_call_AST = id_AST;
 			
 			currentAST.root = procedure_call_AST;
 			if ( procedure_call_AST!=RefDNode(antlr::nullAST) &&
@@ -4488,7 +4445,7 @@ void GDLParser::procedure_call() {
 			procedure_call_AST = RefDNode(currentAST.root);
 			
 			id_AST->setType(CONTINUE); // text is already "continue"
-			procedure_call_AST = id_AST; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			procedure_call_AST = id_AST;
 			
 			currentAST.root = procedure_call_AST;
 			if ( procedure_call_AST!=RefDNode(antlr::nullAST) &&
@@ -4527,7 +4484,7 @@ void GDLParser::procedure_call() {
 			procedure_call_AST = RefDNode(currentAST.root);
 			
 			procedure_call_AST = RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(PCALL,"pcall")))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(pa_AST))));
-			procedure_call_AST->SetLine(id->getLine()); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			procedure_call_AST->SetLine(id->getLine());
 			
 			currentAST.root = procedure_call_AST;
 			if ( procedure_call_AST!=RefDNode(antlr::nullAST) &&
@@ -4550,7 +4507,6 @@ void GDLParser::for_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode for_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " for_statement " << std::endl;
 	
 	RefDNode tmp116_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4608,7 +4564,6 @@ void GDLParser::foreach_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode foreach_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " foreach_statement " << std::endl;
 	
 	RefDNode tmp122_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4663,7 +4618,6 @@ void GDLParser::repeat_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode repeat_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " repeat_statement " << std::endl;
 	
 	RefDNode tmp128_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4688,7 +4642,6 @@ void GDLParser::while_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode while_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " while_statement " << std::endl;
 	
 	RefDNode tmp130_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4713,7 +4666,6 @@ void GDLParser::jump_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode jump_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " jump_statement " << std::endl;
 	
 	switch ( LA(1)) {
 	case GOTO:
@@ -4764,7 +4716,6 @@ void GDLParser::if_statement() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode if_statement_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " if_statement " << std::endl;
 	
 	RefDNode tmp138_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -4806,7 +4757,6 @@ void GDLParser::repeat_block() {
 	RefDNode repeat_block_AST = RefDNode(antlr::nullAST);
 	RefDNode st_AST = RefDNode(antlr::nullAST);
 	RefDNode stl_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " repeat_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -4836,7 +4786,7 @@ void GDLParser::repeat_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			repeat_block_AST = RefDNode(currentAST.root);
-			repeat_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST)))); if (debugParser) std::cout<<std::endl;
+			repeat_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST))));
 			currentAST.root = repeat_block_AST;
 			if ( repeat_block_AST!=RefDNode(antlr::nullAST) &&
 				repeat_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4862,7 +4812,7 @@ void GDLParser::repeat_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			repeat_block_AST = RefDNode(currentAST.root);
-			repeat_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST)))); if (debugParser) std::cout<<std::endl;
+			repeat_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST))));
 			currentAST.root = repeat_block_AST;
 			if ( repeat_block_AST!=RefDNode(antlr::nullAST) &&
 				repeat_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4886,7 +4836,6 @@ void GDLParser::while_block() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode while_block_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " while_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -4929,7 +4878,7 @@ void GDLParser::while_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			while_block_AST = RefDNode(currentAST.root);
-			while_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(while_block_AST)))); if (debugParser) std::cout<<std::endl;
+			while_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(while_block_AST))));
 			currentAST.root = while_block_AST;
 			if ( while_block_AST!=RefDNode(antlr::nullAST) &&
 				while_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -4955,7 +4904,6 @@ void GDLParser::for_block() {
 	RefDNode for_block_AST = RefDNode(antlr::nullAST);
 	RefDNode st_AST = RefDNode(antlr::nullAST);
 	RefDNode stl_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " for_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -4985,7 +4933,7 @@ void GDLParser::for_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			for_block_AST = RefDNode(currentAST.root);
-			for_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST)))); if (debugParser) std::cout<<std::endl;
+			for_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST))));
 			currentAST.root = for_block_AST;
 			if ( for_block_AST!=RefDNode(antlr::nullAST) &&
 				for_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5011,7 +4959,7 @@ void GDLParser::for_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			for_block_AST = RefDNode(currentAST.root);
-			for_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST)))); if (debugParser) std::cout<<std::endl;
+			for_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST))));
 			currentAST.root = for_block_AST;
 			if ( for_block_AST!=RefDNode(antlr::nullAST) &&
 				for_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5037,7 +4985,6 @@ void GDLParser::foreach_block() {
 	RefDNode foreach_block_AST = RefDNode(antlr::nullAST);
 	RefDNode st_AST = RefDNode(antlr::nullAST);
 	RefDNode stl_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " foreach_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -5067,7 +5014,7 @@ void GDLParser::foreach_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			foreach_block_AST = RefDNode(currentAST.root);
-			foreach_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST)))); if (debugParser) std::cout<<std::endl;
+			foreach_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(st_AST))));
 			currentAST.root = foreach_block_AST;
 			if ( foreach_block_AST!=RefDNode(antlr::nullAST) &&
 				foreach_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5093,7 +5040,7 @@ void GDLParser::foreach_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			foreach_block_AST = RefDNode(currentAST.root);
-			foreach_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST)))); if (debugParser) std::cout<<std::endl;
+			foreach_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(stl_AST))));
 			currentAST.root = foreach_block_AST;
 			if ( foreach_block_AST!=RefDNode(antlr::nullAST) &&
 				foreach_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5117,7 +5064,6 @@ void GDLParser::if_block() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode if_block_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " if_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -5160,7 +5106,7 @@ void GDLParser::if_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			if_block_AST = RefDNode(currentAST.root);
-			if_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(if_block_AST)))); if (debugParser) std::cout<<std::endl;
+			if_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(if_block_AST))));
 			currentAST.root = if_block_AST;
 			if ( if_block_AST!=RefDNode(antlr::nullAST) &&
 				if_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5184,7 +5130,6 @@ void GDLParser::else_block() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode else_block_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " else_block " << std::endl;
 	
 	switch ( LA(1)) {
 	case FOR:
@@ -5227,7 +5172,7 @@ void GDLParser::else_block() {
 		}
 		if ( inputState->guessing==0 ) {
 			else_block_AST = RefDNode(currentAST.root);
-			else_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(else_block_AST)))); if (debugParser) std::cout<<std::endl;
+			else_block_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(BLOCK,"block")))->add(antlr::RefAST(else_block_AST))));
 			currentAST.root = else_block_AST;
 			if ( else_block_AST!=RefDNode(antlr::nullAST) &&
 				else_block_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5251,7 +5196,6 @@ void GDLParser::parameter_def_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode parameter_def_list_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " parameter_def_list -> " /* << std::endl */;
 	
 	parameter_def();
 	if (inputState->guessing==0) {
@@ -5281,7 +5225,6 @@ void GDLParser::formal_function_call() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode formal_function_call_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " formal_function_call -> " /* << std::endl */;
 	
 	RefDNode tmp148_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -5413,7 +5356,6 @@ void GDLParser::parameter_def() {
 	antlr::ASTPair currentAST;
 	RefDNode parameter_def_AST = RefDNode(antlr::nullAST);
 	RefDNode id_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " parameter_def -> " /* << std::endl */;
 	
 	if ((_tokenSet_10.member(LA(1))) && (LA(2) == EQUAL)) {
 		identifier();
@@ -5427,7 +5369,7 @@ void GDLParser::parameter_def() {
 		}
 		if ( inputState->guessing==0 ) {
 			parameter_def_AST = RefDNode(currentAST.root);
-			parameter_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(KEYDEF,"!=!")))->add(antlr::RefAST(parameter_def_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			parameter_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(KEYDEF,"!=!")))->add(antlr::RefAST(parameter_def_AST))));
 			currentAST.root = parameter_def_AST;
 			if ( parameter_def_AST!=RefDNode(antlr::nullAST) &&
 				parameter_def_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5458,7 +5400,7 @@ void GDLParser::parameter_def() {
 			RefDNode c=static_cast<RefDNode>( astFactory->create(CONSTANT,"1"));
 			c->Text2Int(10);
 			c->SetLine( id_AST->getLine());
-			parameter_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(KEYDEF,"!=!")))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(c)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			parameter_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(KEYDEF,"!=!")))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(c))));
 			
 			currentAST.root = parameter_def_AST;
 			if ( parameter_def_AST!=RefDNode(antlr::nullAST) &&
@@ -5487,7 +5429,6 @@ void GDLParser::array_def() {
 	
 	bool constant = true;
 	int flexible_array_def_count=1;
-	if (debugParser) std::cout << " array_def -> " /* << std::endl */; 
 	
 	
 	match(LSQUARE);
@@ -5531,7 +5472,7 @@ void GDLParser::array_def() {
 			if( constant)
 			array_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYDEF_CONST,"array_def_const")))->add(antlr::RefAST(array_def_AST))));
 			else
-			array_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYDEF,"array_def")))->add(antlr::RefAST(array_def_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			array_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYDEF,"array_def")))->add(antlr::RefAST(array_def_AST))));
 			
 			currentAST.root = array_def_AST;
 			if ( array_def_AST!=RefDNode(antlr::nullAST) &&
@@ -5572,7 +5513,7 @@ void GDLParser::array_def() {
 			array_def_AST = RefDNode(currentAST.root);
 			
 			if (flexible_array_def_count>3 || flexible_array_def_count<2) throw GDLException( "Illegal array creation syntax.");
-			array_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYDEF_GENERALIZED_INDGEN,"array_def_generalized_indgen")))->add(antlr::RefAST(array_def_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			array_def_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYDEF_GENERALIZED_INDGEN,"array_def_generalized_indgen")))->add(antlr::RefAST(array_def_AST))));
 			
 			currentAST.root = array_def_AST;
 			if ( array_def_AST!=RefDNode(antlr::nullAST) &&
@@ -5604,7 +5545,6 @@ void GDLParser::struct_identifier() {
 	RefDNode e_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  i = antlr::nullToken;
 	RefDNode i_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " struct_identifier -> " /* << std::endl */;
 	
 	{
 	switch ( LA(1)) {
@@ -5672,7 +5612,6 @@ void GDLParser::struct_name() {
 	antlr::ASTPair currentAST;
 	RefDNode struct_name_AST = RefDNode(antlr::nullAST);
 	RefDNode s_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " struct_name -> " /* << std::endl */;
 	
 	struct_identifier();
 	if (inputState->guessing==0) {
@@ -5695,7 +5634,6 @@ void GDLParser::struct_def() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode struct_def_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " struct_def -> " /* << std::endl */;
 	
 	match(LCURLY);
 	{
@@ -5729,7 +5667,7 @@ void GDLParser::struct_def() {
 		if ( inputState->guessing==0 ) {
 			struct_def_AST = RefDNode(currentAST.root);
 			struct_def_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(NSTRUC_REF,"nstruct_ref")))->add(antlr::RefAST(struct_def_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(NSTRUC_REF,"nstruct_ref")))->add(antlr::RefAST(struct_def_AST))));
 			currentAST.root = struct_def_AST;
 			if ( struct_def_AST!=RefDNode(antlr::nullAST) &&
 				struct_def_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5748,7 +5686,7 @@ void GDLParser::struct_def() {
 		if ( inputState->guessing==0 ) {
 			struct_def_AST = RefDNode(currentAST.root);
 			struct_def_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(STRUC,"struct")))->add(antlr::RefAST(struct_def_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(STRUC,"struct")))->add(antlr::RefAST(struct_def_AST))));
 			currentAST.root = struct_def_AST;
 			if ( struct_def_AST!=RefDNode(antlr::nullAST) &&
 				struct_def_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -5771,7 +5709,6 @@ void GDLParser::named_tag_def_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode named_tag_def_list_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " named_tag_def_list -> " /* << std::endl */;
 	
 	named_tag_def_entry();
 	if (inputState->guessing==0) {
@@ -5801,7 +5738,6 @@ void GDLParser::tag_def_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode tag_def_list_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " tag_def_list -> " /* << std::endl */;
 	
 	tag_def();
 	if (inputState->guessing==0) {
@@ -5831,7 +5767,6 @@ void GDLParser::tag_def() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode tag_def_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " tag_def -> " /* << std::endl */;
 	
 	struct_identifier();
 	if (inputState->guessing==0) {
@@ -5850,7 +5785,6 @@ void GDLParser::ntag_def() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode ntag_def_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " ntag_def -> " /* << std::endl */;
 	
 	if ((_tokenSet_13.member(LA(1))) && (LA(2) == COLON)) {
 		tag_def();
@@ -5877,7 +5811,6 @@ void GDLParser::ntag_defs() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode ntag_defs_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " ntag_defs -> " /* << std::endl */;
 	
 	ntag_def();
 	if (inputState->guessing==0) {
@@ -5907,7 +5840,6 @@ void GDLParser::named_tag_def_entry() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode named_tag_def_entry_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " named_tag_def_entry -> " /* << std::endl */;
 	
 	{
 	bool synPredMatched147 = false;
@@ -7480,7 +7412,6 @@ void GDLParser::arrayindex_list() {
 	RefDNode arrayindex_list_AST = RefDNode(antlr::nullAST);
 	
 	int rank = 1;
-	if (debugParser) std::cout << " arrayindex_list -> " /* << std::endl */; 
 	
 	
 	if ((LA(1) == LSQUARE)) {
@@ -7544,7 +7475,6 @@ void GDLParser::arrayindex() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode arrayindex_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " arrayindex -> " /* << std::endl */;
 	
 	{
 	bool synPredMatched203 = false;
@@ -7758,7 +7688,7 @@ void GDLParser::arrayindex() {
 	}
 	if ( inputState->guessing==0 ) {
 		arrayindex_AST = RefDNode(currentAST.root);
-		arrayindex_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYIX,"arrayix")))->add(antlr::RefAST(arrayindex_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+		arrayindex_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYIX,"arrayix")))->add(antlr::RefAST(arrayindex_AST))));
 		currentAST.root = arrayindex_AST;
 		if ( arrayindex_AST!=RefDNode(antlr::nullAST) &&
 			arrayindex_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -7775,7 +7705,6 @@ void GDLParser::all_elements() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode all_elements_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " all_elements! -> " /* << std::endl */;
 	
 	RefDNode tmp177_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -7784,7 +7713,7 @@ void GDLParser::all_elements() {
 	match(ASTERIX);
 	if ( inputState->guessing==0 ) {
 		all_elements_AST = RefDNode(currentAST.root);
-		all_elements_AST = RefDNode(astFactory->make((new antlr::ASTArray(1))->add(antlr::RefAST(astFactory->create(ALL,"*"))))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+		all_elements_AST = RefDNode(astFactory->make((new antlr::ASTArray(1))->add(antlr::RefAST(astFactory->create(ALL,"*")))));
 		currentAST.root = all_elements_AST;
 		if ( all_elements_AST!=RefDNode(antlr::nullAST) &&
 			all_elements_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -7800,7 +7729,6 @@ void GDLParser::sysvar() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode sysvar_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " sysvar -> " /* << std::endl */;
 	
 	RefDNode tmp178_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
@@ -7810,7 +7738,7 @@ void GDLParser::sysvar() {
 	match(SYSVARNAME);
 	if ( inputState->guessing==0 ) {
 		sysvar_AST = RefDNode(currentAST.root);
-		sysvar_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(SYSVAR,"SYSVAR")))->add(antlr::RefAST(sysvar_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+		sysvar_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(SYSVAR,"SYSVAR")))->add(antlr::RefAST(sysvar_AST))));
 		currentAST.root = sysvar_AST;
 		if ( sysvar_AST!=RefDNode(antlr::nullAST) &&
 			sysvar_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -7831,7 +7759,6 @@ void GDLParser::var() {
 	RefDNode id_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  ih = antlr::nullToken;
 	RefDNode ih_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " var: " /* << std::endl */;
 	
 	{
 	switch ( LA(1)) {
@@ -7845,7 +7772,7 @@ void GDLParser::var() {
 		if ( inputState->guessing==0 ) {
 			var_AST = RefDNode(currentAST.root);
 			
-			var_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(VAR,"VAR")))->add(antlr::RefAST(id_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			var_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(VAR,"VAR")))->add(antlr::RefAST(id_AST))));
 			
 			currentAST.root = var_AST;
 			if ( var_AST!=RefDNode(antlr::nullAST) &&
@@ -7868,7 +7795,7 @@ void GDLParser::var() {
 			var_AST = RefDNode(currentAST.root);
 			
 			ih_AST->setType( IDENTIFIER);
-			var_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(VAR,"VAR")))->add(antlr::RefAST(ih_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			var_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(VAR,"VAR")))->add(antlr::RefAST(ih_AST))));
 			
 			currentAST.root = var_AST;
 			if ( var_AST!=RefDNode(antlr::nullAST) &&
@@ -7903,7 +7830,7 @@ void GDLParser::brace_expr() {
 	if ( inputState->guessing==0 ) {
 		brace_expr_AST = RefDNode(currentAST.root);
 		brace_expr_AST = 
-		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(EXPR,"expr")))->add(antlr::RefAST(brace_expr_AST)))); if (debugParser) std::cout<<"brace_expr: \""<<LT(0)->getText()<<"\""<<std::endl;
+		RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(EXPR,"expr")))->add(antlr::RefAST(brace_expr_AST))));
 		
 		currentAST.root = brace_expr_AST;
 		if ( brace_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -7921,7 +7848,6 @@ void GDLParser::array_expr_1st_sub() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode array_expr_1st_sub_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " array_expr_1st_sub -> " /* << std::endl */;
 	
 	switch ( LA(1)) {
 	case IDENTIFIER:
@@ -7966,7 +7892,6 @@ void GDLParser::array_expr_1st() {
 	RefDNode array_expr_1st_AST = RefDNode(antlr::nullAST);
 	RefDNode e_AST = RefDNode(antlr::nullAST);
 	RefDNode al_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " array_expr_1st! -> " /* << std::endl */;
 	
 	array_expr_1st_sub();
 	if (inputState->guessing==0) {
@@ -7984,7 +7909,7 @@ void GDLParser::array_expr_1st() {
 		if ( inputState->guessing==0 ) {
 			array_expr_1st_AST = RefDNode(currentAST.root);
 			array_expr_1st_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST)))); if (debugParser) std::cout<<" array_expr_1st: \""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST))));
 			currentAST.root = array_expr_1st_AST;
 			if ( array_expr_1st_AST!=RefDNode(antlr::nullAST) &&
 				array_expr_1st_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8056,7 +7981,7 @@ void GDLParser::array_expr_1st() {
 	{
 		if ( inputState->guessing==0 ) {
 			array_expr_1st_AST = RefDNode(currentAST.root);
-			array_expr_1st_AST = e_AST; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			array_expr_1st_AST = e_AST;
 			currentAST.root = array_expr_1st_AST;
 			if ( array_expr_1st_AST!=RefDNode(antlr::nullAST) &&
 				array_expr_1st_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8080,7 +8005,6 @@ void GDLParser::array_expr_nth_sub() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode array_expr_nth_sub_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " array_expr_nth_sub -> " /* << std::endl */;
 	
 	switch ( LA(1)) {
 	case IDENTIFIER:
@@ -8117,7 +8041,6 @@ void GDLParser::array_expr_nth() {
 	RefDNode array_expr_nth_AST = RefDNode(antlr::nullAST);
 	RefDNode e_AST = RefDNode(antlr::nullAST);
 	RefDNode al_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " array_expr_nth! -> " /* << std::endl */;
 	
 	array_expr_nth_sub();
 	if (inputState->guessing==0) {
@@ -8135,7 +8058,7 @@ void GDLParser::array_expr_nth() {
 		if ( inputState->guessing==0 ) {
 			array_expr_nth_AST = RefDNode(currentAST.root);
 			array_expr_nth_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST)))); if (debugParser) std::cout<<"array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST))));
 			currentAST.root = array_expr_nth_AST;
 			if ( array_expr_nth_AST!=RefDNode(antlr::nullAST) &&
 				array_expr_nth_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8150,7 +8073,7 @@ void GDLParser::array_expr_nth() {
 	{
 		if ( inputState->guessing==0 ) {
 			array_expr_nth_AST = RefDNode(currentAST.root);
-			array_expr_nth_AST = e_AST; if (debugParser) std::cout<<"array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;
+			array_expr_nth_AST = e_AST;
 			currentAST.root = array_expr_nth_AST;
 			if ( array_expr_nth_AST!=RefDNode(antlr::nullAST) &&
 				array_expr_nth_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8178,7 +8101,6 @@ void GDLParser::tag_array_expr_nth_sub() {
 	RefDNode s_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  e = antlr::nullToken;
 	RefDNode e_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " tag_array_expr_nth_sub -> " /* << std::endl */;
 	
 	switch ( LA(1)) {
 	case IDENTIFIER:
@@ -8243,7 +8165,6 @@ void GDLParser::tag_array_expr_nth() {
 	RefDNode tag_array_expr_nth_AST = RefDNode(antlr::nullAST);
 	RefDNode e_AST = RefDNode(antlr::nullAST);
 	RefDNode al_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " tag_array_expr_nth! -> " /* << std::endl */;
 	
 	tag_array_expr_nth_sub();
 	if (inputState->guessing==0) {
@@ -8261,7 +8182,7 @@ void GDLParser::tag_array_expr_nth() {
 		if ( inputState->guessing==0 ) {
 			tag_array_expr_nth_AST = RefDNode(currentAST.root);
 			tag_array_expr_nth_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST)))); if (debugParser) std::cout<<"tag_array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(3))->add(antlr::RefAST(astFactory->create(ARRAYEXPR,"arrayexpr")))->add(antlr::RefAST(e_AST))->add(antlr::RefAST(al_AST))));
 			currentAST.root = tag_array_expr_nth_AST;
 			if ( tag_array_expr_nth_AST!=RefDNode(antlr::nullAST) &&
 				tag_array_expr_nth_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8333,7 +8254,7 @@ void GDLParser::tag_array_expr_nth() {
 	{
 		if ( inputState->guessing==0 ) {
 			tag_array_expr_nth_AST = RefDNode(currentAST.root);
-			tag_array_expr_nth_AST = e_AST; if (debugParser) std::cout<<"tag_array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;
+			tag_array_expr_nth_AST = e_AST;
 			currentAST.root = tag_array_expr_nth_AST;
 			if ( tag_array_expr_nth_AST!=RefDNode(antlr::nullAST) &&
 				tag_array_expr_nth_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8362,7 +8283,6 @@ int  GDLParser::tag_access_keeplast() {
 	int t;
 	bool parent = false;
 	nDot=1;
-	if (debugParser) std::cout << " tag_access_keeplast -> " /* << std::endl */; 
 	
 	
 	match(DOT);
@@ -8418,7 +8338,6 @@ SizeT  GDLParser::tag_access() {
 	RefDNode tag_access_AST = RefDNode(antlr::nullAST);
 	
 	nDot=0;
-	if (debugParser) std::cout << " tag_access -> " /* << std::endl */; 
 	
 	
 	{ // ( ... )+
@@ -8455,7 +8374,6 @@ void GDLParser::deref_dot_expr() {
 	
 	RefDNode dot;
 	SizeT nDot;
-	if (debugParser) std::cout << " deref_dot_expr -> " /* << std::endl */; 
 	
 	
 	switch ( LA(1)) {
@@ -8482,7 +8400,7 @@ void GDLParser::deref_dot_expr() {
 			dot->SetNDot( nDot);    
 			dot->SetLine( a1_AST->getLine());
 			
-			deref_dot_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_dot_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			deref_dot_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(dot))->add(antlr::RefAST(deref_dot_expr_AST))));
 			
 			currentAST.root = deref_dot_expr_AST;
 			if ( deref_dot_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -8506,7 +8424,7 @@ void GDLParser::deref_dot_expr() {
 		if ( inputState->guessing==0 ) {
 			deref_dot_expr_AST = RefDNode(currentAST.root);
 			deref_dot_expr_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_dot_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_dot_expr_AST))));
 			currentAST.root = deref_dot_expr_AST;
 			if ( deref_dot_expr_AST!=RefDNode(antlr::nullAST) &&
 				deref_dot_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8533,7 +8451,6 @@ bool  GDLParser::member_function_call() {
 	RefDNode member_function_call_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  s = antlr::nullToken;
 	RefDNode s_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " member_function_call -> " /* << std::endl */;
 	
 	if ( inputState->guessing==0 ) {
 		parent = false;
@@ -8583,7 +8500,6 @@ void GDLParser::member_function_call_dot() {
 	RefDNode member_function_call_dot_AST = RefDNode(antlr::nullAST);
 	antlr::RefToken  s = antlr::nullToken;
 	RefDNode s_AST = RefDNode(antlr::nullAST);
-	if (debugParser) std::cout << " member_function_call_dot -> " /* << std::endl */;
 	
 	match(DOT);
 	{
@@ -8625,7 +8541,6 @@ void GDLParser::arrayexpr_mfcall() {
 	RefDNode dot;
 	RefDNode tag;
 	int nDot;
-	if (debugParser) std::cout << " arrayexpr_mfcall! -> " /* << std::endl */; 
 	
 	
 	switch ( LA(1)) {
@@ -8671,7 +8586,6 @@ void GDLParser::arrayexpr_mfcall() {
 			arrayexpr_mfcall_AST = RefDNode(astFactory->make((new antlr::ASTArray(4))->add(antlr::RefAST(astFactory->create(ARRAYEXPR_MFCALL,"arrayexpr_mfcall")))->add(antlr::RefAST(tag))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(al_AST))));
 			else
 			arrayexpr_mfcall_AST = RefDNode(astFactory->make((new antlr::ASTArray(4))->add(antlr::RefAST(astFactory->create(ARRAYEXPR_MFCALL,"arrayexpr_mfcall")))->add(antlr::RefAST(a1_AST))->add(antlr::RefAST(id_AST))->add(antlr::RefAST(al_AST))));
-			if (debugParser) std::cout<<"arrayexpr_mfcall : \""<<LT(0)->getText()<<"\""<<std::endl;
 				
 			currentAST.root = arrayexpr_mfcall_AST;
 			if ( arrayexpr_mfcall_AST!=RefDNode(antlr::nullAST) &&
@@ -8697,7 +8611,7 @@ void GDLParser::arrayexpr_mfcall() {
 		if ( inputState->guessing==0 ) {
 			arrayexpr_mfcall_AST = RefDNode(currentAST.root);
 			arrayexpr_mfcall_AST = 
-			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_arrayexpr_mfcall_AST)))); if (debugParser) std::cout<<" deref_arrayexpr_mfcall : \""<<LT(0)->getText()<<"\""<<std::endl;
+			RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(DEREF,"deref")))->add(antlr::RefAST(deref_arrayexpr_mfcall_AST))));
 			currentAST.root = arrayexpr_mfcall_AST;
 			if ( arrayexpr_mfcall_AST!=RefDNode(antlr::nullAST) &&
 				arrayexpr_mfcall_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8730,7 +8644,6 @@ void GDLParser::primary_expr() {
 	RefDNode lc_AST = RefDNode(antlr::nullAST);
 	
 	bool parent;
-	if (debugParser) std::cout << " -> primary_expr -> ";
 	
 	
 	switch ( LA(1)) {
@@ -8746,7 +8659,6 @@ void GDLParser::primary_expr() {
 			primary_expr_AST=astFactory->create(CONSTANT,sl->getText());
 			primary_expr_AST->Text2String();    
 			primary_expr_AST->SetLine( sl_AST->getLine());
-				    { if (debugParser) std::cout << "STRING_LITERAL" <<std::endl;}
 			
 			currentAST.root = primary_expr_AST;
 			if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -8841,8 +8753,7 @@ void GDLParser::primary_expr() {
 			if ( inputState->guessing==0 ) {
 				primary_expr_AST = RefDNode(currentAST.root);
 				
-				if (debugParser) std::cout << " d1:deref_dot_expr_keeplast baseclass_method formal_function_call "<< std::endl;
-				primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL_PARENT,"mfcall::")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+				primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL_PARENT,"mfcall::")))->add(antlr::RefAST(primary_expr_AST))));
 				
 				currentAST.root = primary_expr_AST;
 				if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -8895,9 +8806,6 @@ void GDLParser::primary_expr() {
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 				}
-				if ( inputState->guessing==0 ) {
-					if (debugParser) std::cout << " deref_dot_expr_keeplast (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE))=> arrayexpr_mfcall -> " /*<< std::endl */;
-				}
 				primary_expr_AST = RefDNode(currentAST.root);
 			}
 			else {
@@ -8930,7 +8838,7 @@ void GDLParser::primary_expr() {
 					}
 					if ( inputState->guessing==0 ) {
 						primary_expr_AST = RefDNode(currentAST.root);
-						if (debugParser) std::cout << "  (deref_dot_expr_keeplast formal_function_call)=> d3:deref_dot_expr_keeplast formal_function_call -> " << std::endl; primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL,"mfcall")))->add(antlr::RefAST(primary_expr_AST))));
+						primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL,"mfcall")))->add(antlr::RefAST(primary_expr_AST))));
 						currentAST.root = primary_expr_AST;
 						if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
 							primary_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -8977,12 +8885,10 @@ void GDLParser::primary_expr() {
 								if( parent)
 								{
 								primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL_PARENT,"mfcall::")))->add(antlr::RefAST(primary_expr_AST))));
-										    if (debugParser) std::cout << " (deref_dot_expr)=>deref_expr ( parent=true) " << std::endl;
 								} 
 								else
 								{
 								primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL,"mfcall")))->add(antlr::RefAST(primary_expr_AST))));
-										    if (debugParser) std::cout << " (deref_dot_expr)=>deref_expr -> primary_expr " << std::endl;
 								}
 								
 								currentAST.root = primary_expr_AST;
@@ -9051,9 +8957,6 @@ void GDLParser::primary_expr() {
 						case LOG_OR:
 						case QUESTION:
 						{
-							if ( inputState->guessing==0 ) {
-								if (debugParser) std::cout << " | empty -> array expression -> "/* << std::endl */;
-							}
 							break;
 						}
 						default:
@@ -9107,8 +9010,7 @@ void GDLParser::primary_expr() {
 								if ( inputState->guessing==0 ) {
 									primary_expr_AST = RefDNode(currentAST.root);
 									
-									if (debugParser) std::cout << " (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE)=> formal_function_call " /* << std::endl */;
-									primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+									primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST))));
 									
 									currentAST.root = primary_expr_AST;
 									if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -9149,9 +9051,7 @@ void GDLParser::primary_expr() {
 									if ( inputState->guessing==0 ) {
 										primary_expr_AST = RefDNode(currentAST.root);
 										
-										if (debugParser) std::cout << "(var arrayindex_list)=> var arrayindex_list -> " /* << std::endl */;
-										
-										primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYEXPR_FCALL,"arrayexpr_fcall")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+										primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYEXPR_FCALL,"arrayexpr_fcall")))->add(antlr::RefAST(primary_expr_AST))));
 											
 										currentAST.root = primary_expr_AST;
 										if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -9169,9 +9069,7 @@ void GDLParser::primary_expr() {
 									}
 									if ( inputState->guessing==0 ) {
 										primary_expr_AST = RefDNode(currentAST.root);
-										if (debugParser) std::cout << " (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE)=>formal_function_call -> " /* << std::endl */;
-										primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
-										
+										primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST))));
 										currentAST.root = primary_expr_AST;
 										if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
 											primary_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -9212,7 +9110,7 @@ void GDLParser::primary_expr() {
 								}
 								if ( inputState->guessing==0 ) {
 									primary_expr_AST = RefDNode(currentAST.root);
-									if (debugParser) std::cout << " (formal_function_call)=> formal_function_call -> " << std::endl; primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST))));
+									primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(FCALL,"fcall")))->add(antlr::RefAST(primary_expr_AST))));
 									currentAST.root = primary_expr_AST;
 									if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
 										primary_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
@@ -9258,13 +9156,11 @@ void GDLParser::primary_expr() {
 											
 											if( parent)
 											{
-											if (debugParser) std::cout << " (deref_expr)=> deref_expr ( parent=true) -> " /* << std::endl */;
-											primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL_PARENT,"mfcall::")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+											primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL_PARENT,"mfcall::")))->add(antlr::RefAST(primary_expr_AST))));
 											}
 											else
 											{
-											if (debugParser) std::cout << " (deref_expr)=> deref_expr ( parent=false) -> " /* << std::endl */;
-											primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL,"mfcall")))->add(antlr::RefAST(primary_expr_AST)))); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+											primary_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(MFCALL,"mfcall")))->add(antlr::RefAST(primary_expr_AST))));
 											}
 											
 											currentAST.root = primary_expr_AST;
@@ -9333,9 +9229,6 @@ void GDLParser::primary_expr() {
 									case LOG_OR:
 									case QUESTION:
 									{
-										if ( inputState->guessing==0 ) {
-											if (debugParser) std::cout << " (deref_expr)=> deref_expr | empty -> array expression No 2!"/* << std::endl */;
-										}
 										break;
 									}
 									default:
@@ -9379,7 +9272,7 @@ void GDLParser::primary_expr() {
 									if ( inputState->guessing==0 ) {
 										primary_expr_AST = RefDNode(currentAST.root);
 										primary_expr_AST=astFactory->create(GDLNULL,"GDLNULL[]");
-										primary_expr_AST->SetLine( ls_AST->getLine()); if (debugParser) std::cout << "NULL" << std::endl;
+										primary_expr_AST->SetLine( ls_AST->getLine());
 										
 										currentAST.root = primary_expr_AST;
 										if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -9402,7 +9295,7 @@ void GDLParser::primary_expr() {
 									if ( inputState->guessing==0 ) {
 										primary_expr_AST = RefDNode(currentAST.root);
 										primary_expr_AST=astFactory->create(GDLNULL,"GDLNULL{}");
-										primary_expr_AST->SetLine( lc_AST->getLine()); if (debugParser) std::cout << "NULL" << std::endl;
+										primary_expr_AST->SetLine( lc_AST->getLine());
 										
 										currentAST.root = primary_expr_AST;
 										if ( primary_expr_AST!=RefDNode(antlr::nullAST) &&
@@ -9494,7 +9387,7 @@ void GDLParser::decinc_expr() {
 			}
 			match(INC);
 			if ( inputState->guessing==0 ) {
-				i_AST->setType( POSTINC); i_AST->setText( "_++");if (debugParser) std::cout << "++" <<std::endl;
+				i_AST->setType( POSTINC); i_AST->setText( "_++");
 			}
 			break;
 		}
@@ -9507,7 +9400,7 @@ void GDLParser::decinc_expr() {
 			}
 			match(DEC);
 			if ( inputState->guessing==0 ) {
-				d_AST->setType( POSTDEC); d_AST->setText( "_--");if (debugParser) std::cout << "--" <<std::endl;
+				d_AST->setType( POSTDEC); d_AST->setText( "_--");
 			}
 			break;
 		}

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -756,6 +756,7 @@ void GDLParser::translation_unit() {
 	if (fussy<2) { //STRICTARR not given in the current PRO/FUN
 	fussy=recovery?0:1;
 	}
+		relaxed=(fussy < 1);
 	if (recovery) {
 	//	    std::cerr<<"recovery:"<<recovery<<", LastGoodPosition="<<LastGoodPosition<<std::endl;
 			this->rewind(LastGoodPosition);
@@ -1039,7 +1040,8 @@ void GDLParser::procedure_def() {
 	
 	std::string name;
 		fussy=recovery?0:1; //recoverable fussy mode
-				LastGoodPosition=mark();
+		relaxed=(fussy < 1);
+		LastGoodPosition=mark();
 	//	std::cerr<<"start pro at "<<LastGoodPosition<<std::endl;
 	
 	
@@ -1163,7 +1165,8 @@ void GDLParser::function_def() {
 	
 	std::string name;
 		fussy=recovery?0:1; //recoverable fussy mode
-				LastGoodPosition=mark();
+		relaxed=(fussy < 1);
+		LastGoodPosition=mark();
 	//	std::cerr<<"start fun"<<std::endl;
 	
 	
@@ -1579,6 +1582,8 @@ void GDLParser::interactive() {
 	antlr::ASTPair currentAST;
 	RefDNode interactive_AST = RefDNode(antlr::nullAST);
 	fussy=((compileOpt & STRICTARR)!=0)?2:0;
+	relaxed=(fussy < 1);
+	
 	
 	try {      // for error handling
 		{ // ( ... )+
@@ -7485,7 +7490,7 @@ void GDLParser::arrayindex_list() {
 		match(RSQUARE);
 		arrayindex_list_AST = RefDNode(currentAST.root);
 	}
-	else if (((LA(1) == LBRACE))&&( fussy==0)) {
+	else if (((LA(1) == LBRACE))&&( relaxed )) {
 		match(LBRACE);
 		arrayindex_sloppy();
 		if (inputState->guessing==0) {

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -751,7 +751,8 @@ void GDLParser::translation_unit() {
 	RefDNode translation_unit_AST = RefDNode(antlr::nullAST);
 	
 	subReached=false;
-	compileOpt=NONE; // reset compileOpt    
+	compileOpt=NONE; // reset compileOpt  
+	relaxed=IsRelaxed();  
 	
 	
 	try {      // for error handling
@@ -766,7 +767,8 @@ void GDLParser::translation_unit() {
 				}
 				if ( inputState->guessing==0 ) {
 					
-					compileOpt=NONE; // reset compileOpt    
+					compileOpt=NONE; // reset compileOpt  
+									relaxed=IsRelaxed();
 					if( subReached) goto bailOut;
 					
 				}
@@ -780,7 +782,8 @@ void GDLParser::translation_unit() {
 				}
 				if ( inputState->guessing==0 ) {
 					
-					compileOpt=NONE; // reset compileOpt    
+					compileOpt=NONE; // reset compileOpt
+									relaxed=IsRelaxed();
 					if( subReached) goto bailOut;
 					
 				}
@@ -7416,7 +7419,7 @@ void GDLParser::arrayindex_list() {
 	
 	if ((LA(1) == LSQUARE)) {
 		match(LSQUARE);
-		arrayindex();
+		arrayindex_fussy();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 		}
@@ -7424,7 +7427,7 @@ void GDLParser::arrayindex_list() {
 		for (;;) {
 			if (((LA(1) == COMMA))&&(++rank <= MAXRANK)) {
 				match(COMMA);
-				arrayindex();
+				arrayindex_fussy();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 				}
@@ -7439,9 +7442,9 @@ void GDLParser::arrayindex_list() {
 		match(RSQUARE);
 		arrayindex_list_AST = RefDNode(currentAST.root);
 	}
-	else if (((LA(1) == LBRACE))&&( IsRelaxed())) {
+	else if (((LA(1) == LBRACE))&&( relaxed )) {
 		match(LBRACE);
-		arrayindex();
+		arrayindex_sloppy();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 		}
@@ -7449,7 +7452,7 @@ void GDLParser::arrayindex_list() {
 		for (;;) {
 			if (((LA(1) == COMMA))&&(++rank <= MAXRANK)) {
 				match(COMMA);
-				arrayindex();
+				arrayindex_sloppy();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 				}
@@ -7471,14 +7474,14 @@ void GDLParser::arrayindex_list() {
 	returnAST = arrayindex_list_AST;
 }
 
-void GDLParser::arrayindex() {
+void GDLParser::arrayindex_fussy() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
-	RefDNode arrayindex_AST = RefDNode(antlr::nullAST);
+	RefDNode arrayindex_fussy_AST = RefDNode(antlr::nullAST);
 	
 	{
 	bool synPredMatched203 = false;
-	if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE || LA(2) == RSQUARE))) {
+	if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RSQUARE))) {
 		int _m203 = mark();
 		synPredMatched203 = true;
 		inputState->guessing++;
@@ -7498,10 +7501,7 @@ void GDLParser::arrayindex() {
 				break;
 			}
 			default:
-				if (((LA(1) == RBRACE))&&( IsRelaxed())) {
-					match(RBRACE);
-				}
-			else {
+			{
 				throw antlr::NoViableAltException(LT(1), getFilename());
 			}
 			}
@@ -7520,7 +7520,7 @@ void GDLParser::arrayindex() {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 		}
 	}
-	else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_17.member(LA(2)))) {
+	else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_16.member(LA(2)))) {
 		expr();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -7532,7 +7532,7 @@ void GDLParser::arrayindex() {
 			match(COLON);
 			{
 			bool synPredMatched208 = false;
-			if (((LA(1) == ASTERIX) && (_tokenSet_18.member(LA(2))))) {
+			if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == COLON || LA(2) == RSQUARE))) {
 				int _m208 = mark();
 				synPredMatched208 = true;
 				inputState->guessing++;
@@ -7557,10 +7557,7 @@ void GDLParser::arrayindex() {
 						break;
 					}
 					default:
-						if (((LA(1) == RBRACE))&&( IsRelaxed())) {
-							match(RBRACE);
-						}
-					else {
+					{
 						throw antlr::NoViableAltException(LT(1), getFilename());
 					}
 					}
@@ -7579,7 +7576,7 @@ void GDLParser::arrayindex() {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 				}
 			}
-			else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_17.member(LA(2)))) {
+			else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_16.member(LA(2)))) {
 				expr();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -7597,7 +7594,7 @@ void GDLParser::arrayindex() {
 				match(COLON);
 				{
 				bool synPredMatched213 = false;
-				if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE || LA(2) == RSQUARE))) {
+				if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RSQUARE))) {
 					int _m213 = mark();
 					synPredMatched213 = true;
 					inputState->guessing++;
@@ -7617,10 +7614,7 @@ void GDLParser::arrayindex() {
 							break;
 						}
 						default:
-							if (((LA(1) == RBRACE))&&( IsRelaxed())) {
-								match(RBRACE);
-							}
-						else {
+						{
 							throw antlr::NoViableAltException(LT(1), getFilename());
 						}
 						}
@@ -7634,6 +7628,225 @@ void GDLParser::arrayindex() {
 					inputState->guessing--;
 				}
 				if ( synPredMatched213 ) {
+					match(ASTERIX);
+					if ( inputState->guessing==0 ) {
+						
+						throw  GDLException( "n:n:* subscript form not allowed.");
+						
+					}
+				}
+				else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_17.member(LA(2)))) {
+					expr();
+					if (inputState->guessing==0) {
+						astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+					}
+				}
+				else {
+					throw antlr::NoViableAltException(LT(1), getFilename());
+				}
+				
+				}
+				break;
+			}
+			case COMMA:
+			case RSQUARE:
+			{
+				break;
+			}
+			default:
+			{
+				throw antlr::NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			break;
+		}
+		case COMMA:
+		case RSQUARE:
+		{
+			break;
+		}
+		default:
+		{
+			throw antlr::NoViableAltException(LT(1), getFilename());
+		}
+		}
+		}
+	}
+	else {
+		throw antlr::NoViableAltException(LT(1), getFilename());
+	}
+	
+	}
+	if ( inputState->guessing==0 ) {
+		arrayindex_fussy_AST = RefDNode(currentAST.root);
+		arrayindex_fussy_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYIX,"arrayix")))->add(antlr::RefAST(arrayindex_fussy_AST))));
+		currentAST.root = arrayindex_fussy_AST;
+		if ( arrayindex_fussy_AST!=RefDNode(antlr::nullAST) &&
+			arrayindex_fussy_AST->getFirstChild() != RefDNode(antlr::nullAST) )
+			  currentAST.child = arrayindex_fussy_AST->getFirstChild();
+		else
+			currentAST.child = arrayindex_fussy_AST;
+		currentAST.advanceChildToEnd();
+	}
+	arrayindex_fussy_AST = RefDNode(currentAST.root);
+	returnAST = arrayindex_fussy_AST;
+}
+
+void GDLParser::arrayindex_sloppy() {
+	returnAST = RefDNode(antlr::nullAST);
+	antlr::ASTPair currentAST;
+	RefDNode arrayindex_sloppy_AST = RefDNode(antlr::nullAST);
+	
+	{
+	bool synPredMatched218 = false;
+	if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE))) {
+		int _m218 = mark();
+		synPredMatched218 = true;
+		inputState->guessing++;
+		try {
+			{
+			match(ASTERIX);
+			{
+			switch ( LA(1)) {
+			case COMMA:
+			{
+				match(COMMA);
+				break;
+			}
+			case RBRACE:
+			{
+				match(RBRACE);
+				break;
+			}
+			default:
+			{
+				throw antlr::NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			}
+		}
+		catch (antlr::RecognitionException& pe) {
+			synPredMatched218 = false;
+		}
+		rewind(_m218);
+		inputState->guessing--;
+	}
+	if ( synPredMatched218 ) {
+		all_elements();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+		}
+	}
+	else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_18.member(LA(2)))) {
+		expr();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+		}
+		{
+		switch ( LA(1)) {
+		case COLON:
+		{
+			match(COLON);
+			{
+			bool synPredMatched223 = false;
+			if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == COLON || LA(2) == RBRACE))) {
+				int _m223 = mark();
+				synPredMatched223 = true;
+				inputState->guessing++;
+				try {
+					{
+					match(ASTERIX);
+					{
+					switch ( LA(1)) {
+					case COMMA:
+					{
+						match(COMMA);
+						break;
+					}
+					case RBRACE:
+					{
+						match(RBRACE);
+						break;
+					}
+					case COLON:
+					{
+						match(COLON);
+						break;
+					}
+					default:
+					{
+						throw antlr::NoViableAltException(LT(1), getFilename());
+					}
+					}
+					}
+					}
+				}
+				catch (antlr::RecognitionException& pe) {
+					synPredMatched223 = false;
+				}
+				rewind(_m223);
+				inputState->guessing--;
+			}
+			if ( synPredMatched223 ) {
+				all_elements();
+				if (inputState->guessing==0) {
+					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+				}
+			}
+			else if ((_tokenSet_11.member(LA(1))) && (_tokenSet_18.member(LA(2)))) {
+				expr();
+				if (inputState->guessing==0) {
+					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+				}
+			}
+			else {
+				throw antlr::NoViableAltException(LT(1), getFilename());
+			}
+			
+			}
+			{
+			switch ( LA(1)) {
+			case COLON:
+			{
+				match(COLON);
+				{
+				bool synPredMatched228 = false;
+				if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE))) {
+					int _m228 = mark();
+					synPredMatched228 = true;
+					inputState->guessing++;
+					try {
+						{
+						match(ASTERIX);
+						{
+						switch ( LA(1)) {
+						case COMMA:
+						{
+							match(COMMA);
+							break;
+						}
+						case RBRACE:
+						{
+							match(RBRACE);
+							break;
+						}
+						default:
+						{
+							throw antlr::NoViableAltException(LT(1), getFilename());
+						}
+						}
+						}
+						}
+					}
+					catch (antlr::RecognitionException& pe) {
+						synPredMatched228 = false;
+					}
+					rewind(_m228);
+					inputState->guessing--;
+				}
+				if ( synPredMatched228 ) {
 					match(ASTERIX);
 					if ( inputState->guessing==0 ) {
 						
@@ -7656,7 +7869,6 @@ void GDLParser::arrayindex() {
 			}
 			case COMMA:
 			case RBRACE:
-			case RSQUARE:
 			{
 				break;
 			}
@@ -7670,7 +7882,6 @@ void GDLParser::arrayindex() {
 		}
 		case COMMA:
 		case RBRACE:
-		case RSQUARE:
 		{
 			break;
 		}
@@ -7687,18 +7898,18 @@ void GDLParser::arrayindex() {
 	
 	}
 	if ( inputState->guessing==0 ) {
-		arrayindex_AST = RefDNode(currentAST.root);
-		arrayindex_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYIX,"arrayix")))->add(antlr::RefAST(arrayindex_AST))));
-		currentAST.root = arrayindex_AST;
-		if ( arrayindex_AST!=RefDNode(antlr::nullAST) &&
-			arrayindex_AST->getFirstChild() != RefDNode(antlr::nullAST) )
-			  currentAST.child = arrayindex_AST->getFirstChild();
+		arrayindex_sloppy_AST = RefDNode(currentAST.root);
+		arrayindex_sloppy_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ARRAYIX,"arrayix")))->add(antlr::RefAST(arrayindex_sloppy_AST))));
+		currentAST.root = arrayindex_sloppy_AST;
+		if ( arrayindex_sloppy_AST!=RefDNode(antlr::nullAST) &&
+			arrayindex_sloppy_AST->getFirstChild() != RefDNode(antlr::nullAST) )
+			  currentAST.child = arrayindex_sloppy_AST->getFirstChild();
 		else
-			currentAST.child = arrayindex_AST;
+			currentAST.child = arrayindex_sloppy_AST;
 		currentAST.advanceChildToEnd();
 	}
-	arrayindex_AST = RefDNode(currentAST.root);
-	returnAST = arrayindex_AST;
+	arrayindex_sloppy_AST = RefDNode(currentAST.root);
+	returnAST = arrayindex_sloppy_AST;
 }
 
 void GDLParser::all_elements() {
@@ -7706,9 +7917,9 @@ void GDLParser::all_elements() {
 	antlr::ASTPair currentAST;
 	RefDNode all_elements_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp177_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp180_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp177_AST = astFactory->create(LT(1));
+		tmp180_AST = astFactory->create(LT(1));
 	}
 	match(ASTERIX);
 	if ( inputState->guessing==0 ) {
@@ -7730,10 +7941,10 @@ void GDLParser::sysvar() {
 	antlr::ASTPair currentAST;
 	RefDNode sysvar_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp178_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp181_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp178_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp178_AST));
+		tmp181_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp181_AST));
 	}
 	match(SYSVARNAME);
 	if ( inputState->guessing==0 ) {
@@ -8009,10 +8220,10 @@ void GDLParser::array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp181_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp184_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp181_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp181_AST));
+			tmp184_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp184_AST));
 		}
 		match(IDENTIFIER);
 		array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8105,10 +8316,10 @@ void GDLParser::tag_array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp182_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp185_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp182_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp182_AST));
+			tmp185_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp185_AST));
 		}
 		match(IDENTIFIER);
 		tag_array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8287,10 +8498,10 @@ int  GDLParser::tag_access_keeplast() {
 	
 	match(DOT);
 	{
-	bool synPredMatched230 = false;
+	bool synPredMatched245 = false;
 	if (((_tokenSet_20.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-		int _m230 = mark();
-		synPredMatched230 = true;
+		int _m245 = mark();
+		synPredMatched245 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -8299,12 +8510,12 @@ int  GDLParser::tag_access_keeplast() {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched230 = false;
+			synPredMatched245 = false;
 		}
-		rewind(_m230);
+		rewind(_m245);
 		inputState->guessing--;
 	}
-	if ( synPredMatched230 ) {
+	if ( synPredMatched245 ) {
 		{
 		tag_array_expr_nth();
 		if (inputState->guessing==0) {
@@ -8341,7 +8552,7 @@ SizeT  GDLParser::tag_access() {
 	
 	
 	{ // ( ... )+
-	int _cnt236=0;
+	int _cnt251=0;
 	for (;;) {
 		if ((LA(1) == DOT)) {
 			match(DOT);
@@ -8354,12 +8565,12 @@ SizeT  GDLParser::tag_access() {
 			}
 		}
 		else {
-			if ( _cnt236>=1 ) { goto _loop236; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+			if ( _cnt251>=1 ) { goto _loop251; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt236++;
+		_cnt251++;
 	}
-	_loop236:;
+	_loop251:;
 	}  // ( ... )+
 	tag_access_AST = RefDNode(currentAST.root);
 	returnAST = tag_access_AST;
@@ -8599,9 +8810,9 @@ void GDLParser::arrayexpr_mfcall() {
 	}
 	case ASTERIX:
 	{
-		RefDNode tmp190_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp193_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp190_AST = astFactory->create(LT(1));
+			tmp193_AST = astFactory->create(LT(1));
 		}
 		match(ASTERIX);
 		arrayexpr_mfcall();
@@ -8719,10 +8930,10 @@ void GDLParser::primary_expr() {
 		break;
 	}
 	default:
-		bool synPredMatched252 = false;
+		bool synPredMatched267 = false;
 		if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-			int _m252 = mark();
-			synPredMatched252 = true;
+			int _m267 = mark();
+			synPredMatched267 = true;
 			inputState->guessing++;
 			try {
 				{
@@ -8731,12 +8942,12 @@ void GDLParser::primary_expr() {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched252 = false;
+				synPredMatched267 = false;
 			}
-			rewind(_m252);
+			rewind(_m267);
 			inputState->guessing--;
 		}
-		if ( synPredMatched252 ) {
+		if ( synPredMatched267 ) {
 			deref_dot_expr_keeplast();
 			if (inputState->guessing==0) {
 				d1_AST = returnAST;
@@ -8766,10 +8977,10 @@ void GDLParser::primary_expr() {
 			primary_expr_AST = RefDNode(currentAST.root);
 		}
 		else {
-			bool synPredMatched257 = false;
+			bool synPredMatched272 = false;
 			if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-				int _m257 = mark();
-				synPredMatched257 = true;
+				int _m272 = mark();
+				synPredMatched272 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -8785,23 +8996,23 @@ void GDLParser::primary_expr() {
 							expr();
 						}
 						else {
-							goto _loop256;
+							goto _loop271;
 						}
 						
 					}
-					_loop256:;
+					_loop271:;
 					} // ( ... )*
 					match(RBRACE);
 					}
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched257 = false;
+					synPredMatched272 = false;
 				}
-				rewind(_m257);
+				rewind(_m272);
 				inputState->guessing--;
 			}
-			if ( synPredMatched257 ) {
+			if ( synPredMatched272 ) {
 				arrayexpr_mfcall();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -8809,10 +9020,10 @@ void GDLParser::primary_expr() {
 				primary_expr_AST = RefDNode(currentAST.root);
 			}
 			else {
-				bool synPredMatched259 = false;
+				bool synPredMatched274 = false;
 				if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-					int _m259 = mark();
-					synPredMatched259 = true;
+					int _m274 = mark();
+					synPredMatched274 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -8821,12 +9032,12 @@ void GDLParser::primary_expr() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched259 = false;
+						synPredMatched274 = false;
 					}
-					rewind(_m259);
+					rewind(_m274);
 					inputState->guessing--;
 				}
-				if ( synPredMatched259 ) {
+				if ( synPredMatched274 ) {
 					deref_dot_expr_keeplast();
 					if (inputState->guessing==0) {
 						d3_AST = returnAST;
@@ -8850,10 +9061,10 @@ void GDLParser::primary_expr() {
 					primary_expr_AST = RefDNode(currentAST.root);
 				}
 				else {
-					bool synPredMatched261 = false;
+					bool synPredMatched276 = false;
 					if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-						int _m261 = mark();
-						synPredMatched261 = true;
+						int _m276 = mark();
+						synPredMatched276 = true;
 						inputState->guessing++;
 						try {
 							{
@@ -8861,12 +9072,12 @@ void GDLParser::primary_expr() {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched261 = false;
+							synPredMatched276 = false;
 						}
-						rewind(_m261);
+						rewind(_m276);
 						inputState->guessing--;
 					}
-					if ( synPredMatched261 ) {
+					if ( synPredMatched276 ) {
 						deref_expr();
 						if (inputState->guessing==0) {
 							astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -8968,10 +9179,10 @@ void GDLParser::primary_expr() {
 						primary_expr_AST = RefDNode(currentAST.root);
 					}
 					else {
-						bool synPredMatched266 = false;
+						bool synPredMatched281 = false;
 						if (((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE || LA(2) == LSQUARE))) {
-							int _m266 = mark();
-							synPredMatched266 = true;
+							int _m281 = mark();
+							synPredMatched281 = true;
 							inputState->guessing++;
 							try {
 								{
@@ -8985,22 +9196,22 @@ void GDLParser::primary_expr() {
 										expr();
 									}
 									else {
-										goto _loop265;
+										goto _loop280;
 									}
 									
 								}
-								_loop265:;
+								_loop280:;
 								} // ( ... )*
 								match(RBRACE);
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched266 = false;
+								synPredMatched281 = false;
 							}
-							rewind(_m266);
+							rewind(_m281);
 							inputState->guessing--;
 						}
-						if ( synPredMatched266 ) {
+						if ( synPredMatched281 ) {
 							{
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))&&( IsFun(LT(1)))) {
 								formal_function_call();
@@ -9022,10 +9233,10 @@ void GDLParser::primary_expr() {
 								}
 							}
 							else {
-								bool synPredMatched269 = false;
+								bool synPredMatched284 = false;
 								if (((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE || LA(2) == LSQUARE))) {
-									int _m269 = mark();
-									synPredMatched269 = true;
+									int _m284 = mark();
+									synPredMatched284 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9034,12 +9245,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched269 = false;
+										synPredMatched284 = false;
 									}
-									rewind(_m269);
+									rewind(_m284);
 									inputState->guessing--;
 								}
-								if ( synPredMatched269 ) {
+								if ( synPredMatched284 ) {
 									var();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9087,10 +9298,10 @@ void GDLParser::primary_expr() {
 							primary_expr_AST = RefDNode(currentAST.root);
 						}
 						else {
-							bool synPredMatched271 = false;
+							bool synPredMatched286 = false;
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))) {
-								int _m271 = mark();
-								synPredMatched271 = true;
+								int _m286 = mark();
+								synPredMatched286 = true;
 								inputState->guessing++;
 								try {
 									{
@@ -9098,12 +9309,12 @@ void GDLParser::primary_expr() {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched271 = false;
+									synPredMatched286 = false;
 								}
-								rewind(_m271);
+								rewind(_m286);
 								inputState->guessing--;
 							}
-							if ( synPredMatched271 ) {
+							if ( synPredMatched286 ) {
 								formal_function_call();
 								if (inputState->guessing==0) {
 									astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9122,10 +9333,10 @@ void GDLParser::primary_expr() {
 								primary_expr_AST = RefDNode(currentAST.root);
 							}
 							else {
-								bool synPredMatched273 = false;
+								bool synPredMatched288 = false;
 								if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-									int _m273 = mark();
-									synPredMatched273 = true;
+									int _m288 = mark();
+									synPredMatched288 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9133,12 +9344,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched273 = false;
+										synPredMatched288 = false;
 									}
-									rewind(_m273);
+									rewind(_m288);
 									inputState->guessing--;
 								}
-								if ( synPredMatched273 ) {
+								if ( synPredMatched288 ) {
 									deref_expr();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9264,9 +9475,9 @@ void GDLParser::primary_expr() {
 									ls = LT(1);
 									ls_AST = astFactory->create(ls);
 									match(LSQUARE);
-									RefDNode tmp191_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp194_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp191_AST = astFactory->create(LT(1));
+										tmp194_AST = astFactory->create(LT(1));
 									}
 									match(RSQUARE);
 									if ( inputState->guessing==0 ) {
@@ -9287,9 +9498,9 @@ void GDLParser::primary_expr() {
 									lc = LT(1);
 									lc_AST = astFactory->create(lc);
 									match(LCURLY);
-									RefDNode tmp192_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp195_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp192_AST = astFactory->create(LT(1));
+										tmp195_AST = astFactory->create(LT(1));
 									}
 									match(RCURLY);
 									if ( inputState->guessing==0 ) {
@@ -9471,10 +9682,10 @@ void GDLParser::decinc_expr() {
 	}
 	case INC:
 	{
-		RefDNode tmp193_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp196_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp193_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp193_AST));
+			tmp196_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp196_AST));
 		}
 		match(INC);
 		primary_expr();
@@ -9486,10 +9697,10 @@ void GDLParser::decinc_expr() {
 	}
 	case DEC:
 	{
-		RefDNode tmp194_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp197_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp194_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp194_AST));
+			tmp197_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp197_AST));
 		}
 		match(DEC);
 		primary_expr();
@@ -9519,10 +9730,10 @@ void GDLParser::exponential_expr() {
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == POW)) {
-			RefDNode tmp195_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp198_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp195_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp195_AST));
+				tmp198_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp198_AST));
 			}
 			match(POW);
 			decinc_expr();
@@ -9531,11 +9742,11 @@ void GDLParser::exponential_expr() {
 			}
 		}
 		else {
-			goto _loop279;
+			goto _loop294;
 		}
 		
 	}
-	_loop279:;
+	_loop294:;
 	} // ( ... )*
 	exponential_expr_AST = RefDNode(currentAST.root);
 	returnAST = exponential_expr_AST;
@@ -9557,240 +9768,240 @@ void GDLParser::multiplicative_expr() {
 			switch ( LA(1)) {
 			case ASTERIX:
 			{
-				RefDNode tmp196_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp199_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp196_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp196_AST));
+					tmp199_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp199_AST));
 				}
 				match(ASTERIX);
 				break;
 			}
 			case MATRIX_OP1:
 			{
-				RefDNode tmp197_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp200_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp197_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp197_AST));
+					tmp200_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp200_AST));
 				}
 				match(MATRIX_OP1);
 				break;
 			}
 			case MATRIX_OP2:
 			{
-				RefDNode tmp198_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp201_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp198_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp198_AST));
+					tmp201_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp201_AST));
 				}
 				match(MATRIX_OP2);
 				break;
 			}
 			case SLASH:
 			{
-				RefDNode tmp199_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp202_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp199_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp199_AST));
+					tmp202_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp202_AST));
 				}
 				match(SLASH);
 				break;
 			}
 			case MOD_OP:
 			{
-				RefDNode tmp200_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp203_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp200_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp200_AST));
+					tmp203_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp203_AST));
 				}
 				match(MOD_OP);
 				break;
 			}
 			case AND_OP_EQ:
 			{
-				RefDNode tmp201_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp204_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp201_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp201_AST));
+					tmp204_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp204_AST));
 				}
 				match(AND_OP_EQ);
 				break;
 			}
 			case ASTERIX_EQ:
 			{
-				RefDNode tmp202_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp205_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp202_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp202_AST));
+					tmp205_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp205_AST));
 				}
 				match(ASTERIX_EQ);
 				break;
 			}
 			case EQ_OP_EQ:
 			{
-				RefDNode tmp203_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp206_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp203_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp203_AST));
+					tmp206_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp206_AST));
 				}
 				match(EQ_OP_EQ);
 				break;
 			}
 			case GE_OP_EQ:
 			{
-				RefDNode tmp204_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp207_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp204_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp204_AST));
+					tmp207_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp207_AST));
 				}
 				match(GE_OP_EQ);
 				break;
 			}
 			case GTMARK_EQ:
 			{
-				RefDNode tmp205_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp208_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp205_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp205_AST));
+					tmp208_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp208_AST));
 				}
 				match(GTMARK_EQ);
 				break;
 			}
 			case GT_OP_EQ:
 			{
-				RefDNode tmp206_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp209_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp206_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp206_AST));
+					tmp209_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp209_AST));
 				}
 				match(GT_OP_EQ);
 				break;
 			}
 			case LE_OP_EQ:
 			{
-				RefDNode tmp207_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp210_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp207_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp207_AST));
+					tmp210_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp210_AST));
 				}
 				match(LE_OP_EQ);
 				break;
 			}
 			case LTMARK_EQ:
 			{
-				RefDNode tmp208_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp211_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp208_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp208_AST));
+					tmp211_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp211_AST));
 				}
 				match(LTMARK_EQ);
 				break;
 			}
 			case LT_OP_EQ:
 			{
-				RefDNode tmp209_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp212_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp209_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp209_AST));
+					tmp212_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp212_AST));
 				}
 				match(LT_OP_EQ);
 				break;
 			}
 			case MATRIX_OP1_EQ:
 			{
-				RefDNode tmp210_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp213_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp210_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp210_AST));
+					tmp213_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp213_AST));
 				}
 				match(MATRIX_OP1_EQ);
 				break;
 			}
 			case MATRIX_OP2_EQ:
 			{
-				RefDNode tmp211_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp214_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp211_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp211_AST));
+					tmp214_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp214_AST));
 				}
 				match(MATRIX_OP2_EQ);
 				break;
 			}
 			case MINUS_EQ:
 			{
-				RefDNode tmp212_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp215_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp212_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp212_AST));
+					tmp215_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp215_AST));
 				}
 				match(MINUS_EQ);
 				break;
 			}
 			case MOD_OP_EQ:
 			{
-				RefDNode tmp213_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp216_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp213_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp213_AST));
+					tmp216_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp216_AST));
 				}
 				match(MOD_OP_EQ);
 				break;
 			}
 			case NE_OP_EQ:
 			{
-				RefDNode tmp214_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp217_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp214_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp214_AST));
+					tmp217_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp217_AST));
 				}
 				match(NE_OP_EQ);
 				break;
 			}
 			case OR_OP_EQ:
 			{
-				RefDNode tmp215_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp218_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp215_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp215_AST));
+					tmp218_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp218_AST));
 				}
 				match(OR_OP_EQ);
 				break;
 			}
 			case PLUS_EQ:
 			{
-				RefDNode tmp216_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp219_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp216_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp216_AST));
+					tmp219_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp219_AST));
 				}
 				match(PLUS_EQ);
 				break;
 			}
 			case POW_EQ:
 			{
-				RefDNode tmp217_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp220_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp217_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp217_AST));
+					tmp220_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp220_AST));
 				}
 				match(POW_EQ);
 				break;
 			}
 			case SLASH_EQ:
 			{
-				RefDNode tmp218_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp221_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp218_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp218_AST));
+					tmp221_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
 				}
 				match(SLASH_EQ);
 				break;
 			}
 			case XOR_OP_EQ:
 			{
-				RefDNode tmp219_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp222_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp219_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp219_AST));
+					tmp222_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
 				}
 				match(XOR_OP_EQ);
 				break;
@@ -9807,11 +10018,11 @@ void GDLParser::multiplicative_expr() {
 			}
 		}
 		else {
-			goto _loop283;
+			goto _loop298;
 		}
 		
 	}
-	_loop283:;
+	_loop298:;
 	} // ( ... )*
 	multiplicative_expr_AST = RefDNode(currentAST.root);
 	returnAST = multiplicative_expr_AST;
@@ -10010,40 +10221,40 @@ void GDLParser::additive_expr() {
 			switch ( LA(1)) {
 			case PLUS:
 			{
-				RefDNode tmp221_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp221_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
+					tmp224_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
 				}
 				match(PLUS);
 				break;
 			}
 			case MINUS:
 			{
-				RefDNode tmp222_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp225_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp222_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
+					tmp225_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp225_AST));
 				}
 				match(MINUS);
 				break;
 			}
 			case LTMARK:
 			{
-				RefDNode tmp223_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp226_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp223_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp223_AST));
+					tmp226_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp226_AST));
 				}
 				match(LTMARK);
 				break;
 			}
 			case GTMARK:
 			{
-				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp227_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp224_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
+					tmp227_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp227_AST));
 				}
 				match(GTMARK);
 				break;
@@ -10130,11 +10341,11 @@ void GDLParser::additive_expr() {
 			}
 		}
 		else {
-			goto _loop290;
+			goto _loop305;
 		}
 		
 	}
-	_loop290:;
+	_loop305:;
 	} // ( ... )*
 	additive_expr_AST = RefDNode(currentAST.root);
 	returnAST = additive_expr_AST;
@@ -10148,10 +10359,10 @@ void GDLParser::neg_expr() {
 	switch ( LA(1)) {
 	case NOT_OP:
 	{
-		RefDNode tmp225_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp228_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp225_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp225_AST));
+			tmp228_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp228_AST));
 		}
 		match(NOT_OP);
 		multiplicative_expr();
@@ -10163,10 +10374,10 @@ void GDLParser::neg_expr() {
 	}
 	case LOG_NEG:
 	{
-		RefDNode tmp226_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp229_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp226_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp226_AST));
+			tmp229_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp229_AST));
 		}
 		match(LOG_NEG);
 		multiplicative_expr();
@@ -10200,60 +10411,60 @@ void GDLParser::relational_expr() {
 			switch ( LA(1)) {
 			case EQ_OP:
 			{
-				RefDNode tmp227_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp230_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp227_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp227_AST));
+					tmp230_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp230_AST));
 				}
 				match(EQ_OP);
 				break;
 			}
 			case NE_OP:
 			{
-				RefDNode tmp228_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp231_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp228_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp228_AST));
+					tmp231_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp231_AST));
 				}
 				match(NE_OP);
 				break;
 			}
 			case LE_OP:
 			{
-				RefDNode tmp229_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp232_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp229_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp229_AST));
+					tmp232_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp232_AST));
 				}
 				match(LE_OP);
 				break;
 			}
 			case LT_OP:
 			{
-				RefDNode tmp230_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp233_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp230_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp230_AST));
+					tmp233_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp233_AST));
 				}
 				match(LT_OP);
 				break;
 			}
 			case GE_OP:
 			{
-				RefDNode tmp231_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp234_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp231_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp231_AST));
+					tmp234_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp234_AST));
 				}
 				match(GE_OP);
 				break;
 			}
 			case GT_OP:
 			{
-				RefDNode tmp232_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp235_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp232_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp232_AST));
+					tmp235_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp235_AST));
 				}
 				match(GT_OP);
 				break;
@@ -10270,11 +10481,11 @@ void GDLParser::relational_expr() {
 			}
 		}
 		else {
-			goto _loop295;
+			goto _loop310;
 		}
 		
 	}
-	_loop295:;
+	_loop310:;
 	} // ( ... )*
 	relational_expr_AST = RefDNode(currentAST.root);
 	returnAST = relational_expr_AST;
@@ -10296,30 +10507,30 @@ void GDLParser::boolean_expr() {
 			switch ( LA(1)) {
 			case AND_OP:
 			{
-				RefDNode tmp233_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp236_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp233_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp233_AST));
+					tmp236_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp236_AST));
 				}
 				match(AND_OP);
 				break;
 			}
 			case OR_OP:
 			{
-				RefDNode tmp234_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp237_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp234_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp234_AST));
+					tmp237_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp237_AST));
 				}
 				match(OR_OP);
 				break;
 			}
 			case XOR_OP:
 			{
-				RefDNode tmp235_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp238_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp235_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp235_AST));
+					tmp238_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp238_AST));
 				}
 				match(XOR_OP);
 				break;
@@ -10336,11 +10547,11 @@ void GDLParser::boolean_expr() {
 			}
 		}
 		else {
-			goto _loop299;
+			goto _loop314;
 		}
 		
 	}
-	_loop299:;
+	_loop314:;
 	} // ( ... )*
 	boolean_expr_AST = RefDNode(currentAST.root);
 	returnAST = boolean_expr_AST;
@@ -10362,20 +10573,20 @@ void GDLParser::logical_expr() {
 			switch ( LA(1)) {
 			case LOG_AND:
 			{
-				RefDNode tmp236_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp239_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp236_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp236_AST));
+					tmp239_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp239_AST));
 				}
 				match(LOG_AND);
 				break;
 			}
 			case LOG_OR:
 			{
-				RefDNode tmp237_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp240_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp237_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp237_AST));
+					tmp240_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp240_AST));
 				}
 				match(LOG_OR);
 				break;
@@ -10392,11 +10603,11 @@ void GDLParser::logical_expr() {
 			}
 		}
 		else {
-			goto _loop303;
+			goto _loop318;
 		}
 		
 	}
-	_loop303:;
+	_loop318:;
 	} // ( ... )*
 	logical_expr_AST = RefDNode(currentAST.root);
 	returnAST = logical_expr_AST;
@@ -10852,7 +11063,25 @@ const unsigned long GDLParser::_tokenSet_16_data_[] = { 0UL, 0UL, 805306368UL, 3
 // CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
 // PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
 const antlr::BitSet GDLParser::_tokenSet_16(_tokenSet_16_data_,16);
-const unsigned long GDLParser::_tokenSet_17_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4294967194UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLParser::_tokenSet_17_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 3221225354UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
+// "or" "xor" COMMA DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ 
+// GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ MINUS_EQ 
+// MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ MEMBER 
+// LBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE 
+// CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT CONSTANT_HEX_I 
+// CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI CONSTANT_HEX_UINT 
+// CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT CONSTANT_I 
+// CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT CONSTANT_OCT_BYTE 
+// CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT CONSTANT_OCT_I 
+// CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI CONSTANT_OCT_UINT 
+// CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 
+// CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 
+// CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I 
+// ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK 
+// GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+const antlr::BitSet GDLParser::_tokenSet_17(_tokenSet_17_data_,16);
+const unsigned long GDLParser::_tokenSet_18_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4294967194UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
 // "or" "xor" COMMA COLON DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ 
 // GTMARK_EQ GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ 
@@ -10869,10 +11098,7 @@ const unsigned long GDLParser::_tokenSet_17_data_[] = { 0UL, 0UL, 805306368UL, 3
 // CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
 // CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
 // PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
-const antlr::BitSet GDLParser::_tokenSet_17(_tokenSet_17_data_,16);
-const unsigned long GDLParser::_tokenSet_18_data_[] = { 0UL, 0UL, 0UL, 0UL, 1073741848UL, 2UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// COMMA COLON RBRACE RSQUARE 
-const antlr::BitSet GDLParser::_tokenSet_18(_tokenSet_18_data_,12);
+const antlr::BitSet GDLParser::_tokenSet_18(_tokenSet_18_data_,16);
 const unsigned long GDLParser::_tokenSet_19_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4294967178UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
 // "or" "xor" COMMA DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ 

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -4124,23 +4124,225 @@ void GDLParser::assign_expr() {
 	if (inputState->guessing==0) {
 		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 	}
-	match(EQUAL);
+	{
+	switch ( LA(1)) {
+	case EQUAL:
+	{
+		match(EQUAL);
+		if ( inputState->guessing==0 ) {
+			assign_expr_AST = RefDNode(currentAST.root);
+			assign_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(assign_expr_AST))));
+			currentAST.root = assign_expr_AST;
+			if ( assign_expr_AST!=RefDNode(antlr::nullAST) &&
+				assign_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
+				  currentAST.child = assign_expr_AST->getFirstChild();
+			else
+				currentAST.child = assign_expr_AST;
+			currentAST.advanceChildToEnd();
+		}
+		break;
+	}
+	case AND_OP_EQ:
+	{
+		RefDNode tmp109_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp109_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp109_AST));
+		}
+		match(AND_OP_EQ);
+		break;
+	}
+	case ASTERIX_EQ:
+	{
+		RefDNode tmp110_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp110_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp110_AST));
+		}
+		match(ASTERIX_EQ);
+		break;
+	}
+	case EQ_OP_EQ:
+	{
+		RefDNode tmp111_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp111_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp111_AST));
+		}
+		match(EQ_OP_EQ);
+		break;
+	}
+	case GE_OP_EQ:
+	{
+		RefDNode tmp112_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp112_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp112_AST));
+		}
+		match(GE_OP_EQ);
+		break;
+	}
+	case GTMARK_EQ:
+	{
+		RefDNode tmp113_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp113_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp113_AST));
+		}
+		match(GTMARK_EQ);
+		break;
+	}
+	case GT_OP_EQ:
+	{
+		RefDNode tmp114_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp114_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp114_AST));
+		}
+		match(GT_OP_EQ);
+		break;
+	}
+	case LE_OP_EQ:
+	{
+		RefDNode tmp115_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp115_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp115_AST));
+		}
+		match(LE_OP_EQ);
+		break;
+	}
+	case LTMARK_EQ:
+	{
+		RefDNode tmp116_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp116_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp116_AST));
+		}
+		match(LTMARK_EQ);
+		break;
+	}
+	case LT_OP_EQ:
+	{
+		RefDNode tmp117_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp117_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp117_AST));
+		}
+		match(LT_OP_EQ);
+		break;
+	}
+	case MATRIX_OP1_EQ:
+	{
+		RefDNode tmp118_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp118_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp118_AST));
+		}
+		match(MATRIX_OP1_EQ);
+		break;
+	}
+	case MATRIX_OP2_EQ:
+	{
+		RefDNode tmp119_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp119_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp119_AST));
+		}
+		match(MATRIX_OP2_EQ);
+		break;
+	}
+	case MINUS_EQ:
+	{
+		RefDNode tmp120_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp120_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp120_AST));
+		}
+		match(MINUS_EQ);
+		break;
+	}
+	case MOD_OP_EQ:
+	{
+		RefDNode tmp121_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp121_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp121_AST));
+		}
+		match(MOD_OP_EQ);
+		break;
+	}
+	case NE_OP_EQ:
+	{
+		RefDNode tmp122_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp122_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp122_AST));
+		}
+		match(NE_OP_EQ);
+		break;
+	}
+	case OR_OP_EQ:
+	{
+		RefDNode tmp123_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp123_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp123_AST));
+		}
+		match(OR_OP_EQ);
+		break;
+	}
+	case XOR_OP_EQ:
+	{
+		RefDNode tmp124_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp124_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp124_AST));
+		}
+		match(XOR_OP_EQ);
+		break;
+	}
+	case PLUS_EQ:
+	{
+		RefDNode tmp125_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp125_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp125_AST));
+		}
+		match(PLUS_EQ);
+		break;
+	}
+	case POW_EQ:
+	{
+		RefDNode tmp126_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp126_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp126_AST));
+		}
+		match(POW_EQ);
+		break;
+	}
+	case SLASH_EQ:
+	{
+		RefDNode tmp127_AST = RefDNode(antlr::nullAST);
+		if ( inputState->guessing == 0 ) {
+			tmp127_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp127_AST));
+		}
+		match(SLASH_EQ);
+		break;
+	}
+	default:
+	{
+		throw antlr::NoViableAltException(LT(1), getFilename());
+	}
+	}
+	}
 	expr();
 	if (inputState->guessing==0) {
 		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 	}
 	match(RBRACE);
-	if ( inputState->guessing==0 ) {
-		assign_expr_AST = RefDNode(currentAST.root);
-		assign_expr_AST = RefDNode(astFactory->make((new antlr::ASTArray(2))->add(antlr::RefAST(astFactory->create(ASSIGN,":=")))->add(antlr::RefAST(assign_expr_AST))));
-		currentAST.root = assign_expr_AST;
-		if ( assign_expr_AST!=RefDNode(antlr::nullAST) &&
-			assign_expr_AST->getFirstChild() != RefDNode(antlr::nullAST) )
-			  currentAST.child = assign_expr_AST->getFirstChild();
-		else
-			currentAST.child = assign_expr_AST;
-		currentAST.advanceChildToEnd();
-	}
 	assign_expr_AST = RefDNode(currentAST.root);
 	returnAST = assign_expr_AST;
 }
@@ -4229,10 +4431,10 @@ void GDLParser::formal_procedure_call() {
 	antlr::ASTPair currentAST;
 	RefDNode formal_procedure_call_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp111_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp130_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp111_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp111_AST));
+		tmp130_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp130_AST));
 	}
 	match(IDENTIFIER);
 	{
@@ -4559,16 +4761,16 @@ void GDLParser::for_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode for_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp116_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp135_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp116_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp116_AST));
+		tmp135_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp135_AST));
 	}
 	match(FOR);
-	RefDNode tmp117_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp136_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp117_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp117_AST));
+		tmp136_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp136_AST));
 	}
 	match(IDENTIFIER);
 	match(EQUAL);
@@ -4616,16 +4818,16 @@ void GDLParser::foreach_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode foreach_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp122_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp141_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp122_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp122_AST));
+		tmp141_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp141_AST));
 	}
 	match(FOREACH);
-	RefDNode tmp123_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp142_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp123_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp123_AST));
+		tmp142_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp142_AST));
 	}
 	match(IDENTIFIER);
 	match(COMMA);
@@ -4638,10 +4840,10 @@ void GDLParser::foreach_statement() {
 	case COMMA:
 	{
 		match(COMMA);
-		RefDNode tmp126_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp145_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp126_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp126_AST));
+			tmp145_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp145_AST));
 		}
 		match(IDENTIFIER);
 		break;
@@ -4670,10 +4872,10 @@ void GDLParser::repeat_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode repeat_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp128_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp147_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp128_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp128_AST));
+		tmp147_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp147_AST));
 	}
 	match(REPEAT);
 	repeat_block();
@@ -4694,10 +4896,10 @@ void GDLParser::while_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode while_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp130_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp149_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp130_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp130_AST));
+		tmp149_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp149_AST));
 	}
 	match(WHILE);
 	expr();
@@ -4721,17 +4923,17 @@ void GDLParser::jump_statement() {
 	switch ( LA(1)) {
 	case GOTO:
 	{
-		RefDNode tmp132_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp151_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp132_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp132_AST));
+			tmp151_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp151_AST));
 		}
 		match(GOTO);
 		match(COMMA);
-		RefDNode tmp134_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp153_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp134_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp134_AST));
+			tmp153_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp153_AST));
 		}
 		match(IDENTIFIER);
 		jump_statement_AST = RefDNode(currentAST.root);
@@ -4739,17 +4941,17 @@ void GDLParser::jump_statement() {
 	}
 	case ON_IOERROR:
 	{
-		RefDNode tmp135_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp154_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp135_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp135_AST));
+			tmp154_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp154_AST));
 		}
 		match(ON_IOERROR);
 		match(COMMA);
-		RefDNode tmp137_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp156_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp137_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp137_AST));
+			tmp156_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp156_AST));
 		}
 		match(IDENTIFIER);
 		jump_statement_AST = RefDNode(currentAST.root);
@@ -4768,10 +4970,10 @@ void GDLParser::if_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode if_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp138_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp157_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp138_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp138_AST));
+		tmp157_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp157_AST));
 	}
 	match(IF);
 	expr();
@@ -5277,10 +5479,10 @@ void GDLParser::formal_function_call() {
 	antlr::ASTPair currentAST;
 	RefDNode formal_function_call_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp148_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp167_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp148_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp148_AST));
+		tmp167_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp167_AST));
 	}
 	match(IDENTIFIER);
 	match(LBRACE);
@@ -5601,10 +5803,10 @@ void GDLParser::struct_identifier() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp158_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp177_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp158_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp158_AST));
+			tmp177_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp177_AST));
 		}
 		match(IDENTIFIER);
 		break;
@@ -5910,10 +6112,10 @@ void GDLParser::named_tag_def_entry() {
 		inputState->guessing--;
 	}
 	if ( synPredMatched147 ) {
-		RefDNode tmp167_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp186_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp167_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp167_AST));
+			tmp186_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp186_AST));
 		}
 		match(INHERITS);
 		struct_name();
@@ -8017,9 +8219,9 @@ void GDLParser::all_elements() {
 	antlr::ASTPair currentAST;
 	RefDNode all_elements_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp183_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp202_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp183_AST = astFactory->create(LT(1));
+		tmp202_AST = astFactory->create(LT(1));
 	}
 	match(ASTERIX);
 	if ( inputState->guessing==0 ) {
@@ -8041,10 +8243,10 @@ void GDLParser::sysvar() {
 	antlr::ASTPair currentAST;
 	RefDNode sysvar_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp184_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp203_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp184_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp184_AST));
+		tmp203_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp203_AST));
 	}
 	match(SYSVARNAME);
 	if ( inputState->guessing==0 ) {
@@ -8320,10 +8522,10 @@ void GDLParser::array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp187_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp206_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp187_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp187_AST));
+			tmp206_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp206_AST));
 		}
 		match(IDENTIFIER);
 		array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8416,10 +8618,10 @@ void GDLParser::tag_array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp188_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp207_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp188_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp188_AST));
+			tmp207_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp207_AST));
 		}
 		match(IDENTIFIER);
 		tag_array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8910,9 +9112,9 @@ void GDLParser::arrayexpr_mfcall() {
 	}
 	case ASTERIX:
 	{
-		RefDNode tmp196_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp215_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp196_AST = astFactory->create(LT(1));
+			tmp215_AST = astFactory->create(LT(1));
 		}
 		match(ASTERIX);
 		arrayexpr_mfcall();
@@ -9030,10 +9232,10 @@ void GDLParser::primary_expr() {
 		break;
 	}
 	default:
-		bool synPredMatched270 = false;
+		bool synPredMatched271 = false;
 		if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-			int _m270 = mark();
-			synPredMatched270 = true;
+			int _m271 = mark();
+			synPredMatched271 = true;
 			inputState->guessing++;
 			try {
 				{
@@ -9042,12 +9244,12 @@ void GDLParser::primary_expr() {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched270 = false;
+				synPredMatched271 = false;
 			}
-			rewind(_m270);
+			rewind(_m271);
 			inputState->guessing--;
 		}
-		if ( synPredMatched270 ) {
+		if ( synPredMatched271 ) {
 			deref_dot_expr_keeplast();
 			if (inputState->guessing==0) {
 				d1_AST = returnAST;
@@ -9077,10 +9279,10 @@ void GDLParser::primary_expr() {
 			primary_expr_AST = RefDNode(currentAST.root);
 		}
 		else {
-			bool synPredMatched275 = false;
+			bool synPredMatched276 = false;
 			if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-				int _m275 = mark();
-				synPredMatched275 = true;
+				int _m276 = mark();
+				synPredMatched276 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -9096,23 +9298,23 @@ void GDLParser::primary_expr() {
 							expr();
 						}
 						else {
-							goto _loop274;
+							goto _loop275;
 						}
 						
 					}
-					_loop274:;
+					_loop275:;
 					} // ( ... )*
 					match(RBRACE);
 					}
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched275 = false;
+					synPredMatched276 = false;
 				}
-				rewind(_m275);
+				rewind(_m276);
 				inputState->guessing--;
 			}
-			if ( synPredMatched275 ) {
+			if ( synPredMatched276 ) {
 				arrayexpr_mfcall();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9120,10 +9322,10 @@ void GDLParser::primary_expr() {
 				primary_expr_AST = RefDNode(currentAST.root);
 			}
 			else {
-				bool synPredMatched277 = false;
+				bool synPredMatched278 = false;
 				if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-					int _m277 = mark();
-					synPredMatched277 = true;
+					int _m278 = mark();
+					synPredMatched278 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -9132,12 +9334,12 @@ void GDLParser::primary_expr() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched277 = false;
+						synPredMatched278 = false;
 					}
-					rewind(_m277);
+					rewind(_m278);
 					inputState->guessing--;
 				}
-				if ( synPredMatched277 ) {
+				if ( synPredMatched278 ) {
 					deref_dot_expr_keeplast();
 					if (inputState->guessing==0) {
 						d3_AST = returnAST;
@@ -9161,10 +9363,10 @@ void GDLParser::primary_expr() {
 					primary_expr_AST = RefDNode(currentAST.root);
 				}
 				else {
-					bool synPredMatched279 = false;
+					bool synPredMatched280 = false;
 					if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-						int _m279 = mark();
-						synPredMatched279 = true;
+						int _m280 = mark();
+						synPredMatched280 = true;
 						inputState->guessing++;
 						try {
 							{
@@ -9172,12 +9374,12 @@ void GDLParser::primary_expr() {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched279 = false;
+							synPredMatched280 = false;
 						}
-						rewind(_m279);
+						rewind(_m280);
 						inputState->guessing--;
 					}
-					if ( synPredMatched279 ) {
+					if ( synPredMatched280 ) {
 						deref_expr();
 						if (inputState->guessing==0) {
 							astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9233,25 +9435,6 @@ void GDLParser::primary_expr() {
 						case END_U:
 						case DEC:
 						case INC:
-						case AND_OP_EQ:
-						case ASTERIX_EQ:
-						case EQ_OP_EQ:
-						case GE_OP_EQ:
-						case GTMARK_EQ:
-						case GT_OP_EQ:
-						case LE_OP_EQ:
-						case LTMARK_EQ:
-						case LT_OP_EQ:
-						case MATRIX_OP1_EQ:
-						case MATRIX_OP2_EQ:
-						case MINUS_EQ:
-						case MOD_OP_EQ:
-						case NE_OP_EQ:
-						case OR_OP_EQ:
-						case PLUS_EQ:
-						case POW_EQ:
-						case SLASH_EQ:
-						case XOR_OP_EQ:
 						case RBRACE:
 						case SLASH:
 						case RSQUARE:
@@ -9279,10 +9462,10 @@ void GDLParser::primary_expr() {
 						primary_expr_AST = RefDNode(currentAST.root);
 					}
 					else {
-						bool synPredMatched284 = false;
+						bool synPredMatched285 = false;
 						if (((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE))) {
-							int _m284 = mark();
-							synPredMatched284 = true;
+							int _m285 = mark();
+							synPredMatched285 = true;
 							inputState->guessing++;
 							try {
 								{
@@ -9296,22 +9479,22 @@ void GDLParser::primary_expr() {
 										expr();
 									}
 									else {
-										goto _loop283;
+										goto _loop284;
 									}
 									
 								}
-								_loop283:;
+								_loop284:;
 								} // ( ... )*
 								match(RBRACE);
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched284 = false;
+								synPredMatched285 = false;
 							}
-							rewind(_m284);
+							rewind(_m285);
 							inputState->guessing--;
 						}
-						if ( synPredMatched284 ) {
+						if ( synPredMatched285 ) {
 							{
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))&&( IsFun(LT(1)))) {
 								formal_function_call();
@@ -9333,10 +9516,10 @@ void GDLParser::primary_expr() {
 								}
 							}
 							else {
-								bool synPredMatched287 = false;
+								bool synPredMatched288 = false;
 								if ((((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE))&&(fussy < 2))) {
-									int _m287 = mark();
-									synPredMatched287 = true;
+									int _m288 = mark();
+									synPredMatched288 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9345,12 +9528,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched287 = false;
+										synPredMatched288 = false;
 									}
-									rewind(_m287);
+									rewind(_m288);
 									inputState->guessing--;
 								}
-								if ( synPredMatched287 ) {
+								if ( synPredMatched288 ) {
 									var();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9398,10 +9581,10 @@ void GDLParser::primary_expr() {
 							primary_expr_AST = RefDNode(currentAST.root);
 						}
 						else {
-							bool synPredMatched289 = false;
+							bool synPredMatched290 = false;
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))) {
-								int _m289 = mark();
-								synPredMatched289 = true;
+								int _m290 = mark();
+								synPredMatched290 = true;
 								inputState->guessing++;
 								try {
 									{
@@ -9409,12 +9592,12 @@ void GDLParser::primary_expr() {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched289 = false;
+									synPredMatched290 = false;
 								}
-								rewind(_m289);
+								rewind(_m290);
 								inputState->guessing--;
 							}
-							if ( synPredMatched289 ) {
+							if ( synPredMatched290 ) {
 								formal_function_call();
 								if (inputState->guessing==0) {
 									astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9433,10 +9616,10 @@ void GDLParser::primary_expr() {
 								primary_expr_AST = RefDNode(currentAST.root);
 							}
 							else {
-								bool synPredMatched291 = false;
+								bool synPredMatched292 = false;
 								if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-									int _m291 = mark();
-									synPredMatched291 = true;
+									int _m292 = mark();
+									synPredMatched292 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9444,12 +9627,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched291 = false;
+										synPredMatched292 = false;
 									}
-									rewind(_m291);
+									rewind(_m292);
 									inputState->guessing--;
 								}
-								if ( synPredMatched291 ) {
+								if ( synPredMatched292 ) {
 									deref_expr();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9505,25 +9688,6 @@ void GDLParser::primary_expr() {
 									case END_U:
 									case DEC:
 									case INC:
-									case AND_OP_EQ:
-									case ASTERIX_EQ:
-									case EQ_OP_EQ:
-									case GE_OP_EQ:
-									case GTMARK_EQ:
-									case GT_OP_EQ:
-									case LE_OP_EQ:
-									case LTMARK_EQ:
-									case LT_OP_EQ:
-									case MATRIX_OP1_EQ:
-									case MATRIX_OP2_EQ:
-									case MINUS_EQ:
-									case MOD_OP_EQ:
-									case NE_OP_EQ:
-									case OR_OP_EQ:
-									case PLUS_EQ:
-									case POW_EQ:
-									case SLASH_EQ:
-									case XOR_OP_EQ:
 									case RBRACE:
 									case SLASH:
 									case RSQUARE:
@@ -9575,9 +9739,9 @@ void GDLParser::primary_expr() {
 									ls = LT(1);
 									ls_AST = astFactory->create(ls);
 									match(LSQUARE);
-									RefDNode tmp197_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp216_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp197_AST = astFactory->create(LT(1));
+										tmp216_AST = astFactory->create(LT(1));
 									}
 									match(RSQUARE);
 									if ( inputState->guessing==0 ) {
@@ -9598,9 +9762,9 @@ void GDLParser::primary_expr() {
 									lc = LT(1);
 									lc_AST = astFactory->create(lc);
 									match(LCURLY);
-									RefDNode tmp198_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp217_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp198_AST = astFactory->create(LT(1));
+										tmp217_AST = astFactory->create(LT(1));
 									}
 									match(RCURLY);
 									if ( inputState->guessing==0 ) {
@@ -9634,6 +9798,44 @@ void GDLParser::decinc_expr() {
 	RefDNode d_AST = RefDNode(antlr::nullAST);
 	
 	switch ( LA(1)) {
+	case DEC:
+	case INC:
+	{
+		{
+		switch ( LA(1)) {
+		case INC:
+		{
+			RefDNode tmp218_AST = RefDNode(antlr::nullAST);
+			if ( inputState->guessing == 0 ) {
+				tmp218_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp218_AST));
+			}
+			match(INC);
+			break;
+		}
+		case DEC:
+		{
+			RefDNode tmp219_AST = RefDNode(antlr::nullAST);
+			if ( inputState->guessing == 0 ) {
+				tmp219_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp219_AST));
+			}
+			match(DEC);
+			break;
+		}
+		default:
+		{
+			throw antlr::NoViableAltException(LT(1), getFilename());
+		}
+		}
+		}
+		primary_expr();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+		}
+		decinc_expr_AST = RefDNode(currentAST.root);
+		break;
+	}
 	case IDENTIFIER:
 	case INHERITS:
 	case LBRACE:
@@ -9734,25 +9936,6 @@ void GDLParser::decinc_expr() {
 		case COMMA:
 		case COLON:
 		case END_U:
-		case AND_OP_EQ:
-		case ASTERIX_EQ:
-		case EQ_OP_EQ:
-		case GE_OP_EQ:
-		case GTMARK_EQ:
-		case GT_OP_EQ:
-		case LE_OP_EQ:
-		case LTMARK_EQ:
-		case LT_OP_EQ:
-		case MATRIX_OP1_EQ:
-		case MATRIX_OP2_EQ:
-		case MINUS_EQ:
-		case MOD_OP_EQ:
-		case NE_OP_EQ:
-		case OR_OP_EQ:
-		case PLUS_EQ:
-		case POW_EQ:
-		case SLASH_EQ:
-		case XOR_OP_EQ:
 		case RBRACE:
 		case SLASH:
 		case RSQUARE:
@@ -9780,36 +9963,6 @@ void GDLParser::decinc_expr() {
 		decinc_expr_AST = RefDNode(currentAST.root);
 		break;
 	}
-	case INC:
-	{
-		RefDNode tmp199_AST = RefDNode(antlr::nullAST);
-		if ( inputState->guessing == 0 ) {
-			tmp199_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp199_AST));
-		}
-		match(INC);
-		primary_expr();
-		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-		}
-		decinc_expr_AST = RefDNode(currentAST.root);
-		break;
-	}
-	case DEC:
-	{
-		RefDNode tmp200_AST = RefDNode(antlr::nullAST);
-		if ( inputState->guessing == 0 ) {
-			tmp200_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp200_AST));
-		}
-		match(DEC);
-		primary_expr();
-		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-		}
-		decinc_expr_AST = RefDNode(currentAST.root);
-		break;
-	}
 	default:
 	{
 		throw antlr::NoViableAltException(LT(1), getFilename());
@@ -9830,10 +9983,10 @@ void GDLParser::exponential_expr() {
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == POW)) {
-			RefDNode tmp201_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp220_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp201_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp201_AST));
+				tmp220_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp220_AST));
 			}
 			match(POW);
 			decinc_expr();
@@ -9842,11 +9995,11 @@ void GDLParser::exponential_expr() {
 			}
 		}
 		else {
-			goto _loop297;
+			goto _loop299;
 		}
 		
 	}
-	_loop297:;
+	_loop299:;
 	} // ( ... )*
 	exponential_expr_AST = RefDNode(currentAST.root);
 	returnAST = exponential_expr_AST;
@@ -9868,242 +10021,52 @@ void GDLParser::multiplicative_expr() {
 			switch ( LA(1)) {
 			case ASTERIX:
 			{
-				RefDNode tmp202_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp221_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp202_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp202_AST));
+					tmp221_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
 				}
 				match(ASTERIX);
 				break;
 			}
 			case MATRIX_OP1:
 			{
-				RefDNode tmp203_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp222_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp203_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp203_AST));
+					tmp222_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
 				}
 				match(MATRIX_OP1);
 				break;
 			}
 			case MATRIX_OP2:
 			{
-				RefDNode tmp204_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp223_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp204_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp204_AST));
+					tmp223_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp223_AST));
 				}
 				match(MATRIX_OP2);
 				break;
 			}
 			case SLASH:
 			{
-				RefDNode tmp205_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp205_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp205_AST));
+					tmp224_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
 				}
 				match(SLASH);
 				break;
 			}
 			case MOD_OP:
 			{
-				RefDNode tmp206_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp206_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp206_AST));
-				}
-				match(MOD_OP);
-				break;
-			}
-			case AND_OP_EQ:
-			{
-				RefDNode tmp207_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp207_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp207_AST));
-				}
-				match(AND_OP_EQ);
-				break;
-			}
-			case ASTERIX_EQ:
-			{
-				RefDNode tmp208_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp208_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp208_AST));
-				}
-				match(ASTERIX_EQ);
-				break;
-			}
-			case EQ_OP_EQ:
-			{
-				RefDNode tmp209_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp209_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp209_AST));
-				}
-				match(EQ_OP_EQ);
-				break;
-			}
-			case GE_OP_EQ:
-			{
-				RefDNode tmp210_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp210_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp210_AST));
-				}
-				match(GE_OP_EQ);
-				break;
-			}
-			case GTMARK_EQ:
-			{
-				RefDNode tmp211_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp211_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp211_AST));
-				}
-				match(GTMARK_EQ);
-				break;
-			}
-			case GT_OP_EQ:
-			{
-				RefDNode tmp212_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp212_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp212_AST));
-				}
-				match(GT_OP_EQ);
-				break;
-			}
-			case LE_OP_EQ:
-			{
-				RefDNode tmp213_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp213_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp213_AST));
-				}
-				match(LE_OP_EQ);
-				break;
-			}
-			case LTMARK_EQ:
-			{
-				RefDNode tmp214_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp214_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp214_AST));
-				}
-				match(LTMARK_EQ);
-				break;
-			}
-			case LT_OP_EQ:
-			{
-				RefDNode tmp215_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp215_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp215_AST));
-				}
-				match(LT_OP_EQ);
-				break;
-			}
-			case MATRIX_OP1_EQ:
-			{
-				RefDNode tmp216_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp216_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp216_AST));
-				}
-				match(MATRIX_OP1_EQ);
-				break;
-			}
-			case MATRIX_OP2_EQ:
-			{
-				RefDNode tmp217_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp217_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp217_AST));
-				}
-				match(MATRIX_OP2_EQ);
-				break;
-			}
-			case MINUS_EQ:
-			{
-				RefDNode tmp218_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp218_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp218_AST));
-				}
-				match(MINUS_EQ);
-				break;
-			}
-			case MOD_OP_EQ:
-			{
-				RefDNode tmp219_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp219_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp219_AST));
-				}
-				match(MOD_OP_EQ);
-				break;
-			}
-			case NE_OP_EQ:
-			{
-				RefDNode tmp220_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp220_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp220_AST));
-				}
-				match(NE_OP_EQ);
-				break;
-			}
-			case OR_OP_EQ:
-			{
-				RefDNode tmp221_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp221_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
-				}
-				match(OR_OP_EQ);
-				break;
-			}
-			case PLUS_EQ:
-			{
-				RefDNode tmp222_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp222_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
-				}
-				match(PLUS_EQ);
-				break;
-			}
-			case POW_EQ:
-			{
-				RefDNode tmp223_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp223_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp223_AST));
-				}
-				match(POW_EQ);
-				break;
-			}
-			case SLASH_EQ:
-			{
-				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
-				if ( inputState->guessing == 0 ) {
-					tmp224_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
-				}
-				match(SLASH_EQ);
-				break;
-			}
-			case XOR_OP_EQ:
-			{
 				RefDNode tmp225_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp225_AST = astFactory->create(LT(1));
 					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp225_AST));
 				}
-				match(XOR_OP_EQ);
+				match(MOD_OP);
 				break;
 			}
 			default:
@@ -10118,11 +10081,11 @@ void GDLParser::multiplicative_expr() {
 			}
 		}
 		else {
-			goto _loop301;
+			goto _loop303;
 		}
 		
 	}
-	_loop301:;
+	_loop303:;
 	} // ( ... )*
 	multiplicative_expr_AST = RefDNode(currentAST.root);
 	returnAST = multiplicative_expr_AST;
@@ -10441,11 +10404,11 @@ void GDLParser::additive_expr() {
 			}
 		}
 		else {
-			goto _loop308;
+			goto _loop310;
 		}
 		
 	}
-	_loop308:;
+	_loop310:;
 	} // ( ... )*
 	additive_expr_AST = RefDNode(currentAST.root);
 	returnAST = additive_expr_AST;
@@ -10581,11 +10544,11 @@ void GDLParser::relational_expr() {
 			}
 		}
 		else {
-			goto _loop313;
+			goto _loop315;
 		}
 		
 	}
-	_loop313:;
+	_loop315:;
 	} // ( ... )*
 	relational_expr_AST = RefDNode(currentAST.root);
 	returnAST = relational_expr_AST;
@@ -10647,11 +10610,11 @@ void GDLParser::boolean_expr() {
 			}
 		}
 		else {
-			goto _loop317;
+			goto _loop319;
 		}
 		
 	}
-	_loop317:;
+	_loop319:;
 	} // ( ... )*
 	boolean_expr_AST = RefDNode(currentAST.root);
 	returnAST = boolean_expr_AST;
@@ -10703,11 +10666,11 @@ void GDLParser::logical_expr() {
 			}
 		}
 		else {
-			goto _loop321;
+			goto _loop323;
 		}
 		
 	}
-	_loop321:;
+	_loop323:;
 	} // ( ... )*
 	logical_expr_AST = RefDNode(currentAST.root);
 	returnAST = logical_expr_AST;
@@ -11092,13 +11055,29 @@ const unsigned long GDLParser::_tokenSet_11_data_[] = { 0UL, 0UL, 268435456UL, 3
 // CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
 // CONSTANT_CMPLXDBL_I ASTERIX STRING_LITERAL PLUS MINUS LOG_NEG 
 const antlr::BitSet GDLParser::_tokenSet_11(_tokenSet_11_data_,16);
-const unsigned long GDLParser::_tokenSet_12_data_[] = { 0UL, 0UL, 805306368UL, 334831624UL, 4294967211UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLParser::_tokenSet_12_data_[] = { 0UL, 0UL, 805306368UL, 334831624UL, 4026532267UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "else" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" 
-// "not" "or" "until" "xor" COMMA END_U DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ 
-// GE_OP_EQ GTMARK_EQ GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ 
-// MATRIX_OP2_EQ MINUS_EQ MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ 
-// XOR_OP_EQ MEMBER LBRACE RBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION 
-// LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 
+// "not" "or" "until" "xor" COMMA END_U DEC INC MEMBER LBRACE RBRACE SLASH 
+// LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE 
+// CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT CONSTANT_HEX_I 
+// CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI CONSTANT_HEX_UINT 
+// CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT CONSTANT_I 
+// CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT CONSTANT_OCT_BYTE 
+// CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT CONSTANT_OCT_I 
+// CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI CONSTANT_OCT_UINT 
+// CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 
+// CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 
+// CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I 
+// ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK 
+// GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+const antlr::BitSet GDLParser::_tokenSet_12(_tokenSet_12_data_,16);
+const unsigned long GDLParser::_tokenSet_13_data_[] = { 0UL, 0UL, 268435456UL, 1048576UL, 0UL, 12UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// IDENTIFIER "inherits" SYSVARNAME EXCLAMATION 
+const antlr::BitSet GDLParser::_tokenSet_13(_tokenSet_13_data_,12);
+const unsigned long GDLParser::_tokenSet_14_data_[] = { 2UL, 0UL, 805306368UL, 334831616UL, 2952790410UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// EOF IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" 
+// "not" "or" "xor" COMMA DEC INC MEMBER LBRACE SLASH LSQUARE RSQUARE SYSVARNAME 
+// EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 
 // CONSTANT_HEX_INT CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 
 // CONSTANT_HEX_UI CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 
 // CONSTANT_INT CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI 
@@ -11110,27 +11089,6 @@ const unsigned long GDLParser::_tokenSet_12_data_[] = { 0UL, 0UL, 805306368UL, 3
 // CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW 
 // MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR 
 // QUESTION 
-const antlr::BitSet GDLParser::_tokenSet_12(_tokenSet_12_data_,16);
-const unsigned long GDLParser::_tokenSet_13_data_[] = { 0UL, 0UL, 268435456UL, 1048576UL, 0UL, 12UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// IDENTIFIER "inherits" SYSVARNAME EXCLAMATION 
-const antlr::BitSet GDLParser::_tokenSet_13(_tokenSet_13_data_,12);
-const unsigned long GDLParser::_tokenSet_14_data_[] = { 2UL, 0UL, 805306368UL, 334831616UL, 3221225354UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// EOF IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" 
-// "not" "or" "xor" COMMA DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ 
-// GTMARK_EQ GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ 
-// MINUS_EQ MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ 
-// MEMBER LBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY 
-// CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT 
-// CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI 
-// CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT 
-// CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT 
-// CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT 
-// CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI 
-// CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG 
-// CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG 
-// CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
-// CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
-// PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
 const antlr::BitSet GDLParser::_tokenSet_14(_tokenSet_14_data_,16);
 const unsigned long GDLParser::_tokenSet_15_data_[] = { 0UL, 0UL, 268435456UL, 34603008UL, 536871296UL, 4294967261UL, 20021247UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "inherits" "not" DEC INC LBRACE LSQUARE SYSVARNAME EXCLAMATION 
@@ -11145,91 +11103,42 @@ const unsigned long GDLParser::_tokenSet_15_data_[] = { 0UL, 0UL, 268435456UL, 3
 // CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
 // CONSTANT_CMPLXDBL_I ASTERIX STRING_LITERAL PLUS MINUS LOG_NEG 
 const antlr::BitSet GDLParser::_tokenSet_15(_tokenSet_15_data_,16);
-const unsigned long GDLParser::_tokenSet_16_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 3221225370UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLParser::_tokenSet_16_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 2952790426UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
-// "or" "xor" COMMA COLON DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ 
-// GTMARK_EQ GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ 
-// MINUS_EQ MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ 
-// MEMBER LBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY 
-// CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT 
-// CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI 
-// CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT 
-// CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT 
-// CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT 
-// CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI 
-// CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG 
-// CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG 
-// CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
-// CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
-// PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+// "or" "xor" COMMA COLON DEC INC MEMBER LBRACE SLASH LSQUARE RSQUARE SYSVARNAME 
+// EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 
+// CONSTANT_HEX_INT CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 
+// CONSTANT_HEX_UI CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 
+// CONSTANT_INT CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI 
+// CONSTANT_UINT CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 
+// CONSTANT_OCT_INT CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 
+// CONSTANT_OCT_UI CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE 
+// CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I 
+// CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT 
+// CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW 
+// MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR 
+// QUESTION 
 const antlr::BitSet GDLParser::_tokenSet_16(_tokenSet_16_data_,16);
-const unsigned long GDLParser::_tokenSet_17_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 3221225354UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLParser::_tokenSet_17_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 2952790410UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
-// "or" "xor" COMMA DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ 
-// GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ MINUS_EQ 
-// MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ MEMBER 
-// LBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE 
-// CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT CONSTANT_HEX_I 
-// CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI CONSTANT_HEX_UINT 
-// CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT CONSTANT_I 
-// CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT CONSTANT_OCT_BYTE 
-// CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT CONSTANT_OCT_I 
-// CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI CONSTANT_OCT_UINT 
-// CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 
-// CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 
-// CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I 
-// ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK 
-// GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+// "or" "xor" COMMA DEC INC MEMBER LBRACE SLASH LSQUARE RSQUARE SYSVARNAME 
+// EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 
+// CONSTANT_HEX_INT CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 
+// CONSTANT_HEX_UI CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 
+// CONSTANT_INT CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI 
+// CONSTANT_UINT CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 
+// CONSTANT_OCT_INT CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 
+// CONSTANT_OCT_UI CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE 
+// CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I 
+// CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT 
+// CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW 
+// MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR 
+// QUESTION 
 const antlr::BitSet GDLParser::_tokenSet_17(_tokenSet_17_data_,16);
-const unsigned long GDLParser::_tokenSet_18_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4294967194UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long GDLParser::_tokenSet_18_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4026532250UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
-// "or" "xor" COMMA COLON DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ 
-// GTMARK_EQ GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ 
-// MINUS_EQ MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ 
-// MEMBER LBRACE RBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY 
-// RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT 
-// CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI 
-// CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT 
-// CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT 
-// CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT 
-// CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI 
-// CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG 
-// CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG 
-// CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
-// CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
-// PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
-const antlr::BitSet GDLParser::_tokenSet_18(_tokenSet_18_data_,16);
-const unsigned long GDLParser::_tokenSet_19_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4294967178UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
-// "or" "xor" COMMA DEC INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ 
-// GT_OP_EQ LE_OP_EQ LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ MINUS_EQ 
-// MOD_OP_EQ NE_OP_EQ OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ MEMBER 
-// LBRACE RBRACE SLASH LSQUARE RSQUARE SYSVARNAME EXCLAMATION LCURLY RCURLY 
-// CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT 
-// CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI 
-// CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT 
-// CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT 
-// CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT 
-// CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI 
-// CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG 
-// CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG 
-// CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
-// CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
-// PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
-const antlr::BitSet GDLParser::_tokenSet_19(_tokenSet_19_data_,16);
-const unsigned long GDLParser::_tokenSet_20_data_[] = { 0UL, 0UL, 268435456UL, 0UL, 536870912UL, 12UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// IDENTIFIER LBRACE SYSVARNAME EXCLAMATION 
-const antlr::BitSet GDLParser::_tokenSet_20(_tokenSet_20_data_,12);
-const unsigned long GDLParser::_tokenSet_21_data_[] = { 0UL, 0UL, 0UL, 8UL, 536870957UL, 1UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// "else" "until" METHOD COMMA END_U LBRACE LSQUARE 
-const antlr::BitSet GDLParser::_tokenSet_21(_tokenSet_21_data_,12);
-const unsigned long GDLParser::_tokenSet_22_data_[] = { 2UL, 0UL, 805306368UL, 2549424140UL, 4294967227UL, 4294967287UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// EOF IDENTIFIER "and" "do" "else" "eq" "ge" "gt" "inherits" "le" "lt" 
-// "mod" "ne" "not" "of" "or" "then" "until" "xor" COMMA COLON END_U DEC 
-// INC AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ GT_OP_EQ LE_OP_EQ 
-// LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ MINUS_EQ MOD_OP_EQ NE_OP_EQ 
-// OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ MEMBER LBRACE RBRACE SLASH 
-// LSQUARE RSQUARE SYSVARNAME LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG 
+// "or" "xor" COMMA COLON DEC INC MEMBER LBRACE RBRACE SLASH LSQUARE RSQUARE 
+// SYSVARNAME EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG 
 // CONSTANT_HEX_LONG64 CONSTANT_HEX_INT CONSTANT_HEX_I CONSTANT_HEX_ULONG 
 // CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI CONSTANT_HEX_UINT CONSTANT_BYTE 
 // CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT CONSTANT_I CONSTANT_ULONG 
@@ -11241,12 +11150,47 @@ const unsigned long GDLParser::_tokenSet_22_data_[] = { 2UL, 0UL, 805306368UL, 2
 // CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I 
 // ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK 
 // GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+const antlr::BitSet GDLParser::_tokenSet_18(_tokenSet_18_data_,16);
+const unsigned long GDLParser::_tokenSet_19_data_[] = { 0UL, 0UL, 805306368UL, 334831616UL, 4026532234UL, 4294967295UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// IDENTIFIER "and" "eq" "ge" "gt" "inherits" "le" "lt" "mod" "ne" "not" 
+// "or" "xor" COMMA DEC INC MEMBER LBRACE RBRACE SLASH LSQUARE RSQUARE 
+// SYSVARNAME EXCLAMATION LCURLY RCURLY CONSTANT_HEX_BYTE CONSTANT_HEX_LONG 
+// CONSTANT_HEX_LONG64 CONSTANT_HEX_INT CONSTANT_HEX_I CONSTANT_HEX_ULONG 
+// CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI CONSTANT_HEX_UINT CONSTANT_BYTE 
+// CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT CONSTANT_I CONSTANT_ULONG 
+// CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT CONSTANT_OCT_BYTE CONSTANT_OCT_LONG 
+// CONSTANT_OCT_LONG64 CONSTANT_OCT_INT CONSTANT_OCT_I CONSTANT_OCT_ULONG 
+// CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI CONSTANT_OCT_UINT CONSTANT_FLOAT 
+// CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG CONSTANT_BIN_LONG64 
+// CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG CONSTANT_BIN_ULONG64 
+// CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I CONSTANT_CMPLXDBL_I 
+// ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 PLUS MINUS LTMARK 
+// GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
+const antlr::BitSet GDLParser::_tokenSet_19(_tokenSet_19_data_,16);
+const unsigned long GDLParser::_tokenSet_20_data_[] = { 0UL, 0UL, 268435456UL, 0UL, 536870912UL, 12UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// IDENTIFIER LBRACE SYSVARNAME EXCLAMATION 
+const antlr::BitSet GDLParser::_tokenSet_20(_tokenSet_20_data_,12);
+const unsigned long GDLParser::_tokenSet_21_data_[] = { 0UL, 0UL, 0UL, 8UL, 536870957UL, 1UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// "else" "until" METHOD COMMA END_U LBRACE LSQUARE 
+const antlr::BitSet GDLParser::_tokenSet_21(_tokenSet_21_data_,12);
+const unsigned long GDLParser::_tokenSet_22_data_[] = { 2UL, 0UL, 805306368UL, 2549424140UL, 4026532283UL, 4294967287UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// EOF IDENTIFIER "and" "do" "else" "eq" "ge" "gt" "inherits" "le" "lt" 
+// "mod" "ne" "not" "of" "or" "then" "until" "xor" COMMA COLON END_U DEC 
+// INC MEMBER LBRACE RBRACE SLASH LSQUARE RSQUARE SYSVARNAME LCURLY RCURLY 
+// CONSTANT_HEX_BYTE CONSTANT_HEX_LONG CONSTANT_HEX_LONG64 CONSTANT_HEX_INT 
+// CONSTANT_HEX_I CONSTANT_HEX_ULONG CONSTANT_HEX_ULONG64 CONSTANT_HEX_UI 
+// CONSTANT_HEX_UINT CONSTANT_BYTE CONSTANT_LONG CONSTANT_LONG64 CONSTANT_INT 
+// CONSTANT_I CONSTANT_ULONG CONSTANT_ULONG64 CONSTANT_UI CONSTANT_UINT 
+// CONSTANT_OCT_BYTE CONSTANT_OCT_LONG CONSTANT_OCT_LONG64 CONSTANT_OCT_INT 
+// CONSTANT_OCT_I CONSTANT_OCT_ULONG CONSTANT_OCT_ULONG64 CONSTANT_OCT_UI 
+// CONSTANT_OCT_UINT CONSTANT_FLOAT CONSTANT_DOUBLE CONSTANT_BIN_BYTE CONSTANT_BIN_LONG 
+// CONSTANT_BIN_LONG64 CONSTANT_BIN_INT CONSTANT_BIN_I CONSTANT_BIN_ULONG 
+// CONSTANT_BIN_ULONG64 CONSTANT_BIN_UI CONSTANT_BIN_UINT CONSTANT_CMPLX_I 
+// CONSTANT_CMPLXDBL_I ASTERIX DOT STRING_LITERAL POW MATRIX_OP1 MATRIX_OP2 
+// PLUS MINUS LTMARK GTMARK LOG_NEG LOG_AND LOG_OR QUESTION 
 const antlr::BitSet GDLParser::_tokenSet_22(_tokenSet_22_data_,16);
-const unsigned long GDLParser::_tokenSet_23_data_[] = { 0UL, 0UL, 0UL, 8388608UL, 2415918592UL, 0UL, 802816UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// "mod" AND_OP_EQ ASTERIX_EQ EQ_OP_EQ GE_OP_EQ GTMARK_EQ GT_OP_EQ LE_OP_EQ 
-// LTMARK_EQ LT_OP_EQ MATRIX_OP1_EQ MATRIX_OP2_EQ MINUS_EQ MOD_OP_EQ NE_OP_EQ 
-// OR_OP_EQ PLUS_EQ POW_EQ SLASH_EQ XOR_OP_EQ SLASH ASTERIX MATRIX_OP1 
-// MATRIX_OP2 
+const unsigned long GDLParser::_tokenSet_23_data_[] = { 0UL, 0UL, 0UL, 8388608UL, 2147483648UL, 0UL, 802816UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// "mod" SLASH ASTERIX MATRIX_OP1 MATRIX_OP2 
 const antlr::BitSet GDLParser::_tokenSet_23(_tokenSet_23_data_,16);
 const unsigned long GDLParser::_tokenSet_24_data_[] = { 0UL, 0UL, 0UL, 23404544UL, 0UL, 0UL, 0UL, 0UL };
 // "eq" "ge" "gt" "le" "lt" "ne" 

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -25,9 +25,6 @@
 #include <antlr/TokenStreamIOException.hpp>
 #include <antlr/CharInputBuffer.hpp>
 
-// GD: set to 1 to traceout what the Parser does.
-#define debugParser 0
-//#include "dinterpreter.hpp"
 
 // definition in dinterpreter.cpp
 void MemorizeCompileOptForMAINIfNeeded( unsigned int cOpt);

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -58,6 +58,7 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
     bool   searchForPro; // true -> procedure subName, false -> function subName 
     bool   SearchedRoutineFound; 
     unsigned int compileOpt=0;
+	bool relaxed=false; // use of a bool speedups {}? constructs
     int fussy=((compileOpt & STRICTARR)!=0)?2:1; //auto recovery if compile opt is not strictarr
     int LastGoodPosition=0; // last position of start of PRO or FUNC -- used in recovery mode
 	bool recovery=false; //recovery mode going to 'fussy' if STRICTARR generated an error 
@@ -66,9 +67,9 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
         if(      opt == "DEFINT32")          compileOpt |= DEFINT32;
         else if( opt == "HIDDEN")            compileOpt |= HIDDEN;
         else if( opt == "OBSOLETE")          compileOpt |= OBSOLETE;
-        else if( opt == "STRICTARR")         {compileOpt |= STRICTARR; fussy=2;} // fussy=2: a strictarr syntax error is fatal
+        else if( opt == "STRICTARR")         {compileOpt |= STRICTARR; fussy=2; relaxed=false;} // fussy=2: a strictarr syntax error is fatal
         else if( opt == "LOGICAL_PREDICATE") compileOpt |= LOGICAL_PREDICATE;
-        else if( opt == "IDL2")              {compileOpt |= IDL2; fussy=2;}
+        else if( opt == "IDL2")              {compileOpt |= IDL2; fussy=2; relaxed=false;}
         else if( opt == "STRICTARRSUBS")     compileOpt |= STRICTARRSUBS;
         else if( opt == "STATIC")            compileOpt |= STATIC;
         else if( opt == "NOSAVE")            compileOpt |= NOSAVE;

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -54,25 +54,26 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
     }
     
     private:
+    std::string subName; // name of procedure function to be compiled ("" -> all file)
+    bool   searchForPro; // true -> procedure subName, false -> function subName 
+    bool   subReached; 
+    unsigned int compileOpt;
+    bool relaxed=IsRelaxed();
+
     void AddCompileOpt( const std::string &opt)
     {
         if(      opt == "DEFINT32")          compileOpt |= DEFINT32;
         else if( opt == "HIDDEN")            compileOpt |= HIDDEN;
         else if( opt == "OBSOLETE")          compileOpt |= OBSOLETE;
-        else if( opt == "STRICTARR")         compileOpt |= STRICTARR;
+        else if( opt == "STRICTARR")         {compileOpt |= STRICTARR; relaxed=false;}
         else if( opt == "LOGICAL_PREDICATE") compileOpt |= LOGICAL_PREDICATE;
-        else if( opt == "IDL2")              compileOpt |= IDL2;
+        else if( opt == "IDL2")              {compileOpt |= IDL2; relaxed=false;}
         else if( opt == "STRICTARRSUBS")     compileOpt |= STRICTARRSUBS;
         else if( opt == "STATIC")            compileOpt |= STATIC;
         else if( opt == "NOSAVE")            compileOpt |= NOSAVE;
         else throw GDLException("Unrecognised COMPILE_OPT option: "+opt);
         MemorizeCompileOptForMAINIfNeeded( compileOpt);
     }
-
-    std::string subName; // name of procedure function to be compiled ("" -> all file)
-    bool   searchForPro; // true -> procedure subName, false -> function subName 
-    bool   subReached; 
-    unsigned int compileOpt;
 
     bool ConstantExprNode( int t)
     {
@@ -223,7 +224,8 @@ public:
 	public: void constant_cmplxdbl_i();
 	public: void numeric_constant();
 	public: void arrayindex_list();
-	public: void arrayindex();
+	public: void arrayindex_fussy();
+	public: void arrayindex_sloppy();
 	public: void all_elements();
 	public: void sysvar();
 	public: void var();

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -56,9 +56,11 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
     private:
     std::string subName; // name of procedure function to be compiled ("" -> all file)
     bool   searchForPro; // true -> procedure subName, false -> function subName 
-    bool   subReached; 
+    bool   SearchedRoutineFound; 
     unsigned int compileOpt;
-    bool relaxed=IsRelaxed();
+    bool relaxed=!IsStrictArr();
+    int LastGoodPosition=0; // last position of start of PRO or FUNC -- used in recovery mode
+	bool recovery=false; //recovery mode going to 'relaxed' if STRICTARR generated an error 
 
     void AddCompileOpt( const std::string &opt)
     {
@@ -87,7 +89,7 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
               bool searchPro, // true -> search for procedure sName, false -> for function
               unsigned int compileOptIn):
     antlr::LLkParser(selector,2), subName(sName), searchForPro( searchPro), 
-    subReached(false), compileOpt(compileOptIn)
+    SearchedRoutineFound(false), compileOpt(compileOptIn)
     { 
         //        setTokenNames(_tokenNames);
     }

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -57,19 +57,18 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
     std::string subName; // name of procedure function to be compiled ("" -> all file)
     bool   searchForPro; // true -> procedure subName, false -> function subName 
     bool   SearchedRoutineFound; 
-    unsigned int compileOpt;
-    bool relaxed=!IsStrictArr();
+    unsigned int compileOpt=0;
+    int fussy=((compileOpt & STRICTARR)!=0)?2:1; //auto recovery if compile opt is not strictarr
     int LastGoodPosition=0; // last position of start of PRO or FUNC -- used in recovery mode
-	bool recovery=false; //recovery mode going to 'relaxed' if STRICTARR generated an error 
-
+	bool recovery=false; //recovery mode going to 'fussy' if STRICTARR generated an error 
     void AddCompileOpt( const std::string &opt)
     {
         if(      opt == "DEFINT32")          compileOpt |= DEFINT32;
         else if( opt == "HIDDEN")            compileOpt |= HIDDEN;
         else if( opt == "OBSOLETE")          compileOpt |= OBSOLETE;
-        else if( opt == "STRICTARR")         {compileOpt |= STRICTARR; relaxed=false;}
+        else if( opt == "STRICTARR")         {compileOpt |= STRICTARR; fussy=2;} // fussy=2: a strictarr syntax error is fatal
         else if( opt == "LOGICAL_PREDICATE") compileOpt |= LOGICAL_PREDICATE;
-        else if( opt == "IDL2")              {compileOpt |= IDL2; relaxed=false;}
+        else if( opt == "IDL2")              {compileOpt |= IDL2; fussy=2;}
         else if( opt == "STRICTARRSUBS")     compileOpt |= STRICTARRSUBS;
         else if( opt == "STATIC")            compileOpt |= STATIC;
         else if( opt == "NOSAVE")            compileOpt |= NOSAVE;
@@ -227,8 +226,9 @@ public:
 	public: void numeric_constant();
 	public: void arrayindex_list();
 	public: void arrayindex();
-	public: void all_elements();
 	public: void arrayindex_sloppy();
+	public: void arrayindex_list_sloppy();
+	public: void all_elements();
 	public: void sysvar();
 	public: void var();
 	public: void brace_expr();
@@ -322,10 +322,6 @@ private:
 	static const antlr::BitSet _tokenSet_23;
 	static const unsigned long _tokenSet_24_data_[];
 	static const antlr::BitSet _tokenSet_24;
-	static const unsigned long _tokenSet_25_data_[];
-	static const antlr::BitSet _tokenSet_25;
-	static const unsigned long _tokenSet_26_data_[];
-	static const antlr::BitSet _tokenSet_26;
 };
 
 #endif /*INC_GDLParser_hpp_*/

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -226,9 +226,9 @@ public:
 	public: void constant_cmplxdbl_i();
 	public: void numeric_constant();
 	public: void arrayindex_list();
-	public: void arrayindex_fussy();
-	public: void arrayindex_sloppy();
+	public: void arrayindex();
 	public: void all_elements();
+	public: void arrayindex_sloppy();
 	public: void sysvar();
 	public: void var();
 	public: void brace_expr();
@@ -322,6 +322,10 @@ private:
 	static const antlr::BitSet _tokenSet_23;
 	static const unsigned long _tokenSet_24_data_[];
 	static const antlr::BitSet _tokenSet_24;
+	static const unsigned long _tokenSet_25_data_[];
+	static const antlr::BitSet _tokenSet_25;
+	static const unsigned long _tokenSet_26_data_[];
+	static const antlr::BitSet _tokenSet_26;
 };
 
 #endif /*INC_GDLParser_hpp_*/

--- a/src/antlr/ANTLRException.hpp
+++ b/src/antlr/ANTLRException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ANTLRException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ANTLRException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/ANTLRUtil.cpp
+++ b/src/antlr/ANTLRUtil.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ANTLRUtil.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/ANTLRUtil.hpp
+++ b/src/antlr/ANTLRUtil.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ANTLRUtil.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/AST.hpp
+++ b/src/antlr/AST.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: AST.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/AST.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/ASTArray.hpp
+++ b/src/antlr/ASTArray.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTArray.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ASTArray.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/ASTFactory.cpp
+++ b/src/antlr/ASTFactory.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTFactory.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/ASTFactory.cpp#2 $
  */
 
 #include "antlr/CommonAST.hpp"

--- a/src/antlr/ASTFactory.hpp
+++ b/src/antlr/ASTFactory.hpp
@@ -5,16 +5,15 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTFactory.hpp,v 1.2 2013-09-17 20:12:40 gilles-duvert Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ASTFactory.hpp#2 $
  */
 
 #include <antlr/config.hpp>
 #include <antlr/AST.hpp>
 #include <antlr/ASTArray.hpp>
 #include <antlr/ASTPair.hpp>
-#ifdef __PATHCC__
-#include <iostream>
-#endif
+
+#include <istream>
 #include <utility>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE

--- a/src/antlr/ASTNULLType.cpp
+++ b/src/antlr/ASTNULLType.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTNULLType.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 #include "antlr/config.hpp"

--- a/src/antlr/ASTNULLType.hpp
+++ b/src/antlr/ASTNULLType.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTNULLType.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ASTNULLType.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/ASTPair.hpp
+++ b/src/antlr/ASTPair.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ASTPair.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ASTPair.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/BaseAST.cpp
+++ b/src/antlr/BaseAST.cpp
@@ -2,12 +2,13 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: BaseAST.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/BaseAST.cpp#2 $
  */
+
+#include "antlr/config.hpp"
 
 #include <iostream>
 
-#include "antlr/config.hpp"
 #include "antlr/AST.hpp"
 #include "antlr/BaseAST.hpp"
 
@@ -15,52 +16,6 @@ ANTLR_USING_NAMESPACE(std)
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
-
-const char* const BaseAST::TYPE_NAME = "BaseAST";
-
-//bool BaseAST::verboseStringConversion;
-//ANTLR_USE_NAMESPACE(std)vector<ANTLR_USE_NAMESPACE(std)string> BaseAST::tokenNames;
-
-BaseAST::BaseAST() : AST()
-{
-}
-
-BaseAST::~BaseAST()
-{
-}
-
-BaseAST::BaseAST(const BaseAST& other)
-: AST(other) // RK: don't copy links! , down(other.down), right(other.right)
-{
-}
-
-const char* BaseAST::typeName( void ) const
-{
-	return BaseAST::TYPE_NAME;
-}
-
-RefAST BaseAST::clone( void ) const
-{
-	ANTLR_USE_NAMESPACE(std)cerr << "BaseAST::clone()" << ANTLR_USE_NAMESPACE(std)endl;
-	return nullAST;
-}
-
-void BaseAST::addChild( RefAST c )
-{
-	if( !c )
-		return;
-
-	RefBaseAST tmp = down;
-
-	if (tmp)
-	{
-		while (tmp->right)
-			tmp = tmp->right;
-		tmp->right = c;
-	}
-	else
-		down = c;
-}
 
 size_t BaseAST::getNumberOfChildren() const
 {
@@ -231,19 +186,6 @@ ANTLR_USE_NAMESPACE(std)vector<RefAST> BaseAST::findAllPartial(RefAST target)
 		doWorkForFindAll(roots,target,true); // find all matches recursively
 
 	return roots;
-}
-
-void BaseAST::setText( const ANTLR_USE_NAMESPACE(std)string& )
-{
-}
-
-void BaseAST::setType( int )
-{
-}
-
-ANTLR_USE_NAMESPACE(std)string BaseAST::toString() const
-{
-	return getText();
 }
 
 ANTLR_USE_NAMESPACE(std)string BaseAST::toStringList() const

--- a/src/antlr/BaseAST.hpp
+++ b/src/antlr/BaseAST.hpp
@@ -5,11 +5,13 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: BaseAST.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/BaseAST.hpp#2 $
  */
 
 #include <antlr/config.hpp>
 #include <antlr/AST.hpp>
+
+#include <iostream>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
@@ -20,16 +22,22 @@ typedef ASTRefCount<BaseAST> RefBaseAST;
 
 class ANTLR_API BaseAST : public AST {
 public:
-	BaseAST();
-	BaseAST(const BaseAST& other);
-
-	virtual ~BaseAST();
+	BaseAST() : AST()
+	{
+	}
+	BaseAST(const BaseAST& other)
+	: AST(other)
+	{
+	}
+	virtual ~BaseAST()
+	{
+	}
 
 	/// Return the class name
-	virtual const char* typeName( void ) const;
+	virtual const char* typeName( void ) const = 0;
 
 	/// Clone this AST node.
-	virtual RefAST clone( void ) const;
+	virtual RefAST clone( void ) const = 0;
 
    /// Is node t equal to this in terms of token type and text?
 	virtual bool equals(RefAST t) const;
@@ -66,7 +74,23 @@ public:
 	virtual ANTLR_USE_NAMESPACE(std)vector<RefAST> findAllPartial(RefAST t);
 
    /// Add a node to the end of the child list for this node
-	virtual void addChild(RefAST c);
+	virtual void addChild(RefAST c)
+	{
+		if( !c )
+			return;
+
+		RefBaseAST tmp = down;
+
+		if (tmp)
+		{
+			while (tmp->right)
+				tmp = tmp->right;
+			tmp->right = c;
+		}
+		else
+			down = c;
+	}
+
 	/** Get the number of child nodes of this node (shallow e.g. not of the
 	 * whole tree it spans).
 	 */
@@ -107,16 +131,20 @@ public:
 	}
 
 	/// Set the next sibling after this one.
-	void setNextSibling(RefAST n)
+	virtual void setNextSibling(RefAST n)
 	{
 		right = static_cast<BaseAST*>(static_cast<AST*>(n));
 	}
 
 	/// Set the token text for this node
-	virtual void setText(const ANTLR_USE_NAMESPACE(std)string& txt);
+	virtual void setText(const ANTLR_USE_NAMESPACE(std)string& txt)
+	{
+	}
 
 	/// Set the token type for this node
-	virtual void setType(int type);
+	virtual void setType(int type)
+	{
+	}
 
 #ifdef ANTLR_SUPPORT_XML
 	/** print attributes of this node to 'out'. Override to customize XML
@@ -132,13 +160,14 @@ public:
 #endif
 
 	/// Return string representation for the AST
-	virtual ANTLR_USE_NAMESPACE(std)string toString() const;
+	virtual ANTLR_USE_NAMESPACE(std)string toString() const
+	{
+		return getText();
+	}
 
 	/// Print out a child sibling tree in LISP notation
 	virtual ANTLR_USE_NAMESPACE(std)string toStringList() const;
 	virtual ANTLR_USE_NAMESPACE(std)string toStringTree() const;
-
-	static const char* const TYPE_NAME;
 protected:
 	RefBaseAST down;
 	RefBaseAST right;

--- a/src/antlr/BitSet.cpp
+++ b/src/antlr/BitSet.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: BitSet.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/BitSet.cpp#2 $
  */
 #include "antlr/BitSet.hpp"
 #include <string>

--- a/src/antlr/BitSet.hpp
+++ b/src/antlr/BitSet.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: BitSet.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/BitSet.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/CharBuffer.cpp
+++ b/src/antlr/CharBuffer.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharBuffer.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CharBuffer.cpp#2 $
  */
 
 #include "antlr/CharBuffer.hpp"

--- a/src/antlr/CharBuffer.hpp
+++ b/src/antlr/CharBuffer.hpp
@@ -5,12 +5,13 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharBuffer.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CharBuffer.hpp#2 $
  */
+
+#include <antlr/config.hpp>
 
 #include <istream>
 
-#include <antlr/config.hpp>
 #include <antlr/InputBuffer.hpp>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
@@ -32,15 +33,16 @@ namespace antlr {
  */
 
 class ANTLR_API CharBuffer : public InputBuffer {
-private:
+public:
+	/// Create a character buffer
+	CharBuffer( ANTLR_USE_NAMESPACE(std)istream& input );
+	/// Get the next character from the stream
+	int getChar();
+
+protected:
 	// character source
 	ANTLR_USE_NAMESPACE(std)istream& input;
 
-public:
-	/// Create a character buffer
-	CharBuffer(ANTLR_USE_NAMESPACE(std)istream& input_);
-	/// Get the next character from the stream
-	int getChar();
 private:
 	// NOTE: Unimplemented
 	CharBuffer(const CharBuffer& other);

--- a/src/antlr/CharInputBuffer.hpp
+++ b/src/antlr/CharInputBuffer.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharInputBuffer.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 # include <antlr/config.hpp>

--- a/src/antlr/CharScanner.cpp
+++ b/src/antlr/CharScanner.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharScanner.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CharScanner.cpp#2 $
  */
 
 #include <iostream>
@@ -49,46 +49,6 @@ CharScanner::CharScanner( const LexerSharedInputState& state, bool case_sensitiv
 	, traceDepth(0)
 {
 	setTokenObjectFactory(&CommonToken::factory);
-}
-
-void CharScanner::consume()
-{
-	if (inputState->guessing == 0)
-	{
-		int c = LA(1);
-		if (caseSensitive)
-		{
-			append(c);
-		}
-		else
-		{
-			// use input.LA(), not LA(), to get original case
-			// CharScanner.LA() would toLower it.
-			append(inputState->getInput().LA(1));
-		}
-
-		// RK: in a sense I don't like this automatic handling.
-		if (c == '\t')
-			tab();
-		else
-			inputState->column++;
-	}
-	inputState->getInput().consume();
-}
-
-//bool CharScanner::getCaseSensitiveLiterals() const
-//{ return caseSensitiveLiterals; }
-
-void CharScanner::panic()
-{
-	ANTLR_USE_NAMESPACE(std)cerr << "CharScanner: panic" << ANTLR_USE_NAMESPACE(std)endl;
-	exit(1);
-}
-
-void CharScanner::panic(const ANTLR_USE_NAMESPACE(std)string& s)
-{
-	ANTLR_USE_NAMESPACE(std)cerr << "CharScanner: panic: " << s.c_str() << ANTLR_USE_NAMESPACE(std)endl;
-	exit(1);
 }
 
 /** Report exception errors caught in nextToken() */

--- a/src/antlr/CharStreamException.hpp
+++ b/src/antlr/CharStreamException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharStreamException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CharStreamException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/CharStreamIOException.hpp
+++ b/src/antlr/CharStreamIOException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CharStreamIOException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CharStreamIOException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/CircularQueue.hpp
+++ b/src/antlr/CircularQueue.hpp
@@ -5,12 +5,13 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CircularQueue.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CircularQueue.hpp#2 $
  */
 
 #include <antlr/config.hpp>
 #include <antlr/Token.hpp>
 #include <vector>
+#include <cassert>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
@@ -39,7 +40,7 @@ public:
 	}
 
 	/// @todo this should use at or should have a check
-	inline T elementAt( unsigned int idx ) const
+	inline T elementAt( size_t idx ) const
 	{
 		return storage[idx+m_offset];
 	}
@@ -53,8 +54,20 @@ public:
 		else
 			++m_offset;
 	}
-	inline void removeItems( unsigned int nb )
+	inline void removeItems( size_t nb )
 	{
+		// it would be nice if we would not get called with nb > entries
+		// (or to be precise when entries() == 0)
+		// This case is possible when lexer/parser::recover() calls
+		// consume+consumeUntil when the queue is empty.
+		// In recover the consume says to prepare to read another
+		// character/token. Then in the subsequent consumeUntil the
+		// LA() call will trigger
+		// syncConsume which calls this method *before* the same queue
+		// has been sufficiently filled.
+		if( nb > entries() )
+			nb = entries();
+
 		if (m_offset >= OFFSET_MAX_RESIZE)
 		{
 			storage.erase( storage.begin(), storage.begin() + m_offset + nb );
@@ -67,14 +80,14 @@ public:
 	{
 		storage.push_back(t);
 	}
-	inline unsigned int entries() const
+	inline size_t entries() const
 	{
 		return storage.size() - m_offset;
 	}
 
 private:
-	typename ANTLR_USE_NAMESPACE(std)vector<T> storage;
-	unsigned int m_offset;
+	ANTLR_USE_NAMESPACE(std)vector<T> storage;
+	size_t m_offset;
 
 	CircularQueue(const CircularQueue&);
 	const CircularQueue& operator=(const CircularQueue&);

--- a/src/antlr/CommonAST.cpp
+++ b/src/antlr/CommonAST.cpp
@@ -2,84 +2,21 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonAST.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CommonAST.cpp#2 $
  */
-
 #include "antlr/config.hpp"
-#include "antlr/CommonAST.hpp"
-#include "antlr/ANTLRUtil.hpp"
 
 #include <cstdlib>
+#include <iostream>
+
+#include "antlr/CommonAST.hpp"
+#include "antlr/ANTLRUtil.hpp"
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
 
 const char* const CommonAST::TYPE_NAME = "CommonAST";
-
-CommonAST::CommonAST()
-: BaseAST()
-, ttype( Token::INVALID_TYPE )
-, text("")
-{
-}
-
-CommonAST::CommonAST(RefToken t)
-: BaseAST()
-, ttype( t->getType() )
-, text( t->getText() )
-{
-}
-
-CommonAST::~CommonAST()
-{
-}
-
-const char* CommonAST::typeName( void ) const
-{
-	return CommonAST::TYPE_NAME;
-}
-
-CommonAST::CommonAST(const CommonAST& other)
-: BaseAST(other)
-, ttype(other.ttype)
-, text(other.text)
-{
-}
-
-RefAST CommonAST::clone( void ) const
-{
-	CommonAST *ast = new CommonAST( *this );
-	return RefAST(ast);
-}
-
-ANTLR_USE_NAMESPACE(std)string CommonAST::getText() const
-{
-	return text;
-}
-
-int CommonAST::getType() const
-{
-	return ttype;
-}
-
-void CommonAST::initialize(int t,const ANTLR_USE_NAMESPACE(std)string& txt)
-{
-	setType(t);
-	setText(txt);
-}
-
-void CommonAST::initialize(RefAST t)
-{
-	setType(t->getType());
-	setText(t->getText());
-}
-
-void CommonAST::initialize(RefToken t)
-{
-	setType(t->getType());
-	setText(t->getText());
-}
 
 #ifdef ANTLR_SUPPORT_XML
 void CommonAST::initialize( ANTLR_USE_NAMESPACE(std)istream& in )
@@ -100,16 +37,6 @@ void CommonAST::initialize( ANTLR_USE_NAMESPACE(std)istream& in )
 	this->initialize( type, text );
 }
 #endif
-
-void CommonAST::setText(const ANTLR_USE_NAMESPACE(std)string& txt)
-{
-	text = txt;
-}
-
-void CommonAST::setType(int type)
-{
-	ttype = type;
-}
 
 RefAST CommonAST::factory()
 {

--- a/src/antlr/CommonAST.hpp
+++ b/src/antlr/CommonAST.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonAST.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CommonAST.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -17,28 +17,81 @@ namespace antlr {
 
 class ANTLR_API CommonAST : public BaseAST {
 public:
-	CommonAST();
-	CommonAST( RefToken t );
-	CommonAST( const CommonAST& other );
+	CommonAST()
+	: BaseAST()
+	, ttype( Token::INVALID_TYPE )
+	, text()
+	{
+	}
 
-	virtual ~CommonAST();
+	CommonAST( RefToken t )
+	: BaseAST()
+	, ttype( t->getType() )
+	, text( t->getText() )
+	{
+	}
 
-	virtual const char* typeName( void ) const;
+	CommonAST( const CommonAST& other )
+	: BaseAST(other)
+	, ttype(other.ttype)
+	, text(other.text)
+	{
+	}
+
+	virtual ~CommonAST()
+	{
+	}
+
+	virtual const char* typeName( void ) const
+	{
+		return CommonAST::TYPE_NAME;
+	}
+
 	/// Clone this AST node.
-	virtual RefAST clone( void ) const;
+	virtual RefAST clone( void ) const
+	{
+		CommonAST *ast = new CommonAST( *this );
+		return RefAST(ast);
+	}
 
-	virtual ANTLR_USE_NAMESPACE(std)string getText() const;
-	virtual int getType() const;
+	virtual ANTLR_USE_NAMESPACE(std)string getText() const
+	{
+		return text;
+	}
+	virtual int getType() const
+	{
+		return ttype;
+	}
 
-	virtual void initialize( int t, const ANTLR_USE_NAMESPACE(std)string& txt );
-	virtual void initialize( RefAST t );
-	virtual void initialize( RefToken t );
+	virtual void initialize( int t, const ANTLR_USE_NAMESPACE(std)string& txt )
+	{
+		setType(t);
+		setText(txt);
+	}
+
+	virtual void initialize( RefAST t )
+	{
+		setType(t->getType());
+		setText(t->getText());
+	}
+	virtual void initialize( RefToken t )
+	{
+		setType(t->getType());
+		setText(t->getText());
+	}
+
 #ifdef ANTLR_SUPPORT_XML
 	virtual void initialize( ANTLR_USE_NAMESPACE(std)istream& in );
 #endif
 
-	virtual void setText( const ANTLR_USE_NAMESPACE(std)string& txt );
-	virtual void setType( int type );
+	virtual void setText( const ANTLR_USE_NAMESPACE(std)string& txt )
+	{
+		text = txt;
+	}
+	virtual void setType( int type )
+	{
+		ttype = type;
+	}
 
 	static RefAST factory();
 

--- a/src/antlr/CommonASTWithHiddenTokens.cpp
+++ b/src/antlr/CommonASTWithHiddenTokens.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonASTWithHiddenTokens.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CommonASTWithHiddenTokens.cpp#2 $
  */
 #include "antlr/config.hpp"
 #include "antlr/AST.hpp"
@@ -37,6 +37,8 @@ void CommonASTWithHiddenTokens::initialize(int t,const ANTLR_USE_NAMESPACE(std)s
 void CommonASTWithHiddenTokens::initialize(RefAST t)
 {
 	CommonAST::initialize(t);
+	hiddenBefore = RefCommonASTWithHiddenTokens(t)->getHiddenBefore();
+	hiddenAfter = RefCommonASTWithHiddenTokens(t)->getHiddenAfter();
 }
 
 void CommonASTWithHiddenTokens::initialize(RefToken t)

--- a/src/antlr/CommonASTWithHiddenTokens.hpp
+++ b/src/antlr/CommonASTWithHiddenTokens.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonASTWithHiddenTokens.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CommonASTWithHiddenTokens.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/CommonHiddenStreamToken.cpp
+++ b/src/antlr/CommonHiddenStreamToken.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonHiddenStreamToken.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CommonHiddenStreamToken.cpp#2 $
  */
 #include "antlr/CommonHiddenStreamToken.hpp"
 

--- a/src/antlr/CommonHiddenStreamToken.hpp
+++ b/src/antlr/CommonHiddenStreamToken.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonHiddenStreamToken.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CommonHiddenStreamToken.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/CommonToken.cpp
+++ b/src/antlr/CommonToken.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonToken.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/CommonToken.cpp#2 $
  */
 
 #include "antlr/CommonToken.hpp"
@@ -16,16 +16,22 @@ CommonToken::CommonToken() : Token(), line(1), col(1), text("")
 {}
 
 CommonToken::CommonToken(int t, const ANTLR_USE_NAMESPACE(std)string& txt)
-	: Token(t), line(1), col(1), text(txt)
+: Token(t)
+, line(1)
+, col(1)
+, text(txt)
 {}
 
 CommonToken::CommonToken(const ANTLR_USE_NAMESPACE(std)string& s)
-	: Token(), line(1), col(1), text(s)
+: Token()
+, line(1)
+, col(1)
+, text(s)
 {}
 
 ANTLR_USE_NAMESPACE(std)string CommonToken::toString() const
 {
-	return "[\""+getText()+"\",<"+type+">,line="+line+",column="+col+"]";
+	return "[\""+getText()+"\",<"+getType()+">,line="+getLine()+",column="+getColumn()+"]";
 }
 
 RefToken CommonToken::factory()

--- a/src/antlr/CommonToken.hpp
+++ b/src/antlr/CommonToken.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: CommonToken.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CommonToken.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -23,13 +23,13 @@ public:
 	CommonToken(const ANTLR_USE_NAMESPACE(std)string& s);
 
 	/// return contents of token
-	ANTLR_USE_NAMESPACE(std)string getText() const
+	virtual ANTLR_USE_NAMESPACE(std)string getText() const
 	{
 		return text;
 	}
 
 	/// set contents of token
-	void setText(const ANTLR_USE_NAMESPACE(std)string& s)
+	virtual void setText(const ANTLR_USE_NAMESPACE(std)string& s)
 	{
 		text = s;
 	}
@@ -38,7 +38,7 @@ public:
 	 * @see CharScanner::newline()
 	 * @see CharScanner::tab()
 	 */
-	int getLine() const
+	virtual int getLine() const
 	{
 		return line;
 	}
@@ -46,28 +46,23 @@ public:
 	 * @see CharScanner::newline()
 	 * @see CharScanner::tab()
 	 */
-	int getColumn() const
+	virtual int getColumn() const
 	{
 		return col;
 	}
 
 	/// set line for token
-	void setLine(int l)
+	virtual void setLine(int l)
 	{
 		line = l;
 	}
 	/// set column for token
-	void setColumn(int c)
+	virtual void setColumn(int c)
 	{
 		col = c;
 	}
 
-	bool isInvalid() const
-	{
-		return type==INVALID_TYPE;
-	}
-
-	ANTLR_USE_NAMESPACE(std)string toString() const;
+	virtual ANTLR_USE_NAMESPACE(std)string toString() const;
 	static RefToken factory();
 
 protected:

--- a/src/antlr/IOException.hpp
+++ b/src/antlr/IOException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: IOException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/InputBuffer.cpp
+++ b/src/antlr/InputBuffer.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: InputBuffer.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/InputBuffer.cpp#2 $
  */
 
 #include "antlr/config.hpp"

--- a/src/antlr/InputBuffer.hpp
+++ b/src/antlr/InputBuffer.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: InputBuffer.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/InputBuffer.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/LLkParser.cpp
+++ b/src/antlr/LLkParser.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: LLkParser.cpp,v 1.8 2013-05-07 13:13:52 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/LLkParser.cpp#2 $
  */
 
 #include "antlr/LLkParser.hpp"
@@ -40,39 +40,32 @@ LLkParser::LLkParser(TokenStream& lexer, int k_)
 
 void LLkParser::trace(const char* ee, const char* rname)
 {
-  // only show non-guessing (production) calls
-  if(inputState->guessing>0) return;
-	
-  traceIndent();
-  
-  cout << ee << rname << ((inputState->guessing>0)?";                  ?: ":";          <: ");
-  
-  for (int i = 1; i <= k+3; i++)
-    {
-      if (i != 1) {
-	//cout << ", ";
-	cout << " ";
-      }
-      //cout << "LA(" << i << ")==";
-      
-      string temp;
-      
-      try {
-	temp = LT(i)->getText().c_str();
-      }
-      catch( ANTLRException& ae )
+	traceIndent();
+
+	cout << ee << rname << ((inputState->guessing>0)?"; [guessing]":"; ");
+
+	for (int i = 1; i <= k; i++)
 	{
-	  temp = "[error: ";
-	  temp += ae.toString();
-	  temp += ']';
+		if (i != 1) {
+			cout << ", ";
+		}
+		cout << "LA(" << i << ")==";
+
+		string temp;
+
+		try {
+			temp = LT(i)->getText().c_str();
+		}
+		catch( ANTLRException& ae )
+		{
+			temp = "[error: ";
+			temp += ae.toString();
+			temp += ']';
+		}
+		cout << temp;
 	}
-      if( temp == "\n")
-	cout << "\\n";
-      else
-	cout << temp;
-    }
-  
-  cout << endl;
+
+	cout << endl;
 }
 
 void LLkParser::traceIn(const char* rname)

--- a/src/antlr/LLkParser.hpp
+++ b/src/antlr/LLkParser.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: LLkParser.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/LLkParser.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/LexerSharedInputState.hpp
+++ b/src/antlr/LexerSharedInputState.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: LexerSharedInputState.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/LexerSharedInputState.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/MismatchedCharException.cpp
+++ b/src/antlr/MismatchedCharException.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: MismatchedCharException.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/MismatchedCharException.cpp#2 $
  */
 
 #include "antlr/CharScanner.hpp"

--- a/src/antlr/MismatchedCharException.hpp
+++ b/src/antlr/MismatchedCharException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: MismatchedCharException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/MismatchedCharException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/MismatchedTokenException.cpp
+++ b/src/antlr/MismatchedTokenException.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: MismatchedTokenException.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/MismatchedTokenException.cpp#2 $
  */
 
 #include "antlr/MismatchedTokenException.hpp"

--- a/src/antlr/MismatchedTokenException.hpp
+++ b/src/antlr/MismatchedTokenException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: MismatchedTokenException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/MismatchedTokenException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/NoViableAltException.cpp
+++ b/src/antlr/NoViableAltException.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: NoViableAltException.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/NoViableAltException.cpp#2 $
  */
 
 #include "antlr/NoViableAltException.hpp"

--- a/src/antlr/NoViableAltException.hpp
+++ b/src/antlr/NoViableAltException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: NoViableAltException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/NoViableAltException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/NoViableAltForCharException.cpp
+++ b/src/antlr/NoViableAltForCharException.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: NoViableAltForCharException.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/NoViableAltForCharException.cpp#2 $
  */
 
 #include "antlr/NoViableAltForCharException.hpp"

--- a/src/antlr/NoViableAltForCharException.hpp
+++ b/src/antlr/NoViableAltForCharException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: NoViableAltForCharException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/NoViableAltForCharException.hpp#2 $
  */
 
 # include <antlr/config.hpp>

--- a/src/antlr/Parser.cpp
+++ b/src/antlr/Parser.cpp
@@ -2,27 +2,18 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: Parser.cpp,v 1.5 2012-11-13 14:30:14 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/Parser.cpp#2 $
  */
-
-// g++-4.3 needs this
-#include <cstdlib>
-#include <iomanip>
 
 #include "antlr/Parser.hpp"
 
-#include "antlr/BitSet.hpp"
-#include "antlr/TokenBuffer.hpp"
-#include "antlr/MismatchedTokenException.hpp"
-//#include "antlr/ASTFactory.hpp"
 #include <iostream>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
-ANTLR_C_USING(exit)
 
-/**A generic ANTLR parser (LL(k) for k>=1) containing a bunch of
+/** A generic ANTLR parser (LL(k) for k>=1) containing a bunch of
  * utility routines useful at any lookahead depth.  We distinguish between
  * the LL(1) and LL(k) parsers because of efficiency.  This may not be
  * necessary in the near future.
@@ -56,107 +47,7 @@ ANTLR_C_USING(exit)
  * @see antlr.LLkParser
  */
 
-bool DEBUG_PARSER=false;
-
-Parser::Parser(TokenBuffer& input)
-: inputState(new ParserInputState(input)), astFactory(0), traceDepth(0)
-{
-}
-
-Parser::Parser(TokenBuffer* input)
-: inputState(new ParserInputState(input)), astFactory(0), traceDepth(0)
-{
-}
-
-Parser::Parser(const ParserSharedInputState& state)
-: inputState(state), astFactory(0), traceDepth(0)
-{
-}
-
-Parser::~Parser()
-{
-}
-
-/** Consume tokens until one matches the given token */
-void Parser::consumeUntil(int tokenType)
-{
-	while (LA(1) != Token::EOF_TYPE && LA(1) != tokenType)
-		consume();
-}
-
-/** Consume tokens until one matches the given token set */
-void Parser::consumeUntil(const BitSet& set)
-{
-	while (LA(1) != Token::EOF_TYPE && !set.member(LA(1)))
-		consume();
-}
-
-/**Make sure current lookahead symbol matches token type <tt>t</tt>.
- * Throw an exception upon mismatch, which is catch by either the
- * error handler or by the syntactic predicate.
- */
-void Parser::match(int t)
-{
-	if ( DEBUG_PARSER )
-	{
-		traceIndent();
-		ANTLR_USE_NAMESPACE(std)cout << "enter match(" << t << ") with LA(1)=" << LA(1) << ANTLR_USE_NAMESPACE(std)endl;
-	}
-	if ( LA(1)!=t ) {
-		if ( DEBUG_PARSER )
-		{
-			traceIndent();
-			ANTLR_USE_NAMESPACE(std)cout << "token mismatch: " << LA(1) << "!=" << t << ANTLR_USE_NAMESPACE(std)endl;
-		}
-		throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), t, false, getFilename());
-	} else {
-		// mark token as consumed -- fetch next token deferred until LA/LT
-		consume();
-	}
-}
-
-/**Make sure current lookahead symbol matches the given set
- * Throw an exception upon mismatch, which is catch by either the
- * error handler or by the syntactic predicate.
- */
-void Parser::match(const BitSet& b)
-{
-	if ( DEBUG_PARSER )
-	{
-		traceIndent();
-		ANTLR_USE_NAMESPACE(std)cout << "enter match(" << "bitset" /*b.toString()*/
-			  << ") with LA(1)=" << LA(1) << ANTLR_USE_NAMESPACE(std)endl;
-	}
-	if ( !b.member(LA(1)) ) {
-		if ( DEBUG_PARSER )
-		{
-			traceIndent();
-			ANTLR_USE_NAMESPACE(std)cout << "token mismatch: " << LA(1) << " not member of "
-				  << "bitset" /*b.toString()*/ << ANTLR_USE_NAMESPACE(std)endl;
-		}
-		throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), b, false, getFilename());
-	} else {
-		// mark token as consumed -- fetch next token deferred until LA/LT
-		consume();
-	}
-}
-
-void Parser::matchNot(int t)
-{
-	if ( LA(1)==t ) {
-		// Throws inverted-sense exception
-		throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), t, true, getFilename());
-	} else {
-		// mark token as consumed -- fetch next token deferred until LA/LT
-		consume();
-	}
-}
-
-void Parser::panic()
-{
-	ANTLR_USE_NAMESPACE(std)cerr << "Parser: panic" << ANTLR_USE_NAMESPACE(std)endl;
-	exit(1);
-}
+bool DEBUG_PARSER = false;
 
 /** Parser error-reporting function can be overridden in subclass */
 void Parser::reportError(const RecognitionException& ex)
@@ -189,14 +80,11 @@ void Parser::traceIndent()
 {
 	for( int i = 0; i < traceDepth; i++ )
 		ANTLR_USE_NAMESPACE(std)cout << " ";
-	ANTLR_USE_NAMESPACE(std)cout << ANTLR_USE_NAMESPACE(std)setw(3) << traceDepth << " ";
 }
 
 void Parser::traceIn(const char* rname)
 {
 	traceDepth++;
-
-if(inputState->guessing>0) return;
 
 	for( int i = 0; i < traceDepth; i++ )
 		ANTLR_USE_NAMESPACE(std)cout << " ";
@@ -209,7 +97,6 @@ if(inputState->guessing>0) return;
 
 void Parser::traceOut(const char* rname)
 {
-if(inputState->guessing<=0) {
 	for( int i = 0; i < traceDepth; i++ )
 		ANTLR_USE_NAMESPACE(std)cout << " ";
 
@@ -217,7 +104,7 @@ if(inputState->guessing<=0) {
 		<< "; LA(1)==" << LT(1)->getText().c_str()
 		<<	((inputState->guessing>0)?" [guessing]":"")
 		<< ANTLR_USE_NAMESPACE(std)endl;
-}
+
 	traceDepth--;
 }
 

--- a/src/antlr/Parser.hpp
+++ b/src/antlr/Parser.hpp
@@ -5,17 +5,20 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: Parser.hpp,v 1.2 2012-11-13 14:30:14 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/Parser.hpp#2 $
  */
 
 #include <antlr/config.hpp>
+
+#include <iostream>
+#include <exception>
+
 #include <antlr/BitSet.hpp>
 #include <antlr/TokenBuffer.hpp>
 #include <antlr/RecognitionException.hpp>
+#include <antlr/MismatchedTokenException.hpp>
 #include <antlr/ASTFactory.hpp>
 #include <antlr/ParserSharedInputState.hpp>
-
-#include <exception>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
@@ -60,12 +63,22 @@ extern bool DEBUG_PARSER;
  */
 class ANTLR_API Parser {
 protected:
-	Parser(TokenBuffer& input_);
-	Parser(TokenBuffer* input_);
-
-	Parser(const ParserSharedInputState& state);
+	Parser(TokenBuffer& input)
+	: inputState(new ParserInputState(input)), astFactory(0), traceDepth(0)
+	{
+	}
+	Parser(TokenBuffer* input)
+	: inputState(new ParserInputState(input)), astFactory(0), traceDepth(0)
+	{
+	}
+	Parser(const ParserSharedInputState& state)
+	: inputState(state), astFactory(0), traceDepth(0)
+	{
+	}
 public:
-	virtual ~Parser();
+	virtual ~Parser()
+	{
+	}
 
 	/** Return the token type of the ith token of lookahead where i=1
 	 * is the current token being examined by the parser (i.e., it
@@ -128,21 +141,88 @@ public:
 	/// Get another token object from the token stream
 	virtual void consume()=0;
 	/// Consume tokens until one matches the given token
-	virtual void consumeUntil(int tokenType);
+	virtual void consumeUntil(int tokenType)
+	{
+		while (LA(1) != Token::EOF_TYPE && LA(1) != tokenType)
+			consume();
+	}
+
 	/// Consume tokens until one matches the given token set
-	virtual void consumeUntil(const BitSet& set);
+	virtual void consumeUntil(const BitSet& set)
+	{
+		while (LA(1) != Token::EOF_TYPE && !set.member(LA(1)))
+			consume();
+	}
 
 	/** Make sure current lookahead symbol matches token type <tt>t</tt>.
 	 * Throw an exception upon mismatch, which is catch by either the
 	 * error handler or by the syntactic predicate.
 	 */
-	virtual void match(int t);
-	virtual void matchNot(int t);
+	virtual void match(int t)
+	{
+		if ( DEBUG_PARSER )
+		{
+			traceIndent();
+			ANTLR_USE_NAMESPACE(std)cout << "enter match(" << t << ") with LA(1)=" << LA(1) << ANTLR_USE_NAMESPACE(std)endl;
+		}
+		if ( LA(1) != t )
+		{
+			if ( DEBUG_PARSER )
+			{
+				traceIndent();
+				ANTLR_USE_NAMESPACE(std)cout << "token mismatch: " << LA(1) << "!=" << t << ANTLR_USE_NAMESPACE(std)endl;
+			}
+			throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), t, false, getFilename());
+		}
+		else
+		{
+			// mark token as consumed -- fetch next token deferred until LA/LT
+			consume();
+		}
+	}
+
+	virtual void matchNot(int t)
+	{
+		if ( LA(1)==t )
+		{
+			// Throws inverted-sense exception
+			throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), t, true, getFilename());
+		}
+		else
+		{
+			// mark token as consumed -- fetch next token deferred until LA/LT
+			consume();
+		}
+	}
+
 	/** Make sure current lookahead symbol matches the given set
 	 * Throw an exception upon mismatch, which is catch by either the
 	 * error handler or by the syntactic predicate.
 	 */
-	virtual void match(const BitSet& b);
+	virtual void match(const BitSet& b)
+	{
+		if ( DEBUG_PARSER )
+		{
+			traceIndent();
+			ANTLR_USE_NAMESPACE(std)cout << "enter match(" << "bitset" /*b.toString()*/
+				<< ") with LA(1)=" << LA(1) << ANTLR_USE_NAMESPACE(std)endl;
+		}
+		if ( !b.member(LA(1)) )
+		{
+			if ( DEBUG_PARSER )
+			{
+				traceIndent();
+				ANTLR_USE_NAMESPACE(std)cout << "token mismatch: " << LA(1) << " not member of "
+					<< "bitset" /*b.toString()*/ << ANTLR_USE_NAMESPACE(std)endl;
+			}
+			throw MismatchedTokenException(getTokenNames(), getNumTokens(), LT(1), b, false, getFilename());
+		}
+		else
+		{
+			// mark token as consumed -- fetch next token deferred until LA/LT
+			consume();
+		}
+	}
 
 	/** Mark a spot in the input and return the position.
 	 * Forwarded to TokenBuffer.
@@ -156,6 +236,14 @@ public:
 	{
 		inputState->getInput().rewind(pos);
 	}
+	/** called by the generated parser to do error recovery, override to
+	 * customize the behaviour.
+	 */
+	virtual void recover(const RecognitionException& ex, const BitSet& tokenSet)
+	{
+		consume();
+		consumeUntil(tokenSet);
+	}
 
 	/// Parser error-reporting function can be overridden in subclass
 	virtual void reportError(const RecognitionException& ex);
@@ -163,11 +251,6 @@ public:
 	virtual void reportError(const ANTLR_USE_NAMESPACE(std)string& s);
 	/// Parser warning-reporting function can be overridden in subclass
 	virtual void reportWarning(const ANTLR_USE_NAMESPACE(std)string& s);
-
-	/** Give panic message and exit the program. can be overridden in subclass
-	 * @deprecated this method is unused and will dissappear in the next release
-	 */
-	virtual void panic();
 
 	/// get the token name for the token number 'num'
 	virtual const char* getTokenName(int num) const = 0;
@@ -215,7 +298,7 @@ protected:
 		{
 #ifdef ANTLR_CXX_SUPPORTS_UNCAUGHT_EXCEPTION
 			// Only give trace if there's no uncaught exception..
-//			if(!ANTLR_USE_NAMESPACE(std)uncaught_exception())
+			if(!ANTLR_USE_NAMESPACE(std)uncaught_exception())
 #endif
 				parser->traceOut(text);
 		}

--- a/src/antlr/ParserSharedInputState.hpp
+++ b/src/antlr/ParserSharedInputState.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: ParserSharedInputState.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ParserSharedInputState.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/RecognitionException.cpp
+++ b/src/antlr/RecognitionException.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: RecognitionException.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/RecognitionException.cpp#2 $
  */
 
 #include "antlr/RecognitionException.hpp"

--- a/src/antlr/RecognitionException.hpp
+++ b/src/antlr/RecognitionException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: RecognitionException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/RecognitionException.hpp#2 $
  */
 
 # include <antlr/config.hpp>
@@ -21,41 +21,32 @@ namespace antlr
 		RecognitionException();
 		RecognitionException(const ANTLR_USE_NAMESPACE(std)string& s);
 		RecognitionException(const ANTLR_USE_NAMESPACE(std)string& s,
-									const ANTLR_USE_NAMESPACE(std)string& fileName_,
-									int line_,int column_);
+									const ANTLR_USE_NAMESPACE(std)string& fileName,
+									int line, int column );
 
 		virtual ~RecognitionException() throw()
 		{
 		}
 
 		/// Return file where mishap occurred.
-		virtual ANTLR_USE_NAMESPACE(std)string getFilename() const
+		virtual ANTLR_USE_NAMESPACE(std)string getFilename() const throw()
 		{
 			return fileName;
 		}
 		/**
 		 * @return the line number that this exception happened on.
 		 */
-		virtual int getLine() const
+		virtual int getLine() const throw()
 		{
 			return line;
 		}
 		/**
 		 * @return the column number that this exception happened on.
 		 */
-		virtual int getColumn() const
+		virtual int getColumn() const throw()
 		{
 			return column;
 		}
-#if 0
-		/**
-		 * @deprecated As of ANTLR 2.7.0
-		 */
-		virtual ANTLR_USE_NAMESPACE(std)string getErrorMessage() const
-		{
-			return getMessage();
-		}
-#endif
 
 		/// Return complete error message with line/column number info (if present)
 		virtual ANTLR_USE_NAMESPACE(std)string toString() const;

--- a/src/antlr/RefCount.hpp
+++ b/src/antlr/RefCount.hpp
@@ -4,7 +4,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: RefCount.hpp,v 1.2 2010-03-09 23:54:39 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/RefCount.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -62,7 +62,7 @@ public:
 		return ref ? ref->ptr : 0;
 	}
 
-	 T* get() const
+	T* get() const
 	{
 		return ref ? ref->ptr : 0;
 	}

--- a/src/antlr/SemanticException.hpp
+++ b/src/antlr/SemanticException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: SemanticException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/SemanticException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/String.cpp
+++ b/src/antlr/String.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: String.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/String.cpp#2 $
  */
 
 #include "antlr/String.hpp"
@@ -18,12 +18,27 @@
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
+
+// wh: hack for Borland C++ 5.6
+#if __BORLANDC__
+  using std::sprintf;
+#endif
+
+
+// RK: should be using snprintf actually... (or stringstream)
 ANTLR_C_USING(sprintf)
 
 ANTLR_USE_NAMESPACE(std)string operator+( const ANTLR_USE_NAMESPACE(std)string& lhs, const int rhs )
 {
 	char tmp[100];
-	snprintf(tmp,100,"%d",rhs);
+	sprintf(tmp,"%d",rhs);
+	return lhs+tmp;
+}
+
+ANTLR_USE_NAMESPACE(std)string operator+( const ANTLR_USE_NAMESPACE(std)string& lhs, size_t rhs )
+{
+	char tmp[100];
+	sprintf(tmp,"%u",rhs);
 	return lhs+tmp;
 }
 
@@ -37,6 +52,8 @@ ANTLR_USE_NAMESPACE(std)string charName(int ch)
 	{
 		ANTLR_USE_NAMESPACE(std)string s;
 
+		// when you think you've seen it all.. an isprint that crashes...
+		ch = ch & 0xFF;
 #ifdef ANTLR_CCTYPE_NEEDS_STD
 		if( ANTLR_USE_NAMESPACE(std)isprint( ch ) )
 #else

--- a/src/antlr/String.hpp
+++ b/src/antlr/String.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: String.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/String.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -15,9 +15,10 @@
 namespace antlr {
 #endif
 
-ANTLR_API ANTLR_USE_NAMESPACE(std)string operator+(const ANTLR_USE_NAMESPACE(std)string& lhs,const int rhs);
+ANTLR_API ANTLR_USE_NAMESPACE(std)string operator+( const ANTLR_USE_NAMESPACE(std)string& lhs, const int rhs );
+ANTLR_API ANTLR_USE_NAMESPACE(std)string operator+( const ANTLR_USE_NAMESPACE(std)string& lhs, size_t rhs );
 
-ANTLR_API ANTLR_USE_NAMESPACE(std)string charName(int ch);
+ANTLR_API ANTLR_USE_NAMESPACE(std)string charName( int ch );
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 }

--- a/src/antlr/Token.cpp
+++ b/src/antlr/Token.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: Token.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/Token.cpp#2 $
  */
 
 #include "antlr/Token.hpp"
@@ -11,27 +11,6 @@
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
-
-// The below initialization ICED AIX Visualage CC
-//ANTLR_API RefToken Token::badToken(new Token(Token::INVALID_TYPE, "<no text>"));
-// this seemed to work
-// RK: maybe the above one is necessary for MSVC DLL build.
-// leaving it unchanged untill after testing..
-ANTLR_API RefToken Token::badToken = RefToken(new Token(Token::INVALID_TYPE, "<no text>"));
-
-Token::Token() : type(INVALID_TYPE)
-{
-}
-
-Token::Token(int t) : type(t)
-{
-}
-
-Token::Token(int t, const ANTLR_USE_NAMESPACE(std)string& txt)
-: type(t)
-{
-	setText(txt);
-}
 
 int Token::getColumn() const
 {
@@ -54,26 +33,37 @@ int Token::getType() const
 }
 
 void Token::setColumn(int)
-{}
+{
+}
 
 void Token::setLine(int)
-{}
+{
+}
 
 void Token::setText(const ANTLR_USE_NAMESPACE(std)string&)
-{}
+{
+}
 
 void Token::setType(int t)
 {
 	type = t;
 }
 
+void Token::setFilename(const ANTLR_USE_NAMESPACE(std)string&)
+{
+}
+
+ANTLR_USE_NAMESPACE(std)string emptyString("");
+
+const ANTLR_USE_NAMESPACE(std)string& Token::getFilename() const
+{
+	return emptyString;
+}
+
 ANTLR_USE_NAMESPACE(std)string Token::toString() const
 {
 	return "[\""+getText()+"\",<"+type+">]";
 }
-
-Token::~Token()
-{}
 
 ANTLR_API RefToken nullToken;
 

--- a/src/antlr/Token.hpp
+++ b/src/antlr/Token.hpp
@@ -5,25 +5,24 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: Token.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/Token.hpp#2 $
  */
 
 #include <antlr/config.hpp>
-#include <antlr/RefCount.hpp>
+#include <antlr/TokenRefCount.hpp>
 #include <string>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
 
+struct TokenRef;
+
 /** A token is minimally a token type.  Subclasses can add the text matched
  *  for the token and line info.
  */
-
-class ANTLR_API Token;
-typedef RefCount<Token> RefToken;
-
-class ANTLR_API Token {
+class ANTLR_API Token
+{
 public:
 	// constants
 #ifndef NO_STATIC_CONSTS
@@ -42,20 +41,30 @@ public:
 	};
 #endif
 
-	// each Token has at least a token type
-	int type; //=INVALID_TYPE;
-
-public:
-	// the illegal token object
-	static RefToken badToken; // = new Token(INVALID_TYPE, "<no text>");
-
-	Token();
-	Token(int t);
-	Token(int t, const ANTLR_USE_NAMESPACE(std)string& txt);
+	Token()
+	: ref(0)
+	, type(INVALID_TYPE)
+	{
+	}
+	Token(int t)
+	: ref(0)
+	, type(t)
+	{
+	}
+	Token(int t, const ANTLR_USE_NAMESPACE(std)string& txt)
+	: ref(0)
+	, type(t)
+	{
+		setText(txt);
+	}
+	virtual ~Token()
+	{
+	}
 
 	virtual int getColumn() const;
 	virtual int getLine() const;
 	virtual ANTLR_USE_NAMESPACE(std)string getText() const;
+	virtual const ANTLR_USE_NAMESPACE(std)string& getFilename() const;
 	virtual int getType() const;
 
 	virtual void setColumn(int c);
@@ -64,12 +73,21 @@ public:
 	virtual void setText(const ANTLR_USE_NAMESPACE(std)string& t);
 	virtual void setType(int t);
 
+	virtual void setFilename( const std::string& file );
+
 	virtual ANTLR_USE_NAMESPACE(std)string toString() const;
 
-	virtual ~Token();
 private:
+	friend struct TokenRef;
+	TokenRef* ref;
+
+	int type; 							///< the type of the token
+
+	Token(RefToken other);
+	Token& operator=(const Token& other);
+	Token& operator=(RefToken other);
+
 	Token(const Token&);
-	const Token& operator=(const Token&);
 };
 
 extern ANTLR_API RefToken nullToken;

--- a/src/antlr/TokenBuffer.cpp
+++ b/src/antlr/TokenBuffer.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenBuffer.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/TokenBuffer.cpp#2 $
  */
 
 #include "antlr/TokenBuffer.hpp"
@@ -27,8 +27,8 @@ namespace antlr {
  */
 
 /** Create a token buffer */
-TokenBuffer::TokenBuffer( TokenStream& input_ )
-: input(input_)
+TokenBuffer::TokenBuffer( TokenStream& inp )
+: input(inp)
 , nMarkers(0)
 , markerOffset(0)
 , numToConsume(0)
@@ -44,7 +44,7 @@ void TokenBuffer::fill(unsigned int amount)
 {
 	syncConsume();
 	// Fill the buffer sufficiently to hold needed tokens
-	while (queue.entries() <= (amount + markerOffset))
+	while (queue.entries() < (amount + markerOffset))
 	{
 		// Append the next token
 		queue.append(input.nextToken());
@@ -55,7 +55,7 @@ void TokenBuffer::fill(unsigned int amount)
 int TokenBuffer::LA(unsigned int i)
 {
 	fill(i);
-	return queue.elementAt(markerOffset+i-1)->type;
+	return queue.elementAt(markerOffset+i-1)->getType();
 }
 
 /** Get a lookahead token */

--- a/src/antlr/TokenBuffer.hpp
+++ b/src/antlr/TokenBuffer.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenBuffer.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenBuffer.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenRefCount.cpp
+++ b/src/antlr/TokenRefCount.cpp
@@ -2,35 +2,35 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/ASTRefCount.cpp#2 $
+ * $Id:$
  */
-#include "antlr/ASTRefCount.hpp"
-#include "antlr/AST.hpp"
+#include "antlr/TokenRefCount.hpp"
+#include "antlr/Token.hpp"
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
 
-ASTRef::ASTRef(AST* p)
+TokenRef::TokenRef(Token* p)
 : ptr(p), count(1)
 {
 	if (p && !p->ref)
 		p->ref = this;
 }
 
-ASTRef::~ASTRef()
+TokenRef::~TokenRef()
 {
 	delete ptr;
 }
 
-ASTRef* ASTRef::getRef(const AST* p)
+TokenRef* TokenRef::getRef(const Token* p)
 {
 	if (p) {
-		AST* pp = const_cast<AST*>(p);
+		Token* pp = const_cast<Token*>(p);
 		if (pp->ref)
 			return pp->ref->increment();
 		else
-			return new ASTRef(pp);
+			return new TokenRef(pp);
 	} else
 		return 0;
 }

--- a/src/antlr/TokenRefCount.hpp
+++ b/src/antlr/TokenRefCount.hpp
@@ -1,11 +1,11 @@
-#ifndef INC_ASTRefCount_hpp__
-# define INC_ASTRefCount_hpp__
+#ifndef INC_TokenRefCount_hpp__
+# define INC_TokenRefCount_hpp__
 
 /* ANTLR Translator Generator
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/ASTRefCount.hpp#2 $
+ * $Id:$
  */
 
 # include <antlr/config.hpp>
@@ -14,16 +14,16 @@
 namespace antlr {
 #endif
 
-	class AST;
+class Token;
 
-struct ANTLR_API ASTRef
+struct ANTLR_API TokenRef
 {
-	AST* const ptr;
+	Token* const ptr;
 	unsigned int count;
 
-	ASTRef(AST* p);
-	~ASTRef();
-	ASTRef* increment()
+	TokenRef(Token* p);
+	~TokenRef();
+	TokenRef* increment()
 	{
 		++count;
 		return this;
@@ -33,35 +33,35 @@ struct ANTLR_API ASTRef
 		return (--count==0);
 	}
 
-	static ASTRef* getRef(const AST* p);
+	static TokenRef* getRef(const Token* p);
 private:
-	ASTRef( const ASTRef& );
-	ASTRef& operator=( const ASTRef& );
+	TokenRef( const TokenRef& );
+	TokenRef& operator=( const TokenRef& );
 };
 
 template<class T>
-	class ANTLR_API ASTRefCount
+	class ANTLR_API TokenRefCount
 {
 private:
-	ASTRef* ref;
+	TokenRef* ref;
 
 public:
-	ASTRefCount(const AST* p=0)
-	: ref(p ? ASTRef::getRef(p) : 0)
+	TokenRefCount(const Token* p=0)
+	: ref(p ? TokenRef::getRef(p) : 0)
 	{
 	}
-	ASTRefCount(const ASTRefCount<T>& other)
+	TokenRefCount(const TokenRefCount<T>& other)
 	: ref(other.ref ? other.ref->increment() : 0)
 	{
 	}
-	~ASTRefCount()
+	~TokenRefCount()
 	{
 		if (ref && ref->decrement())
 			delete ref;
 	}
-	ASTRefCount<T>& operator=(AST* other)
+	TokenRefCount<T>& operator=(Token* other)
 	{
-		ASTRef* tmp = ASTRef::getRef(other);
+		TokenRef* tmp = TokenRef::getRef(other);
 
 		if (ref && ref->decrement())
 			delete ref;
@@ -70,11 +70,11 @@ public:
 
 		return *this;
 	}
-	ASTRefCount<T>& operator=(const ASTRefCount<T>& other)
+	TokenRefCount<T>& operator=(const TokenRefCount<T>& other)
 	{
 		if( other.ref != ref )
 		{
-			ASTRef* tmp = other.ref ? other.ref->increment() : 0;
+			TokenRef* tmp = other.ref ? other.ref->increment() : 0;
 
 			if (ref && ref->decrement())
 				delete ref;
@@ -89,10 +89,10 @@ public:
 	T* get()        const { return ref ? static_cast<T*>(ref->ptr) : 0; }
 };
 
-typedef ASTRefCount<AST> RefAST;
+typedef TokenRefCount<Token> RefToken;
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 }
 #endif
 
-#endif //INC_ASTRefCount_hpp__
+#endif //INC_TokenRefCount_hpp__

--- a/src/antlr/TokenStream.hpp
+++ b/src/antlr/TokenStream.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStream.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStream.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenStreamBasicFilter.cpp
+++ b/src/antlr/TokenStreamBasicFilter.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamBasicFilter.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/TokenStreamBasicFilter.cpp#2 $
  */
 #include "antlr/TokenStreamBasicFilter.hpp"
 

--- a/src/antlr/TokenStreamBasicFilter.hpp
+++ b/src/antlr/TokenStreamBasicFilter.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamBasicFilter.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamBasicFilter.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenStreamException.hpp
+++ b/src/antlr/TokenStreamException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamException.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -15,6 +15,10 @@
 namespace antlr {
 #endif
 
+/** Baseclass for exceptions thrown by classes implementing the TokenStream
+ * interface.
+ * @see TokenStream
+ */
 class ANTLR_API TokenStreamException : public ANTLRException {
 public:
 	TokenStreamException() 

--- a/src/antlr/TokenStreamHiddenTokenFilter.cpp
+++ b/src/antlr/TokenStreamHiddenTokenFilter.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamHiddenTokenFilter.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/TokenStreamHiddenTokenFilter.cpp#2 $
  */
 #include "antlr/TokenStreamHiddenTokenFilter.hpp"
 #include "antlr/CommonHiddenStreamToken.hpp"

--- a/src/antlr/TokenStreamHiddenTokenFilter.hpp
+++ b/src/antlr/TokenStreamHiddenTokenFilter.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamHiddenTokenFilter.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamHiddenTokenFilter.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenStreamIOException.hpp
+++ b/src/antlr/TokenStreamIOException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamIOException.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamIOException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenStreamRecognitionException.hpp
+++ b/src/antlr/TokenStreamRecognitionException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamRecognitionException.hpp,v 1.1.1.1 2004-12-09 15:10:21 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamRecognitionException.hpp#2 $
  */
 
 #include <antlr/config.hpp>
@@ -15,6 +15,10 @@
 namespace antlr {
 #endif
 
+/** Exception thrown from generated lexers when there's no default error
+ * handler specified.
+ * @see TokenStream
+ */
 class TokenStreamRecognitionException : public TokenStreamException {
 public:
 	TokenStreamRecognitionException(RecognitionException& re)
@@ -22,12 +26,25 @@ public:
 	, recog(re)
 	{
 	}
-	~TokenStreamRecognitionException() throw()
+	virtual ~TokenStreamRecognitionException() throw()
 	{
 	}
-	ANTLR_USE_NAMESPACE(std)string toString() const
+	virtual ANTLR_USE_NAMESPACE(std)string toString() const
 	{
 		return recog.getFileLineColumnString()+getMessage();
+	}
+
+	virtual ANTLR_USE_NAMESPACE(std)string getFilename() const throw()
+	{
+		return recog.getFilename();
+	}
+	virtual int getLine() const throw()
+	{
+		return recog.getLine();
+	}
+	virtual int getColumn() const throw()
+	{
+		return recog.getColumn();
 	}
 private:
 	RecognitionException recog;

--- a/src/antlr/TokenStreamRetryException.hpp
+++ b/src/antlr/TokenStreamRetryException.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamRetryException.hpp,v 1.1.1.1 2004-12-09 15:10:21 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamRetryException.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenStreamRewriteEngine.cpp
+++ b/src/antlr/TokenStreamRewriteEngine.cpp
@@ -1,0 +1,214 @@
+#include <antlr/config.hpp>
+
+#include <string>
+#include <list>
+#include <vector>
+#include <map>
+#include <utility>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <cassert>
+
+#include <antlr/TokenStream.hpp>
+#include <antlr/TokenWithIndex.hpp>
+#include <antlr/BitSet.hpp>
+#include <antlr/TokenStreamRewriteEngine.hpp>
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+namespace antlr {
+#endif
+
+#ifndef NO_STATIC_CONSTS
+const size_t TokenStreamRewriteEngine::MIN_TOKEN_INDEX = 0;
+const int TokenStreamRewriteEngine::PROGRAM_INIT_SIZE = 100;
+#endif
+
+const char* TokenStreamRewriteEngine::DEFAULT_PROGRAM_NAME = "default";
+
+namespace {
+
+	struct compareOperationIndex {
+		typedef TokenStreamRewriteEngine::RewriteOperation RewriteOperation;
+		bool operator() ( const RewriteOperation* a, const RewriteOperation* b ) const
+		{
+			return a->getIndex() < b->getIndex();
+		}
+	};
+	struct dumpTokenWithIndex {
+		dumpTokenWithIndex( ANTLR_USE_NAMESPACE(std)ostream& o ) : out(o) {}
+		void operator() ( const RefTokenWithIndex& t ) {
+			out << "[txt='" << t->getText() << "' tp=" << t->getType() << " idx=" << t->getIndex() << "]\n";
+		}
+		ANTLR_USE_NAMESPACE(std)ostream& out;
+	};
+}
+
+TokenStreamRewriteEngine::TokenStreamRewriteEngine(TokenStream& upstream)
+: stream(upstream)
+, index(MIN_TOKEN_INDEX)
+, tokens()
+, programs()
+, discardMask()
+{
+}
+
+TokenStreamRewriteEngine::TokenStreamRewriteEngine(TokenStream& upstream, size_t initialSize )
+: stream(upstream)
+, index(MIN_TOKEN_INDEX)
+, tokens(initialSize)
+, programs()
+, discardMask()
+{
+}
+
+RefToken TokenStreamRewriteEngine::nextToken( void )
+{
+	RefTokenWithIndex t;
+	// suck tokens until end of stream or we find a non-discarded token
+	do {
+		t = RefTokenWithIndex(stream.nextToken());
+		if ( t )
+		{
+			t->setIndex(index);  // what is t's index in list?
+			if ( t->getType() != Token::EOF_TYPE ) {
+				tokens.push_back(t);  // track all tokens except EOF
+			}
+			index++;			// move to next position
+		}
+	} while ( t && discardMask.member(t->getType()) );
+	return RefToken(t);
+}
+
+void TokenStreamRewriteEngine::rollback( const std::string& programName,
+													  size_t instructionIndex )
+{
+	program_map::iterator rewrite = programs.find(programName);
+	if( rewrite != programs.end() )
+	{
+		operation_list& prog = rewrite->second;
+		operation_list::iterator
+			j = prog.begin(),
+			end = prog.end();
+
+		std::advance(j,instructionIndex);
+		if( j != end )
+			prog.erase(j, end);
+	}
+}
+
+void TokenStreamRewriteEngine::originalToStream( std::ostream& out,
+																 size_t start,
+																 size_t end ) const
+{
+	token_list::const_iterator s = tokens.begin();
+	std::advance( s, start );
+	token_list::const_iterator e = s;
+	std::advance( e, end-start );
+	std::for_each( s, e, tokenToStream(out) );
+}
+
+void TokenStreamRewriteEngine::toStream( std::ostream& out,
+													  const std::string& programName,
+													  size_t firstToken,
+													  size_t lastToken ) const
+{
+	if( tokens.size() == 0 )
+		return;
+
+	program_map::const_iterator rewriter = programs.find(programName);
+
+	if ( rewriter == programs.end() )
+		return;
+
+	// get the prog and some iterators in it...
+	const operation_list& prog = rewriter->second;
+	operation_list::const_iterator
+		rewriteOpIndex = prog.begin(),
+		rewriteOpEnd = prog.end();
+
+	size_t tokenCursor = firstToken;
+	// make sure we don't run out of the tokens we have...
+	if( lastToken > (tokens.size() - 1) )
+		lastToken = tokens.size() - 1;
+
+		while ( tokenCursor <= lastToken )
+		{
+//			std::cout << "tokenCursor = " << tokenCursor << " first prog index = " << (*rewriteOpIndex)->getIndex() << std::endl;
+
+			if( rewriteOpIndex != rewriteOpEnd )
+			{
+				size_t up_to_here = std::min(lastToken,(*rewriteOpIndex)->getIndex());
+				while( tokenCursor < up_to_here )
+					out << tokens[tokenCursor++]->getText();
+			}
+			while ( rewriteOpIndex != rewriteOpEnd &&
+					  tokenCursor == (*rewriteOpIndex)->getIndex() &&
+					  tokenCursor <= lastToken )
+			{
+				tokenCursor = (*rewriteOpIndex)->execute(out);
+				++rewriteOpIndex;
+			}
+			if( tokenCursor <= lastToken )
+				out << tokens[tokenCursor++]->getText();
+		}
+	// std::cout << "Handling tail operations # left = " << std::distance(rewriteOpIndex,rewriteOpEnd) << std::endl;
+	// now see if there are operations (append) beyond last token index
+	std::for_each( rewriteOpIndex, rewriteOpEnd, executeOperation(out) );
+	rewriteOpIndex = rewriteOpEnd;
+}
+
+void TokenStreamRewriteEngine::toDebugStream( std::ostream& out,
+															 size_t start,
+															 size_t end ) const
+{
+	token_list::const_iterator s = tokens.begin();
+	std::advance( s, start );
+	token_list::const_iterator e = s;
+	std::advance( e, end-start );
+	std::for_each( s, e, dumpTokenWithIndex(out) );
+}
+
+void TokenStreamRewriteEngine::addToSortedRewriteList( const std::string& programName,
+																		 RewriteOperation* op )
+{
+	program_map::iterator rewrites = programs.find(programName);
+	// check if we got the program already..
+	if ( rewrites == programs.end() )
+	{
+		// no prog make a new one...
+		operation_list ops;
+		ops.push_back(op);
+		programs.insert(std::make_pair(programName,ops));
+		return;
+	}
+	operation_list& prog = rewrites->second;
+
+	if( prog.empty() )
+	{
+		prog.push_back(op);
+		return;
+	}
+
+	operation_list::iterator i, end = prog.end();
+	i = end;
+	--i;
+	// if at or beyond last op's index, just append
+	if ( op->getIndex() >= (*i)->getIndex() ) {
+		prog.push_back(op); // append to list of operations
+		return;
+	}
+	i = prog.begin();
+
+	if( i != end )
+	{
+		operation_list::iterator pos = std::upper_bound( i, end, op, compareOperationIndex() );
+		prog.insert(pos,op);
+	}
+	else
+		prog.push_back(op);
+}
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+}
+#endif

--- a/src/antlr/TokenStreamRewriteEngine.hpp
+++ b/src/antlr/TokenStreamRewriteEngine.hpp
@@ -1,0 +1,439 @@
+#ifndef INC_TokenStreamRewriteEngine_hpp__
+#define INC_TokenStreamRewriteEngine_hpp__
+
+/* ANTLR Translator Generator
+ * Project led by Terence Parr at http://www.jGuru.com
+ * Software rights: http://www.antlr.org/license.html
+ */
+
+#include <string>
+#include <list>
+#include <vector>
+#include <map>
+#include <utility>
+#include <iostream>
+#include <iterator>
+#include <cassert>
+#include <algorithm>
+
+#include <antlr/config.hpp>
+
+#include <antlr/TokenStream.hpp>
+#include <antlr/TokenWithIndex.hpp>
+#include <antlr/BitSet.hpp>
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+namespace antlr {
+#endif
+
+/** This token stream tracks the *entire* token stream coming from
+ *	 a lexer, but does not pass on the whitespace (or whatever else
+ *	 you want to discard) to the parser.
+ *
+ *	 This class can then be asked for the ith token in the input stream.
+ *	 Useful for dumping out the input stream exactly after doing some
+ *	 augmentation or other manipulations.	Tokens are index from 0..n-1
+ *
+ *	 You can insert stuff, replace, and delete chunks.	 Note that the
+ *	 operations are done lazily--only if you convert the buffer to a
+ *	 String.	 This is very efficient because you are not moving data around
+ *	 all the time.	 As the buffer of tokens is converted to strings, the
+ *	 toString() method(s) check to see if there is an operation at the
+ *	 current index.  If so, the operation is done and then normal String
+ *	 rendering continues on the buffer.	 This is like having multiple Turing
+ *	 machine instruction streams (programs) operating on a single input tape. :)
+ *
+ *	 Since the operations are done lazily at toString-time, operations do not
+ *	 screw up the token index values.  That is, an insert operation at token
+ *	 index i does not change the index values for tokens i+1..n-1.
+ *
+ *	 Because operations never actually alter the buffer, you may always get
+ *	 the original token stream back without undoing anything.  Since
+ *	 the instructions are queued up, you can easily simulate transactions and
+ *	 roll back any changes if there is an error just by removing instructions.
+ *	 For example,
+ *
+ *			TokenStreamRewriteEngine rewriteEngine =
+ *				new TokenStreamRewriteEngine(lexer);
+ *		  JavaRecognizer parser = new JavaRecognizer(rewriteEngine);
+ *		  ...
+ *		  rewriteEngine.insertAfter("pass1", t, "foobar");}
+ *			rewriteEngine.insertAfter("pass2", u, "start");}
+ *			System.out.println(rewriteEngine.toString("pass1"));
+ *			System.out.println(rewriteEngine.toString("pass2"));
+ *
+ *	 You can also have multiple "instruction streams" and get multiple
+ *	 rewrites from a single pass over the input.	 Just name the instruction
+ *	 streams and use that name again when printing the buffer.	This could be
+ *	 useful for generating a C file and also its header file--all from the
+ *	 same buffer.
+ *
+ *	 If you don't use named rewrite streams, a "default" stream is used.
+ *
+ *	 Terence Parr, parrt@cs.usfca.edu
+ *	 University of San Francisco
+ *	 February 2004
+ */
+class TokenStreamRewriteEngine : public TokenStream
+{
+public:
+	typedef ANTLR_USE_NAMESPACE(std)vector<antlr::RefTokenWithIndex> token_list;
+	static const char* DEFAULT_PROGRAM_NAME;
+#ifndef NO_STATIC_CONSTS
+	static const size_t MIN_TOKEN_INDEX;
+	static const int PROGRAM_INIT_SIZE;
+#else
+	enum {
+		MIN_TOKEN_INDEX = 0,
+		PROGRAM_INIT_SIZE = 100
+	};
+#endif
+
+	struct tokenToStream {
+		tokenToStream( ANTLR_USE_NAMESPACE(std)ostream& o ) : out(o) {}
+		template <typename T> void operator() ( const T& t ) {
+			out << t->getText();
+		}
+		ANTLR_USE_NAMESPACE(std)ostream& out;
+	};
+
+	class RewriteOperation {
+	protected:
+		RewriteOperation( size_t idx, const ANTLR_USE_NAMESPACE(std)string& txt )
+		: index(idx), text(txt)
+		{
+		}
+	public:
+		virtual ~RewriteOperation()
+		{
+		}
+		/** Execute the rewrite operation by possibly adding to the buffer.
+		 *	 Return the index of the next token to operate on.
+		 */
+		virtual size_t execute( ANTLR_USE_NAMESPACE(std)ostream& /* out */ ) {
+			return index;
+		}
+		virtual size_t getIndex() const {
+			return index;
+		}
+		virtual const char* type() const {
+			return "RewriteOperation";
+		}
+	protected:
+		size_t index;
+		ANTLR_USE_NAMESPACE(std)string text;
+	};
+
+	struct executeOperation {
+		ANTLR_USE_NAMESPACE(std)ostream& out;
+		executeOperation( ANTLR_USE_NAMESPACE(std)ostream& s ) : out(s) {}
+		void operator () ( RewriteOperation* t ) {
+			t->execute(out);
+		}
+	};
+
+	/// list of rewrite operations
+	typedef ANTLR_USE_NAMESPACE(std)list<RewriteOperation*> operation_list;
+	/// map program name to <program counter,program> tuple
+	typedef ANTLR_USE_NAMESPACE(std)map<ANTLR_USE_NAMESPACE(std)string,operation_list> program_map;
+
+	class InsertBeforeOp : public RewriteOperation
+	{
+	public:
+		InsertBeforeOp( size_t index, const ANTLR_USE_NAMESPACE(std)string& text )
+		: RewriteOperation(index, text)
+		{
+		}
+		virtual ~InsertBeforeOp() {}
+		virtual size_t execute( ANTLR_USE_NAMESPACE(std)ostream& out )
+		{
+			out << text;
+			return index;
+		}
+		virtual const char* type() const {
+			return "InsertBeforeOp";
+		}
+	};
+
+	class ReplaceOp : public RewriteOperation
+	{
+	public:
+		ReplaceOp(size_t from, size_t to, ANTLR_USE_NAMESPACE(std)string text)
+		: RewriteOperation(from,text)
+		, lastIndex(to)
+		{
+		}
+		virtual ~ReplaceOp() {}
+		virtual size_t execute( ANTLR_USE_NAMESPACE(std)ostream& out ) {
+			out << text;
+			return lastIndex+1;
+		}
+		virtual const char* type() const {
+			return "ReplaceOp";
+		}
+	protected:
+		size_t lastIndex;
+	};
+
+	class DeleteOp : public ReplaceOp {
+	public:
+		DeleteOp(size_t from, size_t to)
+		: ReplaceOp(from,to,"")
+		{
+		}
+		virtual const char* type() const {
+			return "DeleteOp";
+		}
+	};
+
+	TokenStreamRewriteEngine(TokenStream& upstream);
+
+	TokenStreamRewriteEngine(TokenStream& upstream, size_t initialSize);
+
+	RefToken nextToken( void );
+
+	void rollback(size_t instructionIndex) {
+		rollback(DEFAULT_PROGRAM_NAME, instructionIndex);
+	}
+
+	/** Rollback the instruction stream for a program so that
+	 *	 the indicated instruction (via instructionIndex) is no
+	 *	 longer in the stream.	UNTESTED!
+	 */
+	void rollback(const ANTLR_USE_NAMESPACE(std)string& programName,
+					  size_t instructionIndex );
+
+	void deleteProgram() {
+		deleteProgram(DEFAULT_PROGRAM_NAME);
+	}
+
+	/** Reset the program so that no instructions exist */
+	void deleteProgram(const ANTLR_USE_NAMESPACE(std)string& programName) {
+		rollback(programName, MIN_TOKEN_INDEX);
+	}
+
+	void insertAfter( RefTokenWithIndex t,
+							const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		insertAfter(DEFAULT_PROGRAM_NAME, t, text);
+	}
+
+	void insertAfter(size_t index, const ANTLR_USE_NAMESPACE(std)string& text) {
+		insertAfter(DEFAULT_PROGRAM_NAME, index, text);
+	}
+
+	void insertAfter( const ANTLR_USE_NAMESPACE(std)string& programName,
+							RefTokenWithIndex t,
+							const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		insertAfter(programName, t->getIndex(), text);
+	}
+
+	void insertAfter( const ANTLR_USE_NAMESPACE(std)string& programName,
+							size_t index,
+							const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		// to insert after, just insert before next index (even if past end)
+		insertBefore(programName,index+1, text);
+	}
+
+	void insertBefore( RefTokenWithIndex t,
+							 const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		// std::cout << "insertBefore index " << t->getIndex() << " " << text << std::endl;
+		insertBefore(DEFAULT_PROGRAM_NAME, t, text);
+	}
+
+	void insertBefore(size_t index, const ANTLR_USE_NAMESPACE(std)string& text) {
+		insertBefore(DEFAULT_PROGRAM_NAME, index, text);
+	}
+
+	void insertBefore( const ANTLR_USE_NAMESPACE(std)string& programName,
+							 RefTokenWithIndex t,
+							 const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		insertBefore(programName, t->getIndex(), text);
+	}
+
+	void insertBefore( const ANTLR_USE_NAMESPACE(std)string& programName,
+							 size_t index,
+							 const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		addToSortedRewriteList(programName, new InsertBeforeOp(index,text));
+	}
+
+	void replace(size_t index, const ANTLR_USE_NAMESPACE(std)string& text)
+	{
+		replace(DEFAULT_PROGRAM_NAME, index, index, text);
+	}
+
+	void replace( size_t from, size_t to,
+					  const ANTLR_USE_NAMESPACE(std)string& text)
+	{
+		replace(DEFAULT_PROGRAM_NAME, from, to, text);
+	}
+
+	void replace( RefTokenWithIndex indexT,
+					  const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		replace(DEFAULT_PROGRAM_NAME, indexT->getIndex(), indexT->getIndex(), text);
+	}
+
+	void replace( RefTokenWithIndex from,
+					  RefTokenWithIndex to,
+					  const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		replace(DEFAULT_PROGRAM_NAME, from, to, text);
+	}
+
+	void replace(const ANTLR_USE_NAMESPACE(std)string& programName,
+					 size_t from, size_t to,
+					 const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		addToSortedRewriteList(programName,new ReplaceOp(from, to, text));
+	}
+
+	void replace( const ANTLR_USE_NAMESPACE(std)string& programName,
+					  RefTokenWithIndex from,
+					  RefTokenWithIndex to,
+					  const ANTLR_USE_NAMESPACE(std)string& text )
+	{
+		replace(programName,
+				  from->getIndex(),
+				  to->getIndex(),
+				  text);
+	}
+
+	void remove(size_t index) {
+		remove(DEFAULT_PROGRAM_NAME, index, index);
+	}
+
+	void remove(size_t from, size_t to) {
+		remove(DEFAULT_PROGRAM_NAME, from, to);
+	}
+
+	void remove(RefTokenWithIndex indexT) {
+		remove(DEFAULT_PROGRAM_NAME, indexT, indexT);
+	}
+
+	void remove(RefTokenWithIndex from, RefTokenWithIndex to) {
+		remove(DEFAULT_PROGRAM_NAME, from, to);
+	}
+
+	void remove( const ANTLR_USE_NAMESPACE(std)string& programName,
+					 size_t from, size_t to)
+	{
+		replace(programName,from,to,"");
+	}
+
+	void remove( const ANTLR_USE_NAMESPACE(std)string& programName,
+					 RefTokenWithIndex from, RefTokenWithIndex to )
+	{
+		replace(programName,from,to,"");
+	}
+
+	void discard(int ttype) {
+		discardMask.add(ttype);
+	}
+
+	RefToken getToken( size_t i )
+	{
+		return RefToken(tokens.at(i));
+	}
+
+	size_t getTokenStreamSize() const {
+		return tokens.size();
+	}
+
+	void originalToStream( ANTLR_USE_NAMESPACE(std)ostream& out ) const {
+		ANTLR_USE_NAMESPACE(std)for_each( tokens.begin(), tokens.end(), tokenToStream(out) );
+	}
+
+	void originalToStream( ANTLR_USE_NAMESPACE(std)ostream& out,
+								  size_t start, size_t end ) const;
+
+	void toStream( ANTLR_USE_NAMESPACE(std)ostream& out ) const {
+		toStream( out, MIN_TOKEN_INDEX, getTokenStreamSize());
+	}
+
+	void toStream( ANTLR_USE_NAMESPACE(std)ostream& out,
+						const ANTLR_USE_NAMESPACE(std)string& programName ) const
+	{
+		toStream( out, programName, MIN_TOKEN_INDEX, getTokenStreamSize());
+	}
+
+	void toStream( ANTLR_USE_NAMESPACE(std)ostream& out,
+						size_t start, size_t end ) const
+	{
+		toStream(out, DEFAULT_PROGRAM_NAME, start, end);
+	}
+
+	void toStream( ANTLR_USE_NAMESPACE(std)ostream& out,
+						const ANTLR_USE_NAMESPACE(std)string& programName,
+						size_t firstToken, size_t lastToken ) const;
+
+	void toDebugStream( ANTLR_USE_NAMESPACE(std)ostream& out ) const {
+		toDebugStream( out, MIN_TOKEN_INDEX, getTokenStreamSize());
+	}
+
+	void toDebugStream( ANTLR_USE_NAMESPACE(std)ostream& out,
+							  size_t start, size_t end ) const;
+
+	size_t getLastRewriteTokenIndex() const {
+		return getLastRewriteTokenIndex(DEFAULT_PROGRAM_NAME);
+	}
+
+	/** Return the last index for the program named programName
+	 * return 0 if the program does not exist or the program is empty.
+	 * (Note this is different from the java implementation that returns -1)
+	 */
+	size_t getLastRewriteTokenIndex(const ANTLR_USE_NAMESPACE(std)string& programName) const {
+		program_map::const_iterator rewrites = programs.find(programName);
+
+		if( rewrites == programs.end() )
+			return 0;
+
+		const operation_list& prog = rewrites->second;
+		if( !prog.empty() )
+		{
+			operation_list::const_iterator last = prog.end();
+			--last;
+			return (*last)->getIndex();
+		}
+		return 0;
+	}
+
+protected:
+	/** If op.index > lastRewriteTokenIndexes, just add to the end.
+	 *	 Otherwise, do linear */
+	void addToSortedRewriteList(RewriteOperation* op) {
+		addToSortedRewriteList(DEFAULT_PROGRAM_NAME, op);
+	}
+
+	void addToSortedRewriteList( const ANTLR_USE_NAMESPACE(std)string& programName,
+										  RewriteOperation* op );
+
+protected:
+	/** Who do we suck tokens from? */
+	TokenStream& stream;
+	/** track index of tokens */
+	size_t index;
+
+	/** Track the incoming list of tokens */
+	token_list tokens;
+
+	/** You may have multiple, named streams of rewrite operations.
+	 *  I'm calling these things "programs."
+	 *  Maps String (name) -> rewrite (List)
+	 */
+	program_map programs;
+
+	/** Which (whitespace) token(s) to throw out */
+	BitSet discardMask;
+};
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+}
+#endif
+
+#endif

--- a/src/antlr/TokenStreamSelector.cpp
+++ b/src/antlr/TokenStreamSelector.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamSelector.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/TokenStreamSelector.cpp#2 $
  */
 #include "antlr/TokenStreamSelector.hpp"
 #include "antlr/TokenStreamRetryException.hpp"

--- a/src/antlr/TokenStreamSelector.hpp
+++ b/src/antlr/TokenStreamSelector.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TokenStreamSelector.hpp,v 1.1.1.1 2004-12-09 15:10:21 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TokenStreamSelector.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/TokenWithIndex.hpp
+++ b/src/antlr/TokenWithIndex.hpp
@@ -1,0 +1,84 @@
+#ifndef INC_TokenWithIndex_hpp__
+#define INC_TokenWithIndex_hpp__
+
+/* ANTLR Translator Generator
+ * Project led by Terence Parr at http://www.jGuru.com
+ * Software rights: http://www.antlr.org/license.html
+ *
+ * $Id:$
+ */
+
+#include <antlr/config.hpp>
+#include <antlr/CommonToken.hpp>
+#include <antlr/String.hpp>
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+namespace antlr {
+#endif
+
+class ANTLR_API TokenWithIndex : public ANTLR_USE_NAMESPACE(antlr)CommonToken {
+public:
+	// static size_t count;
+	TokenWithIndex() : CommonToken(), index(0)
+	{
+		// std::cout << __PRETTY_FUNCTION__ << std::endl;
+		// count++;
+	}
+	TokenWithIndex(int t, const ANTLR_USE_NAMESPACE(std)string& txt)
+	: CommonToken(t,txt)
+	, index(0)
+	{
+		// std::cout << __PRETTY_FUNCTION__ << std::endl;
+		// count++;
+	}
+	TokenWithIndex(const ANTLR_USE_NAMESPACE(std)string& s)
+	: CommonToken(s)
+	, index(0)
+	{
+		// std::cout << __PRETTY_FUNCTION__ << std::endl;
+		// count++;
+	}
+	~TokenWithIndex()
+	{
+		// count--;
+	}
+	void setIndex( size_t idx )
+	{
+		index = idx;
+	}
+	size_t getIndex( void ) const
+	{
+		return index;
+	}
+
+	ANTLR_USE_NAMESPACE(std)string toString() const
+	{
+		return ANTLR_USE_NAMESPACE(std)string("[")+
+			index+
+			":\""+
+			getText()+"\",<"+
+			getType()+">,line="+
+			getLine()+",column="+
+			getColumn()+"]";
+	}
+
+	static RefToken factory()
+	{
+		return RefToken(new TokenWithIndex());
+	}
+
+protected:
+	size_t index;
+
+private:
+	TokenWithIndex(const TokenWithIndex&);
+	const TokenWithIndex& operator=(const TokenWithIndex&);
+};
+
+typedef TokenRefCount<TokenWithIndex> RefTokenWithIndex;
+
+#ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
+}
+#endif
+
+#endif //INC_CommonToken_hpp__

--- a/src/antlr/TreeParser.cpp
+++ b/src/antlr/TreeParser.cpp
@@ -2,42 +2,15 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TreeParser.cpp,v 1.3 2010-04-05 01:22:05 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/src/TreeParser.cpp#2 $
  */
-
-// g++-4.3 needs this
-#include <cstdlib>
-#include <iomanip>
 
 #include "antlr/TreeParser.hpp"
 #include "antlr/ASTNULLType.hpp"
-#include "antlr/MismatchedTokenException.hpp"
-#include <iostream>
-#include <stdio.h>
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
 #endif
-
-ANTLR_C_USING(exit)
-
-TreeParser::TreeParser()
-: astFactory(0)
-, inputState(new TreeParserInputState())
-, traceDepth(0)
-{
-}
-
-TreeParser::TreeParser(const TreeParserSharedInputState& state)
-: astFactory(0)
-, inputState(state)
-, traceDepth(0)
-{
-}
-
-TreeParser::~TreeParser()
-{
-}
 
 /** The AST Null object; the parsing cursor is set to this when
  *  it is found to be null.  This way, we can test the
@@ -45,37 +18,6 @@ TreeParser::~TreeParser()
  *  everywhere.
  */
 RefAST TreeParser::ASTNULL(new ASTNULLType);
-
-void TreeParser::match(RefAST t, int ttype)
-{
-	if (!t || t == ASTNULL || t->getType() != ttype )
-		throw MismatchedTokenException( getTokenNames(), getNumTokens(),
-												  t, ttype, false );
-}
-
-/** Make sure current lookahead symbol matches the given set
- * Throw an exception upon mismatch, which is caught by either the
- * error handler or by the syntactic predicate.
- */
-void TreeParser::match(RefAST t, const BitSet& b)
-{
-	if ( !t || t==ASTNULL || !b.member(t->getType()) )
-		throw MismatchedTokenException( getTokenNames(), getNumTokens(),
-												  t, b, false );
-}
-
-void TreeParser::matchNot(RefAST t, int ttype)
-{
-	if ( !t || t == ASTNULL || t->getType() == ttype )
-		throw MismatchedTokenException( getTokenNames(), getNumTokens(),
-												  t, ttype, true );
-}
-
-void TreeParser::panic()
-{
-	ANTLR_USE_NAMESPACE(std)cerr << "TreeWalker: panic" << ANTLR_USE_NAMESPACE(std)endl;
-	exit(1);
-}
 
 /** Parser error-reporting function can be overridden in subclass */
 void TreeParser::reportError(const RecognitionException& ex)
@@ -99,8 +41,7 @@ void TreeParser::reportWarning(const ANTLR_USE_NAMESPACE(std)string& s)
 void TreeParser::traceIndent()
 {
 	for( int i = 0; i < traceDepth; i++ )
-		ANTLR_USE_NAMESPACE(std)cout << "  ";
-	ANTLR_USE_NAMESPACE(std)cout << ANTLR_USE_NAMESPACE(std)setw(3) << traceDepth << ": ";
+		ANTLR_USE_NAMESPACE(std)cout << " ";
 }
 
 void TreeParser::traceIn(const char* rname, RefAST t)

--- a/src/antlr/TreeParserSharedInputState.hpp
+++ b/src/antlr/TreeParserSharedInputState.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: TreeParserSharedInputState.hpp,v 1.1.1.1 2004-12-09 15:10:21 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/TreeParserSharedInputState.hpp#2 $
  */
 
 #include <antlr/config.hpp>

--- a/src/antlr/config.hpp
+++ b/src/antlr/config.hpp
@@ -5,7 +5,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: config.hpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/config.hpp#2 $
  */
 
 /*
@@ -41,12 +41,20 @@
 // _MSC_VER == 1100 for Microsoft Visual C++ 5.0
 // _MSC_VER == 1200 for Microsoft Visual C++ 6.0
 // _MSC_VER == 1300 for Microsoft Visual C++ 7.0
-#if defined(_MSC_VER) && !defined(__ICL)
+#if defined(_MSC_VER)
+
+# if _MSC_VER < 1300
+#	define NOMINMAX
+#	pragma warning(disable : 4786)
+#	define min _cpp_min
+# endif
 
 // This warning really gets on my nerves.
 // It's the one about symbol longer than 256 chars, and it happens
 // all the time with STL.
 # pragma warning( disable : 4786 4231 )
+// this shuts up some DLL interface warnings for STL
+# pragma warning( disable : 4251 )
 
 # ifdef ANTLR_CXX_USE_STLPORT
 #	undef ANTLR_CXX_SUPPORTS_UNCAUGHT_EXCEPTION
@@ -71,35 +79,33 @@
 #	define ANTLR_API __declspec(dllimport)
 # endif
 
+# if ( _MSC_VER < 1200 )
+// supposedly only for MSVC5 and before...
+// Using vector<XXX> requires operator<(X,X) to be defined
+#	define NEEDS_OPERATOR_LESS_THAN
+# endif
+
 // VC6
 # if ( _MSC_VER == 1200 )
 #	undef ANTLR_ATOI_IN_STD
 # endif
 
-// These should be verified for newer MSVC's
+# if ( _MSC_VER < 1310 )
+// Supposedly only for MSVC7 and before...
 // Not allowed to put 'static const int XXX=20;' in a class definition
-# define NO_STATIC_CONSTS
-// Using vector<XXX> requires operator<(X,X) to be defined
-# define NEEDS_OPERATOR_LESS_THAN
+#	define NO_STATIC_CONSTS
+#	define NO_TEMPLATE_PARTS
+# endif
+
 // No strcasecmp in the C library (so use stricmp instead)
 // - Anyone know which is in which standard?
 # define NO_STRCASECMP
 # undef ANTLR_CCTYPE_NEEDS_STD
-
-// needed for CharScannerLiteralsLess
-# define NO_TEMPLATE_PARTS
-
+#	define NO_STATIC_CONSTS
 #endif	// End of Microsoft Visual C++
 
 /*}}}*/
 /******************************************************************************/
-
-// RK: belongs to what compiler?
-#if defined(__ICL)
-# define NO_STRCASECMP
-#endif
-
-/*****************************************************************************/
 /*{{{ SunPro Compiler (Using OBJECTSPACE STL)
  *****************************************************************************/
 #ifdef __SUNPRO_CC
@@ -178,8 +184,12 @@
 
 // No strcasecmp in the C library (so use stricmp instead)
 // - Anyone know which is in which standard?
+#if (defined(_AIX) && (__IBMCPP__ >= 600))
+# define NO_STATIC_CONSTS
+#else
 # define NO_STRCASECMP
 # undef ANTLR_CCTYPE_NEEDS_STD
+#endif
 
 #endif	// end IBM VisualAge C++
 /*}}}*/
@@ -255,6 +265,15 @@
 #endif
 /*}}}*/
 /*****************************************************************************/
+#ifdef __BORLANDC__
+# if  __BORLANDC__ >= 560
+#	include <ctype>
+#	include <stdlib>
+#	define ANTLR_CCTYPE_NEEDS_STD
+# else
+#	error "sorry, compiler is too old - consider an update."
+# endif
+#endif
 
 // Redefine these for backwards compatability..
 #undef ANTLR_BEGIN_NAMESPACE

--- a/src/antlr/dll.cpp
+++ b/src/antlr/dll.cpp
@@ -2,7 +2,7 @@
  * Project led by Terence Parr at http://www.jGuru.com
  * Software rights: http://www.antlr.org/license.html
  *
- * $Id: dll.cpp,v 1.1.1.1 2004-12-09 15:10:20 m_schellens Exp $
+ * $Id:$
  */
 
 /*
@@ -26,6 +26,11 @@
 // implementation. This needs some work though. (and don't try it if you're
 // not that familiar with compilers/building C++ DLL's in windows)
 #endif
+
+#include <vector>
+#include "antlr/config.hpp"
+#include "antlr/Token.hpp"
+#include "antlr/CircularQueue.hpp"
 
 #ifdef ANTLR_CXX_SUPPORTS_NAMESPACE
 namespace antlr {
@@ -114,7 +119,12 @@ template class  ANTLR_API ANTLR_USE_NAMESPACE(std)_Deque_val< TokenStream*, ANTL
 template class  ANTLR_API ANTLR_USE_NAMESPACE(std)deque< TokenStream*, ANTLR_USE_NAMESPACE(std)allocator< TokenStream* > >;
 template class  ANTLR_API ANTLR_USE_NAMESPACE(std)stack< TokenStream*, ANTLR_USE_NAMESPACE(std)deque<TokenStream*> >;
 
-// #else // Add instantiations for MSVC 7.1 here if necessary..
+#elif  defined( _MSC_VER ) && ( _MSC_VER == 1310 )
+// Instantiations for MSVC 7.1
+template class ANTLR_API CircularQueue< int >;
+template class ANTLR_API CircularQueue< RefToken >;
+
+// #else future msvc's
 
 #endif
 

--- a/src/antlr4/README
+++ b/src/antlr4/README
@@ -1,0 +1,18 @@
+GD, Apr 2025
+
+This is a pretty useable ANTLR4 grammar for GDL.
+The only thing, one has yet to write all the annoying c++ part converting listeners/walkers to the ASTs used internally as 'compiled' code in GDL.
+
+One can test the .g4 grammar just by doing, e.g.:
+
+$ antlr4-parse gdlParser.g4 gdlLexer.g4 interactive -gui
+x=b*(a*(b*(a*(b*(a*(b*(a*(a*(a*b)))))))))
+
+(end with ^D), shows a nice diagram.
+
+
+or use compileantlr4 to produce 'demo' and try something on a .pro file like
+$ ./demo --tree test_slowantlr2.pro
+
+
+(test_slowantrl2 is just a kind of procedure that takes forever to cimpile with the simple LLK(1) parser of antlr2.)

--- a/src/antlr4/compileantlr4
+++ b/src/antlr4/compileantlr4
@@ -1,0 +1,12 @@
+#!/bin/bash
+if test $# -eq 0
+ then
+ PROG="gdl"
+else
+ PROG=$1
+fi
+
+antlr4 -Dlanguage=Cpp ${PROG}Lexer.g4
+antlr4 -Dlanguage=Cpp ${PROG}Parser.g4
+g++ --std=c++17 -c -O3 -Wno-attributes -I/usr/include/antlr4-runtime/ -L/usr/lib64/  ${PROG}Lexer.cpp ${PROG}Parser.cpp
+g++ --std=c++17 -O3 -Wno-attributes -o demo  -I/usr/include/antlr4-runtime/ -L/usr/lib64/ -lantlr4-runtime  main.cpp  *.o

--- a/src/antlr4/doCombined.sh
+++ b/src/antlr4/doCombined.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if test $# -lt 1
+ then
+     echo "usage: $0 [interactive | translation_unit | interactive_compile ..."
+     exit 1
+fi
+echo "grammar gdlCombined;" > gdlCombined.g4; for i in gdl*_include.g4; do grep -v 'grammar ' $i  >> gdlCombined.g4; done; echo "prog: $1 ;" >> gdlCombined.g4

--- a/src/antlr4/gdlLexer.g4
+++ b/src/antlr4/gdlLexer.g4
@@ -1,0 +1,290 @@
+lexer grammar gdlLexer;
+
+tokens {
+NULLSTRING,
+STRING,
+END_U}
+
+DOT:'.';
+AND_OP_EQ: [aA] [nN] [dD] '='; 
+ASTERIX_EQ:'*=';
+EQ_OP_EQ: [eE] [qQ] '=';
+GE_OP_EQ:  [gG] [eE] '=';
+GTMARK_EQ:'>=';
+GT_OP_EQ:  [gG] [tT] '=';
+LE_OP_EQ:  [lL] [eE] '=';
+LTMARK_EQ:'<=';
+LT_OP_EQ:  [lL] [tT] '=';
+MATRIX_OP1_EQ:'#=';
+MATRIX_OP2_EQ:'##=';
+MINUS_EQ:'-=';
+MOD_OP_EQ:  [mM] [oO] [dD] '=';
+NE_OP_EQ:  [nN] [eE] '=';
+OR_OP_EQ:  [oO] [rR] '=';
+PLUS_EQ:'+=';
+POW_EQ:'^=';
+SLASH_EQ:'/=';
+XOR_OP_EQ:  [xX] [oO] [rR] '=';
+
+MATRIX_OP1:'#';
+MATRIX_OP2:'##';
+METHOD:'::';
+MEMBER:'->';
+COMMA:',';
+COLON:':';
+ASSIGN:'=';
+LBRACE:'(';
+RBRACE:')';
+LCURLY:'{';
+RCURLY:'}';
+LSQUARE:'[';
+RSQUARE:']';
+QUESTION:'?';
+EXCLAMATION:'!';
+POW:'^';
+ASTERIX:'*';
+SLASH:'/';
+MINUS:'-';
+PLUS:'+';
+INC:'++';
+DEC:'--';
+GTMARK:'>';
+LTMARK:'<';
+LOG_AND:'&&';
+LOG_OR:'||';
+LOG_NEG:'~';
+AND_OP: [aA] [nN] [dD]; 
+BEGIN:  [bB] [eE] [gG] [iI] [nN];
+BREAK:  [bB] [rR] [eE] [aA] [kK];
+CASE:  [cC] [aA] [sS] [eE]; 
+COMMON: [cC] [oO] [mM] [mM] [oO] [nN];
+COMPILE_OPT: [cC] [oO] [mM] [pP] [iI] [lL] [eE] '_'  [oO] [pP] [tT];
+
+// tentative trap of "CONTINUE" as the real CONTINUE in the lexer.
+CONTINUE:  [cC] [oO] [nN] [tT] [iI] [nN] [uU] [eE] ;
+
+
+DO:  [dD] [oO];
+ELSE:  [eE] [lL] [sS] [eE];
+END: [eE] [nN] [dD];
+ENDCASE: [eE] [nN] [dD] [cC] [aA] [sS] [eE];
+ENDELSE: [eE] [nN] [dD] [eE] [lL] [sS] [eE];
+ENDFOR: [eE] [nN] [dD] [fF] [oO] [rR];
+ENDFOREACH: [eE] [nN] [dD] [fF] [oO] [rR] [eE] [aA] [cC] [hH];
+ENDIF: [eE] [nN] [dD] [iI] [fF];
+ENDREP: [eE] [nN] [dD] [rR] [eE] [pP];
+ENDSWITCH: [eE] [nN] [dD] [sS] [wW] [iI] [tT] [cC] [hH];
+ENDWHILE: [eE] [nN] [dD] [wW] [hH] [iI] [lL] [eE];
+EQ_OP: [eE] [qQ];
+FOR: [fF] [oO] [rR];
+FOREACH: [fF] [oO] [rR] [eE] [aA] [cC] [hH];
+FORWARD_FUNCTION: [fF] [oO] [rR] [wW] [aA] [rR] [dD] '_'  [fF] [uU] [nN] [cC] [tT] [iI] [oO] [nN];
+FUNCTION: [fF] [uU] [nN] [cC] [tT] [iI] [oO] [nN];
+GE_OP: [gG] [eE];
+GOTO: [gG] [oO] [tT] [oO];
+GT_OP: [gG] [tT];
+IF: [iI] [fF];
+INHERITS: [iI] [nN] [hH] [eE] [rR] [iI] [tT] [sS];
+LE_OP: [lL] [eE];
+LT_OP: [lL] [tT];
+MOD_OP: [mM] [oO] [dD];
+NE_OP: [nN] [eE];
+NOT_OP: [nN] [oO] [tT];
+OF: [oO] [fF];
+ON_IOERROR: [oO] [nN] '_'  [iI] [oO] [eE] [rR] [rR] [oO] [rR];
+OR_OP: [oO] [rR];
+PRO: [pP] [rR] [oO];
+REPEAT: [rR] [eE] [pP] [eE] [aA] [tT];
+RETURN: [rR] [eE] [tT] [uU] [rR] [nN]; // unspecified return (replaced by tree parser with RETF/RETP)
+SWITCH: [sS] [wW] [iI] [tT] [cC] [hH];
+THEN: [tT] [hH] [eE] [nN];
+UNTIL: [uU] [nN] [tT] [iI] [lL];
+WHILE: [wW] [hH] [iI] [lL] [eE];
+XOR_OP: [xX] [oO] [rR];
+
+//fragment
+EOL:  '\r'? '\n' ->type(END_U) ;
+
+fragment
+WS : [ \t\u000C] ;
+
+fragment
+INCLUDE_FILENAME    : ( ~('\r'|'\n') )*
+    ;
+
+INCLUDE
+      :    '@' INCLUDE_FILENAME {std::cerr<<"please handle Include in Lexer"<<std::endl; /*assert(false);*/}-> skip
+    ;
+
+fragment
+ DIGIT : [0-9] ;
+
+fragment
+LETTER
+    : [a-zA-Z_]
+    ;
+
+fragment
+HEXADECIMAL 
+    : [a-fA-F0-9]
+    ;
+
+fragment
+OCTAL
+    : [0-7]
+    ;
+fragment
+BINARY
+    : [0-1]
+    ;
+
+fragment
+EXP
+    : ([eE] ([+\-]? ( DIGIT)+)? )
+    ;
+
+fragment
+DBL
+    : ([dD] ([+\-]? ( DIGIT)+)? )
+    ;
+
+CONSTANT_BIN_I: '\'' (BINARY)+ '\'' [bB];
+CONSTANT_BIN_INT:     CONSTANT_BIN_I [sS];
+CONSTANT_BIN_BYTE:    CONSTANT_BIN_I  ([bB]|[uU] [bB]);
+CONSTANT_BIN_UI:      CONSTANT_BIN_I [uU];
+CONSTANT_BIN_UINT:    CONSTANT_BIN_I  [uU] [sS];
+CONSTANT_BIN_LONG:    CONSTANT_BIN_I  [lL];
+CONSTANT_BIN_LONG64:  CONSTANT_BIN_I  [lL] [lL] ;
+CONSTANT_BIN_ULONG:   CONSTANT_BIN_I  [uU] [lL];
+CONSTANT_BIN_ULONG64: CONSTANT_BIN_I  [uU] [lL] [lL];
+
+//hexadecimal variant 1: NOT 'b' as B is part of (HEXADECIMAL) : ex: 0x3BAFB 
+CONSTANT_HEX_I:  '0' [xX] (HEXADECIMAL)+ ; // DEFINT32
+CONSTANT_HEX_INT:     CONSTANT_HEX_I  [sS];
+CONSTANT_HEX_UI:      CONSTANT_HEX_I  [uU];
+CONSTANT_HEX_UINT:    CONSTANT_HEX_I  [uU] [sS];
+CONSTANT_HEX_BYTE:    CONSTANT_HEX_I  [uU] [bB];
+CONSTANT_HEX_LONG:    CONSTANT_HEX_I  [lL];
+CONSTANT_HEX_LONG64:  CONSTANT_HEX_I  [lL] [lL] ;
+CONSTANT_HEX_ULONG:   CONSTANT_HEX_I  [uU] [lL];
+CONSTANT_HEX_ULONG64: CONSTANT_HEX_I  [uU] [lL] [lL];
+
+VariantConstant_hex_i:  '\'' (HEXADECIMAL)+ '\'' [xX] ->type(CONSTANT_HEX_I); // DEFINT32
+VariantConstant_hex_int:     VariantConstant_hex_i  [sS]->type(CONSTANT_HEX_INT);
+VariantConstant_hex_ui:      VariantConstant_hex_i  [uU]->type(CONSTANT_HEX_UI);
+VariantConstant_hex_uint:    VariantConstant_hex_i  [uU] [sS]->type(CONSTANT_HEX_UINT);
+VariantConstant_hex_byte:    VariantConstant_hex_i  ([bB] | [uU] [bB])->type(CONSTANT_HEX_BYTE);
+VariantConstant_hex_long:    VariantConstant_hex_i  [lL]->type(CONSTANT_HEX_LONG);
+VariantConstant_hex_long64:  VariantConstant_hex_i  [lL] [lL]->type(CONSTANT_HEX_LONG64) ;
+VariantConstant_hex_ulong:   VariantConstant_hex_i  [uU] [lL]->type(CONSTANT_HEX_ULONG);
+VariantConstant_hex_ulong64: VariantConstant_hex_i  [uU] [lL] [lL]->type(CONSTANT_HEX_ULONG64);
+
+CONSTANT_OCT_I: '\'' (OCTAL)+ '\'' [oO];
+CONSTANT_OCT_INT:     CONSTANT_OCT_I [sS];
+CONSTANT_OCT_BYTE:    CONSTANT_OCT_I  ([bB]|[uU] [bB]);
+CONSTANT_OCT_UI:      CONSTANT_OCT_I [uU];
+CONSTANT_OCT_UINT:    CONSTANT_OCT_I  [uU] [sS];
+CONSTANT_OCT_LONG:    CONSTANT_OCT_I  [lL];
+CONSTANT_OCT_LONG64:  CONSTANT_OCT_I  [lL] [lL] ;
+CONSTANT_OCT_ULONG:   CONSTANT_OCT_I  [uU] [lL];
+CONSTANT_OCT_ULONG64: CONSTANT_OCT_I  [uU] [lL] [lL];
+
+CONSTANT_I: (DIGIT)+ ;
+CONSTANT_INT:     CONSTANT_I [sS];
+CONSTANT_BYTE:    CONSTANT_I  ([bB]|[uU] [bB]);
+CONSTANT_UINT:    CONSTANT_I  [uU]([sS])?;
+CONSTANT_LONG:    CONSTANT_I  [lL];
+CONSTANT_LONG64:  CONSTANT_I  [lL] [lL] ;
+CONSTANT_ULONG:   CONSTANT_I  [uU] [lL];
+CONSTANT_ULONG64: CONSTANT_I  [uU] [lL] [lL];
+
+CONSTANT_DOUBLE: 
+        (
+            (
+                ( DIGIT)+ 
+                ( DBL 
+                | '.'( DIGIT)*(DBL)
+                )
+            ) 
+        | '.'( DIGIT)+(DBL)) 
+;
+CONSTANT_FLOAT:
+        (
+            (
+                ( DIGIT)+ 
+                ( EXP 
+                | '.'( DIGIT)*(EXP)?
+                )
+            ) 
+        | '.'( DIGIT)+(EXP)?) 
+;
+
+Trap_null_quoted_string: ('""'|'"' '\r'?'\n') -> type(NULLSTRING);
+Trap_null_single_quoted_string: ('\'\''|'\'' '\r'?'\n') -> type(NULLSTRING);
+Trap_old_octal_form:  '"' OCTAL -> more, pushMode(Old_octal_notation);
+Trap_quoted_string: '"' ~('0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'"' |'\r'|'\n') -> more, pushMode(Quoted_string);
+Single_quoted_string:   '\'' ( '\'\''| ~('\''|'\r'|'\n') )*  ( '\'' | )   -> type(STRING) ;
+
+UNDEFINED: ( '[' ']' | '{' '}' ); 
+
+COMMENT: ';' ~('\r'|'\n')* ->skip;
+
+IDENTIFIER
+    : (LETTER)(LETTER| DIGIT|'$')*
+    ;
+
+SYSVARNAME
+    : ('!') (LETTER| DIGIT|'$')+
+    ;
+
+STATEMENT_SEPARATOR: '&' ->type(END_U) ;
+
+  WHITESPACE
+  : (WS)+ ->skip
+  ;
+
+
+// this subrule eats lines to skip
+// 1. comment only lines
+// 2. blank lines
+
+fragment 
+SKIP_LINES
+  : ( COMMENT
+    | WS
+    | EOL
+    )*
+  ;
+
+// IDL ignores everything on the line after the $.
+// Note: The '$' command in interactive mode is filtered by GDL in DInterpreter::ExecuteLine
+CONT_STATEMENT: '$' (~('\r'|'\n'))* EOL SKIP_LINES -> skip;
+
+END_OF_LINE 
+  :  EOL SKIP_LINES ->type(END_U)
+  ;
+
+
+
+ANY: . { std::cerr<<"SOMETHING IS BAD IN THE ANTLR RULES OR THE SOURCE CODE!"<<std::endl; assert(false);} ->skip; //catchall meaning something was not correctly parsed by the other rules.
+
+// just to know how many tokens are there
+fragment
+MAX_TOKEN_NUMBER :;
+
+mode Old_octal_notation;
+Old_constant_oct_i:          (OCTAL)* ->type(CONSTANT_OCT_I), popMode;
+Old_constant_oct_int:        Old_constant_oct_i [sS] ->type(CONSTANT_OCT_INT), popMode;
+Old_constant_oct_byte:       Old_constant_oct_i ([bB]|[uU] [bB]) ->type(CONSTANT_OCT_BYTE), popMode;
+Old_constant_oct_ui:         Old_constant_oct_i [uU] ->type(CONSTANT_OCT_UI), popMode;
+Old_constant_oct_uint:       Old_constant_oct_i [uU] [sS] ->type(CONSTANT_OCT_UINT), popMode;
+Old_constant_oct_long:       Old_constant_oct_i [lL] ->type(CONSTANT_OCT_LONG), popMode;
+Old_constant_oct_long64:     Old_constant_oct_i [lL] [lL] ->type(CONSTANT_OCT_LONG64), popMode ;
+Old_constant_oct_ulong:      Old_constant_oct_i [uU] [lL] ->type(CONSTANT_OCT_ULONG), popMode;
+Old_constant_oct_ulong64:    Old_constant_oct_i [uU] [lL] [lL] ->type(CONSTANT_OCT_ULONG64), popMode;
+Old_constant_oct_is_string:  Old_constant_oct_i '"' ->type(STRING), popMode;
+
+mode Quoted_string;
+IsAQuotedString: ( '""' | ~('"'|'\r'|'\n') )* ('"'|) ->type(STRING), popMode;
+
+

--- a/src/antlr4/gdlParser.g4
+++ b/src/antlr4/gdlParser.g4
@@ -1,0 +1,784 @@
+parser grammar gdlParser;
+options {
+        tokenVocab = gdlLexer;
+}
+// following are in conjunction with main() and used to present a relatively correct parsing
+// in absence of proper management of variables that interefere with  the parsing ( *_insideLoop() and IsRelaxed())
+// *_insideLoop() is probably well treated. STRICTARR cannot be enforced at this stage.
+@parser::context {
+extern bool amIRelaxed;
+static bool IsRelaxed() {return amIRelaxed;}
+static void setRelaxed(bool b){amIRelaxed=b;}
+}
+@parser::declarations{
+int inloop_include;
+int inloop_break;
+bool interactiveMode=false;
+bool include_insideLoop(){return ( inloop_include > 0 );}
+bool break_insideLoop(){return ( inloop_break > 0 );}
+bool isInteractive(){return interactiveMode;}
+void setInteractive(){interactiveMode=true;}
+void unSetInteractive(){interactiveMode=false;}
+}
+// Actual grammar start.
+tokens {
+    ALL,        // arrayindex (*, e.g. [1:*])
+//    ASSIGN, //already defined
+    ASSIGN_INPLACE,
+    ASSIGN_REPLACE,
+    ASSIGN_ARRAYEXPR_MFCALL,
+    ARRAYDEF,
+    ARRAYDEF_CONST,
+    ARRAYDEF_GENERALIZED_INDGEN,
+    ARRAYIX,
+    ARRAYIX_ALL,
+    ARRAYIX_ORANGE,
+    ARRAYIX_RANGE,
+    ARRAYIX_ORANGE_S, // with stride
+    ARRAYIX_RANGE_S,
+    ARRAYEXPR,
+    ARRAYEXPR_FCALL,
+    ARRAYEXPR_MFCALL,
+    BLOCK,
+//    BREAK, //already defined
+    CSBLOCK,
+//    CONTINUE, //already defined
+    COMMONDECL,
+    COMMONDEF,
+    CONSTANT,
+    DEREF,
+    ELSEBLK,
+    EXPR,
+//    FOR, //already defined
+    FOR_STEP, // for with step
+//    FOREACH, //already defined
+    FOREACH_INDEX, // foreach with index (hash) variable
+    FOR_LOOP,
+    FOR_STEP_LOOP, // for with step
+    FOREACH_LOOP,
+    FOREACH_INDEX_LOOP,
+    FCALL,
+    FCALL_LIB, // library function call
+     FCALL_LIB_DIRECT, // direct call
+     FCALL_LIB_N_ELEMENTS, // N_ELEMENTS
+    FCALL_LIB_RETNEW, // library function call always return newly allocated data
+    GDLNULL,
+    IF_ELSE,
+    KEYDECL,
+    KEYDEF,
+    KEYDEF_REF, // keyword passed by reference
+    KEYDEF_REF_CHECK, // keyword maybe passed by reference
+    KEYDEF_REF_EXPR,  // keyword with assign/inc/dec passed by reference
+      LABEL,
+    MPCALL,
+    MPCALL_PARENT, // explicit call to parent 
+    MFCALL,
+    MFCALL_LIB,
+    MFCALL_LIB_RETNEW,
+    MFCALL_PARENT, // explicit call to parent
+    MFCALL_PARENT_LIB,
+    MFCALL_PARENT_LIB_RETNEW,
+      NOP,     // no operation
+    NSTRUC,     // named struct
+    NSTRUC_REF, // named struct reference
+    ON_IOERROR_NULL,
+    PCALL,
+    PCALL_LIB, // library procedure call
+    PARADECL,
+    PARAEXPR,  // parameter
+    PARAEXPR_VN, // _VN Variable Number of parameters version
+    DEC_REF_CHECK, // called from EvalRefCheck() (no temporary needed then)
+    INC_REF_CHECK, // called from EvalRefCheck() (no temporary needed then)
+    POSTDEC,  //post-decrement : i--
+    POSTINC, // Post-increment : i++
+    DECSTATEMENT, // as a statement
+    INCSTATEMENT, // as a statement
+    REF,        // expr pass by reference
+    REF_VN,        // expr pass by reference
+    REF_CHECK,  // expr maybe be passed by reference
+    REF_CHECK_VN,  // expr maybe be passed by reference
+    REF_EXPR,   // assign/dec/inc expr passed by reference
+    REF_EXPR_VN,   // assign/dec/inc expr passed by reference
+//    REPEAT, //already defined
+    REPEAT_LOOP,
+//    RETURN,  //already defined
+      RETF,    // return from function (return argument)
+      RETP,    // return from procedure (no return argument)
+    STRUC,  // struct
+    SYSVAR,
+//    UPLUS,
+    UMINUS,
+    VAR,     // variable, referenced through index
+    VARPTR  //,  // variable, referenced through pointer
+//    WHILE // unspecified return (replaced by tree parser with RETF/RETP)
+}
+
+ // 'reverse' identifier
+ // allows reserved words as identifiers
+ // needed for keyword abbreviations
+ // if you change some keywords here you probably need to change
+ // the reserved word list above
+ reservedWords
+     : AND_OP 
+     | BEGIN  
+     | CASE 
+     | COMMON 
+     | COMPILE_OPT
+     | CONTINUE
+     | DO 
+     | ELSE 
+     | END 
+     | ENDCASE 
+     | ENDELSE 
+     | ENDFOR 
+     | ENDFOREACH 
+     | ENDIF 
+     | ENDREP 
+     | ENDSWITCH 
+     | ENDWHILE 
+     | EQ_OP 
+     | FOR 
+     | FOREACH 
+     | FORWARD_FUNCTION
+     | FUNCTION 
+     | GE_OP 
+     | GOTO 
+     | GT_OP 
+     | IF 
+     | INHERITS 
+     | LE_OP 
+     | LT_OP 
+     | MOD_OP 
+     | NE_OP 
+     | NOT_OP 
+     | OF 
+     | ON_IOERROR
+     | OR_OP 
+     | PRO 
+     | REPEAT 
+     | SWITCH 
+     | THEN 
+     | UNTIL 
+     | WHILE 
+     | XOR_OP 
+     ;
+
+
+validIdentifier:
+       IDENTIFIER
+     | CONTINUE
+     | INHERITS
+     | BREAK
+     ;
+
+// whereever one END_U is there might be more
+// end_unit is syntactical necessary, but not for the AST
+endUnit:   (END_U)+ //(END_OF_LINE)+
+	 ;
+includeFileStatement: INCLUDE;
+
+translation_unit
+   :    ( endUnit
+   	| forwardFunction endUnit
+        | procedureDefinition
+        | functionDefinition
+        | commonBlock
+        )* // optional - only main program is also ok
+        (  statementList END (endUnit)? )? // $MAIN$ program
+        (EOF)  // braces necessary because goto crosses initialization otherwise
+{ bailOut:;} // bailout jump label
+    ;
+//    catch[...] { /* catching translation_unit errors here */ }
+
+// interactive compilation is not allowed
+warnInteractiveCompile
+    : (FUNCTION | PRO)      validIdentifier
+       {
+           /* throw GDLException( "Programs can't be compiled from "
+                "single statement mode."); */
+        }
+	(METHOD validIdentifier)?      (COMMA keywordDeclaration)?    endUnit
+    ;
+
+// interactive usage: analyze one line = statement or statementList with '&'. Must catch any PRO or FUNCTION definition as this is not yet programmed.
+interactive
+@init{setInteractive();}
+@after{unSetInteractive();}
+    :   (  endUnit (anyEndMark)?
+    	| warnInteractiveCompile
+        | interactiveStatement
+        )+
+    ;
+//    catch[...] { /* catching interactive errors here */ }
+
+
+identifierList : listOfIdentifiers+=validIdentifier (COMMA listOfIdentifiers+=validIdentifier)*    ; //create std::vector<antlr4::Token *> listOfIdentifiers to hold the tokens.
+
+
+
+
+statement:                
+      conditionalStatement
+    | loopStatement       
+    | jumpStatement       
+    | forwardFunction     
+    | commonBlock         
+    | compileOpt          
+    | procedureCall       
+    | assignmentStatement 
+    | includeFileStatement
+    ;
+
+conditionalStatement
+    : ifStatement
+    | caseStatement
+    | switchStatement
+    ;
+
+loopStatement
+    : forStatement
+    | foreachStatement
+    | repeatStatement
+    | whileStatement
+    ;
+
+jumpStatement
+   :
+   (gotoStatement
+   | onIoErrorStatement
+   | RETURN (COMMA expression)?
+   )
+   ;
+
+forwardFunction : FORWARD_FUNCTION identifierList;
+
+compileOpt : COMPILE_OPT identifierList;
+
+commonBlock : COMMON validIdentifier  (COMMA identifierList)?  //should use a semantic predicate to say "% Common block ZZZZ must contain variables." if ZZZ is not defined
+    ;
+
+anyEndMark
+    : END
+    | ENDIF
+    | ENDELSE
+    | ENDCASE
+    | ENDSWITCH
+    | ENDFOR
+    | ENDFOREACH
+    | ENDWHILE
+    | ENDREP
+    ;
+
+// idl allows more than one ELSE: first is executed, *all*
+// (including expression) later branches are ignored (case) or 
+// executed (switch)
+
+switchSelector: expression;   
+switchStatement: SWITCH switchSelector OF (endUnit)? (switchBody )*  ( ENDSWITCH | END); 
+
+switchClause: expression;
+switchBody
+    : switchClause COLON 
+        ( labelledStatement
+	| statement
+	| BEGIN statementList  ( ENDSWITCH | END) 
+	)? endUnit
+    | ELSE COLON 
+        ( labelledStatement
+	| statement
+	| BEGIN statementList ( ENDSWITCH | ENDELSE | END)
+	)? endUnit
+    ;    
+
+caseSelector: expression ;
+caseStatement    : CASE caseSelector OF (endUnit)?  (caseBody)*  (ENDCASE | END)    ;
+
+caseClause: expression;
+caseBody
+    : caseClause COLON 
+        ( labelledStatement
+	| statement
+	| BEGIN statementList (ENDCASE | END))? endUnit
+    | ELSE COLON 
+        ( labelledStatement
+	| statement
+	| BEGIN statementList (ENDCASE | ENDELSE | END))? endUnit
+	;
+
+// compound statements don't care about the specific anyEndMark
+compoundStatement
+    : BEGIN statementList anyEndMark
+    | statement
+    ;
+    
+label:  validIdentifier COLON;
+
+labelledStatement: (label)+  (compoundStatement)?;
+
+statementList
+    :  ( endUnit
+       | compoundStatement endUnit
+       | labelledStatement endUnit
+       )+
+       ;
+
+compoundAssignment:
+      AND_OP_EQ 
+    | ASTERIX_EQ 
+    | EQ_OP_EQ 
+    | GE_OP_EQ
+    | GTMARK_EQ
+    | GT_OP_EQ
+    | LE_OP_EQ
+    | LTMARK_EQ
+    | LT_OP_EQ
+    | MATRIX_OP1_EQ
+    | MATRIX_OP2_EQ
+    | MINUS_EQ
+    | MOD_OP_EQ
+    | NE_OP_EQ
+    | OR_OP_EQ
+    | XOR_OP_EQ
+    | PLUS_EQ
+    | POW_EQ
+    | SLASH_EQ
+    ;
+
+assignmentOperator:
+     ASSIGN
+    | compoundAssignment
+    ;
+    
+repeatExpression: expression;
+repeatStatement
+@init{ inloop_include ++; inloop_break ++;}
+@after{ inloop_include--; inloop_break --;}
+: REPEAT repeatBlock UNTIL repeatExpression ;
+
+
+repeatBlock
+@init{ inloop_break ++;}
+@after{ inloop_break --;}
+    : BEGIN statementList (ENDREP | END)
+    | statement
+    ;
+
+whileExpression: expression;
+whileStatement
+@init{ inloop_include ++; inloop_break ++;}
+@after{ inloop_include--; inloop_break --;}
+    : WHILE whileExpression DO whileBlock;
+
+
+whileBlock
+@init{ inloop_break ++;}
+@after{ inloop_break --;}
+    : BEGIN statementList (ENDWHILE | END) 
+    | statement
+    ;
+
+forVariable: variableName;
+forInit: expression;
+forLimit: expression;
+forStep: expression;
+forStatement: FOR forVariable ASSIGN forInit COMMA forLimit (COMMA forStep)? DO (
+            {isInteractive()}? BEGIN statement
+	    | forBlock
+	    )
+	    ;
+
+forBlock
+@init{ inloop_include ++; inloop_break ++;}
+@after{ inloop_include--; inloop_break --;}
+    : BEGIN statementList ( ENDFOR | END )
+    | statement
+    ;    
+
+foreachElement: validIdentifier;
+foreachVariable: expression;
+foreachIndex: validIdentifier;
+foreachStatement
+@init{ inloop_include ++; inloop_break ++;}
+@after{ inloop_include--; inloop_break --;}
+: FOREACH foreachElement COMMA foreachVariable (COMMA foreachIndex)? DO (
+            {isInteractive()}? BEGIN statement
+	    | foreachBlock
+	    )
+	    ;
+
+foreachBlock
+    : BEGIN statementList (END | ENDFOREACH )
+    | statement
+    ;    
+
+
+gotoStatement:  GOTO COMMA validIdentifier;
+onIoErrorStatement: ON_IOERROR COMMA validIdentifier;
+
+ifExpression: expression;
+ifStatement: IF ifExpression THEN  ifBlock ( ELSE elseBlock )? ;
+
+
+ifBlock
+    : BEGIN statementList (ENDIF | END) 
+    | statement
+    ;
+
+
+elseBlock
+    : BEGIN statementList ( ENDELSE | END)
+    | statement
+    ;
+
+valuedParameter    :<assoc=right> (validIdentifier | reservedWords) ASSIGN expression;
+setParameter: SLASH (validIdentifier | reservedWords);
+simpleParameter: (validIdentifier | reservedWords | expression);
+
+callParameter:
+      valuedParameter
+    | setParameter
+    | simpleParameter
+    ;
+
+
+parameterList : callParameter ( COMMA callParameter)*  ;
+
+formalProcedureCall :
+  { include_insideLoop() }? CONTINUE
+| { break_insideLoop() }? BREAK
+|   validIdentifier (COMMA parameterList)?
+;
+
+memberProcedureCall: variableAccessByValueOrReference (MEMBER|DOT) (validIdentifier METHOD)? formalProcedureCall;
+
+procedureCall:
+    memberProcedureCall
+  | formalProcedureCall
+  ;
+
+formalFunctionCall : validIdentifier LBRACE (parameterList)? RBRACE  ;
+memberFunctionCall : variableAccessByValueOrReference (MEMBER|DOT) (validIdentifier METHOD)? formalFunctionCall;
+functionCall:
+       memberFunctionCall
+     | formalFunctionCall
+     ;
+
+valuedKeyword:<assoc=right> (validIdentifier | reservedWords) ASSIGN  (validIdentifier | reservedWords);
+simpleKeyword: (validIdentifier | reservedWords);
+keywordDeclaration:
+         valuedKeyword
+	|simpleKeyword
+        ;
+	
+keywordDeclarationList : keywordDeclaration ( COMMA keywordDeclaration )*    ;
+    
+
+procedureDefinition :
+        PRO ( objectName | validIdentifier ) (COMMA keywordDeclarationList)? endUnit (statementList)*  END
+  ;
+ 
+
+functionDefinition:
+        FUNCTION ( objectName | validIdentifier ) (COMMA keywordDeclarationList)? endUnit (statementList)* END
+    ;
+
+objectName : validIdentifier METHOD validIdentifier ;    
+
+
+expressionList: expression  ( COMMA expression )* ;
+
+//arrayListDefinition:          LSQUARE expressionList RSQUARE    ;
+//arrayAutoDefinition:          LSQUARE expression COLON expression RSQUARE    ;
+//arrayAutoIncrementDefinition: LSQUARE expression COLON expression COLON expression RSQUARE    ;
+//
+//arrayDefinition:
+// | arrayListDefinition        
+// | arrayAutoDefinition        
+// | arrayAutoIncrementDefinition
+//;
+
+
+namedStructure:
+	  LCURLY (validIdentifier|SYSVARNAME)
+	                    ( (COMMA inheritsOrTagDef)*
+	                    | COMMA expressionList 
+	                    | ) RCURLY
+	;
+anonymousStructure: LCURLY inheritsOrTagDef (COMMA inheritsOrTagDef)* RCURLY;
+
+inheritsOrTagDef
+    : inheritsStructure
+    | normalTag
+    ;
+
+inheritsStructure: INHERITS validIdentifier;
+normalTag:  validIdentifier COLON expression ;
+
+structureDefinition
+    : namedStructure
+    | anonymousStructure
+    ;
+
+
+//constant_hex_byte    	:  CONSTANT_HEX_BYTE    ;
+//constant_hex_long 	:  CONSTANT_HEX_LONG ;
+//constant_hex_long64 	:  CONSTANT_HEX_LONG64 ;
+//constant_hex_int 	:  CONSTANT_HEX_INT ;
+//constant_hex_i 		:  CONSTANT_HEX_I ;  // DEFINT32
+//constant_hex_ulong 	:  CONSTANT_HEX_ULONG ;
+//constant_hex_ulong64	:  CONSTANT_HEX_ULONG64;
+//constant_hex_ui		:  CONSTANT_HEX_UI;        // DEFINT32
+//constant_hex_uint	:  CONSTANT_HEX_UINT;
+//constant_byte  		:  CONSTANT_BYTE  ;
+//constant_long 		:  CONSTANT_LONG ;
+//constant_long64 	:  CONSTANT_LONG64 ;
+//constant_int		:  CONSTANT_INT;
+//constant_i		:  CONSTANT_I;        // DEFINT32
+//constant_ulong 		:  CONSTANT_ULONG ;
+//constant_ulong64 	:  CONSTANT_ULONG64 ;
+//constant_uint		:  CONSTANT_UINT;
+//constant_oct_byte  	:  CONSTANT_OCT_BYTE  ;
+//constant_oct_long 	:  CONSTANT_OCT_LONG ;
+//constant_oct_long64 	:  CONSTANT_OCT_LONG64 ;
+//constant_oct_int	:  CONSTANT_OCT_INT;
+//constant_oct_i		:  CONSTANT_OCT_I;        // DEFINT32
+//constant_oct_ulong 	:  CONSTANT_OCT_ULONG ;
+//constant_oct_ulong64 	:  CONSTANT_OCT_ULONG64 ;
+//constant_oct_ui		:  CONSTANT_OCT_UI;
+//constant_oct_uint	:  CONSTANT_OCT_UINT;
+//constant_float     	:  CONSTANT_FLOAT     ;
+//constant_double		:  CONSTANT_DOUBLE;
+//constant_bin_byte  	:  CONSTANT_BIN_BYTE  ;
+//constant_bin_long 	:  CONSTANT_BIN_LONG ;
+//constant_bin_long64 	:  CONSTANT_BIN_LONG64 ;
+//constant_bin_int	:  CONSTANT_BIN_INT;
+//constant_bin_i		:  CONSTANT_BIN_I;        // DEFINT32
+//constant_bin_ulong 	:  CONSTANT_BIN_ULONG ;
+//constant_bin_ulong64 	:  CONSTANT_BIN_ULONG64 ;
+//constant_bin_ui		:  CONSTANT_BIN_UI;        // DEFINT32
+//constant_bin_uint	:  CONSTANT_BIN_UINT;
+
+numeric_constant:
+   CONSTANT_HEX_BYTE     #constant_hex_byte     
+ | CONSTANT_HEX_LONG     #constant_hex_long     
+ | CONSTANT_HEX_LONG64   #constant_hex_long64   
+ | CONSTANT_HEX_INT      #constant_hex_int      
+ | CONSTANT_HEX_I 	 #constant_hex_i 	     
+ | CONSTANT_HEX_ULONG    #constant_hex_ulong    
+ | CONSTANT_HEX_ULONG64  #constant_hex_ulong64  
+ | CONSTANT_HEX_UI	 #constant_hex_ui	     
+ | CONSTANT_HEX_UINT     #constant_hex_uint     
+ | CONSTANT_BYTE  	 #constant_byte  	     
+ | CONSTANT_LONG 	 #constant_long 	     
+ | CONSTANT_LONG64       #constant_long64       
+ | CONSTANT_INT	     	 #constant_int	     	 
+ | CONSTANT_I	     	 #constant_i	     	 
+ | CONSTANT_ULONG 	 #constant_ulong 	     
+ | CONSTANT_ULONG64      #constant_ulong64      
+ | CONSTANT_UINT	 #constant_uint	     
+ | CONSTANT_OCT_BYTE     #constant_oct_byte     
+ | CONSTANT_OCT_LONG     #constant_oct_long     
+ | CONSTANT_OCT_LONG64   #constant_oct_long64   
+ | CONSTANT_OCT_INT      #constant_oct_int      
+ | CONSTANT_OCT_I	 #constant_oct_i	     
+ | CONSTANT_OCT_ULONG    #constant_oct_ulong    
+ | CONSTANT_OCT_ULONG64  #constant_oct_ulong64  
+ | CONSTANT_OCT_UI	 #constant_oct_ui	     
+ | CONSTANT_OCT_UINT     #constant_oct_uint     
+ | CONSTANT_FLOAT        #constant_float        
+ | CONSTANT_DOUBLE	 #constant_double	     
+ | CONSTANT_BIN_BYTE     #constant_bin_byte     
+ | CONSTANT_BIN_LONG     #constant_bin_long     
+ | CONSTANT_BIN_LONG64   #constant_bin_long64   
+ | CONSTANT_BIN_INT      #constant_bin_int      
+ | CONSTANT_BIN_I	 #constant_bin_i	     
+ | CONSTANT_BIN_ULONG    #constant_bin_ulong    
+ | CONSTANT_BIN_ULONG64  #constant_bin_ulong64  
+ | CONSTANT_BIN_UI	 #constant_bin_ui	     
+ | CONSTANT_BIN_UINT     #constant_bin_uint      
+
+ ;
+
+listOfArrayIndexes:
+    LSQUARE arrayIndex (COMMA arrayIndex)* RSQUARE; // C++  LSQUARE arrayIndex ({++rank <= MAXRANK}? COMMA arrayIndex)* RSQUARE
+
+relaxedListOfArrayIndexes: LBRACE arrayIndex ( COMMA arrayIndex)* RBRACE; // C++  LSBRACE arrayIndex ({++rank <= MAXRANK}? COMMA arrayIndex)* RBRACE
+
+//allElements : ASTERIX ;
+//index : expression;
+//range:   expression COLON (allElements | expression );
+//stepRange: expression COLON (allElements | expression ) COLON expression;
+//arrayIndex: ( allElements  | stepRange | range | index) ; 
+arrayIndex: ( ASTERIX|expression (COLON (ASTERIX|expression) (COLON expression)? )? ) ; 
+
+// the expressions *************************************
+
+variableName : validIdentifier; //not SYSVARNAME
+
+// this is SYNTATICALLY ok as an lvalue, but if one try to assign
+// something to an non-var an error is raised
+// bracedExpression :  LBRACE expression RBRACE ;
+
+operatedVariable : LBRACE variableAccessByValueOrReference assignmentOperator expression RBRACE ;
+// only used in variableAccessByValueOrReference
+// sysvar or expression (first in struct access - therefore the name)
+// a variable MUST be already defined here
+varDesignator
+    :  SYSVARNAME
+    |  operatedVariable
+    |  variableName
+    |  LBRACE expression RBRACE //bracedExpression
+    ;
+
+//relaxed mode slows terribly the parser, for a few rare cases. MUST use a two-pass parsing, where relaxed mode is enabled only of there is a problem
+varSubset:  varDesignator  ( {IsRelaxed()}? relaxedListOfArrayIndexes | listOfArrayIndexes)
+	   ;
+
+implicitArray:
+  UNDEFINED
+| listOfArrayIndexes
+;
+
+tagNumberIndicator: LBRACE expression RBRACE;
+
+tagIdentifier
+    : tagNumberIndicator
+    | SYSVARNAME  
+    | validIdentifier
+    | EXCLAMATION // IDL allows '!' as tag despite the documentation.
+    ;
+
+taggedEntryTarget
+    : taggedEntry
+    | varSubset
+    | varDesignator
+    ;
+
+variableAccessByValueOrReference
+    : pointedVariable
+    | taggedEntry
+    | varSubset
+    | varDesignator
+    ;
+    
+taggedEntry    :
+      varSubset  DOT taggedEntryTarget //reflect struct-in-struct hierarchy.
+    | varDesignator DOT taggedEntryTarget
+    ;
+pointedVariable : ASTERIX variableAccessByValueOrReference ;
+
+string:
+   NULLSTRING
+   | STRING
+   ;
+
+primaryLevelExpression:
+      numeric_constant 	   
+    | string
+    | structureDefinition
+    | implicitArray //always between '[]'
+    | variableAccessByValueOrReference //variable is Named
+    | functionCall
+    ;
+    
+decincExpression:
+          primaryLevelExpression ( INC | DEC )?
+        | (INC |DEC)  primaryLevelExpression
+        ;
+	
+thirdLevelExpression:<assoc=right>
+     decincExpression
+     (
+       POW decincExpression
+     )*
+     ;
+     
+multiplicativeExpression: // '*' | '#' | '##' | '/' | 'mod' // level 4
+      thirdLevelExpression
+      (
+        ( ASTERIX
+	| MATRIX_OP1
+	| MATRIX_OP2
+	| SLASH
+	| MOD_OP
+	) thirdLevelExpression
+      )*
+      ;
+
+signedMultiplicativeExpression:
+      ( PLUS
+      | MINUS
+      |      ) multiplicativeExpression
+      ;
+      
+additiveExpression: // '+' | '-' | '<' | '>'  // level 5
+       ( signedMultiplicativeExpression | negativeExpression )
+         (
+	    ( PLUS
+            | MINUS
+            | LTMARK
+            | GTMARK
+	    ) (  multiplicativeExpression | negativeExpression )
+	 )*
+	 ;
+	    
+negativeExpression:
+    (  NOT_OP 
+    | LOG_NEG ) multiplicativeExpression // true precedence of ~ operator
+    ;
+
+relationalExpression: // 'eq' | 'ne' | 'le' | 'lt' | 'ge' | 'gt' // level 6
+        additiveExpression
+        (
+            ( EQ_OP
+            | NE_OP
+            | LE_OP
+            | LT_OP
+            | GE_OP
+            | GT_OP
+            ) additiveExpression
+        )*
+    ;
+
+bitwiseExpression: // 'and' | 'or' | 'xor' // level 7
+        relationalExpression
+        ( 
+            ( AND_OP 
+            | OR_OP 
+            | XOR_OP 
+            ) relationalExpression
+        )*
+    ;
+    
+logicalExpression : // '&&' | '||'  //level 8
+        left = bitwiseExpression
+        ( 
+           local_operator= ( LOG_AND 
+            | LOG_OR 
+            ) operand = bitwiseExpression
+        )*
+    ;
+
+expression:<assoc=right> logicalExpression (QUESTION expression COLON expression)? ;  //' ?:' // level 9
+
+assignmentStatement
+    : variableAccessByValueOrReference assignmentOperator expression
+    | decincExpression
+    ;
+
+autoPrintStatement: expressionList;
+interactiveStatement
+     : (BEGIN | validIdentifier COLON)*
+        ( assignmentStatement
+	| compoundStatement
+        | ifStatement
+	| switchStatement
+	| caseStatement
+	| forStatement
+	| foreachStatement
+	| repeatStatement
+	| whileStatement
+	| autoPrintStatement
+        ) endUnit
+    ;
+

--- a/src/antlr4/main.cpp
+++ b/src/antlr4/main.cpp
@@ -1,0 +1,98 @@
+bool amIRelaxed=true;
+//int inloop=0;
+
+#include "gdlLexer.h"
+#include "gdlParser.h"
+
+using namespace antlr4;
+using namespace std;
+
+// test program will be faster on a list of files as every previoulsy compiled file contributes to the warmup,
+// see https://github.com/antlr/antlr4/issues/3111 discussion
+// by splitting input files in smaller procedures/functions one would have it even better.
+// this can be done also at the parser level, by presenting all tokens between PRO|FUNCTION and END (provided
+// the lexer isolates the procedure END from the other possible END tokens inside the procedure).
+// see https://groups.google.com/g/antlr-discussion/c/q-8MPVI9lrw for possible ameliorations to this test
+// program using the last version of the cpp runtime.
+
+int main(int argc, char *argv[]){
+    bool showtree=false;
+    bool showtokens=false;
+    bool token_only=false;
+    bool interactive=false;
+    std::vector<string> filenames;
+    for( auto a=1; a< argc; ++a)
+    {
+      if( string( argv[a]) == "--help" || string( argv[a]) == "-h") {
+      cerr << "Usage: cat xxx.pro | demo [-options]" << endl;
+      cerr << "options:" << endl;
+      cerr << "  --help (-h)        display this message" << endl;
+      cerr << "  --tree (-t)    show tree" << endl;
+      cerr << "  --tokens (-o)    show tokens" << endl;
+      cerr << "  --strict (-s)    set strictarray" << endl;
+      cerr << "  --interactive (-i)  will parse as in interactive mode" << endl;
+      return 0;
+      }
+      else if (string(argv[a])=="--tree" || string(argv[a])=="-t" || string(argv[a])=="-T")
+	{
+	  showtree=true;
+	}
+      else if (string(argv[a])=="--tokens" || string(argv[a])=="-o" || string(argv[a])=="-O")
+	{
+	  showtokens=true;
+	} 
+      else if (string(argv[a])=="--token-only" || string(argv[a])=="-x" || string(argv[a])=="-X")
+	{
+	  token_only=true;
+	}
+      else if (string(argv[a])=="--strict" || string(argv[a])=="-s" || string(argv[a])=="-S")
+	{
+	  amIRelaxed=false;
+	}
+      else if (string(argv[a])=="--interactive" || string(argv[a])=="-i" || string(argv[a])=="-I")
+	{
+	  interactive=true;
+	}
+       else filenames.push_back(string(argv[a]));
+   }
+  
+ if (interactive) {
+  ANTLRInputStream input(std::cin); // read stdin
+  gdlLexer lexer(&input);
+
+  CommonTokenStream tokens(&lexer);
+  gdlParser parser(&tokens);
+
+  tree::ParseTree *tree;
+  if (interactive)  tree = parser.interactive();
+  if (showtokens) {
+    for (auto token : tokens.getTokens()) std::cout << token->toString() << std::endl;
+  }
+  if (showtree) std::cout << tree->toStringTree(&parser) << std::endl << std::endl;
+ } else {
+
+for (auto i = 0; i< filenames.size(); ++i) {
+  std::filebuf fb;
+  if (!fb.open (filenames[i],std::ios::in)) continue;
+  std::istream is(&fb);
+  ANTLRInputStream input(is);
+  gdlLexer lexer(&input);
+
+  CommonTokenStream tokens(&lexer);
+  gdlParser parser(&tokens);
+
+  tree::ParseTree *tree;
+  auto start = std::chrono::steady_clock::now();
+  tree = parser.translation_unit();
+
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start);
+  if (showtokens) {
+    for (auto token : tokens.getTokens()) std::cout << token->toString() << std::endl;
+  }
+  if (showtree) std::cout << tree->toStringTree(&parser) << std::endl << std::endl;
+  std::cout  << filenames[i]<<"  "<< duration.count()/1000000. << std::endl;
+
+  }
+ }
+  return 0;
+}

--- a/src/antlr4/test_slowantlr2.pro
+++ b/src/antlr4/test_slowantlr2.pro
@@ -1,0 +1,8 @@
+pro test_slowantlr2
+  a=!DPI
+  b=2
+; veeery slow
+  x=b*(a*(b*(a*(b*(a*(b*(a*(a*(a*b)))))))))
+;  x=a*(b*(a*(b*(a*(a*(a*b))))))
+end
+

--- a/src/dnode.cpp
+++ b/src/dnode.cpp
@@ -124,11 +124,11 @@ DNode::~DNode()
  * @return 
  */
 template<typename T> bool DNode::Text2Number(T& out, int base) {
-  throw GDLException("Text2Number called on unsupported type.");
+  throw GDLException(this->getLine(),4, "Text2Number called on unsupported type.");
 }
 
 template<> bool DNode::Text2Number(DLong& out, int base) {
-  if (base == 16 && text.size() > sizeof ( DLong)*2) throw GDLException("Int hexadecimal constant can only have 8 digits.");
+  if (base == 16 && text.size() > sizeof ( DLong)*2) throw GDLException(this->getLine(),4, "Int hexadecimal constant can only have 8 digits.");
   bool noOverflow = true;
   DLong number = 0;
   if (base != 10) { //hexa or oct decoding, can give a negative result.
@@ -307,7 +307,7 @@ template<> bool DNode::Text2Number(DUInt& out, int base) {
 }
 // ints are signed. Only the abs() value is passed to this function in decimal, but not in Hexa.
 template<> bool DNode::Text2Number(DInt& out, int base) {
-  if (base == 16 && text.size() > sizeof ( DInt)*2) throw GDLException("Int hexadecimal constant can only have 4 digits.");
+  if (base == 16 && text.size() > sizeof ( DInt)*2) throw GDLException(this->getLine(),4, "Int hexadecimal constant can only have 4 digits.");
 
   bool noOverflow = true;
 
@@ -354,7 +354,7 @@ void DNode::Text2Byte(int base)
 {
   // cout << "byte" << endl;
   DByte val;
-  if (Text2Number( val, base)==false) throw GDLException( "Byte constant must be less than 256.");
+  if (Text2Number( val, base)==false) throw GDLException(this->getLine(), 4, "Byte constant must be less than 256.");
   cData=new DByteGDL(val);
 }
 
@@ -389,7 +389,7 @@ void DNode::Text2Int(int base, bool promote)
   else
     {
     DInt val;
-      if (Text2Number( val, base)==false) throw GDLException( "Integer constant must be less than 32768.");
+      if (Text2Number( val, base)==false) throw GDLException(this->getLine(),4,  "Integer constant must be less than 32768.");
     cData = new DIntGDL(val);
   }
 }
@@ -423,7 +423,7 @@ void DNode::Text2UInt(int base, bool promote)
   else
     {
       DUInt val;
-      if (Text2Number( val, base)==false) throw GDLException( "Unsigned integer constant must be less than 65536.");
+      if (Text2Number( val, base)==false) throw GDLException(this->getLine(),4,  "Unsigned integer constant must be less than 65536.");
       cData=new DUIntGDL(val);
     }
 }
@@ -447,11 +447,11 @@ void DNode::Text2Long(int base, bool promote) {
 	
   if (base == 16) {
       if( text.size() > sizeof( DLong)*2) 
-	throw GDLException( "Long hexadecimal constant can only have "+
+	throw GDLException(this->getLine(),4,  "Long hexadecimal constant can only have "+
 			    i2s(sizeof( DLong)*2)+" digits.");
 
       DLong val;
-      if (Text2Number( val, base)==false) throw GDLException( "Long integer constant must be less than 2147483648.");
+      if (Text2Number( val, base)==false) throw GDLException(this->getLine(),4,  "Long integer constant must be less than 2147483648.");
       cData=new DLongGDL(val);
       return;
     }
@@ -460,7 +460,7 @@ void DNode::Text2Long(int base, bool promote) {
   bool noOverFlow = Text2Number( val, base);
 
   if( !noOverFlow || val > std::numeric_limits< DLong>::max())
-    throw GDLException( "Long integer constant must be less than 2147483648.");
+    throw GDLException(this->getLine(),4,  "Long integer constant must be less than 2147483648.");
 
   cData=new DLongGDL(val);
 }
@@ -489,7 +489,7 @@ void DNode::Text2ULong(int base, bool promote)
   if( base == 16)
     {
       if( text.size() > sizeof(DULong)*2)
-	throw GDLException( "Unsigned long hexadecimal constant can only have "+
+	throw GDLException(this->getLine(),4,  "Unsigned long hexadecimal constant can only have "+
 			    i2s(sizeof( DLong)*2)+" digits.");
 
       DULong val;
@@ -502,7 +502,7 @@ void DNode::Text2ULong(int base, bool promote)
   bool noOverFlow = Text2Number( val, base);
 
   if( !noOverFlow || val > std::numeric_limits< DULong>::max())
-    throw GDLException( "Unsigned long integer constant must be less than 4294967296.");
+    throw GDLException(this->getLine(),4,  "Unsigned long integer constant must be less than 4294967296.");
 
   cData=new DULongGDL(val);
 }

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -303,12 +303,7 @@ int main(int argc, char *argv[])
       cerr << "  --help (-h)        display this message" << endl;
       cerr << "  --version (-V, -v) show version information" << endl;
       cerr << "  --fakerelease X.y  pretend that !VERSION.RELEASE is X.y" << endl;
-      cerr << "  --fussy            implies that procedures adhere with modern IDL, where \"()\" are for functions and \"[]\" are for arrays." << endl;
-      cerr << "                     This speeds up (sometimes terribly) compilation but choke on every use of \"()\" with arrays." << endl;
-      cerr << "                     Conversion of procedures to modern IDL can be done with D. Landsman's idlv4_to_v5 procedure." << endl;
-      cerr << "                     Use enviromnment variable \"GDL_IS_FUSSY\" to set up permanently this feature." << endl;
-      cerr << "  --sloppy           Sets the traditional (default) compiling option where \"()\"  can be used both with functions and arrays." << endl;
-      cerr << "                     Needed to counteract temporarily the effect of the enviromnment variable \"GDL_IS_FUSSY\"." << endl;
+      cerr << "  --trace-old-syntax print lines that do not adhere with modern IDL, where \"()\" are for functions and \"[]\" are for arrays." << endl;
       cerr << "  --MAC              Graphic device will be called 'MAC' on MacOSX. (default: 'X')" << endl;
       cerr << "  [--no-use-wx | -X] Tells GDL not to use WxWidgets graphics and resort to X11 (if available)." << endl;
       cerr << "                     Also enabled by setting the environment variable GDL_DISABLE_WX_PLOTS to a non-null value." << endl;
@@ -403,14 +398,8 @@ int main(int argc, char *argv[])
       {
           gdlde = true;
       }
-      else if (string(argv[a]) == "--fussy")
+      else if (string(argv[a]) == "--trace-old-syntax")
       {
-          strict_syntax = true;
-          syntaxOptionSet = true;
-      }
-      else if (string(argv[a]) == "--sloppy")
-      {
-          strict_syntax = false;
           syntaxOptionSet = true;
       }
       else if (string(argv[a]) == "--no-dSFMT")
@@ -550,12 +539,10 @@ int main(int argc, char *argv[])
   (*static_cast<DByteGDL*> (gdlconfig->GetTag(useWXTAG, 0)))[0]=useWxWidgetsForGraphics;
   
   if (!pretendRelease.empty()) SysVar::SetFakeRelease(pretendRelease);
-  //fussyness setup and change if switch at start
-  if (syntaxOptionSet) { //take it no matters any env. var.
-    if (strict_syntax == true) SetTraceSyntaxErrors(true);
-  } else {
-    if (GetEnvString("GDL_IS_FUSSY").size()> 0) SetTraceSyntaxErrors(true);
-  }
+  //trace old syntax locations in procedures.
+  if (syntaxOptionSet) { 
+    SetTraceSyntaxErrors(true);
+  } else SetTraceSyntaxErrors(false);
   
   
   string startup=GetEnvPathString("GDL_STARTUP");

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -552,9 +552,9 @@ int main(int argc, char *argv[])
   if (!pretendRelease.empty()) SysVar::SetFakeRelease(pretendRelease);
   //fussyness setup and change if switch at start
   if (syntaxOptionSet) { //take it no matters any env. var.
-    if (strict_syntax == true) SetStrict(true);
+    if (strict_syntax == true) SetTraceSyntaxErrors(true);
   } else {
-    if (GetEnvString("GDL_IS_FUSSY").size()> 0) SetStrict(true);
+    if (GetEnvString("GDL_IS_FUSSY").size()> 0) SetTraceSyntaxErrors(true);
   }
   
   

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -69,9 +69,6 @@ header {
 #include <antlr/TokenStreamIOException.hpp>
 #include <antlr/CharInputBuffer.hpp>
 
-// GD: set to 1 to traceout what the Parser does.
-#define debugParser 0
-//#include "dinterpreter.hpp"
 
 // definition in dinterpreter.cpp
 void MemorizeCompileOptForMAINIfNeeded( unsigned int cOpt);
@@ -308,7 +305,6 @@ translation_unit
 { 
     subReached=false;
     compileOpt=NONE; // reset compileOpt    
-    if (debugParser) std::cout << " translation_unit" << std::endl;
 }
     :   ( options {greedy=true;}: end_unit
         | forward_function end_unit
@@ -370,7 +366,6 @@ translation_unit
 // to give a more precise error message
 // interactive compilation is not allowed
 interactive_compile!
-{    if (debugParser) std::cout << " interactive_compile! " << std::endl; }
     : (FUNCTION | PRO)
         IDENTIFIER 
         {
@@ -384,8 +379,6 @@ interactive_compile!
 
 // interactive usage
 interactive
-{    if (debugParser) std::cout << " interactive " << std::endl; }
-
     :   ( end_unit (end_mark)? 
         | interactive_statement
         | interactive_compile
@@ -431,7 +424,6 @@ interactive
 // compound statements in the original don't care about the specific end_mark
 // in interactive mode end need not to be there and labels are ignored
 interactive_statement
-{    if (debugParser) std::cout << " interactive_statement " << std::endl; }
   :  (BEGIN! | IDENTIFIER! COLON!)* 
     statement end_unit
   ;
@@ -443,7 +435,6 @@ interactive_statement
 switch_statement
 {
     int numBranch=0;
-    if (debugParser) std::cout  << " switch_statement " << std::endl; 
 }
     : SWITCH^ expr OF! (end_unit)? 
         (switch_body
@@ -458,21 +449,19 @@ switch_statement
     ;
 
 switch_body
-{    if (debugParser) std::cout  << " switch_body " << std::endl; }
     : expr COLON! 
         ( statement
         | BEGIN! statement_list endswitch_mark)? end_unit
-        { #switch_body = #([BLOCK, "block"], #switch_body); if (debugParser) std::cout<<std::endl;}
+        { #switch_body = #([BLOCK, "block"], #switch_body);}
     | ELSE! COLON! 
         ( statement
         | BEGIN! statement_list endswitchelse_mark)? end_unit
-        { #switch_body = #([ELSEBLK, "elseblk"], #switch_body); if (debugParser) std::cout<<std::endl;}
+        { #switch_body = #([ELSEBLK, "elseblk"], #switch_body); }
     ;    
 
 case_statement
 {
     int numBranch=0;
-    if (debugParser) std::cout  << " case_statement " << std::endl; 
 }
     : CASE^ expr OF! (end_unit)? 
         (case_body
@@ -482,55 +471,49 @@ case_statement
         )*
         endcase_mark
         {
-        #CASE->SetNumBranch(numBranch); if (debugParser) std::cout<<std::endl;
+        #CASE->SetNumBranch(numBranch); 
         }
     ;
 
 case_body
-{    if (debugParser) std::cout  << " case_body " << std::endl; }
     : expr COLON! 
         (statement
         | BEGIN! statement_list endcase_mark)? end_unit
-        { #case_body = #([BLOCK, "block"], #case_body); if (debugParser) std::cout<<std::endl;}
+        { #case_body = #([BLOCK, "block"], #case_body); }
     | ELSE! COLON! 
         (statement
         | BEGIN! statement_list endcaseelse_mark)? end_unit
-        { #case_body = #([ELSEBLK, "elseblk"], #case_body); if (debugParser) std::cout<<std::endl;}
+        { #case_body = #([ELSEBLK, "elseblk"], #case_body); }
     ;
 
 // whereever one END_U is there might be more
 // end_unit is syntactical necessary, but not for the AST
 end_unit!
-{    if (debugParser) std::cout  << " end_unit!" << std::endl; }
     : (options {greedy=true;}: END_U)+
     ;
 
 
 forward_function
-{    if (debugParser) std::cout  << " forward_function -> " /* << std::endl */; }
   : FORWARD^ identifier_list
   ;
 
 
 parameter_declaration
-{    if (debugParser) std::cout  << " parameter_declaration -> " /* << std::endl */; }
     : (IDENTIFIER | keyword_declaration) 
         (COMMA! (IDENTIFIER | keyword_declaration))*
         { #parameter_declaration = 
-            #([PARADECL,"paradecl"], #parameter_declaration); if (debugParser) std::cout<<std::endl;}
+            #([PARADECL,"paradecl"], #parameter_declaration); }
     ;
     
     
 keyword_declaration
-{    if (debugParser) std::cout  << " keyword_declaration -> " /* << std::endl */; }
     : IDENTIFIER EQUAL! IDENTIFIER
         { #keyword_declaration =
-            #([KEYDECL,"keydecl"], #keyword_declaration); if (debugParser) std::cout<<std::endl;}
+            #([KEYDECL,"keydecl"], #keyword_declaration); }
     ;
 
 protected
 object_name! returns [std::string name] // !//
-{    if (debugParser) std::cout  << " object_name! -> " /* << std::endl */; }
       : i1:IDENTIFIER m:METHOD i2:IDENTIFIER
         { 
         // here we translate IDL_OBECT to GDL_OBJECT for source code compatibility
@@ -542,14 +525,13 @@ object_name! returns [std::string name] // !//
         }
 
             #object_name = #(NULL, i2, m, i1); // NULL -> no root
-            name= std::string( i1->getText()+"__"+i2->getText()); if (debugParser) std::cout<<std::endl;
+            name= std::string( i1->getText()+"__"+i2->getText()); 
         }
       ;    
 
 procedure_def
 {
     std::string name;
-    if (debugParser) std::cout  << " procedure_def -> " /* << std::endl */; 
 }
     : p:PRO^
         ( n:IDENTIFIER { name=n->getText(); }
@@ -559,14 +541,13 @@ procedure_def
         (statement_list)? END!
         { 
             if( subName == name && searchForPro == true) subReached=true;
-            #p->SetCompileOpt( compileOpt); if (debugParser) std::cout<<std::endl;
+            #p->SetCompileOpt( compileOpt); 
         }
   ;
 
 function_def
 {
     std::string name;
-    if (debugParser) std::cout  << " function_def -> " /* << std::endl */; 
 }
     : f:FUNCTION^
         ( n:IDENTIFIER { name=n->getText(); }
@@ -576,13 +557,12 @@ function_def
         (statement_list)? END!
         { 
             if( subName == name && searchForPro == false) subReached=true;
-            #f->SetCompileOpt( compileOpt); if (debugParser) std::cout<<std::endl;
+            #f->SetCompileOpt( compileOpt); 
         }
     ;
 
 // change defaultbehaviour of the compiling
 compile_opt!
-{    if (debugParser) std::cout  << " compile_opt! -> " /* << std::endl */; }
     : COMPILE_OPT i:IDENTIFIER 
         {
             AddCompileOpt( i->getText());
@@ -595,23 +575,20 @@ compile_opt!
     ;
 
 common_block
-{    if (debugParser) std::cout  << " common_block -> " /* << std::endl */; }
     : COMMON! IDENTIFIER 
         (
-            { #common_block = #([COMMONDECL,"commondecl"], #common_block); if (debugParser) std::cout<<std::endl;}
+            { #common_block = #([COMMONDECL,"commondecl"], #common_block); }
         | COMMA! identifier_list
-            { #common_block = #([COMMONDEF,"commondef"], #common_block); if (debugParser) std::cout<<std::endl;}
+            { #common_block = #([COMMONDEF,"commondef"], #common_block); }
         )
     ;
 
 identifier_list
-{    if (debugParser) std::cout  << " identifier_list -> " /* << std::endl */; }
     : IDENTIFIER (COMMA! IDENTIFIER)*
     ;
 
 // no ASTs for end marks
 end_mark!
-{    if (debugParser) std::cout  << " end_mark! -> " /* << std::endl */; }
     : END
     | ENDIF
     | ENDELSE
@@ -624,82 +601,67 @@ end_mark!
     ;
 
 endforeach_mark!
-{    if (debugParser) std::cout  << " endforeach_mark! " << std::endl; }
     : ENDFOREACH | END
     ;
 
 endfor_mark!
-{    if (debugParser) std::cout  << " endfor_mark! " << std::endl; }
     : ENDFOR | END
     ;
 
 endrep_mark!
-{    if (debugParser) std::cout  << " endrep_mark! " << std::endl; }
     : ENDREP | END
     ;
 
 endwhile_mark!
-{    if (debugParser) std::cout  << " endwhile_mark! " << std::endl; }
     : ENDWHILE | END
     ;
 
 endif_mark!
-{    if (debugParser) std::cout  << " endif_mark! " << std::endl; }
     : ENDIF    | END
     ;
 
 endelse_mark!
-{    if (debugParser) std::cout  << " endelse_mark! " << std::endl; }
     : ENDELSE | END
     ;
 
 endcase_mark!
-{    if (debugParser) std::cout  << " endcase_mark! " << std::endl; }
     : ENDCASE | END
     ;
 
 endcaseelse_mark!
-{    if (debugParser) std::cout  << " endcaseelse_mark! " << std::endl; }
     : endcase_mark | ENDELSE
     ;
 
 endswitch_mark!
-{    if (debugParser) std::cout  << " endswitch_mark! " << std::endl; }
     : ENDSWITCH | END
     ;
 
 endswitchelse_mark!
-{    if (debugParser) std::cout  << " endswitchelse_mark! " << std::endl; }
     : endswitch_mark | ENDELSE
     ;
 
 statement_list
-{    if (debugParser) std::cout  << " statement_list -> " /* << std::endl */; }
     : (end_unit 
         | compound_statement end_unit 
         | label_statement end_unit)+
     ;
 
 label
-{    if (debugParser) std::cout  << " label -> " /* << std::endl */; }
       : IDENTIFIER^ COLON
       ;
 
 label_statement
-{    if (debugParser) std::cout  << " label_statement -> " /* << std::endl */; }
     : (label)+ (compound_statement)?
     ;
 
 // compound statements don't care about the specific end_mark
 compound_statement
-{    if (debugParser) std::cout  << " compound_statement -> " /* << std::endl */; }
     : statement
     | BEGIN! statement_list end_mark
-        { #compound_statement = #([BLOCK, "block"], #compound_statement); if (debugParser) std::cout<<std::endl;}
+        { #compound_statement = #([BLOCK, "block"], #compound_statement); }
     ;
 
 baseclass_method
-{    if (debugParser) std::cout  << " baseclass_method -> " /* << std::endl */; }
     : s:IDENTIFIER METHOD!
         // here we translate IDL_OBECT to GDL_OBJECT for source code compatibility
         {
@@ -714,22 +676,20 @@ statement
 // assignment and member_procedure_call starting with deref_expr
 {
     bool parent=false;
-    if (debugParser) std::cout << " statement -> " /* << std::endl */; 
 }
     : (assign_expr)=> assign_expr (DEC^ | INC^)?
     | (deref_dot_expr_keeplast IDENTIFIER COMMA)=>
         d1:deref_dot_expr_keeplast formal_procedure_call
                 { 
                         #statement = #([MPCALL, "mpcall"], #statement);
-                        #statement->SetLine( #d1->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
-
+                        #statement->SetLine( #d1->getLine());
                 }
     | (deref_dot_expr_keeplast baseclass_method)=>
         d2:deref_dot_expr_keeplast baseclass_method formal_procedure_call
                 { 
                         #statement = #([MPCALL_PARENT, "mpcall::"], 
                                         #statement);
-                        #statement->SetLine( #d2->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
+                        #statement->SetLine( #d2->getLine());
                 }
     | ( deref_expr
                 ( EQUAL
@@ -759,7 +719,7 @@ statement
       )=>
         deref_expr
             (EQUAL! expr             
-                { #statement = #([ASSIGN,":="], #statement); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;}
+                { #statement = #([ASSIGN,":="], #statement);}
             |   ( AND_OP_EQ^ 
                 | ASTERIX_EQ^ 
                 | EQ_OP_EQ^ 
@@ -789,13 +749,12 @@ statement
                                         #statement); 
                     else
                         #statement = #([MPCALL, "mpcall"], #statement);
-		if (debugParser) std::cout<<"statement : \""<<LT(0)->getText()<<"\""<<std::endl;
                 }
             )
     | d3:deref_dot_expr_keeplast formal_procedure_call
                 { 
                     #statement = #([MPCALL, "mpcall"], #statement);
-                    #statement->SetLine( #d3->getLine()); if (debugParser) std::cout<<" statement : \""<<LT(0)->getText()<<"\""<<std::endl;
+                    #statement->SetLine( #d3->getLine());
                 }
     | (DEC^ | INC^) expr
     | procedure_call // next two handled by procedure_call also
@@ -816,7 +775,6 @@ statement
 
 
 repeat_statement
-{    if (debugParser) std::cout << " repeat_statement " << std::endl; }
     : REPEAT^ 
         repeat_block
         UNTIL! expr
@@ -824,16 +782,14 @@ repeat_statement
 
 
 repeat_block
-{    if (debugParser) std::cout << " repeat_block " << std::endl; }
     : st:statement
-        { #repeat_block = #([BLOCK, "block"], #st); if (debugParser) std::cout<<std::endl;}
+        { #repeat_block = #([BLOCK, "block"], #st); }
     | BEGIN! stl:statement_list endrep_mark
-        { #repeat_block = #([BLOCK, "block"], #stl); if (debugParser) std::cout<<std::endl;}
+        { #repeat_block = #([BLOCK, "block"], #stl); }
     ;
 
 
 while_statement
-{    if (debugParser) std::cout << " while_statement " << std::endl; }
     : WHILE^
         expr DO! 
         while_block
@@ -841,15 +797,13 @@ while_statement
 
 
 while_block
-{    if (debugParser) std::cout << " while_block " << std::endl; }
     : statement 
     | BEGIN! statement_list endwhile_mark
-        { #while_block = #([BLOCK, "block"], #while_block); if (debugParser) std::cout<<std::endl;}
+        { #while_block = #([BLOCK, "block"], #while_block); }
     ;
 
 
 for_statement
-{    if (debugParser) std::cout << " for_statement " << std::endl; }
     : FOR^ IDENTIFIER EQUAL! expr COMMA! expr 
         (COMMA! expr)? DO!
         for_block
@@ -857,35 +811,30 @@ for_statement
 
 // GD reverted (below) to historical version as the following, while permitting #52 creates #1599 and #1608
 //for_block
-//{    if (debugParser) std::cout << " for_block " << std::endl; }
 //    :
-//      (BEGIN statement)=> (BEGIN! stb:statement) { #for_block = #([BLOCK, "block"], #stb); if (debugParser) std::cout<<std::endl;}
-//    |  BEGIN! stl:statement_list endfor_mark { #for_block = #([BLOCK, "block"], #stl); if (debugParser) std::cout<<std::endl;}
-//    |  st:statement { #for_block = #([BLOCK, "block"], #st); if (debugParser) std::cout<<std::endl;}
+//      (BEGIN statement)=> (BEGIN! stb:statement) { #for_block = #([BLOCK, "block"], #stb); }
+//    |  BEGIN! stl:statement_list endfor_mark { #for_block = #([BLOCK, "block"], #stl); }
+//    |  st:statement { #for_block = #([BLOCK, "block"], #st); }
 //    ;    
 
 for_block
-{    if (debugParser) std::cout << " for_block " << std::endl; }
-    :  st:statement { #for_block = #([BLOCK, "block"], #st); if (debugParser) std::cout<<std::endl;}
-    |  BEGIN! stl:statement_list endfor_mark { #for_block = #([BLOCK, "block"], #stl); if (debugParser) std::cout<<std::endl;}
+    :  st:statement { #for_block = #([BLOCK, "block"], #st); }
+    |  BEGIN! stl:statement_list endfor_mark { #for_block = #([BLOCK, "block"], #stl); }
     ;    
 
 foreach_statement
-{    if (debugParser) std::cout << " foreach_statement " << std::endl; }
     : FOREACH^ IDENTIFIER COMMA! expr (COMMA! IDENTIFIER)? DO!
         foreach_block
     ;
 
 foreach_block
-{    if (debugParser) std::cout << " foreach_block " << std::endl; }
     : st:statement
-        { #foreach_block = #([BLOCK, "block"], #st); if (debugParser) std::cout<<std::endl;}
+        { #foreach_block = #([BLOCK, "block"], #st); }
     | BEGIN! stl:statement_list endforeach_mark
-        { #foreach_block = #([BLOCK, "block"], #stl); if (debugParser) std::cout<<std::endl;}
+        { #foreach_block = #([BLOCK, "block"], #stl); }
     ;    
 
 jump_statement
-{    if (debugParser) std::cout << " jump_statement " << std::endl; }
     : GOTO^ COMMA! IDENTIFIER
 // now handled as a procedure_call because RETURN is no reserved word
 //    | RETURN^ (COMMA! expr)?
@@ -894,7 +843,6 @@ jump_statement
 
 // the classical greedy case (match ELSE as soon as possible)
 if_statement
-{    if (debugParser) std::cout << " if_statement " << std::endl; }
     : IF^ expr THEN!
         if_block
         ( options {greedy=true;}: ELSE! 
@@ -904,28 +852,24 @@ if_statement
 
 
 if_block
-{    if (debugParser) std::cout << " if_block " << std::endl; }
     : statement 
     | BEGIN! statement_list endif_mark
-        { #if_block = #([BLOCK, "block"], #if_block); if (debugParser) std::cout<<std::endl;}
+        { #if_block = #([BLOCK, "block"], #if_block); }
     ;
 
 
 else_block
-{    if (debugParser) std::cout << " else_block " << std::endl; }
     : statement
     | BEGIN! statement_list endelse_mark
-        { #else_block = #([BLOCK, "block"], #else_block); if (debugParser) std::cout<<std::endl;}
+        { #else_block = #([BLOCK, "block"], #else_block); }
     ;
 
 formal_procedure_call
-{    if (debugParser) std::cout << " formal_procedure_call -> " /* << std::endl */; }
     : IDENTIFIER (COMMA! parameter_def_list)?
     ;    
 
 // must handle RETURN, BREAK, CONTINUE also
 procedure_call!//
-{    if (debugParser) std::cout << " procedure_call! -> " /* << std::endl */; }
 // was:
 // formal_procedure_call
     : id:IDENTIFIER 
@@ -934,21 +878,21 @@ procedure_call!//
             { 
                 #id->setType(RETURN); // text is already "return"
                 #procedure_call = #( #id, #e); // make root
-             if (debugParser) std::cout<<" procedure_call : \""<<LT(0)->getText()<<"\""<<std::endl;}
+            }
         | {id->getText() == "BREAK"}?
             {
                 #id->setType(BREAK); // text is already "break"
-                #procedure_call = #id; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #procedure_call = #id;
             }
         | {id->getText() == "CONTINUE"}?
             {
                 #id->setType(CONTINUE); // text is already "continue"
-                #procedure_call = #id; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #procedure_call = #id;
             }
         | (COMMA! pa:parameter_def_list)? 
         { 
             #procedure_call = #([PCALL, "pcall"], #id, #pa);
-            #procedure_call->SetLine(id->getLine()); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+            #procedure_call->SetLine(id->getLine());
         }
         )
     ;    
@@ -957,15 +901,13 @@ procedure_call!//
 // but as arrays got priority, only real function calls need
 // to be handled here
 formal_function_call
-{    if (debugParser) std::cout << " formal_function_call -> " /* << std::endl */; }
     : IDENTIFIER LBRACE! (parameter_def_list)? RBRACE!
     ;
 
 parameter_def
-{    if (debugParser) std::cout << " parameter_def -> " /* << std::endl */; }
 //    : IDENTIFIER EQUAL! expr
     : identifier EQUAL! expr
-        { #parameter_def = #([KEYDEF,"!=!"], #parameter_def); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+        { #parameter_def = #([KEYDEF,"!=!"], #parameter_def);}
     | expr
 //    | SLASH! id:IDENTIFIER
     | SLASH! id:identifier
@@ -973,12 +915,11 @@ parameter_def
             RefDNode c=static_cast<RefDNode>( #[CONSTANT,"1"]);
             c->Text2Int(10);
             c->SetLine( #id->getLine());
-            #parameter_def = #([KEYDEF,"!=!"], id, c); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+            #parameter_def = #([KEYDEF,"!=!"], id, c);
         }
     ;
 
 parameter_def_list
-{    if (debugParser) std::cout << " parameter_def_list -> " /* << std::endl */; }
     : parameter_def ( COMMA! parameter_def)*
     ;
 
@@ -987,7 +928,6 @@ array_def
 {
 bool constant = true;
 int flexible_array_def_count=1;
-    if (debugParser) std::cout << " array_def -> " /* << std::endl */; 
 }
     : LSQUARE! e:expr {if( !ConstantExprNode( #e->getType())) constant = false;}
       (
@@ -996,18 +936,17 @@ int flexible_array_def_count=1;
               if( constant)
               #array_def = #([ARRAYDEF_CONST, "array_def_const"], #array_def);
               else
-              #array_def = #([ARRAYDEF, "array_def"], #array_def); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+              #array_def = #([ARRAYDEF, "array_def"], #array_def);
             }
         | (COLON! eee:expr {flexible_array_def_count++;})+ RSQUARE!
           {
             if (flexible_array_def_count>3 || flexible_array_def_count<2) throw GDLException( "Illegal array creation syntax.");
-            #array_def = #([ARRAYDEF_GENERALIZED_INDGEN, "array_def_generalized_indgen"], #array_def); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+            #array_def = #([ARRAYDEF_GENERALIZED_INDGEN, "array_def_generalized_indgen"], #array_def);
           } 
       )
     ;
 
 struct_identifier
-{    if (debugParser) std::cout << " struct_identifier -> " /* << std::endl */; }
     :   ( IDENTIFIER 
         | s:SYSVARNAME  { #s->setType( IDENTIFIER);}  
         | e:EXCLAMATION { #e->setType( IDENTIFIER);}  
@@ -1019,7 +958,6 @@ struct_identifier
     ;
 
 struct_name
-{    if (debugParser) std::cout << " struct_name -> " /* << std::endl */; }
     :   s:struct_identifier
         // here we translate IDL_OBECT to GDL_OBJECT for source code compatibility
         {
@@ -1031,47 +969,40 @@ struct_name
     ;
 
 struct_def
-{    if (debugParser) std::cout << " struct_def -> " /* << std::endl */; }
     : LCURLY! 
         (struct_name (COMMA! named_tag_def_list)? RCURLY!
             { #struct_def = 
-                #([NSTRUC_REF, "nstruct_ref"], #struct_def); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+                #([NSTRUC_REF, "nstruct_ref"], #struct_def);}
         | tag_def_list RCURLY!
             { #struct_def = 
-                #([STRUC, "struct"], #struct_def); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+                #([STRUC, "struct"], #struct_def);}
         )
     ;
 
 tag_def
-{    if (debugParser) std::cout << " tag_def -> " /* << std::endl */; }
     : struct_identifier COLON! expr    
     ;    
 
 tag_def_list
-{    if (debugParser) std::cout << " tag_def_list -> " /* << std::endl */; }
     : tag_def (options {greedy=true;} : COMMA! tag_def)*
     ;    
 
 ntag_def
-{    if (debugParser) std::cout << " ntag_def -> " /* << std::endl */; }
     : tag_def
     | expr // for named structs, just the definition is ok
     ;    
 
 ntag_defs
-{    if (debugParser) std::cout << " ntag_defs -> " /* << std::endl */; }
     : ntag_def (options {greedy=true;} : COMMA! ntag_def)*
     ;    
 
 named_tag_def_entry
-{    if (debugParser) std::cout << " named_tag_def_entry -> " /* << std::endl */; }
     :   ( (INHERITS) => INHERITS struct_name
         | ntag_def
         )
     ;
 
 named_tag_def_list
-{    if (debugParser) std::cout << " named_tag_def_list -> " /* << std::endl */; }
     : named_tag_def_entry ( COMMA! named_tag_def_entry)*
     ;    
 
@@ -1357,20 +1288,17 @@ numeric_constant
 arrayindex_list
 {        
     int rank = 1;
-    if (debugParser) std::cout << " arrayindex_list -> " /* << std::endl */; 
 }
     : LSQUARE! arrayindex ({++rank <= MAXRANK}? COMMA! arrayindex)* RSQUARE!
     | { IsRelaxed()}? LBRACE! arrayindex ({++rank <= MAXRANK}? COMMA! arrayindex)* RBRACE!
     ;    
 
 all_elements!
-{    if (debugParser) std::cout << " all_elements! -> " /* << std::endl */; }
-    : ASTERIX { #all_elements = #([ALL,"*"]); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+    : ASTERIX { #all_elements = #([ALL,"*"]);}
     ;
 
 // used only from arrayindex_list
 arrayindex
-{    if (debugParser) std::cout << " arrayindex -> " /* << std::endl */; }
   : ((ASTERIX (COMMA|{ IsRelaxed()}? RBRACE|RSQUARE))=> all_elements
     | expr
          (COLON! 
@@ -1389,29 +1317,27 @@ arrayindex
               )?
          )?
     )
-    { #arrayindex = #([ARRAYIX,"arrayix"], #arrayindex); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+    { #arrayindex = #([ARRAYIX,"arrayix"], #arrayindex);}
     ;
 
 // the expressions *************************************
 
 // system variable name
 sysvar
-{    if (debugParser) std::cout << " sysvar -> " /* << std::endl */; }
   : SYSVARNAME
-    { #sysvar = #([SYSVAR,"SYSVAR"],sysvar); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+    { #sysvar = #([SYSVAR,"SYSVAR"],sysvar);}
       ;
 
 // variable name
 var!
-{    if (debugParser) std::cout << " var: " /* << std::endl */; }
     :   ( id:IDENTIFIER
             {
-                #var = #([VAR,"VAR"],id); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #var = #([VAR,"VAR"],id);
             }
         | ih:INHERITS 
             { 
                 #ih->setType( IDENTIFIER);
-                #var = #([VAR,"VAR"],ih); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #var = #([VAR,"VAR"],ih);
             }  
         // fake IDENTIFIER (variable name can be "INHERITS")
         )
@@ -1422,14 +1348,13 @@ var!
 brace_expr
     :  LBRACE! expr RBRACE!       
         { #brace_expr = 
-            #([EXPR,"expr"], #brace_expr); if (debugParser) std::cout<<"brace_expr: \""<<LT(0)->getText()<<"\""<<std::endl;
+            #([EXPR,"expr"], #brace_expr);
                 }
     ;
 
 // only used in deref_expr
 // sysvar or expr (first in struct access - therefore the name)
 array_expr_1st_sub
-{    if (debugParser) std::cout << " array_expr_1st_sub -> " /* << std::endl */; }
     // a variable MUST be already defined here
     :  var 
     |  sysvar 
@@ -1437,37 +1362,33 @@ array_expr_1st_sub
     ;
 
 array_expr_1st!
-{    if (debugParser) std::cout << " array_expr_1st! -> " /* << std::endl */; }
 // a variable MUST be already defined here
     : e:array_expr_1st_sub
         ( al:arrayindex_list
             { #array_expr_1st = 
-                #([ARRAYEXPR,"arrayexpr"], #e, #al); if (debugParser) std::cout<<" array_expr_1st: \""<<LT(0)->getText()<<"\""<<std::endl;}
+                #([ARRAYEXPR,"arrayexpr"], #e, #al);}
         | // empty
-            { #array_expr_1st = #e; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+            { #array_expr_1st = #e;}
         )
     ;    
 
 array_expr_nth_sub
-{    if (debugParser) std::cout << " array_expr_nth_sub -> " /* << std::endl */; }
     : IDENTIFIER
     | brace_expr
     ;
 
 // expr
 array_expr_nth!
-{    if (debugParser) std::cout << " array_expr_nth! -> " /* << std::endl */; }
     : e:array_expr_nth_sub
         ( al:arrayindex_list
             { #array_expr_nth = 
-                #([ARRAYEXPR,"arrayexpr"], #e, #al); if (debugParser) std::cout<<"array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;}
+                #([ARRAYEXPR,"arrayexpr"], #e, #al);}
         | // empty
-            { #array_expr_nth = #e; if (debugParser) std::cout<<"array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;}
+            { #array_expr_nth = #e;}
         )
     ;    
 
 tag_array_expr_nth_sub
-{    if (debugParser) std::cout << " tag_array_expr_nth_sub -> " /* << std::endl */; }
     : IDENTIFIER
     | s:SYSVARNAME  
         { #s->setType( IDENTIFIER); /* #s->setText( "!" + #s->getText()); */}  
@@ -1476,13 +1397,12 @@ tag_array_expr_nth_sub
     ;
 
 tag_array_expr_nth!
-{    if (debugParser) std::cout << " tag_array_expr_nth! -> " /* << std::endl */; }
     : e:tag_array_expr_nth_sub
         ( al:arrayindex_list
             { #tag_array_expr_nth = 
-                #([ARRAYEXPR,"arrayexpr"], #e, #al); if (debugParser) std::cout<<"tag_array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;}
+                #([ARRAYEXPR,"arrayexpr"], #e, #al);}
         | // empty
-            { #tag_array_expr_nth = #e; if (debugParser) std::cout<<"tag_array_expr_nth: \""<<LT(0)->getText()<<"\""<<std::endl;}
+            { #tag_array_expr_nth = #e;}
         )
     ;    
 
@@ -1492,7 +1412,6 @@ tag_access_keeplast returns [int nDot]
     int t;
     bool parent = false;
     nDot=1;
-    if (debugParser) std::cout << " tag_access_keeplast -> " /* << std::endl */; 
 }
     : DOT!
         (
@@ -1509,7 +1428,6 @@ deref_dot_expr_keeplast
 {
     RefDNode dot;
     int nDot;
-    if (debugParser) std::cout << " deref_dot_expr_keeplast -> " /* << std::endl */; 
 }
     : a1:array_expr_1st 
         (// (tag_access_keeplast)=>
@@ -1520,21 +1438,20 @@ deref_dot_expr_keeplast
                         dot=#[DOT,"."];
                         dot->SetNDot( nDot);    
                         dot->SetLine( #a1->getLine());
-                        #deref_dot_expr_keeplast = #(dot, #deref_dot_expr_keeplast); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                        #deref_dot_expr_keeplast = #(dot, #deref_dot_expr_keeplast);
                     }
             }        
-//      |   { #deref_dot_expr_keeplast = #a1; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+//      |   { #deref_dot_expr_keeplast = #a1;}
         )
     | ASTERIX! deref_dot_expr_keeplast
         { #deref_dot_expr_keeplast = 
-            #([DEREF,"deref"], #deref_dot_expr_keeplast); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+            #([DEREF,"deref"], #deref_dot_expr_keeplast);}
     ;
 
 protected
 tag_access returns [SizeT nDot]
 {
     nDot=0;
-    if (debugParser) std::cout << " tag_access -> " /* << std::endl */; 
 }
     : (options {greedy=true;}: DOT! { ++nDot;} tag_array_expr_nth)+
     ;
@@ -1543,7 +1460,6 @@ deref_dot_expr
 {
     RefDNode dot;
     SizeT nDot;
-    if (debugParser) std::cout << " deref_dot_expr -> " /* << std::endl */; 
 }
 //    : array_expr_1st (DOT array_expr_nth)*
     : a1:array_expr_1st 
@@ -1554,20 +1470,19 @@ deref_dot_expr
                 dot->SetNDot( nDot);    
                 dot->SetLine( #a1->getLine());
 
-                #deref_dot_expr = #(dot, #deref_dot_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #deref_dot_expr = #(dot, #deref_dot_expr);
             }        
 //        |   { #deref_expr = #a1;}
         )
     | ASTERIX! deref_dot_expr
         { #deref_dot_expr = 
-            #([DEREF,"deref"], #deref_dot_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+            #([DEREF,"deref"], #deref_dot_expr);}
     ;
 
 deref_expr
 {
     RefDNode dot;
     SizeT nDot;
-    if (debugParser) std::cout << " deref_expr -> " /* << std::endl */; 
 }
 //    : array_expr_1st (DOT array_expr_nth)*
     : a1:array_expr_1st 
@@ -1579,19 +1494,18 @@ deref_expr
                 dot->SetNDot( nDot);    
                 dot->SetLine( #a1->getLine());
 
-                #deref_expr = #(dot, #deref_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #deref_expr = #(dot, #deref_expr);
             }        
-        |   { #deref_expr = #a1; if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+        |   { #deref_expr = #a1;}
         )
     | ASTERIX! deref_expr
         { #deref_expr = 
-            #([DEREF,"deref"], #deref_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;}
+            #([DEREF,"deref"], #deref_expr);}
     ;
 
 
 protected
 member_function_call returns [bool parent]
-{    if (debugParser) std::cout << " member_function_call -> " /* << std::endl */; }
     : { parent = false;} MEMBER! 
         (s:IDENTIFIER METHOD! 
             { 
@@ -1606,7 +1520,6 @@ member_function_call returns [bool parent]
             } )? formal_function_call
       ;
 member_function_call_dot
-{    if (debugParser) std::cout << " member_function_call_dot -> " /* << std::endl */; }
     :  DOT! (s:IDENTIFIER METHOD!
         // here we translate IDL_OBECT to GDL_OBJECT for source code compatibility
         {
@@ -1619,9 +1532,8 @@ member_function_call_dot
       ;
 
 assign_expr
-{    if (debugParser) std::cout << " assign_expr -> " /* << std::endl */; }
     : LBRACE! deref_expr EQUAL! expr RBRACE! // assignment
-        { #assign_expr = #([ASSIGN,":="], #assign_expr); if (debugParser) std::cout<<" assign_expr : \""<<LT(0)->getText()<<"\""<<std::endl;}
+        { #assign_expr = #([ASSIGN,":="], #assign_expr);}
     ;
 
 // arrayexpr_mfcall_last
@@ -1634,7 +1546,6 @@ arrayexpr_mfcall!
     RefDNode dot;
     RefDNode tag;
     int nDot;
-    if (debugParser) std::cout << " arrayexpr_mfcall! -> " /* << std::endl */; 
 }
     : a1:array_expr_1st 
         (   // this rule is only for production // (tag_access_keeplast)=>
@@ -1655,11 +1566,10 @@ arrayexpr_mfcall!
                 #arrayexpr_mfcall = #([ARRAYEXPR_MFCALL,"arrayexpr_mfcall"], #tag, #id, #al);
             else
                 #arrayexpr_mfcall = #([ARRAYEXPR_MFCALL,"arrayexpr_mfcall"], #a1, #id, #al);
-         if (debugParser) std::cout<<"arrayexpr_mfcall : \""<<LT(0)->getText()<<"\""<<std::endl;
 	 }
     | ASTERIX deref_arrayexpr_mfcall:arrayexpr_mfcall
         { #arrayexpr_mfcall = 
-            #([DEREF,"deref"], #deref_arrayexpr_mfcall); if (debugParser) std::cout<<" deref_arrayexpr_mfcall : \""<<LT(0)->getText()<<"\""<<std::endl;}
+            #([DEREF,"deref"], #deref_arrayexpr_mfcall);}
     ;
 
 
@@ -1667,19 +1577,17 @@ arrayexpr_mfcall!
 primary_expr 
 {
     bool parent;
-    if (debugParser) std::cout << " -> primary_expr -> ";
     }
     : 
         // with METHOD
         (deref_dot_expr_keeplast baseclass_method)=>
         d1:deref_dot_expr_keeplast baseclass_method formal_function_call
         {
-        if (debugParser) std::cout << " d1:deref_dot_expr_keeplast baseclass_method formal_function_call "<< std::endl;
-            #primary_expr = #([MFCALL_PARENT, "mfcall::"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+            #primary_expr = #([MFCALL_PARENT, "mfcall::"], #primary_expr);
         }   
     | 
         // ambiguity (arrayexpr or mfcall)
-        (deref_dot_expr_keeplast (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE))=> arrayexpr_mfcall {if (debugParser) std::cout << " deref_dot_expr_keeplast (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE))=> arrayexpr_mfcall -> " /*<< std::endl */;}
+        (deref_dot_expr_keeplast (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE))=> arrayexpr_mfcall 
     | 
         // not the above -> unambigous mfcall (or unambigous array expr handled below)
         (deref_dot_expr_keeplast formal_function_call)=> 
@@ -1687,7 +1595,7 @@ primary_expr
             // here it is impossible to decide about function call
             // as we do not know the object type/struct tag
             formal_function_call
-            { if (debugParser) std::cout << "  (deref_dot_expr_keeplast formal_function_call)=> d3:deref_dot_expr_keeplast formal_function_call -> " << std::endl; #primary_expr = #([MFCALL, "mfcall"], #primary_expr);}
+            {#primary_expr = #([MFCALL, "mfcall"], #primary_expr);}
     |   // a member function call starts with a deref_expr 
          (deref_dot_expr)=>
         // same parsing as (deref_expr)=> see below
@@ -1697,15 +1605,13 @@ primary_expr
                 if( parent)
                 {
                     #primary_expr = #([MFCALL_PARENT, "mfcall::"], #primary_expr);
-		    if (debugParser) std::cout << " (deref_dot_expr)=>deref_expr ( parent=true) " << std::endl;
                 } 
                 else
                 {
                     #primary_expr = #([MFCALL, "mfcall"], #primary_expr);
-		    if (debugParser) std::cout << " (deref_dot_expr)=>deref_expr -> primary_expr " << std::endl;
                 }
             }
-        | { if (debugParser) std::cout << " | empty -> array expression -> "/* << std::endl */;}  // empty -> array expression
+        | 
         )
     |   
         // ambiguity (arrayexpr or fcall)
@@ -1716,27 +1622,22 @@ primary_expr
             // (could be reordered, but this is conform to original)
             { IsFun(LT(1))}? formal_function_call
             { 
-             if (debugParser) std::cout << " (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE)=> formal_function_call " /* << std::endl */;
-                   #primary_expr = #([FCALL, "fcall"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                   #primary_expr = #([FCALL, "fcall"], #primary_expr);
             }
         | 
             // still ambiguity (arrayexpr or fcall)
         (var arrayindex_list)=> var arrayindex_list     // array_expr_fn
             { 
-             if (debugParser) std::cout << "(var arrayindex_list)=> var arrayindex_list -> " /* << std::endl */;
-
-                #primary_expr = #([ARRAYEXPR_FCALL,"arrayexpr_fcall"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                #primary_expr = #([ARRAYEXPR_FCALL,"arrayexpr_fcall"], #primary_expr);
 	    }
         |   // if arrayindex_list failed (due to to many indices)
             // this must be a function call
             formal_function_call
-            {  if (debugParser) std::cout << " (IDENTIFIER LBRACE expr (COMMA expr)* RBRACE)=>formal_function_call -> " /* << std::endl */;
-                   #primary_expr = #([FCALL, "fcall"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
-            }
+                 {#primary_expr = #([FCALL, "fcall"], #primary_expr);}
         )
     |   // not the above => keyword parameter (or no args) => function call
          (formal_function_call)=> formal_function_call
-         { if (debugParser) std::cout << " (formal_function_call)=> formal_function_call -> " << std::endl; #primary_expr = #([FCALL, "fcall"], #primary_expr);}
+         { #primary_expr = #([FCALL, "fcall"], #primary_expr);}
 
     |   // a member function call starts with a deref_expr 
         // deref_dot_expr already failed
@@ -1746,23 +1647,20 @@ primary_expr
             { 
                 if( parent)
                 {
-                    if (debugParser) std::cout << " (deref_expr)=> deref_expr ( parent=true) -> " /* << std::endl */;
-                    #primary_expr = #([MFCALL_PARENT, "mfcall::"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                    #primary_expr = #([MFCALL_PARENT, "mfcall::"], #primary_expr);
                 }
                 else
                 {
-                    if (debugParser) std::cout << " (deref_expr)=> deref_expr ( parent=false) -> " /* << std::endl */;
-                    #primary_expr = #([MFCALL, "mfcall"], #primary_expr); if (debugParser) std::cout<<"\""<<LT(0)->getText()<<"\""<<std::endl;
+                    #primary_expr = #([MFCALL, "mfcall"], #primary_expr);
                 }
             }
-        |{ if (debugParser) std::cout << " (deref_expr)=> deref_expr | empty -> array expression No 2!"/* << std::endl */;}  // empty -> array expression
+        |
         )
 
     |! sl:STRING_LITERAL // also a CONSTANT
         { #primary_expr=#[CONSTANT,sl->getText()];
             #primary_expr->Text2String();    
             #primary_expr->SetLine( #sl->getLine());
-	    { if (debugParser) std::cout << "STRING_LITERAL" <<std::endl;}
         }  
     | assign_expr 	   
     | numeric_constant 	   
@@ -1770,20 +1668,19 @@ primary_expr
     | struct_def 	   
     | ! ls:LSQUARE !RSQUARE
         { #primary_expr=#[GDLNULL,"GDLNULL[]"];
-            #primary_expr->SetLine( #ls->getLine()); if (debugParser) std::cout << "NULL" << std::endl;
+            #primary_expr->SetLine( #ls->getLine());
         }  
     | ! lc:LCURLY !RCURLY
         { #primary_expr=#[GDLNULL,"GDLNULL{}"];
-            #primary_expr->SetLine( #lc->getLine()); if (debugParser) std::cout << "NULL" << std::endl;
+            #primary_expr->SetLine( #lc->getLine());
         }  
 	;
 
 // only one INC/DEC allowed per target
 decinc_expr
-//{    if (debugParser) std::cout << " -> decinc_expr "; }
     : primary_expr 
-        ( i:INC^ { #i->setType( POSTINC); #i->setText( "_++");if (debugParser) std::cout << "++" <<std::endl;} 
-        | d:DEC^ { #d->setType( POSTDEC); #d->setText( "_--");if (debugParser) std::cout << "--" <<std::endl;} 
+        ( i:INC^ { #i->setType( POSTINC); #i->setText( "_++");} 
+        | d:DEC^ { #d->setType( POSTDEC); #d->setText( "_--");} 
         | // empty
         )
     | INC^ primary_expr
@@ -1791,7 +1688,6 @@ decinc_expr
     ;
 
 exponential_expr
-//{    if (debugParser) std::cout << " -> exponential_expr" ; }
     : decinc_expr 
         (POW^ decinc_expr 
         )*
@@ -1799,7 +1695,6 @@ exponential_expr
 
 
 multiplicative_expr
-//{    if (debugParser) std::cout << " -> multiplicative_expr "; }
     : exponential_expr
         (
             ( ASTERIX^
@@ -1832,7 +1727,6 @@ multiplicative_expr
 
 // only one allowed per target
 signed_multiplicative_expr
-//{    if (debugParser) std::cout << " -> signed_multiplicative_expr "; }
     : PLUS! multiplicative_expr
     | m:MINUS^ multiplicative_expr
         { 
@@ -1843,7 +1737,6 @@ signed_multiplicative_expr
     ;
 
 additive_expr
-//{    if (debugParser) std::cout << " -> additive_expr "; }
     : (signed_multiplicative_expr | neg_expr)
         ( 
             ( PLUS^
@@ -1859,7 +1752,6 @@ additive_expr
     ;
 
 neg_expr
-//{    if (debugParser) std::cout << " -> neg_expr "; }
     : NOT_OP^ multiplicative_expr
 // true precedence of ~ operator
     | LOG_NEG^ multiplicative_expr
@@ -1867,7 +1759,6 @@ neg_expr
 
 
 relational_expr
-//{    if (debugParser) std::cout << " -> relational_expr "; }
     : additive_expr
         (
             ( EQ_OP^
@@ -1881,7 +1772,6 @@ relational_expr
     ;
 
 boolean_expr
-//{    if (debugParser) std::cout << " -> boolean_expr" ; }
     : relational_expr
         ( 
             ( AND_OP^ 
@@ -1892,7 +1782,6 @@ boolean_expr
     ;
 
 logical_expr
-//{    if (debugParser) std::cout << " -> logical_expr "; }
     : boolean_expr
         ( 
             ( LOG_AND^ 
@@ -1902,7 +1791,6 @@ logical_expr
     ;
 
 expr
-{    if (debugParser) std::cout << " expr-> "; }
   : logical_expr
     (
       QUESTION^ expr

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -1622,9 +1622,31 @@ member_function_call_dot
       ;
 
 assign_expr
-    : LBRACE! deref_expr EQUAL! expr RBRACE! // assignment
-        { #assign_expr = #([ASSIGN,":="], #assign_expr);}
-    ;
+    : LBRACE! deref_expr 
+	(
+      EQUAL!  { #assign_expr = #([ASSIGN,":="], #assign_expr);} 
+    | AND_OP_EQ^ 
+    | ASTERIX_EQ^ 
+    | EQ_OP_EQ^ 
+    | GE_OP_EQ^
+    | GTMARK_EQ^
+    | GT_OP_EQ^
+    | LE_OP_EQ^
+    | LTMARK_EQ^
+    | LT_OP_EQ^
+    | MATRIX_OP1_EQ^
+    | MATRIX_OP2_EQ^
+    | MINUS_EQ^
+    | MOD_OP_EQ^
+    | NE_OP_EQ^
+    | OR_OP_EQ^
+    | XOR_OP_EQ^
+    | PLUS_EQ^
+    | POW_EQ^
+    | SLASH_EQ^
+    ) expr RBRACE! // assignment
+//        { #assign_expr = #([ASSIGN,":="], #assign_expr);}
+;
 
 // arrayexpr_mfcall_last
 //     : (IDENTIFIER^ arrayindex_list) 
@@ -1766,52 +1788,50 @@ primary_expr
 
 // only one INC/DEC allowed per target
 decinc_expr
-    : primary_expr 
+    : (INC^ | DEC^) primary_expr
+    | primary_expr 
         ( i:INC^ { #i->setType( POSTINC); #i->setText( "_++");} 
         | d:DEC^ { #d->setType( POSTDEC); #d->setText( "_--");} 
-        | // empty
-        )
-    | INC^ primary_expr
-    | DEC^ primary_expr
+        )?
     ;
 
-exponential_expr
-    : decinc_expr 
-        (POW^ decinc_expr 
-        )*
-    ;
+exponential_expr: //<assoc=right> for ANTLR4
+     decinc_expr
+     (
+       POW^ decinc_expr
+     )*
+     ;
 
-
-multiplicative_expr
-    : exponential_expr
-        (
-            ( ASTERIX^
-            | MATRIX_OP1^
-            | MATRIX_OP2^
-            | SLASH^ 
-            | MOD_OP^
-            | AND_OP_EQ^ 
-            | ASTERIX_EQ^ 
-            | EQ_OP_EQ^ 
-            | GE_OP_EQ^
-            | GTMARK_EQ^
-            | GT_OP_EQ^
-            | LE_OP_EQ^
-            | LTMARK_EQ^
-            | LT_OP_EQ^
-            | MATRIX_OP1_EQ^
-            | MATRIX_OP2_EQ^
-            | MINUS_EQ^
-            | MOD_OP_EQ^
-            | NE_OP_EQ^
-            | OR_OP_EQ^
-            | PLUS_EQ^
-            | POW_EQ^
-            | SLASH_EQ^
-            | XOR_OP_EQ^
-            ) exponential_expr
-        )*
-    ;
+multiplicative_expr: // '*' | '#' | '##' | '/' | 'mod' // level 4
+      exponential_expr
+      (
+        ( ASTERIX^
+	| MATRIX_OP1^
+	| MATRIX_OP2^
+	| SLASH^
+	| MOD_OP^
+//            | AND_OP_EQ^ 
+//            | ASTERIX_EQ^ 
+//            | EQ_OP_EQ^ 
+//            | GE_OP_EQ^
+//            | GTMARK_EQ^
+//            | GT_OP_EQ^
+//            | LE_OP_EQ^
+//            | LTMARK_EQ^
+//            | LT_OP_EQ^
+//            | MATRIX_OP1_EQ^
+//            | MATRIX_OP2_EQ^
+//            | MINUS_EQ^
+//            | MOD_OP_EQ^
+//            | NE_OP_EQ^
+//            | OR_OP_EQ^
+//            | PLUS_EQ^
+//            | POW_EQ^
+//            | SLASH_EQ^
+//            | XOR_OP_EQ^
+	) exponential_expr
+      )*
+      ;
 
 // only one allowed per target
 signed_multiplicative_expr

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -347,7 +347,7 @@ translation_unit
 				recovery=false;
 // HERE WE COULD COUNT THE ERRORS and replace "No parser output generated." in dinterpreter.cpp by something like
 // "% XXX Compilation error(s) in module YYY."
-//				throw;
+				throw; //seems necessary, for execute in particular. this patch is not very clever.
 		}
         catch [ antlr::NoViableAltException& e] 
         {  //this exception may come from using () instead of [] for array indexes.
@@ -430,7 +430,8 @@ relaxed=(fussy < 1);
         exception 
         catch [ GDLException& e] 
         { 
-				printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn(), e.toString());
+          printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn(), e.toString());
+		  throw; //necessary for EXECUTE to get the error state. Alas.
         }
         catch [ antlr::NoViableAltException& e] 
         {

--- a/src/gdlc.g
+++ b/src/gdlc.g
@@ -1919,7 +1919,7 @@ options {
     testLiterals =false;
     caseSensitiveLiterals=false;
     exportVocab=GDL;
-    k=3;
+    k=4;
     defaultErrorHandler = false;
 //    defaultErrorHandler = true;
 //      analyzerDebug=true;
@@ -2140,7 +2140,7 @@ INCLUDE!
         }
     ;
 
-AND_OP_EQ: { LA(4) == '='}? "and="; 
+AND_OP_EQ: "and="; 
 ASTERIX_EQ:"*=";
 EQ_OP_EQ:"eq=";
 GE_OP_EQ:"ge=";
@@ -2152,13 +2152,13 @@ LT_OP_EQ:"lt=";
 MATRIX_OP1_EQ:"#=";
 MATRIX_OP2_EQ:"##=";
 MINUS_EQ:"-=";
-MOD_OP_EQ: { LA(4) == '='}? "mod=";
+MOD_OP_EQ: "mod=";
 NE_OP_EQ:"ne=";
 OR_OP_EQ:"or=";
 PLUS_EQ:"+=";
 POW_EQ:"^=";
 SLASH_EQ:"/=";
-XOR_OP_EQ: { LA(4) == '='}? "xor=";
+XOR_OP_EQ: "xor=";
 
 MATRIX_OP1:'#';
 MATRIX_OP2:"##";

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -960,7 +960,7 @@ DLong GetLUN()
   
   return 0;
 }
-bool IsRelaxed(){return !strictInterpreter;}
+bool IsStrictArr(){return strictInterpreter;}
 void SetStrict(bool value){strictInterpreter=value;}
 
 // for semantic predicate

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -72,7 +72,7 @@ GDLFileListT  fileUnits;
 // flag for control-c
 volatile bool sigControlC;
 int           debugMode;
-bool  strictInterpreter;
+bool  traceSyntaxErrors;
 //	global garbage collection flag in support of HEAP_REFCOUNT:
 static bool enabled_GC=true;
 	bool IsEnabledGC()  // Referenced from GDLInterpreter.hpp
@@ -960,8 +960,8 @@ DLong GetLUN()
   
   return 0;
 }
-bool IsStrictArr(){return strictInterpreter;}
-void SetStrict(bool value){strictInterpreter=value;}
+bool IsTracingSyntaxErrors(){return traceSyntaxErrors;}
+void SetTraceSyntaxErrors(bool value){traceSyntaxErrors=value;}
 
 // for semantic predicate
 bool IsFun(antlr::RefToken rT1)

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -133,7 +133,7 @@ int LibProIx(const std::string& n);
 int LibFunIx(const std::string& n);
 
 bool IsFun(antlr::RefToken); // used by Lexer and Parser
-bool IsRelaxed(); //tells if syntax is not strict (i.e. parenthesis for array indexes).
+bool IsStrictArr(); //tells if syntax is not strict (i.e. parenthesis for array indexes).
 void SetStrict(bool value);
 
 bool BigEndian();

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -133,8 +133,8 @@ int LibProIx(const std::string& n);
 int LibFunIx(const std::string& n);
 
 bool IsFun(antlr::RefToken); // used by Lexer and Parser
-bool IsStrictArr(); //tells if syntax is not strict (i.e. parenthesis for array indexes).
-void SetStrict(bool value);
+bool IsTracingSyntaxErrors(); //tells if syntax is not strict (i.e. parenthesis for array indexes).
+void SetTraceSyntaxErrors(bool value);
 
 bool BigEndian();
 int get_suggested_omp_num_threads();


### PR DESCRIPTION
Here I propose changes in the ANTLR code that aims at speed up (quite a lot in some cases) the compilation of procedures.
The Parser always start parsing a procedure in STRICTARR mode, the normal, modern, way to write IDL code, using '[' and ']' instead of '(' and ')' to mark array indices. The parser is much faster at parsing the procedure if this rule is respected.
If the parser encounters an problem, at locations where an array index is acceptable, it reparses the whole procedure using a 'relaxed' mode where z=toto(a,b,c) can be in fact z=toto[a,b,c] and not the function toto called with a,b,c as arguments.
parsing speed gain is 3 to 10 (still waaay below IDL's homegrown parser :smile: )

Additionnaly this removes the need of the `--fussy` and `--sloppy` commandline swiches, that are removed.
I've added the `--trace-old-syntax` switch that can permit to find ALL (??)  occurences of the pre-v5 (i.e;, non-strictarr) way of writing IDL code. An example:
```
$ gdl --trace-old-syntax -e ".compile /home/gildas/IDLAstro/coyote/cgpickcolorname.pro"
old syntax at line 523, column 26
% Compiled module: CGPICKCOLORNAME_SELECT_COLOR.
```
closes #2012 
 thanks to @brandy125 for mentioning the speed problem.

Note that all this cannot solve the 'nested parenthesis' nigthmare. See the (added) antlr4 diectory to an example of code that talkes forever with ANTLR2 and is immediate with ANTLR4.