### PR TITLE
avoid failures of rebuild on github's osx or windows

### DIFF
--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -369,6 +369,7 @@ function prep_packages {
             exit 1
         fi
         brew update-reset
+		export SDKROOT=$(xcrun --show-sdk-path) #solves IA64 brew problems?
         log "Installing packages: ${BREW_PACKAGES[@]}"
         if [ ${DRY_RUN} == "true" ]; then
             log "Please run below command to install required packages to build GDL."

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -364,6 +364,8 @@ function prep_packages {
             fi
         fi
     elif [ ${BUILD_OS} == "macOS" ]; then
+        log "Checking xcode-select" 
+        xcode-select -p
         if ! command -v brew >/dev/null 2>&1; then
             log "Fatal error! Homebrew not found."
             exit 1

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -364,8 +364,6 @@ function prep_packages {
             fi
         fi
     elif [ ${BUILD_OS} == "macOS" ]; then
-        log "Checking xcode-select" 
-        xcode-select -p
         if ! command -v brew >/dev/null 2>&1; then
             log "Fatal error! Homebrew not found."
             exit 1
@@ -417,15 +415,15 @@ function configure_gdl {
     fi
     
     if [[ ${BUILD_OS} == "macOS" ]]; then
+#patch to be tested: should avoid the error "tried including <stddef.h> but didn't find libc++'s <stddef.h> header."
+            sudo xcode-select -s /Library/Developer/CommandLineTools
+#end patch
         if [[ ${Platform} == "arm64" ]]; then
             export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/llvm/lib
             CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/opt/homebrew/opt/readline"
                                     "-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++"
                                     "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
         else
-#patch to be tested: should avoid the error "tried including <stddef.h> but didn't find libc++'s <stddef.h> header."
-#            sudo xcode-select -s /Library/Developer/CommandLineTools
-#end patch
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
             CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"
                                     "-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -118,7 +118,7 @@ elif [ ${BUILD_OS} == "Linux" ]; then
 elif [ ${BUILD_OS} == "macOS" ]; then
     BREW_PACKAGES=(
         llvm libx11 libomp ncurses readline zlib libpng gsl wxwidgets graphicsmagick libtiff libgeotiff netcdf hdf5 fftw proj open-mpi python numpy udunits eigen
-        eccodes glpk shapelib expat gcc@11 qhull dylibbundler cmake
+        eccodes glpk shapelib expat gcc qhull dylibbundler cmake
     ) # JP 2021 Mar 21: HDF4 isn't available - not so critical I guess
       # JP 2021 May 25: Added GCC 10 which includes libgfortran, which the numpy tap relies on.
       # J-KL 2022 July 30: GCC 10 didn't work with apple silicon mac. So I replaced it with GCC 11
@@ -369,7 +369,6 @@ function prep_packages {
             exit 1
         fi
         brew update-reset
-		export SDKROOT=$(xcrun --show-sdk-path) #solves IA64 brew problems?
         log "Installing packages: ${BREW_PACKAGES[@]}"
         if [ ${DRY_RUN} == "true" ]; then
             log "Please run below command to install required packages to build GDL."

--- a/scripts/build_gdl.sh
+++ b/scripts/build_gdl.sh
@@ -424,7 +424,7 @@ function configure_gdl {
                                     "-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang" ) 
         else
 #patch to be tested: should avoid the error "tried including <stddef.h> but didn't find libc++'s <stddef.h> header."
-            sudo xcode-select -s /Library/Developer/CommandLineTools
+#            sudo xcode-select -s /Library/Developer/CommandLineTools
 #end patch
             export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/llvm/lib
             CMAKE_ADDITIONAL_ARGS=( "-DMPI=OFF -DREADLINEDIR=/usr/local/opt/readline"

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(TEST ${TESTS})
   endif()
 endforeach(TEST TESTS)
 
-set_tests_properties(${TESTS} PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 3600) # autoconf's setting
+set_tests_properties(${TESTS} PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 120) # autoconf's setting
 set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "LC_COLLATE=C;GDL_PATH=${BASE_SOURCE}/testsuite/${PATH_SEP}${BASE_SOURCE}/src/pro/${PATH_SEP}${BASE_SOURCE}/src/pro/CMprocedures/${PATH_SEP}${BASE_SOURCE}/src/pro/dicom/${PATH_SEP}${BASE_SOURCE}/src/pro/utilities/;GDL_STARTUP=;IDL_STARTUP=")
 
 set(ARM_XFAIL_TESTS


### PR DESCRIPTION
After painful tests, these failures were due to GitHub ("Travis") changes that need to be analyzed each time by a knowledgeable person. The symptoms are:

1. GDL can be compiled / tested without errors on individual (personal) machines
2. same GDL version rebuils stops prematurely/ lots of errors when rebuild automatically on Travis (the "Checks button above)

In this case the PR contents are not culprit and the PR is candidate to merging, irrespective of the "Checks" failures. AND the conditions of rebuild on Travis (use of CACHE, workflow .yml code .... ) must be checked by  a knowledgeable person (who?).