### PR TITLE
More NetCDF functionality

### DIFF
--- a/src/hdf5_fun.cpp
+++ b/src/hdf5_fun.cpp
@@ -557,7 +557,7 @@ namespace lib {
         field = new DULongGDL(dim);
       } else if (ourType == GDL_LONG64) {
         field = new DLong64GDL(dim);
-      } else if (ourType == GDL_LONG64) {
+      } else if (ourType == GDL_ULONG64) {
         field = new DULong64GDL(dim);
       } else if (ourType == GDL_FLOAT) {
         field = new DFloatGDL(dim);

--- a/src/ncdf_cl.cpp
+++ b/src/ncdf_cl.cpp
@@ -45,12 +45,14 @@ namespace lib {
     switch (vartype)
       {
       case NC_BYTE:  return DStringGDL("BYTE");//8 bit
-      case NC_UBYTE:  return DStringGDL("UBYTE");//8 bit
+      case NC_UBYTE: return DStringGDL("UBYTE");//8 bit
       case NC_CHAR:  return DStringGDL("CHAR");//8 bit as string
       case NC_SHORT: return DStringGDL("INT");//16 bit
-      case NC_USHORT: return DStringGDL("UINT");//16 bit
+      case NC_USHORT:return DStringGDL("UINT");//16 bit
       case NC_INT:   return DStringGDL("LONG");//32 bit
-      case NC_UINT:   return DStringGDL("ULONG");//32 bit
+      case NC_UINT:  return DStringGDL("ULONG");//32 bit
+      case NC_INT64: return DStringGDL("LONG64");//64 bit
+      case NC_UINT64:return DStringGDL("ULONG64");//64 bit
       case NC_FLOAT: return DStringGDL("FLOAT");//32 bit float
       case NC_DOUBLE:return DStringGDL("DOUBLE");//64 bit double
       case NC_STRING:return DStringGDL("STRING");//String


### PR DESCRIPTION
Mods add some more NetCDF functionality including read string arrays and unsigned int64
Also more datatypes can be written
When writing, overflow of datatype is now allowed (e.g. when writing int value=300 to a byte NetCDF variable the conversion will overflow but this is allowed) - this is to reproduce the behaviour of IDL. 
Also fixes a remaining bug in HDF read of unsigned long64 (partially fixed before)