### PR TITLE
Fix include

### DIFF
--- a/src/gdlwxstream.cpp
+++ b/src/gdlwxstream.cpp
@@ -15,14 +15,12 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <wx-3.0/wx/graphics.h>
-
 #include "includefirst.hpp"
 
 #ifdef HAVE_LIBWXWIDGETS
 
 #include "gdlwxstream.hpp"
-
+#include <wx/graphics.h>
 
 
 GDLWXStream::GDLWXStream( int width, int height )


### PR DESCRIPTION
Recent PR for #2141 breaks build on current Archlinux, since wx header is in another subdir than "wx-3.0", Stripped unnneded path in include and moved include after the `#ifdef`. 

Need to look into the apply build error...