### PR TITLE
WIP Towards a GDL with smaller memory imprint and no memory leaks.

### DIFF
--- a/src/devicenull.hpp
+++ b/src/devicenull.hpp
@@ -58,7 +58,7 @@ class DeviceNULL : public GraphicsDevice
   
 public:
   //  DeviceNULL(): GraphicsDevice(), fileName( "gdl.null"), actStream( NULL)
-  DeviceNULL(): GraphicsDevice()
+  DeviceNULL(): GraphicsDevice(), actStream( NULL)
   {
     name = "NULL";
 

--- a/src/dpro.cpp
+++ b/src/dpro.cpp
@@ -394,7 +394,8 @@ DSubUD::~DSubUD()
       DCommonRef* cRef=dynamic_cast<DCommonRef*>(*it);
       delete cRef; // also ok if cRef is NULL
     }
-
+  file.clear();
+  var.clear();
   labelList.Clear();
   delete tree;
   sccList.erase(this);

--- a/src/dvar.cpp
+++ b/src/dvar.cpp
@@ -23,8 +23,8 @@
 
 using namespace std;
 
-DVar::DVar(const string& n, BaseGDL* data) :
-  name(n), d(data),callback(defaultDVarCallback)
+DVar::DVar(const string& n, BaseGDL* data, bool isacopy) : //isacopy to tell if this DVAR just points to another (used in some cases. These DVars MUST NOT be destroyed!)
+  name(n), d(data),callback(defaultDVarCallback),isAClone(isacopy)
 {}
 
 DVar::DVar() : name(), d(0) ,callback(defaultDVarCallback)
@@ -33,15 +33,18 @@ DVar::DVar() : name(), d(0) ,callback(defaultDVarCallback)
 DVar::~DVar() 
 {
   // Note: !NULL would be naturally destroyed from here at program end
-  // we explicitely preventing the deltion to be able to flag possible
+  // we explicitely preventing the deletion to be able to flag possible
   // other destructions of !NULL (which are bugs)
   //if( d != NullGDL::GetSingleInstance()) 
-  GDLDelete(d);
-}
+  if (!isAClone) GDLDelete(d);
+  name.clear();
+  d=NULL;
+  }
 
 void DVar::Delete() // for ResetObjects() to resolve COMMON/STRUCT mutual dependency
 {
-  GDLDelete( d);
+if (!isAClone)  GDLDelete( d);
+  name.clear();
   d = NULL;
 }
 

--- a/src/dvar.hpp
+++ b/src/dvar.hpp
@@ -32,12 +32,12 @@ class DVar
 private:
   std::string     name; // the name
   BaseGDL* d;
+  bool isAClone=false;
   void (*callback)();
 public:
   DVar();
-  DVar(const std::string& n, BaseGDL* = 0); 
+  DVar(const std::string& n, BaseGDL* = 0, bool isacopy=false); 
   ~DVar();
-
   void Delete(); // for ResetObjects() to resolve COMMON/STRUCT mutual dependency
   
   const std::string& Name() const {return name;}

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -114,7 +114,7 @@ void AtExit()
 {
   //this function cleans objets and should be called only for debugging purposes.(for debugging memory leaks)
   // enabled with flag --clean-at-exit
-  ResetObjects();
+  ResetObjects(true);
   PurgeContainer(libFunList);
   PurgeContainer(libProList);
 }

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -86,26 +86,26 @@ void SetGDLGenericGSLErrorHandler(); // defined in gsl_fun.cpp
 void InitOpenMP() {
 #ifdef _OPENMP
   int suggested_num_threads, omp_num_core;  
-  suggested_num_threads=get_suggested_omp_num_threads();
-  omp_num_core=omp_get_num_procs();
+//  suggested_num_threads=get_suggested_omp_num_threads();
+//  omp_num_core=omp_get_num_procs();
 
   //  cerr << "estimated Threads :" << suggested_num_threads << endl;
 
   // we update iff needed (by default, "omp_num_threads" is initialiazed to "omp_num_core"
-  if ((suggested_num_threads > 0) && (suggested_num_threads < omp_num_core)) {
-
-    // update of !cpu.TPOOL_NTHREADS
-    DStructGDL* cpu = SysVar::Cpu();
-    static unsigned NTHREADSTag = cpu->Desc()->TagIndex( "TPOOL_NTHREADS");
-    (*static_cast<DLongGDL*>( cpu->GetTag( NTHREADSTag, 0)))[0] =suggested_num_threads;
-
-    // effective global change of num of treads using omp_set_num_threads()
-    CpuTPOOL_NTHREADS=suggested_num_threads;
-    omp_set_num_threads(suggested_num_threads);
-  } else {
+//  if ((suggested_num_threads > 0) && (suggested_num_threads < omp_num_core)) {
+//
+//    // update of !cpu.TPOOL_NTHREADS
+//    DStructGDL* cpu = SysVar::Cpu();
+//    static unsigned NTHREADSTag = cpu->Desc()->TagIndex( "TPOOL_NTHREADS");
+//    (*static_cast<DLongGDL*>( cpu->GetTag( NTHREADSTag, 0)))[0] =suggested_num_threads;
+//
+//    // effective global change of num of treads using omp_set_num_threads()
+//    CpuTPOOL_NTHREADS=suggested_num_threads;
+//    omp_set_num_threads(suggested_num_threads);
+//  } else {
     CpuTPOOL_NTHREADS=omp_get_num_procs();
     omp_set_num_threads(CpuTPOOL_NTHREADS);
-  }
+//  }
   //  cout << CpuTPOOL_NTHREADS <<endl;
 #endif
 }
@@ -311,7 +311,8 @@ int main(int argc, char *argv[])
       cerr << "  --no-dSFMT         Tells GDL not to use double precision SIMD oriented Fast Mersenne Twister(dSFMT) for random doubles." << endl;
       cerr << "                     Also disable by setting the environment variable GDL_NO_DSFMT to a non-null value." << endl;
       cerr << "  --with-eigen-transpose lets GDL use Eigen::transpose and related functions instead of our accelerated transpose function. Normally slower." <<endl;
-      cerr << "  --smart-tpool      switch to a mode where the number of threads is adaptive (experimental). Should enable better perfs on many core machines." <<endl;
+      cerr << "  --smart-tpool      switch to a mode where the number of threads is adaptive (DEFAULT). Should enable better perfs on many core machines." <<endl;
+      cerr << "  --no-smart-tpool   switch to a mode where the number of threads is NOT adaptive." <<endl;
       cerr << "  --silent           Supresses some messages (mainly \"Compiled Module XXX\" ." <<endl;
 #ifdef _WIN32
       cerr << "  --posix (Windows only): paths will be posix paths (experimental)." << endl;
@@ -421,6 +422,10 @@ int main(int argc, char *argv[])
       else if (string(argv[a]) == "--with-eigen-transpose")
       {
          useEigenForTransposeOps = true;
+      }
+      else if (string(argv[a]) == "--no-smart-tpool")
+      {
+         useSmartTpool = false;
       }
       else if (string(argv[a]) == "--smart-tpool")
       {

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -20,7 +20,7 @@
 #include "gdlarray.hpp"
 template<class T, bool IsPOD>
 T* GDLArray<T,IsPOD>::InitScalar() {
-    assert(sz <= smallArraySize);
+    assert(sz <= FixedBufferSize<T>());
     if (IsPOD) {
       return reinterpret_cast<T*> (scalarBuf);
     } else {
@@ -76,7 +76,7 @@ template<class T, bool IsPOD>
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>::GDLArray(const GDLArray& cp) : sz(cp.size()) {
     try {
-      buf = (cp.size() > smallArraySize) ? New(cp.size()) /*new T[ cp.size()]*/ : InitScalar();
+      buf = (cp.size() > FixedBufferSize<T>()) ? New(cp.size()) /*new T[ cp.size()]*/ : InitScalar();
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
@@ -92,7 +92,7 @@ template<class T, bool IsPOD>
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>::GDLArray(SizeT s, bool dummy) : sz(s) {
     try {
-      buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
+      buf = (s > FixedBufferSize<T>()) ? New(s) /*T[ s]*/ : InitScalar();
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
@@ -101,7 +101,7 @@ template<class T, bool IsPOD>
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>::GDLArray(T val, SizeT s) : sz(s) {
     try {
-      buf = (s > smallArraySize) ? New(s) /*T[ s]*/ : InitScalar();
+      buf = (s > FixedBufferSize<T>()) ? New(s) /*T[ s]*/ : InitScalar();
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
@@ -117,7 +117,7 @@ template<class T, bool IsPOD>
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>::GDLArray(const T* arr, SizeT s) : sz(s) {
     try {
-      buf = (s > smallArraySize) ? New(s) /*new T[ s]*/ : InitScalar();
+      buf = (s > FixedBufferSize<T>()) ? New(s) /*new T[ s]*/ : InitScalar();
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
@@ -256,7 +256,7 @@ template<class T, bool IsPOD>
   {
     assert(sz == 0);
     sz = newSz;
-    if (sz > smallArraySize) {
+    if (sz > FixedBufferSize<T>()) {
       try {
         buf = New(sz) /*new T[ newSz]*/;
       }      catch (std::bad_alloc&) {

--- a/src/gdlarray.cpp
+++ b/src/gdlarray.cpp
@@ -18,6 +18,9 @@
 #include "basegdl.hpp"
 #include "dstructdesc.hpp"
 #include "gdlarray.hpp"
+
+#define USE_PARALLEL_INITIALIZATION // see also datatypes.cpp
+
 template<class T, bool IsPOD>
 T* GDLArray<T,IsPOD>::InitScalar() {
     assert(sz <= FixedBufferSize<T>());
@@ -80,6 +83,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
+#ifdef USE_PARALLEL_INITIALIZATION
     if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     } else {
@@ -87,6 +91,9 @@ template<class T, bool IsPOD>
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
     }
+#else
+    for (SizeT i = 0; i < sz; ++i) buf[ i] = cp.buf[ i];
+#endif
   }
 
 template<class T, bool IsPOD>
@@ -105,6 +112,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
+#ifdef USE_PARALLEL_INITIALIZATION
     if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     } else {
@@ -112,6 +120,9 @@ template<class T, bool IsPOD>
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
     }
+#else
+    for (SizeT i = 0; i < sz; ++i) buf[ i] = val;
+#endif
   }
 
 template<class T, bool IsPOD>
@@ -121,6 +132,7 @@ template<class T, bool IsPOD>
     } catch (std::bad_alloc&) {
       ThrowGDLException("Array requires more memory than available");
     }
+#ifdef USE_PARALLEL_INITIALIZATION
     if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     } else {
@@ -128,6 +140,9 @@ template<class T, bool IsPOD>
 #pragma omp parallel for num_threads(GDL_NTHREADS)
         for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
     }
+#else
+    for (SizeT i = 0; i < sz; ++i) buf[ i] = arr[ i];
+#endif
   }
 
 
@@ -157,6 +172,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy((void*) buf, (void*) right.buf, sz * sizeof (T)); //explicitly cast the pointer to silence [-Wnontrivial-memcall] warning
     } else {
+#ifdef USE_PARALLEL_INITIALIZATION
       if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
@@ -164,6 +180,9 @@ template<class T, bool IsPOD>
 #pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       }
+#else
+      for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+#endif
     }
   }
 
@@ -174,6 +193,7 @@ template<class T, bool IsPOD>
     if (IsPOD) {
       std::memcpy((void*) buf, (void*) right.buf, sz * sizeof (T)); //explicitly cast the pointer to silence [-Wnontrivial-memcall] warning
     } else {
+#ifdef USE_PARALLEL_INITIALIZATION
       if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
         for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       } else {
@@ -181,13 +201,16 @@ template<class T, bool IsPOD>
 #pragma omp parallel for num_threads(GDL_NTHREADS)
           for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
       }
+#else
+      for (SizeT i = 0; i < sz; ++i) buf[ i] = right.buf[ i];
+#endif
     }
     return *this;
   }
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const GDLArray<T,IsPOD>& right) throw () {
-  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_MEMORY_ACCESS))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -199,7 +222,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const GDLArray<T,IsPOD>& right) throw () {
-  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_MEMORY_ACCESS))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right.buf[ i];
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -220,7 +243,7 @@ template<>
   }
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator+=(const T& right) throw () {
-  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_MEMORY_ACCESS))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] += right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)
@@ -232,7 +255,7 @@ template<class T, bool IsPOD>
 
 template<class T, bool IsPOD>
   GDLArray<T,IsPOD>& GDLArray<T,IsPOD>::operator-=(const T& right) throw () {
-  if ((GDL_NTHREADS=parallelize( sz, TP_ARRAY_INITIALISATION))==1) {
+  if ((GDL_NTHREADS=parallelize( sz, TP_MEMORY_ACCESS))==1) {
       for (SizeT i = 0; i < sz; ++i) buf[ i] -= right;
     } else {
       GDLARRAY_TRACEOMP(__FILE__, __LINE__)

--- a/src/gdlarray.hpp
+++ b/src/gdlarray.hpp
@@ -34,10 +34,13 @@
 // for complex (of POD)
 const bool TreatPODComplexAsPOD = true;
 
-#define BUFFERSIZE 256 // Provision for std::string, size=32 .
+#define GDL_VAR_BUFFERSIZE 32 // Provision for one std::string, size=32 .
+
+// for "normal" numerical objects, buffer is 1 string to 32 bytes, 4 doubles, 8 floats, 4 complex, 2 complexdbl 
 
 template <typename T> static const int FixedBufferSize(){
-	static const int sz=BUFFERSIZE/sizeof(T);
+	static const int sz=GDL_VAR_BUFFERSIZE/sizeof(T);
+//std::cerr<<typeid(T).name()<<": "<<sz<<" elements"<<std::endl;
 	assert (sz != 0);
 	return sz;
 }
@@ -53,9 +56,9 @@ private:
   typedef T Ty;
 
 #ifdef USE_EIGEN  
-  EIGEN_ALIGN16 char scalarBuf[ BUFFERSIZE ];
+  EIGEN_ALIGN16 char scalarBuf[ GDL_VAR_BUFFERSIZE ];
 #else
-  char scalarBuf[ BUFFERSIZE ];
+  char scalarBuf[ GDL_VAR_BUFFERSIZE ];
 #endif
 
   Ty* InitScalar();

--- a/src/gdlarray.hpp
+++ b/src/gdlarray.hpp
@@ -34,21 +34,28 @@
 // for complex (of POD)
 const bool TreatPODComplexAsPOD = true;
 
+#define BUFFERSIZE 256 // Provision for std::string, size=32 .
+
+template <typename T> static const int FixedBufferSize(){
+	static const int sz=BUFFERSIZE/sizeof(T);
+	assert (sz != 0);
+	return sz;
+}
+
 template <typename T, bool IsPOD>
 class GDLArray {
 private:
 
   enum GDLArrayConstants {
-    smallArraySize = 27,
     maxCache = 1000 * 1000 // ComplexDbl is 16 bytes
   };
 
   typedef T Ty;
 
 #ifdef USE_EIGEN  
-  EIGEN_ALIGN16 char scalarBuf[ smallArraySize * sizeof (Ty)];
+  EIGEN_ALIGN16 char scalarBuf[ BUFFERSIZE ];
 #else
-  char scalarBuf[ smallArraySize * sizeof (Ty)];
+  char scalarBuf[ BUFFERSIZE ];
 #endif
 
   Ty* InitScalar();

--- a/src/gdlhelp.cpp
+++ b/src/gdlhelp.cpp
@@ -343,7 +343,7 @@ static void help_Output(BaseGDL** outputKW, ostringstream& ostr, SizeT &nlines, 
     string tmp_fname;
     size_t found;
 
-    StrArr path = SysVar::GDLPath();
+    StrArr path = StrArr(CurrentPathList);
 
     std::sort(path.begin(),path.end());
     ostr << "!PATH Cache (Enabled, "<< path.size() <<" directories)" << '\n';

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -1415,8 +1415,8 @@ bool GDLWidget::InitWx() {
      wxInitialize();
   } catch (...) {return false;}
  //avoid using if no Display is present!
-  wxDisplay *d= new wxDisplay();
-  if(d->GetCount()<1) return false;
+  wxDisplay d;
+  if(d.GetCount()<1) return false;
   wxInitAllImageHandlers(); //do it here once for all
   
 #if wxCHECK_VERSION(3,1,6)

--- a/src/graphicsdevice.cpp
+++ b/src/graphicsdevice.cpp
@@ -267,6 +267,17 @@ void GraphicsDevice::DestroyDevices()
   actDevice = NULL;
 }
 
+// this just to permit purging (in Atexit for example) without using DestroyDevices, 
+// that creates problems in this context (GDLWidget::UnInit())
+void GraphicsDevice::PurgeDeviceList()
+{
+  PurgeContainer( deviceList);
+  actDevice = NULL;
+#ifdef HAVE_LIBWXWIDGETS
+  wxUninitialize();
+#endif
+}
+
 void GraphicsDevice::DefineDStructDesc()
 {
   DStructDesc* dSysVarDesc = FindInStructList( structList, "!DEVICE");

--- a/src/graphicsdevice.hpp
+++ b/src/graphicsdevice.hpp
@@ -152,6 +152,7 @@ public:
 
   static void Init();
   static void DestroyDevices();
+  static void PurgeDeviceList();
   static void HandleEvents();
 
   static void LoadCT(UInt iCT);

--- a/src/initsysvar.hpp
+++ b/src/initsysvar.hpp
@@ -23,8 +23,6 @@ namespace SysVar
 {
   //  extern unsigned int pathIx, dIx;
   DFloat* GetSC();
-  // returns a StrArr with the path to search
-  const StrArr& GDLPath();
   void SetGDLPath( DString& newPath);
   void SetDlmPath( DString& newPath);
 

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -129,7 +129,7 @@ volatile bool useDSFMTAcceleration;
 //Transpose() operations are faster with our method, but setting this may test if this is still true for future Eigen:: versions or platforms.
 volatile bool useEigenForTransposeOps=false;
 //experimental TPOOL use adaptive number of threads.
-volatile bool useSmartTpool=false;
+volatile bool useSmartTpool=true;
 
 void ResetObjects()
 {
@@ -1066,6 +1066,9 @@ void breakpoint()
   num++;
 }
 
+// GD I believe this is not completely satisfactory as of 2025. Removing this function and using the total number of threads,
+// as we enforce smart-tpool now.
+#if 0
 
 #ifndef _OPENMP
 int get_suggested_omp_num_threads() {
@@ -1181,4 +1184,4 @@ int get_suggested_omp_num_threads() {
 }
 #endif
 
-
+#endif // GD

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -45,7 +45,7 @@ extern VarListT      sysVarList;
 extern VarListT      obsoleteSysVarList;
 extern VarListT      sysVarRdOnlyList;
 extern VarListT      sysVarNoSaveList;
-
+extern StrArr        CurrentPathList;
 extern FunListT      funList;
 extern ProListT      proList;
 extern UnknownFunListT      unknownFunList;
@@ -126,7 +126,7 @@ void InitGDL(); // defined in gdl.cpp
 void SaveCallingArgs(int argc, char* argv[]);
 
 void InitObjects();
-void ResetObjects();
+void ResetObjects(bool atexit=false);
 
 DLong GetLUN();
 

--- a/src/str.cpp
+++ b/src/str.cpp
@@ -536,8 +536,7 @@ bool CompleteFileName(std::string& fn)
 
   if( PathGiven(fn)) return false;
 
-  StrArr path=SysVar::GDLPath();
-  if( path.size() == 0) 
+  if( CurrentPathList.size() == 0) 
   {
     std::string act = "./pro/"; // default path if no path is given
 
@@ -556,9 +555,9 @@ bool CompleteFileName(std::string& fn)
     }
   }
   else
-    for(unsigned p=0; p<path.size(); p++)
+    for(unsigned p=0; p<CurrentPathList.size(); p++)
       {
-	std::string act=path[p];
+	std::string act=CurrentPathList[p];
 	
 	AppendIfNeeded(act,lib::PathSeparator());
 	

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -161,7 +161,7 @@ if (section eq 0 or section eq 5) then begin
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=logical_true(*big[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=atan(*big[k],*big[k]) & toc,subclock & end ',$
    'print,what[i] & kernel=[ [0,1,0],[-1,0,1],[0,-1,0] ] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=convol(*big[k],kernel) & toc,subclock & end ',$
-   'print,what[i] & z=findgen(size) & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=interpolate(*big[k],z) & toc,subclock & end ',$
+   'print,what[i] & z=findgen(size) & for k=0,all_numeric do begin & subclock=tic(typenames[k]) &s=memory(/current) & ret=interpolate(*big[k],z) & print,"MemoryLoss: ",memory(/cur)-s & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=poly_2d(*big[k],p,q) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & tvscl,(*big[k]) & toc,subclock & end ' ]
 

--- a/testsuite/test_all_basic_functions.pro
+++ b/testsuite/test_all_basic_functions.pro
@@ -21,7 +21,7 @@ calls="for k=0,limit do ret=(*small[k])"+what+"(*big[k])"
 for i=0,n_elements(what)-1 do z=execute(calls[i])
 ; big big, register time
 calls="for k=0,limit do ret=(*big[k])"+what+"(*big[k])"
-for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
 end
 ; helper for repetitive test with self variable
 pro process_self,what,limit
@@ -41,7 +41,7 @@ pro process_self,what,limit
   for i=0,n_elements(what)-1 do z=execute(calls[i])
 ; big big, register time
   calls="for k=0,limit do begin & var=(*big[k]) & var"+what+"var & endfor"
-for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
 end
 
 pro test_all_basic_functions, size=size, section=section
@@ -73,25 +73,25 @@ pro test_all_basic_functions, size=size, section=section
    
 ; array generation
 if (section eq 0 or section eq 1) then begin
-  command=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
-  calls="ret ="+command+"(size)"
-  for i=0,n_elements(command)-1 do begin  & clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+  what=["BYTARR","COMPLEXARR","DBLARR","DCOMPLEXARR","FLTARR","INTARR","LON64ARR","LONARR","UINTARR","ULON64ARR","ULONARR","OBJARR","PTRARR"]
+  calls="ret ="+what+"(size)"
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
      print
 endif
     
 ;
 if (section eq 0 or section eq 2) then begin
-  command=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
-  calls="ret ="+command+"(size)"
-  for i=0,n_elements(command)-1 do begin &  clock=tic(command[i]) & z=execute(calls[i]) & toc,clock & end
+  what=["BINDGEN","CINDGEN","DCINDGEN","DINDGEN","FINDGEN","INDGEN","L64INDGEN","LINDGEN","SINDGEN","UINDGEN","UL64INDGEN","ULINDGEN"]
+  calls="ret ="+what+"(size)"
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
   print
 endif
 ; conversion
 if (section eq 0 or section eq 3) then begin
-command=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
+what=["BYTE", "COMPLEX", "DCOMPLEX", "DOUBLE", "FIX", "FLOAT", $
       "LONG", "LONG64", "ULONG", "ULONG64"]
-   calls="for k=0,all_numeric do ret="+command+"(*big[k])"
-   for i=0,n_elements(command)-1 do begin & clock=tic(command[i])  &  z=execute(calls[i]) & toc,clock & end
+   calls="for k=0,all_numeric do ret="+what+"(*big[k])"
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
   print
 endif
 ; basic operators. They are 'optimized' inside GDL by calling
@@ -109,18 +109,17 @@ process_new,what, n_elements(what)-1
 ; operators 2
 what=[' # ',' ## ']
 calls="for k=0,all_numeric do  ret=(*big[k])"+what+"(*big[k])"
-for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
-
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
 what=[' #= ',' ##= ']
 ; need to use another variable not to overwrite and change it big[] !
 calls="for k=0,all_numeric do begin & var=(*big[k]) & var"+what+"var & end"
-for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
 
 ; operators 3
 what=[' ++ ',' -- ']
 ; need to use another variable not to overwrite and change it big[] !
 calls="for k=0,all_numeric do begin & var=(*big[k]) & var"+what+" & end"
-for i=0,n_elements(what)-1 do begin & clock=tic(what[i])  &  z=execute(calls[i]) &  toc,clock & endfor
+for i=0,n_elements(what)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& endfor
 
 ; operators 4
 what=[' AND ',' OR ',' EQ ',' NE ',' LE ',' LT ', ' GE ', ' GT ',' ^']
@@ -166,7 +165,7 @@ if (section eq 0 or section eq 5) then begin
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=poly_2d(*big[k],p,q) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & tvscl,(*big[k]) & toc,subclock & end ' ]
 
-for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+for i=0,n_elements(calls)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& end
      print
   endif
 set_plot,olddev
@@ -192,7 +191,7 @@ if (section eq 0 or section eq 6) then begin
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=fft(*big[k]) & toc,subclock & end ',$
    'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & ret=fft(*big[k],dim=2) & toc,subclock & end ']
 
-for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+for i=0,n_elements(calls)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& end
      print
   endif
 
@@ -216,7 +215,7 @@ if (section eq 0 or section eq 8) then begin
      'print,what[i] & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & BYTEORDER,*big[k],/LSWAP & toc,subclock & end ',$
      'print,what[i] & x = FINDGEN(100)*0.02 & y=sin(x) & for k=0,all_numeric do begin & subclock=tic(typenames[k]) & res=interpol(y,x,*big[k]) & toc,subclock & end ']
 
-   for i=0,n_elements(calls)-1 do begin & clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & end
+  for i=0,n_elements(calls)-1 do begin &s=memory(/current)& clock=tic(what[i])  & z=execute(calls[i]) &  toc,clock & print,"MemoryLoss: ",memory(/cur)-s& end
   print
 endif
 


### PR DESCRIPTION
Use of a fixed-size static array for fast storage of a few elements (32 bytes, 16 ints, etc) divides by almost 2 the memory imprint of GDL, and additionnally speeds up some internal functions.
A lot of reported memory leaks (invisible as related to the initialisation of GDL internals, and not cleaned when quitting GDL---why bother?) are also removed. Only memory leaks in the external libraries, inherently unavoidable, are left.
For the record: using the `--clean-at-exit` switch makes GDL delete all known allocated memory before exit. This is the switch one must use when debugging GDL with Valgrind.