### PR TITLE
Revert "should close #2083 and #2105 (#2108)"

### DIFF
--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -55,10 +55,7 @@ BaseGDL& BaseGDL::operator=(const BaseGDL& right)
   this->dim = right.dim;
   return *this;
 }
-BaseGDL& BaseGDL::operator<<=(const BaseGDL& right)
-{
-  throw GDLException("BaseGDL::operator<<=(const BaseGDL& right) called.");
-}
+
 void  BaseGDL::InitFrom(const BaseGDL& right)
 {
   throw GDLException("BaseGDL::InitFrom(const BaseGDL& right) called.");

--- a/src/basegdl.hpp
+++ b/src/basegdl.hpp
@@ -491,7 +491,6 @@ public:
 
 //  private:
   virtual BaseGDL& operator=(const BaseGDL& right);
-  virtual BaseGDL& operator<<=(const BaseGDL& right); //for DStructGDL only
 //  public:
  
   virtual void InitFrom(const BaseGDL& right); // for structs

--- a/src/datatypes.cpp
+++ b/src/datatypes.cpp
@@ -1837,18 +1837,7 @@ Data_<SpDComplex>::Ty Data_<SpDComplex>::Sum() const { TRACE_ROUTINE(__FUNCTION_
 // typename Data_<Sp>::Ty& Data_<Sp>::operator[] (const SizeT d1) 
 // {  return (*this)[d1];}
 
-// really only used from DStructGDL -- only to provide a solution to #2105
-template<class Sp>
-Data_<Sp>& Data_<Sp>::operator<<=(const BaseGDL& r) {
-  TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-  assert(r.Type() == this->Type());
-  const Data_<Sp>& right = static_cast<const Data_<Sp>&> (r);
-  assert(&right != this);
-  // this->dim = right.dim; //only for the special case #2105
-  dd = right.dd;
-  return *this;
-}
-// only used from DStructGDL ?
+// only used from DStructGDL
 template<class Sp> 
 Data_<Sp>&  Data_<Sp>::operator=(const BaseGDL& r)
 { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -130,7 +130,6 @@ static	void operator delete( void *ptr);
   // operators
   // assignment. 
   Data_& operator=(const BaseGDL& right);
-  Data_& operator<<=(const BaseGDL& right);
 
   // for structs
   void InitFrom(const BaseGDL& right);

--- a/src/dimension.hpp
+++ b/src/dimension.hpp
@@ -438,13 +438,7 @@ public:
     dim[0]=1;
     rank=1;
   }
-  void MakeScalarIfOneElement()
-  {
-	  if (rank==1 & dim[0]==1) {
-    dim[0]=0;
-    rank=0;
-	  }
-  }
+
 };
 
 #endif

--- a/src/dstructdesc.cpp
+++ b/src/dstructdesc.cpp
@@ -207,30 +207,25 @@ bool operator==(const DStructDesc& left,
   //  if( left.parent.size() != right.parent.size()) return false;
   // compare all tag names
   // compare the tags (type and dim)
-  for( SizeT i=0; i < left.NTags(); i++) {
-    //      if( left.TagName(i) != right.TagName(i)) return false;
-    // GD: bug #2015 insure 1-element of dimension 1 is equivalent to 1-element dimension 0 (scalar).
-    if (left.tags[i]->Dim() != right.tags[i]->Dim()) {
-      if ((left.tags[i]->Rank() <= 1 && left.tags[i]->N_Elements() == 1) //dimension 0 or 1, 1 element
-          && (right.tags[i]->Rank() <= 1 && right.tags[i]->N_Elements() == 1) //dimension 0 or 1, 1 element
-          ) {
-      }//OK 
-      else return false;
+  for( SizeT i=0; i < left.NTags(); i++)
+    {
+      //      if( left.TagName(i) != right.TagName(i)) return false;
+      if( left.tags[i]->Dim() != right.tags[i]->Dim()) return false;
+      if( left.tags[i]->Type() != right.tags[i]->Type()) return false;
+      if( left.tags[i]->Type() == GDL_STRUCT)
+	{
+	  SpDStruct* castLeft= 
+	    static_cast<SpDStruct*>(left.tags[i]);
+	  SpDStruct* castRight= 
+	    static_cast<SpDStruct*>(right.tags[i]);
+	  DStructDesc* leftD=castLeft->Desc();
+	  DStructDesc* rightD=castRight->Desc();
+	  
+	  // recursive call of operator ==
+	  if( (leftD != rightD) && !(*leftD == *rightD)) 
+	    return false;
+	}
     }
-    if (left.tags[i]->Type() != right.tags[i]->Type()) return false;
-    if (left.tags[i]->Type() == GDL_STRUCT) {
-      SpDStruct* castLeft =
-          static_cast<SpDStruct*> (left.tags[i]);
-      SpDStruct* castRight =
-          static_cast<SpDStruct*> (right.tags[i]);
-      DStructDesc* leftD = castLeft->Desc();
-      DStructDesc* rightD = castRight->Desc();
-
-      // recursive call of operator ==
-      if ((leftD != rightD) && !(*leftD == *rightD))
-        return false;
-    }
-  }
   // compare all parents
   //  for( SizeT i=0; i < left.parent.size(); i++)
   //    {

--- a/src/dstructgdl.cpp
+++ b/src/dstructgdl.cpp
@@ -442,14 +442,14 @@ void DStructGDL::AssignAtIx( RangeT ixR, BaseGDL* srcIn)
     //(*this)[ix] = (*static_cast<Data_*>(srcIn))[0];
     for( SizeT tagIx=0; tagIx<nTags; ++tagIx)
       {
-	*GetTag( tagIx, ix) <<= *src->GetTag( tagIx); //note special operator
+	*GetTag( tagIx, ix) = *src->GetTag( tagIx);
       }
     return;
   } // ixR >= 0
   //(*this)[ixR] = (*static_cast<Data_*>(srcIn))[0];
   for( SizeT tagIx=0; tagIx<nTags; ++tagIx)
     {
-      *GetTag( tagIx, ixR) <<= *src->GetTag( tagIx); //note special operator
+      *GetTag( tagIx, ixR) = *src->GetTag( tagIx);
     }
 }
 void DStructGDL::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList) 
@@ -477,7 +477,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 		{
 // 		  delete dd[cTag+tagIx];
 // 		  dd[ cTag+tagIx]=src->dd[tagIx]->Dup();
-		  *GetTag( tagIx, c) = *src->GetTag( tagIx); //may need special operator <<= TBC
+		  *GetTag( tagIx, c) = *src->GetTag( tagIx);
 		}
 	    }
 	}
@@ -494,7 +494,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 		{
 // 		  delete dd[cTag+tagIx];
 // 		  dd[ cTag+tagIx]=src->dd[tagIx]->Dup();
-		  *GetTag( tagIx, cTag) = *src->GetTag( tagIx); //may need special operator <<= TBC
+		  *GetTag( tagIx, cTag) = *src->GetTag( tagIx);
 		}
 	    }
 	}
@@ -517,7 +517,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 		{
 // 		  delete dd[cTag+tagIx];
 // 		  dd[ cTag+tagIx]=src->dd[srcTag+tagIx]->Dup();
-		  *GetTag( tagIx, c) = *src->GetTag( tagIx, c); //may need special operator <<= TBC
+		  *GetTag( tagIx, c) = *src->GetTag( tagIx, c);
 		}
 	    }
  	}
@@ -546,7 +546,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn, ArrayIndexListT* ixList)
 		    {
 // 		      delete dd[cTag+tagIx];
 // 		      dd[ cTag+tagIx]=src->dd[srcTag+tagIx]->Dup();
-		      *GetTag( tagIx, cTag) = *src->GetTag( tagIx, c); //may need special operator <<= TBC
+		      *GetTag( tagIx, cTag) = *src->GetTag( tagIx, c);
 		    }
 		}
 	    }
@@ -577,7 +577,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn)
 	    {
 	      // 		  delete dd[cTag+tagIx];
 	      // 		  dd[ cTag+tagIx]=src->dd[tagIx]->Dup();
-	      *GetTag( tagIx, c) = *src->GetTag( tagIx); //may need special operator <<= TBC
+	      *GetTag( tagIx, c) = *src->GetTag( tagIx);
 	    }
 	}
     }
@@ -599,7 +599,7 @@ void DStructGDL::AssignAt( BaseGDL* srcIn)
 	    {
 	      // 		  delete dd[cTag+tagIx];
 	      // 		  dd[ cTag+tagIx]=src->dd[srcTag+tagIx]->Dup();
-	      *GetTag( tagIx, c) = *src->GetTag( tagIx, c); //may need special operator <<= TBC
+	      *GetTag( tagIx, c) = *src->GetTag( tagIx, c);
 	    }
 	}
     }

--- a/src/dstructgdl.hpp
+++ b/src/dstructgdl.hpp
@@ -176,8 +176,9 @@ public:
 
     assert( *Desc() == *right.Desc());
     assert( &right != this);
-    this->dim = (right.dim);
-    (this->dim).MakeScalarIfOneElement();
+    
+    this->dim = right.dim;
+
     SizeT nTags = NTags();
     SizeT nEl   = N_Elements();
     for( SizeT e=0; e < nEl; ++e)

--- a/src/nullgdl.cpp
+++ b/src/nullgdl.cpp
@@ -67,10 +67,7 @@ BaseGDL& NullGDL::operator=(const BaseGDL& right)
 {
   return *this;
 }
-BaseGDL& NullGDL::operator<<=(const BaseGDL& right)
-{
-  throw GDLException("NullGDL::operator<<=(const BaseGDL& right) called.");
-}
+
 void  NullGDL::InitFrom(const BaseGDL& right)
 {
   throw GDLException("NullGDL::InitFrom(const BaseGDL& right) called.");

--- a/src/nullgdl.hpp
+++ b/src/nullgdl.hpp
@@ -67,7 +67,6 @@ class NullGDL: public BaseGDL
     }
 //  private:
   /*virtual*/ BaseGDL& operator=(const BaseGDL& right);
-  /*virtual*/ BaseGDL& operator<<=(const BaseGDL& right);
 //  public:
  
   /*virtual*/ void InitFrom(const BaseGDL& right); // for structs

--- a/testsuite/test_struct_assign.pro
+++ b/testsuite/test_struct_assign.pro
@@ -17,12 +17,6 @@ pro test_struct_assign
   ; 
   c=CREATE_STRUCT(NAME='HasStruct', ['un','deux','trois'], [1,5], 2b, findgen(32))
   struct_assign,c,b,/nozero,/verb
-  ; issue #2083
-   a=replicate({x:{y:1}},3)
-   if size(a.x,/n_dim) ne 1 then  err++ 
-  ; issue #2105 (both ways)
-   x0 = {value:'zzzzz'} & xb={value:['test']} & test=xb & test[0]=x0 & if size(test.value,/n_dim) ne 1 then  err++
-   x0 = {value:'zzzzz'} & xb={value:['test']} & test=x0 & test[0]=xb & if size(test.value,/n_dim) ne 0 then  err++
 ;  print,err
     if err ne 0 then begin
       message, 'test FAILED with '+strtrim(err,2)+' errors', /conti


### PR DESCRIPTION
This reverts commit dd37ea05b5230af2e670b861802b949ae1d2801f.
Reason: analysis of behaviour reported in #2083 and #2105 may be wrong, since #2115 may be the real cause.
besides, one of the patches render GDL unable to run NASA's SSW.