### PR TITLE
Update links in README.md (Harris -> NV5; Rogue Wave -> Perforce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GDL development had been started by **Marc Schellens** back in early noughties a
 with help of a team of maintainers, developers, packagers and thanks to feedback from users.
 
 IDL is a registered trademark of [NV5 Geospatial Software, Inc.](https://www.nv5geospatialsoftware.com/).
-PV-WAVE is a product of [Rogue Wave Software](https://www.roguewave.com).
+PV-WAVE is a product of [Perforce](https://www.perforce.com/products/pv-wave).
 
 Overview
 --------
@@ -139,7 +139,8 @@ IDL freely available resources include:
 - the [official IDL documentation](https://www.nv5geospatialsoftware.com/docs/using_idl_home.html)
 - the [idl-pvwave Google Group](https://groups.google.com/forum/#!forum/idl-pvwave)
 - the [comp.lang.idl-pvwave usenet group archives](http://www.idlcoyote.com/comp.lang.idl-pvwave/) (dating back to 1991!)
-- Wikipedia article on [IDL](https://en.wikipedia.org/wiki/IDL_\(programming_language\)) and references therein
+- Wikipedia article on [IDL](https://en.wikipedia.org/wiki/IDL_\(programming_language\))
+- Wikipedia article on [PV-WAVE](https://en.wikipedia.org/wiki/PV-Wave)
 - websites of IDL gurus including [David Fanning](http://www.idlcoyote.com/) and [Michael Galloy](http://michaelgalloy.com/)
 - numerous [tutorials and lecture notes](https://www.google.com/search?q=interactive+data+language) introducing IDL
 - old, used, but still very valid IDL booklets can be found in various libraries, second-hand bookstores etc.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ as astronomy, geosciences and medical imaging.
 GDL development had been started by **Marc Schellens** back in early noughties and has since continued 
 with help of a team of maintainers, developers, packagers and thanks to feedback from users.
 
-IDL is a registered trademark of [Harris Geospatial Solutions](https://www.harrisgeospatial.com).
+IDL is a registered trademark of [NV5 Geospatial Software, Inc.](https://www.nv5geospatialsoftware.com/).
 PV-WAVE is a product of [Rogue Wave Software](https://www.roguewave.com).
 
 Overview
@@ -136,7 +136,7 @@ GDL does not maintain a proper documentation: as GDL is aimed as a drop-in repla
 resources for IDL constitute the valuable sources of information for GDL users as well. GDL MUST behave (at least) as IDL, and any discrepancy should be reported by opening an issue.
 Conversely, the GDL issues and discussion forum on GitHub are not the good place for beginners to ask for advice on how to use IDL (or GDL). Use the forum below.
 IDL freely available resources include:
-- the [official IDL documentation](https://www.harrisgeospatial.com/docs/)
+- the [official IDL documentation](https://www.nv5geospatialsoftware.com/docs/using_idl_home.html)
 - the [idl-pvwave Google Group](https://groups.google.com/forum/#!forum/idl-pvwave)
 - the [comp.lang.idl-pvwave usenet group archives](http://www.idlcoyote.com/comp.lang.idl-pvwave/) (dating back to 1991!)
 - Wikipedia article on [IDL](https://en.wikipedia.org/wiki/IDL_\(programming_language\)) and references therein


### PR DESCRIPTION
Update links for IDL and its documentation as provided by NV5 Geospatial Solutions, Inc.