### PR TITLE
Drop wx-3.0 include dir

### DIFF
--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <wx-3.0/wx/graphics.h>
+#include <wx/graphics.h>
 
 #include "includefirst.hpp"
 


### PR DESCRIPTION
This fixes building with wx 3.2 in Fedora rawhide