### PR TITLE
patch for #2122

### DIFF
--- a/src/plotting.cpp
+++ b/src/plotting.cpp
@@ -2132,15 +2132,16 @@ PLFLT gdlGetBoxNYSize() {
         do_color=true;
       }
     }
-    //IDL does not complain if thick is undefined.
-    do_thick=false;
-    thethick=0;
+    //IDL uses (and forces) thick=1 if thisk is not defined
+    do_thick=true; //to avoid changing too much code, I keep this old switch.
+    // would certainly speedup a bit the plots if removal of do_thick was was propagated to draw_polyline
+    thethick=1;
     int THICKIx = e->KeywordIx("THICK");
     if ( e->KeywordPresent(THICKIx))
     {
       if (e->IfDefGetKWAs<DFloatGDL>( THICKIx )) {
         e->AssureFloatScalarKW(THICKIx, thethick);
-        do_thick=true;
+        do_thick=true; //see above, not useful anymore after #2122
       }
     }    
     SetUsym(n, do_fill, x, y, do_color, thecolor, do_thick, thethick);


### PR DESCRIPTION
did not realize at the time that PSYM=8 thick was by default 1 and thus imposed to the plot if usersym did not precise its thickness.

IMHO this is an error of IDL, people want to master their plot with the THICK= passed to the plot command, not redefining the USERSYM each time. I suspect other oddities for usersym's COLOR.