### PR TITLE
patch for #2124 

### DIFF
--- a/src/basegdl.cpp
+++ b/src/basegdl.cpp
@@ -55,9 +55,10 @@ BaseGDL& BaseGDL::operator=(const BaseGDL& right)
   this->dim = right.dim;
   return *this;
 }
+//Only used in "relaxed assignment for struct copying 
 BaseGDL& BaseGDL::operator<<=(const BaseGDL& right)
 {
-  throw GDLException("BaseGDL::operator<<=(const BaseGDL& right) called.");
+return *this; // just DO NOTHING. It seems the best solution (one-liner) to #2124 // throw GDLException("BaseGDL::operator<<=(const BaseGDL& right) called.");
 }
 void  BaseGDL::InitFrom(const BaseGDL& right)
 {

--- a/testsuite/test_struct_assign.pro
+++ b/testsuite/test_struct_assign.pro
@@ -15,6 +15,7 @@ pro test_struct_assign
   if total(b.trois.deux) ne 4 then err++ ; show also that it is "relaxed"
   ; 
   c=CREATE_STRUCT(NAME='HasStruct', ['un','deux','trois'], [1,5], 2b, findgen(32))
+	print, "following error is EXPECTED:"
   struct_assign,c,b,/nozero,/verb
   ; issue #2083
    a=replicate({x:{y:1}},3)


### PR DESCRIPTION
remove throw for the "relaxed struct assigment" opertor in case of passed BaseGDL --- seems sufficient to solve the problem.