### PR TITLE
2 ANTLR changes

### DIFF
--- a/src/GDLLexer.cpp
+++ b/src/GDLLexer.cpp
@@ -428,11 +428,11 @@ void GDLLexer::mSTRING(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop329;
+			goto _loop333;
 		}
 		
 	}
-	_loop329:;
+	_loop333:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1174,10 +1174,10 @@ void GDLLexer::mEOL(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{
-	bool synPredMatched381 = false;
+	bool synPredMatched385 = false;
 	if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ) && (true) && (true))) {
-		int _m381 = mark();
-		synPredMatched381 = true;
+		int _m385 = mark();
+		synPredMatched385 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -1185,12 +1185,12 @@ void GDLLexer::mEOL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched381 = false;
+			synPredMatched385 = false;
 		}
-		rewind(_m381);
+		rewind(_m385);
 		inputState->guessing--;
 	}
-	if ( synPredMatched381 ) {
+	if ( synPredMatched385 ) {
 		match("\r\n");
 	}
 	else if ((LA(1) == 0xa /* '\n' */ )) {
@@ -1441,18 +1441,18 @@ void GDLLexer::mEXP(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt399=0;
+		int _cnt403=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt399>=1 ) { goto _loop399; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt403>=1 ) { goto _loop403; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt399++;
+			_cnt403++;
 		}
-		_loop399:;
+		_loop403:;
 		}  // ( ... )+
 	}
 	else {
@@ -1526,18 +1526,18 @@ void GDLLexer::mDBL(bool _createToken) {
 		}
 		}
 		{ // ( ... )+
-		int _cnt406=0;
+		int _cnt410=0;
 		for (;;) {
 			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 				mD(false);
 			}
 			else {
-				if ( _cnt406>=1 ) { goto _loop406; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt410>=1 ) { goto _loop410; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt406++;
+			_cnt410++;
 		}
-		_loop406:;
+		_loop410:;
 		}  // ( ... )+
 	}
 	else {
@@ -1987,27 +1987,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 	_ttype = CONSTANT_OR_STRING_LITERAL;
 	std::string::size_type _saveIndex;
 	
-	bool synPredMatched481 = false;
+	bool synPredMatched485 = false;
 	if (((LA(1) == 0x27 /* '\'' */ ) && (_tokenSet_4.member(LA(2))) && (_tokenSet_5.member(LA(3))) && (_tokenSet_6.member(LA(4))))) {
-		int _m481 = mark();
-		synPredMatched481 = true;
+		int _m485 = mark();
+		synPredMatched485 = true;
 		inputState->guessing++;
 		try {
 			{
 			match('\'' /* charlit */ );
 			{ // ( ... )+
-			int _cnt479=0;
+			int _cnt483=0;
 			for (;;) {
 				if ((_tokenSet_4.member(LA(1)))) {
 					mH(false);
 				}
 				else {
-					if ( _cnt479>=1 ) { goto _loop479; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt483>=1 ) { goto _loop483; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt479++;
+				_cnt483++;
 			}
-			_loop479:;
+			_loop483:;
 			}  // ( ... )+
 			match('\'' /* charlit */ );
 			{
@@ -2043,29 +2043,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched481 = false;
+			synPredMatched485 = false;
 		}
-		rewind(_m481);
+		rewind(_m485);
 		inputState->guessing--;
 	}
-	if ( synPredMatched481 ) {
+	if ( synPredMatched485 ) {
 		{
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
 		text.erase(_saveIndex);
 		{ // ( ... )+
-		int _cnt484=0;
+		int _cnt488=0;
 		for (;;) {
 			if ((_tokenSet_4.member(LA(1)))) {
 				mH(false);
 			}
 			else {
-				if ( _cnt484>=1 ) { goto _loop484; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt488>=1 ) { goto _loop488; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt484++;
+			_cnt488++;
 		}
-		_loop484:;
+		_loop488:;
 		}  // ( ... )+
 		_saveIndex = text.length();
 		match('\'' /* charlit */ );
@@ -2162,27 +2162,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 		}
 	}
 	else {
-		bool synPredMatched490 = false;
+		bool synPredMatched494 = false;
 		if (((LA(1) == 0x27 /* '\'' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (_tokenSet_7.member(LA(3))) && (_tokenSet_8.member(LA(4))))) {
-			int _m490 = mark();
-			synPredMatched490 = true;
+			int _m494 = mark();
+			synPredMatched494 = true;
 			inputState->guessing++;
 			try {
 				{
 				match('\'' /* charlit */ );
 				{ // ( ... )+
-				int _cnt488=0;
+				int _cnt492=0;
 				for (;;) {
 					if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 						mO(false);
 					}
 					else {
-						if ( _cnt488>=1 ) { goto _loop488; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt492>=1 ) { goto _loop492; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt488++;
+					_cnt492++;
 				}
-				_loop488:;
+				_loop492:;
 				}  // ( ... )+
 				match('\'' /* charlit */ );
 				{
@@ -2209,29 +2209,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched490 = false;
+				synPredMatched494 = false;
 			}
-			rewind(_m490);
+			rewind(_m494);
 			inputState->guessing--;
 		}
-		if ( synPredMatched490 ) {
+		if ( synPredMatched494 ) {
 			{
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
 			text.erase(_saveIndex);
 			{ // ( ... )+
-			int _cnt493=0;
+			int _cnt497=0;
 			for (;;) {
 				if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 					mO(false);
 				}
 				else {
-					if ( _cnt493>=1 ) { goto _loop493; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+					if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 				}
 				
-				_cnt493++;
+				_cnt497++;
 			}
-			_loop493:;
+			_loop497:;
 			}  // ( ... )+
 			_saveIndex = text.length();
 			match('\'' /* charlit */ );
@@ -2328,27 +2328,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 			}
 		}
 		else {
-			bool synPredMatched499 = false;
+			bool synPredMatched503 = false;
 			if (((LA(1) == 0x27 /* '\'' */ ) && (LA(2) == 0x30 /* '0' */  || LA(2) == 0x31 /* '1' */ ) && (LA(3) == 0x27 /* '\'' */  || LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (_tokenSet_9.member(LA(4))))) {
-				int _m499 = mark();
-				synPredMatched499 = true;
+				int _m503 = mark();
+				synPredMatched503 = true;
 				inputState->guessing++;
 				try {
 					{
 					match('\'' /* charlit */ );
 					{ // ( ... )+
-					int _cnt497=0;
+					int _cnt501=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt497>=1 ) { goto _loop497; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt501>=1 ) { goto _loop501; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt497++;
+						_cnt501++;
 					}
-					_loop497:;
+					_loop501:;
 					}  // ( ... )+
 					match('\'' /* charlit */ );
 					{
@@ -2375,29 +2375,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched499 = false;
+					synPredMatched503 = false;
 				}
-				rewind(_m499);
+				rewind(_m503);
 				inputState->guessing--;
 			}
-			if ( synPredMatched499 ) {
+			if ( synPredMatched503 ) {
 				{
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
 				text.erase(_saveIndex);
 				{ // ( ... )+
-				int _cnt502=0;
+				int _cnt506=0;
 				for (;;) {
 					if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 						mB(false);
 					}
 					else {
-						if ( _cnt502>=1 ) { goto _loop502; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+						if ( _cnt506>=1 ) { goto _loop506; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 					}
 					
-					_cnt502++;
+					_cnt506++;
 				}
-				_loop502:;
+				_loop506:;
 				}  // ( ... )+
 				_saveIndex = text.length();
 				match('\'' /* charlit */ );
@@ -2494,27 +2494,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 				}
 			}
 			else {
-				bool synPredMatched463 = false;
+				bool synPredMatched467 = false;
 				if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x62 /* 'b' */ ) && (LA(3) == 0x30 /* '0' */  || LA(3) == 0x31 /* '1' */ ) && (true))) {
-					int _m463 = mark();
-					synPredMatched463 = true;
+					int _m467 = mark();
+					synPredMatched467 = true;
 					inputState->guessing++;
 					try {
 						{
 						match("0b");
 						{ // ( ... )+
-						int _cnt461=0;
+						int _cnt465=0;
 						for (;;) {
 							if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 								mB(false);
 							}
 							else {
-								if ( _cnt461>=1 ) { goto _loop461; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt465>=1 ) { goto _loop465; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt461++;
+							_cnt465++;
 						}
-						_loop461:;
+						_loop465:;
 						}  // ( ... )+
 						{
 						switch ( LA(1)) {
@@ -2557,29 +2557,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched463 = false;
+						synPredMatched467 = false;
 					}
-					rewind(_m463);
+					rewind(_m467);
 					inputState->guessing--;
 				}
-				if ( synPredMatched463 ) {
+				if ( synPredMatched467 ) {
 					{
 					_saveIndex = text.length();
 					match("0b");
 					text.erase(_saveIndex);
 					{ // ( ... )+
-					int _cnt466=0;
+					int _cnt470=0;
 					for (;;) {
 						if ((LA(1) == 0x30 /* '0' */  || LA(1) == 0x31 /* '1' */ )) {
 							mB(false);
 						}
 						else {
-							if ( _cnt466>=1 ) { goto _loop466; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+							if ( _cnt470>=1 ) { goto _loop470; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 						}
 						
-						_cnt466++;
+						_cnt470++;
 					}
-					_loop466:;
+					_loop470:;
 					}  // ( ... )+
 					if ( inputState->guessing==0 ) {
 						_ttype=CONSTANT_BIN_I;
@@ -2670,27 +2670,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 					}
 				}
 				else {
-					bool synPredMatched445 = false;
+					bool synPredMatched449 = false;
 					if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x78 /* 'x' */ ))) {
-						int _m445 = mark();
-						synPredMatched445 = true;
+						int _m449 = mark();
+						synPredMatched449 = true;
 						inputState->guessing++;
 						try {
 							{
 							match("0x");
 							{ // ( ... )+
-							int _cnt443=0;
+							int _cnt447=0;
 							for (;;) {
 								if ((_tokenSet_4.member(LA(1)))) {
 									mH(false);
 								}
 								else {
-									if ( _cnt443>=1 ) { goto _loop443; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt447>=1 ) { goto _loop447; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt443++;
+								_cnt447++;
 							}
-							_loop443:;
+							_loop447:;
 							}  // ( ... )+
 							{
 							switch ( LA(1)) {
@@ -2717,29 +2717,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched445 = false;
+							synPredMatched449 = false;
 						}
-						rewind(_m445);
+						rewind(_m449);
 						inputState->guessing--;
 					}
-					if ( synPredMatched445 ) {
+					if ( synPredMatched449 ) {
 						{
 						_saveIndex = text.length();
 						match("0x");
 						text.erase(_saveIndex);
 						{ // ( ... )+
-						int _cnt448=0;
+						int _cnt452=0;
 						for (;;) {
 							if ((_tokenSet_4.member(LA(1)))) {
 								mH(false);
 							}
 							else {
-								if ( _cnt448>=1 ) { goto _loop448; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+								if ( _cnt452>=1 ) { goto _loop452; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 							}
 							
-							_cnt448++;
+							_cnt452++;
 						}
-						_loop448:;
+						_loop452:;
 						}  // ( ... )+
 						if ( inputState->guessing==0 ) {
 							_ttype=CONSTANT_HEX_I;
@@ -2816,27 +2816,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 						}
 					}
 					else {
-						bool synPredMatched454 = false;
+						bool synPredMatched458 = false;
 						if (((LA(1) == 0x30 /* '0' */ ) && (LA(2) == 0x6f /* 'o' */ ))) {
-							int _m454 = mark();
-							synPredMatched454 = true;
+							int _m458 = mark();
+							synPredMatched458 = true;
 							inputState->guessing++;
 							try {
 								{
 								match("0o");
 								{ // ( ... )+
-								int _cnt452=0;
+								int _cnt456=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt452>=1 ) { goto _loop452; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt456>=1 ) { goto _loop456; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt452++;
+									_cnt456++;
 								}
-								_loop452:;
+								_loop456:;
 								}  // ( ... )+
 								{
 								switch ( LA(1)) {
@@ -2879,29 +2879,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched454 = false;
+								synPredMatched458 = false;
 							}
-							rewind(_m454);
+							rewind(_m458);
 							inputState->guessing--;
 						}
-						if ( synPredMatched454 ) {
+						if ( synPredMatched458 ) {
 							{
 							_saveIndex = text.length();
 							match("0o");
 							text.erase(_saveIndex);
 							{ // ( ... )+
-							int _cnt457=0;
+							int _cnt461=0;
 							for (;;) {
 								if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 									mO(false);
 								}
 								else {
-									if ( _cnt457>=1 ) { goto _loop457; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+									if ( _cnt461>=1 ) { goto _loop461; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 								}
 								
-								_cnt457++;
+								_cnt461++;
 							}
-							_loop457:;
+							_loop461:;
 							}  // ( ... )+
 							if ( inputState->guessing==0 ) {
 								_ttype=CONSTANT_OCT_I;
@@ -2992,27 +2992,27 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 							}
 						}
 						else {
-							bool synPredMatched472 = false;
+							bool synPredMatched476 = false;
 							if (((LA(1) == 0x22 /* '\"' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x37 /* '7' */ )) && (true) && (true))) {
-								int _m472 = mark();
-								synPredMatched472 = true;
+								int _m476 = mark();
+								synPredMatched476 = true;
 								inputState->guessing++;
 								try {
 									{
 									match('\"' /* charlit */ );
 									{ // ( ... )+
-									int _cnt470=0;
+									int _cnt474=0;
 									for (;;) {
 										if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 											mO(false);
 										}
 										else {
-											if ( _cnt470>=1 ) { goto _loop470; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+											if ( _cnt474>=1 ) { goto _loop474; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 										}
 										
-										_cnt470++;
+										_cnt474++;
 									}
-									_loop470:;
+									_loop474:;
 									}  // ( ... )+
 									{
 									switch ( LA(1)) {
@@ -3060,29 +3060,29 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched472 = false;
+									synPredMatched476 = false;
 								}
-								rewind(_m472);
+								rewind(_m476);
 								inputState->guessing--;
 							}
-							if ( synPredMatched472 ) {
+							if ( synPredMatched476 ) {
 								{
 								_saveIndex = text.length();
 								match('\"' /* charlit */ );
 								text.erase(_saveIndex);
 								{ // ( ... )+
-								int _cnt475=0;
+								int _cnt479=0;
 								for (;;) {
 									if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x37 /* '7' */ ))) {
 										mO(false);
 									}
 									else {
-										if ( _cnt475>=1 ) { goto _loop475; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+										if ( _cnt479>=1 ) { goto _loop479; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 									}
 									
-									_cnt475++;
+									_cnt479++;
 								}
-								_loop475:;
+								_loop479:;
 								}  // ( ... )+
 								if ( inputState->guessing==0 ) {
 									_ttype=CONSTANT_OCT_I;
@@ -3183,10 +3183,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 								}
 							}
 							else {
-								bool synPredMatched523 = false;
+								bool synPredMatched527 = false;
 								if (((_tokenSet_10.member(LA(1))) && (_tokenSet_11.member(LA(2))) && (true) && (true))) {
-									int _m523 = mark();
-									synPredMatched523 = true;
+									int _m527 = mark();
+									synPredMatched527 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -3204,18 +3204,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt515=0;
+											int _cnt519=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt515>=1 ) { goto _loop515; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt519>=1 ) { goto _loop519; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt515++;
+												_cnt519++;
 											}
-											_loop515:;
+											_loop519:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3233,11 +3233,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop518;
+														goto _loop522;
 													}
 													
 												}
-												_loop518:;
+												_loop522:;
 												} // ( ... )*
 												{
 												mDBL(false);
@@ -3257,18 +3257,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt521=0;
+											int _cnt525=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt521>=1 ) { goto _loop521; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt525>=1 ) { goto _loop525; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt521++;
+												_cnt525++;
 											}
-											_loop521:;
+											_loop525:;
 											}  // ( ... )+
 											{
 											mDBL(false);
@@ -3283,12 +3283,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched523 = false;
+										synPredMatched527 = false;
 									}
-									rewind(_m523);
+									rewind(_m527);
 									inputState->guessing--;
 								}
-								if ( synPredMatched523 ) {
+								if ( synPredMatched527 ) {
 									{
 									switch ( LA(1)) {
 									case 0x30 /* '0' */ :
@@ -3304,18 +3304,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										{
 										{ // ( ... )+
-										int _cnt527=0;
+										int _cnt531=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt527>=1 ) { goto _loop527; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt531>=1 ) { goto _loop531; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt527++;
+											_cnt531++;
 										}
-										_loop527:;
+										_loop531:;
 										}  // ( ... )+
 										{
 										switch ( LA(1)) {
@@ -3333,11 +3333,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 													mD(false);
 												}
 												else {
-													goto _loop530;
+													goto _loop534;
 												}
 												
 											}
-											_loop530:;
+											_loop534:;
 											} // ( ... )*
 											{
 											mDBL(false);
@@ -3357,18 +3357,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									{
 										match('.' /* charlit */ );
 										{ // ( ... )+
-										int _cnt533=0;
+										int _cnt537=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt533>=1 ) { goto _loop533; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt537>=1 ) { goto _loop537; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt533++;
+											_cnt537++;
 										}
-										_loop533:;
+										_loop537:;
 										}  // ( ... )+
 										{
 										mDBL(false);
@@ -3414,10 +3414,10 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 								}
 								else {
-									bool synPredMatched548 = false;
+									bool synPredMatched552 = false;
 									if (((_tokenSet_10.member(LA(1))) && (_tokenSet_12.member(LA(2))) && (true) && (true))) {
-										int _m548 = mark();
-										synPredMatched548 = true;
+										int _m552 = mark();
+										synPredMatched552 = true;
 										inputState->guessing++;
 										try {
 											{
@@ -3435,18 +3435,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												{
 												{ // ( ... )+
-												int _cnt540=0;
+												int _cnt544=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt540>=1 ) { goto _loop540; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt544>=1 ) { goto _loop544; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt540++;
+													_cnt544++;
 												}
-												_loop540:;
+												_loop544:;
 												}  // ( ... )+
 												{
 												switch ( LA(1)) {
@@ -3464,11 +3464,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 															mD(false);
 														}
 														else {
-															goto _loop543;
+															goto _loop547;
 														}
 														
 													}
-													_loop543:;
+													_loop547:;
 													} // ( ... )*
 													{
 													if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3493,18 +3493,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											{
 												match('.' /* charlit */ );
 												{ // ( ... )+
-												int _cnt546=0;
+												int _cnt550=0;
 												for (;;) {
 													if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 														mD(false);
 													}
 													else {
-														if ( _cnt546>=1 ) { goto _loop546; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+														if ( _cnt550>=1 ) { goto _loop550; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 													}
 													
-													_cnt546++;
+													_cnt550++;
 												}
-												_loop546:;
+												_loop550:;
 												}  // ( ... )+
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3524,12 +3524,12 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 											}
 										}
 										catch (antlr::RecognitionException& pe) {
-											synPredMatched548 = false;
+											synPredMatched552 = false;
 										}
-										rewind(_m548);
+										rewind(_m552);
 										inputState->guessing--;
 									}
-									if ( synPredMatched548 ) {
+									if ( synPredMatched552 ) {
 										{
 										switch ( LA(1)) {
 										case 0x30 /* '0' */ :
@@ -3545,18 +3545,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											{
 											{ // ( ... )+
-											int _cnt552=0;
+											int _cnt556=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt552>=1 ) { goto _loop552; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt556>=1 ) { goto _loop556; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt552++;
+												_cnt556++;
 											}
-											_loop552:;
+											_loop556:;
 											}  // ( ... )+
 											{
 											switch ( LA(1)) {
@@ -3574,11 +3574,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 														mD(false);
 													}
 													else {
-														goto _loop555;
+														goto _loop559;
 													}
 													
 												}
-												_loop555:;
+												_loop559:;
 												} // ( ... )*
 												{
 												if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3603,18 +3603,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 										{
 											match('.' /* charlit */ );
 											{ // ( ... )+
-											int _cnt558=0;
+											int _cnt562=0;
 											for (;;) {
 												if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 													mD(false);
 												}
 												else {
-													if ( _cnt558>=1 ) { goto _loop558; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+													if ( _cnt562>=1 ) { goto _loop562; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 												}
 												
-												_cnt558++;
+												_cnt562++;
 											}
-											_loop558:;
+											_loop562:;
 											}  // ( ... )+
 											{
 											if ((LA(1) == 0x65 /* 'e' */ )) {
@@ -3682,11 +3682,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop506;
+												goto _loop510;
 											}
 											
 										}
-										_loop506:;
+										_loop510:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x22 /* '\"' */ )) {
@@ -3720,11 +3720,11 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 												}
 											}
 											else {
-												goto _loop510;
+												goto _loop514;
 											}
 											
 										}
-										_loop510:;
+										_loop514:;
 										} // ( ... )*
 										{
 										if ((LA(1) == 0x27 /* '\'' */ )) {
@@ -3748,18 +3748,18 @@ void GDLLexer::mCONSTANT_OR_STRING_LITERAL(bool _createToken) {
 									}
 									else if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ )) && (true) && (true) && (true)) {
 										{ // ( ... )+
-										int _cnt563=0;
+										int _cnt567=0;
 										for (;;) {
 											if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
 												mD(false);
 											}
 											else {
-												if ( _cnt563>=1 ) { goto _loop563; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+												if ( _cnt567>=1 ) { goto _loop567; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 											}
 											
-											_cnt563++;
+											_cnt567++;
 										}
-										_loop563:;
+										_loop567:;
 										}  // ( ... )+
 										if ( inputState->guessing==0 ) {
 											_ttype=CONSTANT_I;
@@ -3904,11 +3904,11 @@ void GDLLexer::mCOMMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop569;
+			goto _loop573;
 		}
 		
 	}
-	_loop569:;
+	_loop573:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -3984,11 +3984,11 @@ void GDLLexer::mIDENTIFIER(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop573;
+			goto _loop577;
 		}
 		}
 	}
-	_loop573:;
+	_loop577:;
 	} // ( ... )*
 	if ( inputState->guessing==0 ) {
 		
@@ -4014,7 +4014,7 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 	match('!' /* charlit */ );
 	}
 	{ // ( ... )+
-	int _cnt577=0;
+	int _cnt581=0;
 	for (;;) {
 		switch ( LA(1)) {
 		case 0x5f /* '_' */ :
@@ -4069,12 +4069,12 @@ void GDLLexer::mSYSVARNAME(bool _createToken) {
 		}
 		default:
 		{
-			if ( _cnt577>=1 ) { goto _loop577; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt581>=1 ) { goto _loop581; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		}
-		_cnt577++;
+		_cnt581++;
 	}
-	_loop577:;
+	_loop581:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		
@@ -4113,18 +4113,18 @@ void GDLLexer::mWHITESPACE(bool _createToken) {
 	std::string::size_type _saveIndex;
 	
 	{ // ( ... )+
-	int _cnt581=0;
+	int _cnt585=0;
 	for (;;) {
 		if ((LA(1) == 0x9 /* '\t' */  || LA(1) == 0xc /* '\14' */  || LA(1) == 0x20 /* ' ' */ )) {
 			mW(false);
 		}
 		else {
-			if ( _cnt581>=1 ) { goto _loop581; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
+			if ( _cnt585>=1 ) { goto _loop585; } else {throw antlr::NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
 		}
 		
-		_cnt581++;
+		_cnt585++;
 	}
-	_loop581:;
+	_loop585:;
 	}  // ( ... )+
 	if ( inputState->guessing==0 ) {
 		_ttype=antlr::Token::SKIP;
@@ -4165,11 +4165,11 @@ void GDLLexer::mSKIP_LINES(bool _createToken) {
 		}
 		default:
 		{
-			goto _loop584;
+			goto _loop588;
 		}
 		}
 	}
-	_loop584:;
+	_loop588:;
 	} // ( ... )*
 	if ( _createToken && _token==antlr::nullToken && _ttype!=antlr::Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -4193,11 +4193,11 @@ void GDLLexer::mCONT_STATEMENT(bool _createToken) {
 			}
 		}
 		else {
-			goto _loop588;
+			goto _loop592;
 		}
 		
 	}
-	_loop588:;
+	_loop592:;
 	} // ( ... )*
 	mEOL(false);
 	mSKIP_LINES(false);

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -775,6 +775,7 @@ void GDLParser::translation_unit() {
 				}
 				if ( inputState->guessing==0 ) {
 					
+					allowInteractiveSyntax=true;
 					compileOpt=NONE; // reset compileOpt  
 					if( SearchedRoutineFound) goto bailOut;
 					
@@ -789,6 +790,7 @@ void GDLParser::translation_unit() {
 				}
 				if ( inputState->guessing==0 ) {
 					
+					allowInteractiveSyntax=true;
 					compileOpt=NONE; // reset compileOpt
 					if( SearchedRoutineFound) goto bailOut;
 					
@@ -932,12 +934,12 @@ void GDLParser::translation_unit() {
 	catch ( antlr::NoViableAltForCharException& e) {
 		if (inputState->guessing==0) {
 			
-							recovery=false;
-							// this partially solves #59 (no line number in '@'-included files
-							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
+						recovery=false;
+						// this partially solves #59 (no line number in '@'-included files
+						printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
 						// LEXER SYNTAX ERROR
 			//			throw GDLException( e.getLine(), e.getColumn(), "Lexer syntax error: "+e.getMessage(), e.getFilename() );
-					
+			
 		} else {
 			throw;
 		}
@@ -1038,6 +1040,7 @@ void GDLParser::procedure_def() {
 	antlr::RefToken  n = antlr::nullToken;
 	RefDNode n_AST = RefDNode(antlr::nullAST);
 	
+	allowInteractiveSyntax=false;
 	std::string name;
 		fussy=recovery?0:1; //recoverable fussy mode
 		relaxed=(fussy < 1);
@@ -1149,6 +1152,7 @@ void GDLParser::procedure_def() {
 		if( subName == name && searchForPro == true) SearchedRoutineFound=true;
 		p_AST->SetCompileOpt( compileOpt); 
 		p_AST->MemorizeUncompiledPro(name); //in case the Parser has to know that a procedure thus named exists. 
+				    allowInteractiveSyntax=true;
 		
 	}
 	procedure_def_AST = RefDNode(currentAST.root);
@@ -1164,6 +1168,7 @@ void GDLParser::function_def() {
 	antlr::RefToken  n = antlr::nullToken;
 	RefDNode n_AST = RefDNode(antlr::nullAST);
 	
+	allowInteractiveSyntax=false;
 	std::string name;
 		fussy=recovery?0:1; //recoverable fussy mode
 		relaxed=(fussy < 1);
@@ -1277,6 +1282,7 @@ void GDLParser::function_def() {
 		f_AST->MemorizeUncompiledFun(name); //since a fun in the same .pro file is not yet 'compiled'
 		//at this time (Parser) but the Parser has to know that it has ben defined for disambiguation
 					//of function calls in the 'sloppy' mode
+				    allowInteractiveSyntax=true;
 		
 	}
 	function_def_AST = RefDNode(currentAST.root);
@@ -1585,6 +1591,8 @@ void GDLParser::interactive() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode interactive_AST = RefDNode(antlr::nullAST);
+	
+	allowInteractiveSyntax=true;
 	fussy=((compileOpt & STRICTARR)!=0)?2:0;
 	relaxed=(fussy < 1);
 	
@@ -2671,7 +2679,7 @@ void GDLParser::statement() {
 						}
 						statement_AST = RefDNode(currentAST.root);
 					}
-					else if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))&&( IsPro(LT(1)))) {
+					else if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))&&( (allowInteractiveSyntax==false || IsPro(LT(1))) )) {
 						deref_dot_expr_keeplast();
 						if (inputState->guessing==0) {
 							d3_AST = returnAST;

--- a/src/GDLParser.cpp
+++ b/src/GDLParser.cpp
@@ -932,12 +932,12 @@ void GDLParser::translation_unit() {
 	catch ( antlr::NoViableAltForCharException& e) {
 		if (inputState->guessing==0) {
 			
-						recovery=false;
-						// this partially solves #59 (no line number in '@'-included files
-						printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
+							recovery=false;
+							// this partially solves #59 (no line number in '@'-included files
+							printLineErrorHelper(e.getFilename(), e.getLine(), e.getColumn());			
 						// LEXER SYNTAX ERROR
 			//			throw GDLException( e.getLine(), e.getColumn(), "Lexer syntax error: "+e.getMessage(), e.getFilename() );
-			
+					
 		} else {
 			throw;
 		}
@@ -1017,15 +1017,12 @@ void GDLParser::forward_function() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
 	RefDNode forward_function_AST = RefDNode(antlr::nullAST);
+	RefDNode i_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp5_AST = RefDNode(antlr::nullAST);
-	if ( inputState->guessing == 0 ) {
-		tmp5_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp5_AST));
-	}
 	match(FORWARD);
-	identifier_list();
+	forward_identifier_list();
 	if (inputState->guessing==0) {
+		i_AST = returnAST;
 		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
 	}
 	forward_function_AST = RefDNode(currentAST.root);
@@ -1151,6 +1148,7 @@ void GDLParser::procedure_def() {
 					fussy=1; //set recoverable fussy mode
 		if( subName == name && searchForPro == true) SearchedRoutineFound=true;
 		p_AST->SetCompileOpt( compileOpt); 
+		p_AST->MemorizeUncompiledPro(name); //in case the Parser has to know that a procedure thus named exists. 
 		
 	}
 	procedure_def_AST = RefDNode(currentAST.root);
@@ -1275,7 +1273,10 @@ void GDLParser::function_def() {
 					recovery=false;
 		//        	std::cerr<<"end fun "<<name<<" at "<<LastGoodPosition<<std::endl;
 					fussy=1; //set recoverable fussy mode
-		f_AST->SetCompileOpt( compileOpt); 
+		f_AST->SetCompileOpt( compileOpt);
+		f_AST->MemorizeUncompiledFun(name); //since a fun in the same .pro file is not yet 'compiled'
+		//at this time (Parser) but the Parser has to know that it has ben defined for disambiguation
+					//of function calls in the 'sloppy' mode
 		
 	}
 	function_def_AST = RefDNode(currentAST.root);
@@ -1372,7 +1373,7 @@ void GDLParser::statement_list() {
 	RefDNode statement_list_AST = RefDNode(antlr::nullAST);
 	
 	{ // ( ... )+
-	int _cnt73=0;
+	int _cnt76=0;
 	for (;;) {
 		if ((LA(1) == END_U)) {
 			end_unit();
@@ -1401,12 +1402,12 @@ void GDLParser::statement_list() {
 			}
 		}
 		else {
-			if ( _cnt73>=1 ) { goto _loop73; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+			if ( _cnt76>=1 ) { goto _loop76; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt73++;
+		_cnt76++;
 	}
-	_loop73:;
+	_loop76:;
 	}  // ( ... )+
 	statement_list_AST = RefDNode(currentAST.root);
 	returnAST = statement_list_AST;
@@ -2046,10 +2047,10 @@ void GDLParser::statement() {
 		break;
 	}
 	default:
-		bool synPredMatched83 = false;
+		bool synPredMatched86 = false;
 		if (((LA(1) == LBRACE) && (_tokenSet_4.member(LA(2))))) {
-			int _m83 = mark();
-			synPredMatched83 = true;
+			int _m86 = mark();
+			synPredMatched86 = true;
 			inputState->guessing++;
 			try {
 				{
@@ -2057,12 +2058,12 @@ void GDLParser::statement() {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched83 = false;
+				synPredMatched86 = false;
 			}
-			rewind(_m83);
+			rewind(_m86);
 			inputState->guessing--;
 		}
-		if ( synPredMatched83 ) {
+		if ( synPredMatched86 ) {
 			assign_expr();
 			if (inputState->guessing==0) {
 				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -2104,10 +2105,10 @@ void GDLParser::statement() {
 			statement_AST = RefDNode(currentAST.root);
 		}
 		else {
-			bool synPredMatched86 = false;
+			bool synPredMatched89 = false;
 			if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-				int _m86 = mark();
-				synPredMatched86 = true;
+				int _m89 = mark();
+				synPredMatched89 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -2117,12 +2118,12 @@ void GDLParser::statement() {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched86 = false;
+					synPredMatched89 = false;
 				}
-				rewind(_m86);
+				rewind(_m89);
 				inputState->guessing--;
 			}
-			if ( synPredMatched86 ) {
+			if ( synPredMatched89 ) {
 				deref_dot_expr_keeplast();
 				if (inputState->guessing==0) {
 					d1_AST = returnAST;
@@ -2149,10 +2150,10 @@ void GDLParser::statement() {
 				statement_AST = RefDNode(currentAST.root);
 			}
 			else {
-				bool synPredMatched88 = false;
+				bool synPredMatched91 = false;
 				if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-					int _m88 = mark();
-					synPredMatched88 = true;
+					int _m91 = mark();
+					synPredMatched91 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -2161,12 +2162,12 @@ void GDLParser::statement() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched88 = false;
+						synPredMatched91 = false;
 					}
-					rewind(_m88);
+					rewind(_m91);
 					inputState->guessing--;
 				}
-				if ( synPredMatched88 ) {
+				if ( synPredMatched91 ) {
 					deref_dot_expr_keeplast();
 					if (inputState->guessing==0) {
 						d2_AST = returnAST;
@@ -2197,10 +2198,10 @@ void GDLParser::statement() {
 					statement_AST = RefDNode(currentAST.root);
 				}
 				else {
-					bool synPredMatched91 = false;
+					bool synPredMatched94 = false;
 					if (((_tokenSet_4.member(LA(1))) && (_tokenSet_6.member(LA(2))))) {
-						int _m91 = mark();
-						synPredMatched91 = true;
+						int _m94 = mark();
+						synPredMatched94 = true;
 						inputState->guessing++;
 						try {
 							{
@@ -2331,12 +2332,12 @@ void GDLParser::statement() {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched91 = false;
+							synPredMatched94 = false;
 						}
-						rewind(_m91);
+						rewind(_m94);
 						inputState->guessing--;
 					}
-					if ( synPredMatched91 ) {
+					if ( synPredMatched94 ) {
 						deref_expr();
 						if (inputState->guessing==0) {
 							astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -2670,7 +2671,7 @@ void GDLParser::statement() {
 						}
 						statement_AST = RefDNode(currentAST.root);
 					}
-					else if ((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2)))) {
+					else if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))&&( IsPro(LT(1)))) {
 						deref_dot_expr_keeplast();
 						if (inputState->guessing==0) {
 							d3_AST = returnAST;
@@ -3575,37 +3576,45 @@ void GDLParser::endcaseelse_mark() {
 	returnAST = endcaseelse_mark_AST;
 }
 
-void GDLParser::identifier_list() {
+void GDLParser::forward_identifier_list() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
-	RefDNode identifier_list_AST = RefDNode(antlr::nullAST);
+	RefDNode forward_identifier_list_AST = RefDNode(antlr::nullAST);
+	antlr::RefToken  i = antlr::nullToken;
+	RefDNode i_AST = RefDNode(antlr::nullAST);
+	antlr::RefToken  j = antlr::nullToken;
+	RefDNode j_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp83_AST = RefDNode(antlr::nullAST);
+	i = LT(1);
 	if ( inputState->guessing == 0 ) {
-		tmp83_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp83_AST));
+		i_AST = astFactory->create(i);
 	}
 	match(IDENTIFIER);
+	if ( inputState->guessing==0 ) {
+		std::string name=i_AST->getText();i_AST->MemorizeUncompiledFun(name);
+	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == COMMA)) {
 			match(COMMA);
-			RefDNode tmp85_AST = RefDNode(antlr::nullAST);
+			j = LT(1);
 			if ( inputState->guessing == 0 ) {
-				tmp85_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, antlr::RefAST(tmp85_AST));
+				j_AST = astFactory->create(j);
 			}
 			match(IDENTIFIER);
+			if ( inputState->guessing==0 ) {
+				std::string name=j_AST->getText();j_AST->MemorizeUncompiledFun(name);
+			}
 		}
 		else {
-			goto _loop59;
+			goto _loop62;
 		}
 		
 	}
-	_loop59:;
+	_loop62:;
 	} // ( ... )*
-	identifier_list_AST = RefDNode(currentAST.root);
-	returnAST = identifier_list_AST;
+	forward_identifier_list_AST = RefDNode(currentAST.root);
+	returnAST = forward_identifier_list_AST;
 }
 
 void GDLParser::keyword_declaration() {
@@ -3613,17 +3622,17 @@ void GDLParser::keyword_declaration() {
 	antlr::ASTPair currentAST;
 	RefDNode keyword_declaration_AST = RefDNode(antlr::nullAST);
 	
+	RefDNode tmp84_AST = RefDNode(antlr::nullAST);
+	if ( inputState->guessing == 0 ) {
+		tmp84_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp84_AST));
+	}
+	match(IDENTIFIER);
+	match(EQUAL);
 	RefDNode tmp86_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp86_AST = astFactory->create(LT(1));
 		astFactory->addASTChild(currentAST, antlr::RefAST(tmp86_AST));
-	}
-	match(IDENTIFIER);
-	match(EQUAL);
-	RefDNode tmp88_AST = RefDNode(antlr::nullAST);
-	if ( inputState->guessing == 0 ) {
-		tmp88_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp88_AST));
 	}
 	match(IDENTIFIER);
 	if ( inputState->guessing==0 ) {
@@ -3704,9 +3713,9 @@ void GDLParser::compile_opt() {
 	antlr::RefToken  ii = antlr::nullToken;
 	RefDNode ii_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp89_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp87_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp89_AST = astFactory->create(LT(1));
+		tmp87_AST = astFactory->create(LT(1));
 	}
 	match(COMPILE_OPT);
 	i = LT(1);
@@ -3722,9 +3731,9 @@ void GDLParser::compile_opt() {
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == COMMA)) {
-			RefDNode tmp90_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp88_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp90_AST = astFactory->create(LT(1));
+				tmp88_AST = astFactory->create(LT(1));
 			}
 			match(COMMA);
 			ii = LT(1);
@@ -3748,6 +3757,39 @@ void GDLParser::compile_opt() {
 	returnAST = compile_opt_AST;
 }
 
+void GDLParser::identifier_list() {
+	returnAST = RefDNode(antlr::nullAST);
+	antlr::ASTPair currentAST;
+	RefDNode identifier_list_AST = RefDNode(antlr::nullAST);
+	
+	RefDNode tmp89_AST = RefDNode(antlr::nullAST);
+	if ( inputState->guessing == 0 ) {
+		tmp89_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp89_AST));
+	}
+	match(IDENTIFIER);
+	{ // ( ... )*
+	for (;;) {
+		if ((LA(1) == COMMA)) {
+			match(COMMA);
+			RefDNode tmp91_AST = RefDNode(antlr::nullAST);
+			if ( inputState->guessing == 0 ) {
+				tmp91_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, antlr::RefAST(tmp91_AST));
+			}
+			match(IDENTIFIER);
+		}
+		else {
+			goto _loop59;
+		}
+		
+	}
+	_loop59:;
+	} // ( ... )*
+	identifier_list_AST = RefDNode(currentAST.root);
+	returnAST = identifier_list_AST;
+}
+
 void GDLParser::endforeach_mark() {
 	returnAST = RefDNode(antlr::nullAST);
 	antlr::ASTPair currentAST;
@@ -3756,18 +3798,18 @@ void GDLParser::endforeach_mark() {
 	switch ( LA(1)) {
 	case ENDFOREACH:
 	{
-		RefDNode tmp91_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp92_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp91_AST = astFactory->create(LT(1));
+			tmp92_AST = astFactory->create(LT(1));
 		}
 		match(ENDFOREACH);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp92_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp93_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp92_AST = astFactory->create(LT(1));
+			tmp93_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -3788,18 +3830,18 @@ void GDLParser::endfor_mark() {
 	switch ( LA(1)) {
 	case ENDFOR:
 	{
-		RefDNode tmp93_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp94_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp93_AST = astFactory->create(LT(1));
+			tmp94_AST = astFactory->create(LT(1));
 		}
 		match(ENDFOR);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp94_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp95_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp94_AST = astFactory->create(LT(1));
+			tmp95_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -3820,18 +3862,18 @@ void GDLParser::endrep_mark() {
 	switch ( LA(1)) {
 	case ENDREP:
 	{
-		RefDNode tmp95_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp96_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp95_AST = astFactory->create(LT(1));
+			tmp96_AST = astFactory->create(LT(1));
 		}
 		match(ENDREP);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp96_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp97_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp96_AST = astFactory->create(LT(1));
+			tmp97_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -3852,18 +3894,18 @@ void GDLParser::endwhile_mark() {
 	switch ( LA(1)) {
 	case ENDWHILE:
 	{
-		RefDNode tmp97_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp98_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp97_AST = astFactory->create(LT(1));
+			tmp98_AST = astFactory->create(LT(1));
 		}
 		match(ENDWHILE);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp98_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp99_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp98_AST = astFactory->create(LT(1));
+			tmp99_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -3884,18 +3926,18 @@ void GDLParser::endif_mark() {
 	switch ( LA(1)) {
 	case ENDIF:
 	{
-		RefDNode tmp99_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp100_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp99_AST = astFactory->create(LT(1));
+			tmp100_AST = astFactory->create(LT(1));
 		}
 		match(ENDIF);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp100_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp101_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp100_AST = astFactory->create(LT(1));
+			tmp101_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -3916,18 +3958,18 @@ void GDLParser::endelse_mark() {
 	switch ( LA(1)) {
 	case ENDELSE:
 	{
-		RefDNode tmp101_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp102_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp101_AST = astFactory->create(LT(1));
+			tmp102_AST = astFactory->create(LT(1));
 		}
 		match(ENDELSE);
 		break;
 	}
 	case END:
 	{
-		RefDNode tmp102_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp103_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp102_AST = astFactory->create(LT(1));
+			tmp103_AST = astFactory->create(LT(1));
 		}
 		match(END);
 		break;
@@ -4012,7 +4054,7 @@ void GDLParser::label_statement() {
 	RefDNode label_statement_AST = RefDNode(antlr::nullAST);
 	
 	{ // ( ... )+
-	int _cnt77=0;
+	int _cnt80=0;
 	for (;;) {
 		if ((LA(1) == IDENTIFIER) && (LA(2) == COLON)) {
 			label();
@@ -4021,12 +4063,12 @@ void GDLParser::label_statement() {
 			}
 		}
 		else {
-			if ( _cnt77>=1 ) { goto _loop77; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+			if ( _cnt80>=1 ) { goto _loop80; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt77++;
+		_cnt80++;
 	}
-	_loop77:;
+	_loop80:;
 	}  // ( ... )+
 	{
 	switch ( LA(1)) {
@@ -4076,16 +4118,16 @@ void GDLParser::label() {
 	antlr::ASTPair currentAST;
 	RefDNode label_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp104_AST = RefDNode(antlr::nullAST);
-	if ( inputState->guessing == 0 ) {
-		tmp104_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp104_AST));
-	}
-	match(IDENTIFIER);
 	RefDNode tmp105_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp105_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp105_AST));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp105_AST));
+	}
+	match(IDENTIFIER);
+	RefDNode tmp106_AST = RefDNode(antlr::nullAST);
+	if ( inputState->guessing == 0 ) {
+		tmp106_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp106_AST));
 	}
 	match(COLON);
 	label_AST = RefDNode(currentAST.root);
@@ -4148,190 +4190,190 @@ void GDLParser::assign_expr() {
 	}
 	case AND_OP_EQ:
 	{
-		RefDNode tmp109_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp110_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp109_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp109_AST));
+			tmp110_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp110_AST));
 		}
 		match(AND_OP_EQ);
 		break;
 	}
 	case ASTERIX_EQ:
 	{
-		RefDNode tmp110_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp111_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp110_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp110_AST));
+			tmp111_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp111_AST));
 		}
 		match(ASTERIX_EQ);
 		break;
 	}
 	case EQ_OP_EQ:
 	{
-		RefDNode tmp111_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp112_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp111_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp111_AST));
+			tmp112_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp112_AST));
 		}
 		match(EQ_OP_EQ);
 		break;
 	}
 	case GE_OP_EQ:
 	{
-		RefDNode tmp112_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp113_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp112_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp112_AST));
+			tmp113_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp113_AST));
 		}
 		match(GE_OP_EQ);
 		break;
 	}
 	case GTMARK_EQ:
 	{
-		RefDNode tmp113_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp114_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp113_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp113_AST));
+			tmp114_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp114_AST));
 		}
 		match(GTMARK_EQ);
 		break;
 	}
 	case GT_OP_EQ:
 	{
-		RefDNode tmp114_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp115_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp114_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp114_AST));
+			tmp115_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp115_AST));
 		}
 		match(GT_OP_EQ);
 		break;
 	}
 	case LE_OP_EQ:
 	{
-		RefDNode tmp115_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp116_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp115_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp115_AST));
+			tmp116_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp116_AST));
 		}
 		match(LE_OP_EQ);
 		break;
 	}
 	case LTMARK_EQ:
 	{
-		RefDNode tmp116_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp117_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp116_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp116_AST));
+			tmp117_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp117_AST));
 		}
 		match(LTMARK_EQ);
 		break;
 	}
 	case LT_OP_EQ:
 	{
-		RefDNode tmp117_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp118_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp117_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp117_AST));
+			tmp118_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp118_AST));
 		}
 		match(LT_OP_EQ);
 		break;
 	}
 	case MATRIX_OP1_EQ:
 	{
-		RefDNode tmp118_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp119_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp118_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp118_AST));
+			tmp119_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp119_AST));
 		}
 		match(MATRIX_OP1_EQ);
 		break;
 	}
 	case MATRIX_OP2_EQ:
 	{
-		RefDNode tmp119_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp120_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp119_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp119_AST));
+			tmp120_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp120_AST));
 		}
 		match(MATRIX_OP2_EQ);
 		break;
 	}
 	case MINUS_EQ:
 	{
-		RefDNode tmp120_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp121_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp120_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp120_AST));
+			tmp121_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp121_AST));
 		}
 		match(MINUS_EQ);
 		break;
 	}
 	case MOD_OP_EQ:
 	{
-		RefDNode tmp121_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp122_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp121_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp121_AST));
+			tmp122_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp122_AST));
 		}
 		match(MOD_OP_EQ);
 		break;
 	}
 	case NE_OP_EQ:
 	{
-		RefDNode tmp122_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp123_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp122_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp122_AST));
+			tmp123_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp123_AST));
 		}
 		match(NE_OP_EQ);
 		break;
 	}
 	case OR_OP_EQ:
 	{
-		RefDNode tmp123_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp124_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp123_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp123_AST));
+			tmp124_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp124_AST));
 		}
 		match(OR_OP_EQ);
 		break;
 	}
 	case XOR_OP_EQ:
 	{
-		RefDNode tmp124_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp125_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp124_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp124_AST));
+			tmp125_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp125_AST));
 		}
 		match(XOR_OP_EQ);
 		break;
 	}
 	case PLUS_EQ:
 	{
-		RefDNode tmp125_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp126_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp125_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp125_AST));
+			tmp126_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp126_AST));
 		}
 		match(PLUS_EQ);
 		break;
 	}
 	case POW_EQ:
 	{
-		RefDNode tmp126_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp127_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp126_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp126_AST));
+			tmp127_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp127_AST));
 		}
 		match(POW_EQ);
 		break;
 	}
 	case SLASH_EQ:
 	{
-		RefDNode tmp127_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp128_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp127_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp127_AST));
+			tmp128_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp128_AST));
 		}
 		match(SLASH_EQ);
 		break;
@@ -4435,10 +4477,10 @@ void GDLParser::formal_procedure_call() {
 	antlr::ASTPair currentAST;
 	RefDNode formal_procedure_call_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp130_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp131_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp130_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp130_AST));
+		tmp131_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp131_AST));
 	}
 	match(IDENTIFIER);
 	{
@@ -4765,16 +4807,16 @@ void GDLParser::for_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode for_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp135_AST = RefDNode(antlr::nullAST);
-	if ( inputState->guessing == 0 ) {
-		tmp135_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp135_AST));
-	}
-	match(FOR);
 	RefDNode tmp136_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp136_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp136_AST));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp136_AST));
+	}
+	match(FOR);
+	RefDNode tmp137_AST = RefDNode(antlr::nullAST);
+	if ( inputState->guessing == 0 ) {
+		tmp137_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp137_AST));
 	}
 	match(IDENTIFIER);
 	match(EQUAL);
@@ -4822,16 +4864,16 @@ void GDLParser::foreach_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode foreach_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp141_AST = RefDNode(antlr::nullAST);
-	if ( inputState->guessing == 0 ) {
-		tmp141_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp141_AST));
-	}
-	match(FOREACH);
 	RefDNode tmp142_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp142_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp142_AST));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp142_AST));
+	}
+	match(FOREACH);
+	RefDNode tmp143_AST = RefDNode(antlr::nullAST);
+	if ( inputState->guessing == 0 ) {
+		tmp143_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp143_AST));
 	}
 	match(IDENTIFIER);
 	match(COMMA);
@@ -4844,10 +4886,10 @@ void GDLParser::foreach_statement() {
 	case COMMA:
 	{
 		match(COMMA);
-		RefDNode tmp145_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp146_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp145_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp145_AST));
+			tmp146_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp146_AST));
 		}
 		match(IDENTIFIER);
 		break;
@@ -4876,10 +4918,10 @@ void GDLParser::repeat_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode repeat_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp147_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp148_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp147_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp147_AST));
+		tmp148_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp148_AST));
 	}
 	match(REPEAT);
 	repeat_block();
@@ -4900,10 +4942,10 @@ void GDLParser::while_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode while_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp149_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp150_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp149_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp149_AST));
+		tmp150_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp150_AST));
 	}
 	match(WHILE);
 	expr();
@@ -4927,17 +4969,17 @@ void GDLParser::jump_statement() {
 	switch ( LA(1)) {
 	case GOTO:
 	{
-		RefDNode tmp151_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp152_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp151_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp151_AST));
+			tmp152_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp152_AST));
 		}
 		match(GOTO);
 		match(COMMA);
-		RefDNode tmp153_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp154_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp153_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp153_AST));
+			tmp154_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp154_AST));
 		}
 		match(IDENTIFIER);
 		jump_statement_AST = RefDNode(currentAST.root);
@@ -4945,17 +4987,17 @@ void GDLParser::jump_statement() {
 	}
 	case ON_IOERROR:
 	{
-		RefDNode tmp154_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp155_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp154_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp154_AST));
+			tmp155_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp155_AST));
 		}
 		match(ON_IOERROR);
 		match(COMMA);
-		RefDNode tmp156_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp157_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp156_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp156_AST));
+			tmp157_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp157_AST));
 		}
 		match(IDENTIFIER);
 		jump_statement_AST = RefDNode(currentAST.root);
@@ -4974,10 +5016,10 @@ void GDLParser::if_statement() {
 	antlr::ASTPair currentAST;
 	RefDNode if_statement_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp157_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp158_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp157_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp157_AST));
+		tmp158_AST = astFactory->create(LT(1));
+		astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp158_AST));
 	}
 	match(IF);
 	expr();
@@ -5468,11 +5510,11 @@ void GDLParser::parameter_def_list() {
 			}
 		}
 		else {
-			goto _loop123;
+			goto _loop126;
 		}
 		
 	}
-	_loop123:;
+	_loop126:;
 	} // ( ... )*
 	parameter_def_list_AST = RefDNode(currentAST.root);
 	returnAST = parameter_def_list_AST;
@@ -5483,10 +5525,10 @@ void GDLParser::formal_function_call() {
 	antlr::ASTPair currentAST;
 	RefDNode formal_function_call_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp167_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp168_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp167_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp167_AST));
+		tmp168_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp168_AST));
 	}
 	match(IDENTIFIER);
 	match(LBRACE);
@@ -5716,11 +5758,11 @@ void GDLParser::array_def() {
 				}
 			}
 			else {
-				goto _loop127;
+				goto _loop130;
 			}
 			
 		}
-		_loop127:;
+		_loop130:;
 		} // ( ... )*
 		match(RSQUARE);
 		if ( inputState->guessing==0 ) {
@@ -5744,7 +5786,7 @@ void GDLParser::array_def() {
 	case COLON:
 	{
 		{ // ( ... )+
-		int _cnt129=0;
+		int _cnt132=0;
 		for (;;) {
 			if ((LA(1) == COLON)) {
 				match(COLON);
@@ -5758,12 +5800,12 @@ void GDLParser::array_def() {
 				}
 			}
 			else {
-				if ( _cnt129>=1 ) { goto _loop129; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+				if ( _cnt132>=1 ) { goto _loop132; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 			}
 			
-			_cnt129++;
+			_cnt132++;
 		}
-		_loop129:;
+		_loop132:;
 		}  // ( ... )+
 		match(RSQUARE);
 		if ( inputState->guessing==0 ) {
@@ -5807,10 +5849,10 @@ void GDLParser::struct_identifier() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp177_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp178_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp177_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp177_AST));
+			tmp178_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp178_AST));
 		}
 		match(IDENTIFIER);
 		break;
@@ -5981,11 +6023,11 @@ void GDLParser::named_tag_def_list() {
 			}
 		}
 		else {
-			goto _loop150;
+			goto _loop153;
 		}
 		
 	}
-	_loop150:;
+	_loop153:;
 	} // ( ... )*
 	named_tag_def_list_AST = RefDNode(currentAST.root);
 	returnAST = named_tag_def_list_AST;
@@ -6010,11 +6052,11 @@ void GDLParser::tag_def_list() {
 			}
 		}
 		else {
-			goto _loop139;
+			goto _loop142;
 		}
 		
 	}
-	_loop139:;
+	_loop142:;
 	} // ( ... )*
 	tag_def_list_AST = RefDNode(currentAST.root);
 	returnAST = tag_def_list_AST;
@@ -6083,11 +6125,11 @@ void GDLParser::ntag_defs() {
 			}
 		}
 		else {
-			goto _loop143;
+			goto _loop146;
 		}
 		
 	}
-	_loop143:;
+	_loop146:;
 	} // ( ... )*
 	ntag_defs_AST = RefDNode(currentAST.root);
 	returnAST = ntag_defs_AST;
@@ -6099,10 +6141,10 @@ void GDLParser::named_tag_def_entry() {
 	RefDNode named_tag_def_entry_AST = RefDNode(antlr::nullAST);
 	
 	{
-	bool synPredMatched147 = false;
+	bool synPredMatched150 = false;
 	if (((LA(1) == INHERITS) && (_tokenSet_13.member(LA(2))))) {
-		int _m147 = mark();
-		synPredMatched147 = true;
+		int _m150 = mark();
+		synPredMatched150 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -6110,16 +6152,16 @@ void GDLParser::named_tag_def_entry() {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched147 = false;
+			synPredMatched150 = false;
 		}
-		rewind(_m147);
+		rewind(_m150);
 		inputState->guessing--;
 	}
-	if ( synPredMatched147 ) {
-		RefDNode tmp186_AST = RefDNode(antlr::nullAST);
+	if ( synPredMatched150 ) {
+		RefDNode tmp187_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp186_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp186_AST));
+			tmp187_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp187_AST));
 		}
 		match(INHERITS);
 		struct_name();
@@ -7687,11 +7729,11 @@ void GDLParser::arrayindex_list() {
 				}
 			}
 			else {
-				goto _loop195;
+				goto _loop198;
 			}
 			
 		}
-		_loop195:;
+		_loop198:;
 		} // ( ... )*
 		match(RSQUARE);
 		arrayindex_list_AST = RefDNode(currentAST.root);
@@ -7712,11 +7754,11 @@ void GDLParser::arrayindex_list() {
 				}
 			}
 			else {
-				goto _loop197;
+				goto _loop200;
 			}
 			
 		}
-		_loop197:;
+		_loop200:;
 		} // ( ... )*
 		match(RBRACE);
 		arrayindex_list_AST = RefDNode(currentAST.root);
@@ -7734,10 +7776,10 @@ void GDLParser::arrayindex() {
 	RefDNode arrayindex_AST = RefDNode(antlr::nullAST);
 	
 	{
-	bool synPredMatched206 = false;
+	bool synPredMatched212 = false;
 	if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RSQUARE))) {
-		int _m206 = mark();
-		synPredMatched206 = true;
+		int _m212 = mark();
+		synPredMatched212 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -7763,12 +7805,12 @@ void GDLParser::arrayindex() {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched206 = false;
+			synPredMatched212 = false;
 		}
-		rewind(_m206);
+		rewind(_m212);
 		inputState->guessing--;
 	}
-	if ( synPredMatched206 ) {
+	if ( synPredMatched212 ) {
 		all_elements();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -7785,10 +7827,10 @@ void GDLParser::arrayindex() {
 		{
 			match(COLON);
 			{
-			bool synPredMatched211 = false;
+			bool synPredMatched217 = false;
 			if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == COLON || LA(2) == RSQUARE))) {
-				int _m211 = mark();
-				synPredMatched211 = true;
+				int _m217 = mark();
+				synPredMatched217 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -7819,12 +7861,12 @@ void GDLParser::arrayindex() {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched211 = false;
+					synPredMatched217 = false;
 				}
-				rewind(_m211);
+				rewind(_m217);
 				inputState->guessing--;
 			}
-			if ( synPredMatched211 ) {
+			if ( synPredMatched217 ) {
 				all_elements();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -7847,10 +7889,10 @@ void GDLParser::arrayindex() {
 			{
 				match(COLON);
 				{
-				bool synPredMatched216 = false;
+				bool synPredMatched222 = false;
 				if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RSQUARE))) {
-					int _m216 = mark();
-					synPredMatched216 = true;
+					int _m222 = mark();
+					synPredMatched222 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -7876,12 +7918,12 @@ void GDLParser::arrayindex() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched216 = false;
+						synPredMatched222 = false;
 					}
-					rewind(_m216);
+					rewind(_m222);
 					inputState->guessing--;
 				}
-				if ( synPredMatched216 ) {
+				if ( synPredMatched222 ) {
 					match(ASTERIX);
 					if ( inputState->guessing==0 ) {
 						
@@ -7953,10 +7995,10 @@ void GDLParser::arrayindex_sloppy() {
 	RefDNode arrayindex_sloppy_AST = RefDNode(antlr::nullAST);
 	
 	{
-	bool synPredMatched221 = false;
+	bool synPredMatched227 = false;
 	if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE))) {
-		int _m221 = mark();
-		synPredMatched221 = true;
+		int _m227 = mark();
+		synPredMatched227 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -7987,12 +8029,12 @@ void GDLParser::arrayindex_sloppy() {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched221 = false;
+			synPredMatched227 = false;
 		}
-		rewind(_m221);
+		rewind(_m227);
 		inputState->guessing--;
 	}
-	if ( synPredMatched221 ) {
+	if ( synPredMatched227 ) {
 		all_elements();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -8009,10 +8051,10 @@ void GDLParser::arrayindex_sloppy() {
 		{
 			match(COLON);
 			{
-			bool synPredMatched226 = false;
+			bool synPredMatched232 = false;
 			if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == COLON || LA(2) == RBRACE))) {
-				int _m226 = mark();
-				synPredMatched226 = true;
+				int _m232 = mark();
+				synPredMatched232 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -8048,12 +8090,12 @@ void GDLParser::arrayindex_sloppy() {
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched226 = false;
+					synPredMatched232 = false;
 				}
-				rewind(_m226);
+				rewind(_m232);
 				inputState->guessing--;
 			}
-			if ( synPredMatched226 ) {
+			if ( synPredMatched232 ) {
 				all_elements();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -8076,10 +8118,10 @@ void GDLParser::arrayindex_sloppy() {
 			{
 				match(COLON);
 				{
-				bool synPredMatched231 = false;
+				bool synPredMatched237 = false;
 				if (((LA(1) == ASTERIX) && (LA(2) == COMMA || LA(2) == RBRACE))) {
-					int _m231 = mark();
-					synPredMatched231 = true;
+					int _m237 = mark();
+					synPredMatched237 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -8110,12 +8152,12 @@ void GDLParser::arrayindex_sloppy() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched231 = false;
+						synPredMatched237 = false;
 					}
-					rewind(_m231);
+					rewind(_m237);
 					inputState->guessing--;
 				}
-				if ( synPredMatched231 ) {
+				if ( synPredMatched237 ) {
 					match(ASTERIX);
 					if ( inputState->guessing==0 ) {
 						
@@ -8207,15 +8249,46 @@ void GDLParser::arrayindex_list_sloppy() {
 			}
 		}
 		else {
-			goto _loop200;
+			goto _loop203;
 		}
 		
 	}
-	_loop200:;
+	_loop203:;
 	} // ( ... )*
 	match(RBRACE);
 	arrayindex_list_sloppy_AST = RefDNode(currentAST.root);
 	returnAST = arrayindex_list_sloppy_AST;
+}
+
+void GDLParser::arrayindex_list_sloppy_silent() {
+	returnAST = RefDNode(antlr::nullAST);
+	antlr::ASTPair currentAST;
+	RefDNode arrayindex_list_sloppy_silent_AST = RefDNode(antlr::nullAST);
+	
+	match(LBRACE);
+	arrayindex_sloppy();
+	if (inputState->guessing==0) {
+		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+	}
+	{ // ( ... )*
+	for (;;) {
+		if ((LA(1) == COMMA)) {
+			match(COMMA);
+			arrayindex_sloppy();
+			if (inputState->guessing==0) {
+				astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
+			}
+		}
+		else {
+			goto _loop206;
+		}
+		
+	}
+	_loop206:;
+	} // ( ... )*
+	match(RBRACE);
+	arrayindex_list_sloppy_silent_AST = RefDNode(currentAST.root);
+	returnAST = arrayindex_list_sloppy_silent_AST;
 }
 
 void GDLParser::all_elements() {
@@ -8223,9 +8296,9 @@ void GDLParser::all_elements() {
 	antlr::ASTPair currentAST;
 	RefDNode all_elements_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp202_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp206_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp202_AST = astFactory->create(LT(1));
+		tmp206_AST = astFactory->create(LT(1));
 	}
 	match(ASTERIX);
 	if ( inputState->guessing==0 ) {
@@ -8247,10 +8320,10 @@ void GDLParser::sysvar() {
 	antlr::ASTPair currentAST;
 	RefDNode sysvar_AST = RefDNode(antlr::nullAST);
 	
-	RefDNode tmp203_AST = RefDNode(antlr::nullAST);
+	RefDNode tmp207_AST = RefDNode(antlr::nullAST);
 	if ( inputState->guessing == 0 ) {
-		tmp203_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, antlr::RefAST(tmp203_AST));
+		tmp207_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, antlr::RefAST(tmp207_AST));
 	}
 	match(SYSVARNAME);
 	if ( inputState->guessing==0 ) {
@@ -8526,10 +8599,10 @@ void GDLParser::array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp206_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp210_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp206_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp206_AST));
+			tmp210_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp210_AST));
 		}
 		match(IDENTIFIER);
 		array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8622,10 +8695,10 @@ void GDLParser::tag_array_expr_nth_sub() {
 	switch ( LA(1)) {
 	case IDENTIFIER:
 	{
-		RefDNode tmp207_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp211_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp207_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, antlr::RefAST(tmp207_AST));
+			tmp211_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, antlr::RefAST(tmp211_AST));
 		}
 		match(IDENTIFIER);
 		tag_array_expr_nth_sub_AST = RefDNode(currentAST.root);
@@ -8804,10 +8877,10 @@ int  GDLParser::tag_access_keeplast() {
 	
 	match(DOT);
 	{
-	bool synPredMatched248 = false;
+	bool synPredMatched254 = false;
 	if (((_tokenSet_20.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-		int _m248 = mark();
-		synPredMatched248 = true;
+		int _m254 = mark();
+		synPredMatched254 = true;
 		inputState->guessing++;
 		try {
 			{
@@ -8816,12 +8889,12 @@ int  GDLParser::tag_access_keeplast() {
 			}
 		}
 		catch (antlr::RecognitionException& pe) {
-			synPredMatched248 = false;
+			synPredMatched254 = false;
 		}
-		rewind(_m248);
+		rewind(_m254);
 		inputState->guessing--;
 	}
-	if ( synPredMatched248 ) {
+	if ( synPredMatched254 ) {
 		{
 		tag_array_expr_nth();
 		if (inputState->guessing==0) {
@@ -8858,7 +8931,7 @@ SizeT  GDLParser::tag_access() {
 	
 	
 	{ // ( ... )+
-	int _cnt254=0;
+	int _cnt260=0;
 	for (;;) {
 		if ((LA(1) == DOT)) {
 			match(DOT);
@@ -8871,12 +8944,12 @@ SizeT  GDLParser::tag_access() {
 			}
 		}
 		else {
-			if ( _cnt254>=1 ) { goto _loop254; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
+			if ( _cnt260>=1 ) { goto _loop260; } else {throw antlr::NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt254++;
+		_cnt260++;
 	}
-	_loop254:;
+	_loop260:;
 	}  // ( ... )+
 	tag_access_AST = RefDNode(currentAST.root);
 	returnAST = tag_access_AST;
@@ -8984,7 +9057,7 @@ bool  GDLParser::member_function_call() {
 		match(METHOD);
 		if ( inputState->guessing==0 ) {
 			
-			// here we translate IDL_OBECT to GDL_OBJECT for source code compatibility
+			// here we translate IDL_OBJECT to GDL_OBJECT for source code compatibility
 			{
 			if( s_AST->getText() == "IDL_OBJECT")
 			s_AST->setText(GDL_OBJECT_NAME);
@@ -9009,39 +9082,6 @@ bool  GDLParser::member_function_call() {
 	member_function_call_AST = RefDNode(currentAST.root);
 	returnAST = member_function_call_AST;
 	return parent;
-}
-
-void GDLParser::member_function_call_dot() {
-	returnAST = RefDNode(antlr::nullAST);
-	antlr::ASTPair currentAST;
-	RefDNode member_function_call_dot_AST = RefDNode(antlr::nullAST);
-	antlr::RefToken  s = antlr::nullToken;
-	RefDNode s_AST = RefDNode(antlr::nullAST);
-	
-	match(DOT);
-	{
-	s = LT(1);
-	if ( inputState->guessing == 0 ) {
-		s_AST = astFactory->create(s);
-		astFactory->addASTChild(currentAST, antlr::RefAST(s_AST));
-	}
-	match(IDENTIFIER);
-	match(METHOD);
-	if ( inputState->guessing==0 ) {
-		
-		if( s_AST->getText() == "IDL_OBJECT")
-		s_AST->setText(GDL_OBJECT_NAME);
-		else if( s_AST->getText() == "IDL_CONTAINER")
-		s_AST->setText(GDL_CONTAINER_NAME);
-		
-	}
-	}
-	formal_function_call();
-	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
-	}
-	member_function_call_dot_AST = RefDNode(currentAST.root);
-	returnAST = member_function_call_dot_AST;
 }
 
 void GDLParser::arrayexpr_mfcall() {
@@ -9092,7 +9132,7 @@ void GDLParser::arrayexpr_mfcall() {
 			id_AST = astFactory->create(id);
 		}
 		match(IDENTIFIER);
-		arrayindex_list();
+		arrayindex_list_sloppy_silent();
 		if (inputState->guessing==0) {
 			al_AST = returnAST;
 		}
@@ -9116,9 +9156,9 @@ void GDLParser::arrayexpr_mfcall() {
 	}
 	case ASTERIX:
 	{
-		RefDNode tmp215_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp217_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp215_AST = astFactory->create(LT(1));
+			tmp217_AST = astFactory->create(LT(1));
 		}
 		match(ASTERIX);
 		arrayexpr_mfcall();
@@ -9236,10 +9276,10 @@ void GDLParser::primary_expr() {
 		break;
 	}
 	default:
-		bool synPredMatched271 = false;
+		bool synPredMatched275 = false;
 		if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-			int _m271 = mark();
-			synPredMatched271 = true;
+			int _m275 = mark();
+			synPredMatched275 = true;
 			inputState->guessing++;
 			try {
 				{
@@ -9248,12 +9288,12 @@ void GDLParser::primary_expr() {
 				}
 			}
 			catch (antlr::RecognitionException& pe) {
-				synPredMatched271 = false;
+				synPredMatched275 = false;
 			}
-			rewind(_m271);
+			rewind(_m275);
 			inputState->guessing--;
 		}
-		if ( synPredMatched271 ) {
+		if ( synPredMatched275 ) {
 			deref_dot_expr_keeplast();
 			if (inputState->guessing==0) {
 				d1_AST = returnAST;
@@ -9283,10 +9323,10 @@ void GDLParser::primary_expr() {
 			primary_expr_AST = RefDNode(currentAST.root);
 		}
 		else {
-			bool synPredMatched276 = false;
+			bool synPredMatched280 = false;
 			if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-				int _m276 = mark();
-				synPredMatched276 = true;
+				int _m280 = mark();
+				synPredMatched280 = true;
 				inputState->guessing++;
 				try {
 					{
@@ -9302,23 +9342,23 @@ void GDLParser::primary_expr() {
 							expr();
 						}
 						else {
-							goto _loop275;
+							goto _loop279;
 						}
 						
 					}
-					_loop275:;
+					_loop279:;
 					} // ( ... )*
 					match(RBRACE);
 					}
 					}
 				}
 				catch (antlr::RecognitionException& pe) {
-					synPredMatched276 = false;
+					synPredMatched280 = false;
 				}
-				rewind(_m276);
+				rewind(_m280);
 				inputState->guessing--;
 			}
-			if ( synPredMatched276 ) {
+			if ( synPredMatched280 ) {
 				arrayexpr_mfcall();
 				if (inputState->guessing==0) {
 					astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9326,10 +9366,10 @@ void GDLParser::primary_expr() {
 				primary_expr_AST = RefDNode(currentAST.root);
 			}
 			else {
-				bool synPredMatched278 = false;
+				bool synPredMatched282 = false;
 				if (((_tokenSet_4.member(LA(1))) && (_tokenSet_5.member(LA(2))))) {
-					int _m278 = mark();
-					synPredMatched278 = true;
+					int _m282 = mark();
+					synPredMatched282 = true;
 					inputState->guessing++;
 					try {
 						{
@@ -9338,12 +9378,12 @@ void GDLParser::primary_expr() {
 						}
 					}
 					catch (antlr::RecognitionException& pe) {
-						synPredMatched278 = false;
+						synPredMatched282 = false;
 					}
-					rewind(_m278);
+					rewind(_m282);
 					inputState->guessing--;
 				}
-				if ( synPredMatched278 ) {
+				if ( synPredMatched282 ) {
 					deref_dot_expr_keeplast();
 					if (inputState->guessing==0) {
 						d3_AST = returnAST;
@@ -9367,10 +9407,10 @@ void GDLParser::primary_expr() {
 					primary_expr_AST = RefDNode(currentAST.root);
 				}
 				else {
-					bool synPredMatched280 = false;
+					bool synPredMatched284 = false;
 					if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-						int _m280 = mark();
-						synPredMatched280 = true;
+						int _m284 = mark();
+						synPredMatched284 = true;
 						inputState->guessing++;
 						try {
 							{
@@ -9378,12 +9418,12 @@ void GDLParser::primary_expr() {
 							}
 						}
 						catch (antlr::RecognitionException& pe) {
-							synPredMatched280 = false;
+							synPredMatched284 = false;
 						}
-						rewind(_m280);
+						rewind(_m284);
 						inputState->guessing--;
 					}
-					if ( synPredMatched280 ) {
+					if ( synPredMatched284 ) {
 						deref_expr();
 						if (inputState->guessing==0) {
 							astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9466,10 +9506,10 @@ void GDLParser::primary_expr() {
 						primary_expr_AST = RefDNode(currentAST.root);
 					}
 					else {
-						bool synPredMatched285 = false;
+						bool synPredMatched289 = false;
 						if (((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE))) {
-							int _m285 = mark();
-							synPredMatched285 = true;
+							int _m289 = mark();
+							synPredMatched289 = true;
 							inputState->guessing++;
 							try {
 								{
@@ -9483,22 +9523,22 @@ void GDLParser::primary_expr() {
 										expr();
 									}
 									else {
-										goto _loop284;
+										goto _loop288;
 									}
 									
 								}
-								_loop284:;
+								_loop288:;
 								} // ( ... )*
 								match(RBRACE);
 								}
 							}
 							catch (antlr::RecognitionException& pe) {
-								synPredMatched285 = false;
+								synPredMatched289 = false;
 							}
-							rewind(_m285);
+							rewind(_m289);
 							inputState->guessing--;
 						}
-						if ( synPredMatched285 ) {
+						if ( synPredMatched289 ) {
 							{
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))&&( IsFun(LT(1)))) {
 								formal_function_call();
@@ -9520,10 +9560,10 @@ void GDLParser::primary_expr() {
 								}
 							}
 							else {
-								bool synPredMatched288 = false;
+								bool synPredMatched292 = false;
 								if ((((LA(1) == IDENTIFIER || LA(1) == INHERITS) && (LA(2) == LBRACE))&&(fussy < 2))) {
-									int _m288 = mark();
-									synPredMatched288 = true;
+									int _m292 = mark();
+									synPredMatched292 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9532,12 +9572,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched288 = false;
+										synPredMatched292 = false;
 									}
-									rewind(_m288);
+									rewind(_m292);
 									inputState->guessing--;
 								}
-								if ( synPredMatched288 ) {
+								if ( synPredMatched292 ) {
 									var();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9585,10 +9625,10 @@ void GDLParser::primary_expr() {
 							primary_expr_AST = RefDNode(currentAST.root);
 						}
 						else {
-							bool synPredMatched290 = false;
+							bool synPredMatched294 = false;
 							if (((LA(1) == IDENTIFIER) && (LA(2) == LBRACE))) {
-								int _m290 = mark();
-								synPredMatched290 = true;
+								int _m294 = mark();
+								synPredMatched294 = true;
 								inputState->guessing++;
 								try {
 									{
@@ -9596,12 +9636,12 @@ void GDLParser::primary_expr() {
 									}
 								}
 								catch (antlr::RecognitionException& pe) {
-									synPredMatched290 = false;
+									synPredMatched294 = false;
 								}
-								rewind(_m290);
+								rewind(_m294);
 								inputState->guessing--;
 							}
-							if ( synPredMatched290 ) {
+							if ( synPredMatched294 ) {
 								formal_function_call();
 								if (inputState->guessing==0) {
 									astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9620,10 +9660,10 @@ void GDLParser::primary_expr() {
 								primary_expr_AST = RefDNode(currentAST.root);
 							}
 							else {
-								bool synPredMatched292 = false;
+								bool synPredMatched296 = false;
 								if (((_tokenSet_4.member(LA(1))) && (_tokenSet_22.member(LA(2))))) {
-									int _m292 = mark();
-									synPredMatched292 = true;
+									int _m296 = mark();
+									synPredMatched296 = true;
 									inputState->guessing++;
 									try {
 										{
@@ -9631,12 +9671,12 @@ void GDLParser::primary_expr() {
 										}
 									}
 									catch (antlr::RecognitionException& pe) {
-										synPredMatched292 = false;
+										synPredMatched296 = false;
 									}
-									rewind(_m292);
+									rewind(_m296);
 									inputState->guessing--;
 								}
-								if ( synPredMatched292 ) {
+								if ( synPredMatched296 ) {
 									deref_expr();
 									if (inputState->guessing==0) {
 										astFactory->addASTChild(currentAST, antlr::RefAST(returnAST));
@@ -9743,9 +9783,9 @@ void GDLParser::primary_expr() {
 									ls = LT(1);
 									ls_AST = astFactory->create(ls);
 									match(LSQUARE);
-									RefDNode tmp216_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp218_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp216_AST = astFactory->create(LT(1));
+										tmp218_AST = astFactory->create(LT(1));
 									}
 									match(RSQUARE);
 									if ( inputState->guessing==0 ) {
@@ -9766,9 +9806,9 @@ void GDLParser::primary_expr() {
 									lc = LT(1);
 									lc_AST = astFactory->create(lc);
 									match(LCURLY);
-									RefDNode tmp217_AST = RefDNode(antlr::nullAST);
+									RefDNode tmp219_AST = RefDNode(antlr::nullAST);
 									if ( inputState->guessing == 0 ) {
-										tmp217_AST = astFactory->create(LT(1));
+										tmp219_AST = astFactory->create(LT(1));
 									}
 									match(RCURLY);
 									if ( inputState->guessing==0 ) {
@@ -9809,20 +9849,20 @@ void GDLParser::decinc_expr() {
 		switch ( LA(1)) {
 		case INC:
 		{
-			RefDNode tmp218_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp220_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp218_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp218_AST));
+				tmp220_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp220_AST));
 			}
 			match(INC);
 			break;
 		}
 		case DEC:
 		{
-			RefDNode tmp219_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp221_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp219_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp219_AST));
+				tmp221_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
 			}
 			match(DEC);
 			break;
@@ -9987,10 +10027,10 @@ void GDLParser::exponential_expr() {
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == POW)) {
-			RefDNode tmp220_AST = RefDNode(antlr::nullAST);
+			RefDNode tmp222_AST = RefDNode(antlr::nullAST);
 			if ( inputState->guessing == 0 ) {
-				tmp220_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp220_AST));
+				tmp222_AST = astFactory->create(LT(1));
+				astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
 			}
 			match(POW);
 			decinc_expr();
@@ -9999,11 +10039,11 @@ void GDLParser::exponential_expr() {
 			}
 		}
 		else {
-			goto _loop299;
+			goto _loop303;
 		}
 		
 	}
-	_loop299:;
+	_loop303:;
 	} // ( ... )*
 	exponential_expr_AST = RefDNode(currentAST.root);
 	returnAST = exponential_expr_AST;
@@ -10025,50 +10065,50 @@ void GDLParser::multiplicative_expr() {
 			switch ( LA(1)) {
 			case ASTERIX:
 			{
-				RefDNode tmp221_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp223_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp221_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp221_AST));
+					tmp223_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp223_AST));
 				}
 				match(ASTERIX);
 				break;
 			}
 			case MATRIX_OP1:
 			{
-				RefDNode tmp222_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp222_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp222_AST));
+					tmp224_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
 				}
 				match(MATRIX_OP1);
 				break;
 			}
 			case MATRIX_OP2:
 			{
-				RefDNode tmp223_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp225_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp223_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp223_AST));
+					tmp225_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp225_AST));
 				}
 				match(MATRIX_OP2);
 				break;
 			}
 			case SLASH:
 			{
-				RefDNode tmp224_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp226_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp224_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp224_AST));
+					tmp226_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp226_AST));
 				}
 				match(SLASH);
 				break;
 			}
 			case MOD_OP:
 			{
-				RefDNode tmp225_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp227_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp225_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp225_AST));
+					tmp227_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp227_AST));
 				}
 				match(MOD_OP);
 				break;
@@ -10085,11 +10125,11 @@ void GDLParser::multiplicative_expr() {
 			}
 		}
 		else {
-			goto _loop303;
+			goto _loop307;
 		}
 		
 	}
-	_loop303:;
+	_loop307:;
 	} // ( ... )*
 	multiplicative_expr_AST = RefDNode(currentAST.root);
 	returnAST = multiplicative_expr_AST;
@@ -10288,40 +10328,40 @@ void GDLParser::additive_expr() {
 			switch ( LA(1)) {
 			case PLUS:
 			{
-				RefDNode tmp227_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp229_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp227_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp227_AST));
+					tmp229_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp229_AST));
 				}
 				match(PLUS);
 				break;
 			}
 			case MINUS:
 			{
-				RefDNode tmp228_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp230_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp228_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp228_AST));
+					tmp230_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp230_AST));
 				}
 				match(MINUS);
 				break;
 			}
 			case LTMARK:
 			{
-				RefDNode tmp229_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp231_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp229_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp229_AST));
+					tmp231_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp231_AST));
 				}
 				match(LTMARK);
 				break;
 			}
 			case GTMARK:
 			{
-				RefDNode tmp230_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp232_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp230_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp230_AST));
+					tmp232_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp232_AST));
 				}
 				match(GTMARK);
 				break;
@@ -10408,11 +10448,11 @@ void GDLParser::additive_expr() {
 			}
 		}
 		else {
-			goto _loop310;
+			goto _loop314;
 		}
 		
 	}
-	_loop310:;
+	_loop314:;
 	} // ( ... )*
 	additive_expr_AST = RefDNode(currentAST.root);
 	returnAST = additive_expr_AST;
@@ -10426,10 +10466,10 @@ void GDLParser::neg_expr() {
 	switch ( LA(1)) {
 	case NOT_OP:
 	{
-		RefDNode tmp231_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp233_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp231_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp231_AST));
+			tmp233_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp233_AST));
 		}
 		match(NOT_OP);
 		multiplicative_expr();
@@ -10441,10 +10481,10 @@ void GDLParser::neg_expr() {
 	}
 	case LOG_NEG:
 	{
-		RefDNode tmp232_AST = RefDNode(antlr::nullAST);
+		RefDNode tmp234_AST = RefDNode(antlr::nullAST);
 		if ( inputState->guessing == 0 ) {
-			tmp232_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp232_AST));
+			tmp234_AST = astFactory->create(LT(1));
+			astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp234_AST));
 		}
 		match(LOG_NEG);
 		multiplicative_expr();
@@ -10478,60 +10518,60 @@ void GDLParser::relational_expr() {
 			switch ( LA(1)) {
 			case EQ_OP:
 			{
-				RefDNode tmp233_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp235_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp233_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp233_AST));
+					tmp235_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp235_AST));
 				}
 				match(EQ_OP);
 				break;
 			}
 			case NE_OP:
 			{
-				RefDNode tmp234_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp236_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp234_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp234_AST));
+					tmp236_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp236_AST));
 				}
 				match(NE_OP);
 				break;
 			}
 			case LE_OP:
 			{
-				RefDNode tmp235_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp237_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp235_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp235_AST));
+					tmp237_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp237_AST));
 				}
 				match(LE_OP);
 				break;
 			}
 			case LT_OP:
 			{
-				RefDNode tmp236_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp238_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp236_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp236_AST));
+					tmp238_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp238_AST));
 				}
 				match(LT_OP);
 				break;
 			}
 			case GE_OP:
 			{
-				RefDNode tmp237_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp239_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp237_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp237_AST));
+					tmp239_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp239_AST));
 				}
 				match(GE_OP);
 				break;
 			}
 			case GT_OP:
 			{
-				RefDNode tmp238_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp240_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp238_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp238_AST));
+					tmp240_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp240_AST));
 				}
 				match(GT_OP);
 				break;
@@ -10548,11 +10588,11 @@ void GDLParser::relational_expr() {
 			}
 		}
 		else {
-			goto _loop315;
+			goto _loop319;
 		}
 		
 	}
-	_loop315:;
+	_loop319:;
 	} // ( ... )*
 	relational_expr_AST = RefDNode(currentAST.root);
 	returnAST = relational_expr_AST;
@@ -10574,30 +10614,30 @@ void GDLParser::boolean_expr() {
 			switch ( LA(1)) {
 			case AND_OP:
 			{
-				RefDNode tmp239_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp241_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp239_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp239_AST));
+					tmp241_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp241_AST));
 				}
 				match(AND_OP);
 				break;
 			}
 			case OR_OP:
 			{
-				RefDNode tmp240_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp242_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp240_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp240_AST));
+					tmp242_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp242_AST));
 				}
 				match(OR_OP);
 				break;
 			}
 			case XOR_OP:
 			{
-				RefDNode tmp241_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp243_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp241_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp241_AST));
+					tmp243_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp243_AST));
 				}
 				match(XOR_OP);
 				break;
@@ -10614,11 +10654,11 @@ void GDLParser::boolean_expr() {
 			}
 		}
 		else {
-			goto _loop319;
+			goto _loop323;
 		}
 		
 	}
-	_loop319:;
+	_loop323:;
 	} // ( ... )*
 	boolean_expr_AST = RefDNode(currentAST.root);
 	returnAST = boolean_expr_AST;
@@ -10640,20 +10680,20 @@ void GDLParser::logical_expr() {
 			switch ( LA(1)) {
 			case LOG_AND:
 			{
-				RefDNode tmp242_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp244_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp242_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp242_AST));
+					tmp244_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp244_AST));
 				}
 				match(LOG_AND);
 				break;
 			}
 			case LOG_OR:
 			{
-				RefDNode tmp243_AST = RefDNode(antlr::nullAST);
+				RefDNode tmp245_AST = RefDNode(antlr::nullAST);
 				if ( inputState->guessing == 0 ) {
-					tmp243_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp243_AST));
+					tmp245_AST = astFactory->create(LT(1));
+					astFactory->makeASTRoot(currentAST, antlr::RefAST(tmp245_AST));
 				}
 				match(LOG_OR);
 				break;
@@ -10670,11 +10710,11 @@ void GDLParser::logical_expr() {
 			}
 		}
 		else {
-			goto _loop323;
+			goto _loop327;
 		}
 		
 	}
-	_loop323:;
+	_loop327:;
 	} // ( ... )*
 	logical_expr_AST = RefDNode(currentAST.root);
 	returnAST = logical_expr_AST;
@@ -11174,8 +11214,8 @@ const antlr::BitSet GDLParser::_tokenSet_19(_tokenSet_19_data_,16);
 const unsigned long GDLParser::_tokenSet_20_data_[] = { 0UL, 0UL, 268435456UL, 0UL, 536870912UL, 12UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // IDENTIFIER LBRACE SYSVARNAME EXCLAMATION 
 const antlr::BitSet GDLParser::_tokenSet_20(_tokenSet_20_data_,12);
-const unsigned long GDLParser::_tokenSet_21_data_[] = { 0UL, 0UL, 0UL, 8UL, 536870957UL, 1UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// "else" "until" METHOD COMMA END_U LBRACE LSQUARE 
+const unsigned long GDLParser::_tokenSet_21_data_[] = { 0UL, 0UL, 0UL, 8UL, 536870957UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+// "else" "until" METHOD COMMA END_U LBRACE 
 const antlr::BitSet GDLParser::_tokenSet_21(_tokenSet_21_data_,12);
 const unsigned long GDLParser::_tokenSet_22_data_[] = { 2UL, 0UL, 805306368UL, 2549424140UL, 4026532283UL, 4294967287UL, 268435455UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // EOF IDENTIFIER "and" "do" "else" "eq" "ge" "gt" "inherits" "le" "lt" 

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -58,6 +58,7 @@ class CUSTOM_API GDLParser : public antlr::LLkParser, public GDLTokenTypes
     bool   searchForPro; // true -> procedure subName, false -> function subName 
     bool   SearchedRoutineFound; 
     unsigned int compileOpt=0;
+	bool allowInteractiveSyntax=false;
 	bool relaxed=false; // use of a bool speedups {}? constructs
     int fussy=((compileOpt & STRICTARR)!=0)?2:1; //auto recovery if compile opt is not strictarr
     int LastGoodPosition=0; // last position of start of PRO or FUNC -- used in recovery mode

--- a/src/GDLParser.hpp
+++ b/src/GDLParser.hpp
@@ -140,10 +140,11 @@ public:
 	public: void case_body();
 	public: void endcase_mark();
 	public: void endcaseelse_mark();
-	public: void identifier_list();
+	public: void forward_identifier_list();
 	public: void keyword_declaration();
 	protected: std::string  object_name();
 	public: void compile_opt();
+	public: void identifier_list();
 	public: void endforeach_mark();
 	public: void endfor_mark();
 	public: void endrep_mark();
@@ -229,6 +230,7 @@ public:
 	public: void arrayindex();
 	public: void arrayindex_sloppy();
 	public: void arrayindex_list_sloppy();
+	public: void arrayindex_list_sloppy_silent();
 	public: void all_elements();
 	public: void sysvar();
 	public: void var();
@@ -243,7 +245,6 @@ public:
 	protected: SizeT  tag_access();
 	public: void deref_dot_expr();
 	protected: bool  member_function_call();
-	public: void member_function_call_dot();
 	public: void arrayexpr_mfcall();
 	public: void primary_expr();
 	public: void decinc_expr();

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -7849,8 +7849,6 @@ namespace lib {
     bool parametersKW = e->KeywordSet(parametersIx);
     static int sourceIx = e->KeywordIx("SOURCE");
     bool sourceKW = e->KeywordSet(sourceIx);
-    static int VARIABLES = e->KeywordIx("VARIABLES");
-    bool variables = e->KeywordSet(VARIABLES);
     static int UNRESOLVED = e->KeywordIx("UNRESOLVED");
     bool unresolved = e->KeywordSet(UNRESOLVED);
 
@@ -7867,7 +7865,10 @@ namespace lib {
 	  }
 	  return res;
 	}
-	if (variables) return new DStringGDL("");
+// Job not done, "VARIABLES" is in WarnKwList in definition at libinit.cpp    
+//    static int VARIABLES = e->KeywordIx("VARIABLES");
+//    bool variables = e->KeywordSet(VARIABLES);
+//	if (variables) return new DStringGDL("");
     
     if (sourceKW) {
 

--- a/src/dnode.cpp
+++ b/src/dnode.cpp
@@ -602,9 +602,24 @@ void DNode::SetFunIx(const int ix) {
     WarnAboutObsoleteRoutine(this, funList[ix]->Name());
 }
 
+void doUpCasing( std::string& s)
+  {
+    unsigned len=s.length();
+    for(unsigned i=0;i<len;i++)
+    s[i]=std::toupper(s[i]);
+  }
+
+void DNode::MemorizeUncompiledFun(std::string & name) {
+  doUpCasing(name);
+  unknownFunList.insert(name);
+}
 void DNode::SetProIx(const int ix) {
   if (ix == -1) unknownProList.insert(getText());
   proIx = ix;
   if (ix != -1 && proList[ix]->isObsolete()) WarnAboutObsoleteRoutine(this, proList[ix]->Name());
 }
 
+void DNode::MemorizeUncompiledPro(std::string & name) {
+  doUpCasing(name);
+  unknownProList.insert(name);
+}

--- a/src/dnode.hpp
+++ b/src/dnode.hpp
@@ -234,7 +234,9 @@ public:
   void SetArrayDepth(const int aD) { arrayDepth=aD;} 
 
   void SetFunIx(const int ix);
+  void MemorizeUncompiledFun(std::string & s);
   void SetProIx(const int ix);
+  void MemorizeUncompiledPro(std::string & s);
   void SetLibFun(DLibFun* const l) { libFun=l;}
   void SetLibPro(DLibPro* const l) { libPro=l;}
   void SetNDot(const int n) { nDot=n;}

--- a/src/envt.cpp
+++ b/src/envt.cpp
@@ -179,7 +179,7 @@ EnvUDT::EnvUDT( ProgNodeP cN, BaseGDL* self,
   obj = true;
 
   DType selfType = self->Type();
-  if( selfType == GDL_STRUCT) throw GDLException( cN, "AutoPrint currently impossible on structure/objects elements.");
+  if( selfType == GDL_STRUCT) throw GDLException( cN, "AutoPrint currently impossible on such construct.");
   if( selfType != GDL_OBJ) 
     throw GDLException( cN, "Object reference type"
 			" required in this context: "+interpreter->Name(self));

--- a/src/gdl.cpp
+++ b/src/gdl.cpp
@@ -611,6 +611,7 @@ int main(int argc, char *argv[])
   
   //always between try{} catch{} when calling ExecuteStringLine!
   try {
+    unknownProList.insert("DLM_REGISTER"); //necessary as "DLM_REGISTER" is not yet known by parser at this time.
   std::string dlmCommand=("dlm_register,/silent");
   interpreter.ExecuteStringLine(dlmCommand);
   } catch (...) {std::cerr<<"Problem starting DLMs\n";}

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -144,8 +144,9 @@ void LibInit()
   new DLibFunRetNew(lib::terminal_size_fun,string("TERMINAL_SIZE"),2);
 
   const string routine_infoKey[]={"FUNCTIONS","SYSTEM","DISABLED","ENABLED",
-				  "PARAMETERS","SOURCE","UNRESOLVED","VARIABLES", KLISTEND};
-  new DLibFunRetNew(lib::routine_info,string("ROUTINE_INFO"),1,routine_infoKey);
+				  "PARAMETERS","SOURCE","UNRESOLVED", KLISTEND};
+  const string routine_infoWarnKey[]={"VARIABLES", KLISTEND};
+  new DLibFunRetNew(lib::routine_info,string("ROUTINE_INFO"),1,routine_infoKey,routine_infoWarnKey);
 
   new DLibFunRetNew(lib::routine_name_fun,string("ROUTINE_NAME_INTERNALGDL"),1);
   new DLibFunRetNew(lib::routine_dir_fun,string("ROUTINE_DIR"),1);

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -1007,6 +1007,41 @@ bool IsFun(antlr::RefToken rT1)
 			       Is_eq<DFun>(searchName));
   if( q != funList.end()) if( *q != NULL) return true;
 
+	// newly compiled DFun. ?
+  for ( UnknownFunListT::iterator r=unknownFunList.begin(); r!=unknownFunList.end(); ++r) {
+    if( (*r) == searchName )  return true;
+  }
+
+  //  cout << "Not found: " << searchName << endl;
+
+  return false;
+}
+
+// for semantic predicate
+bool IsPro(antlr::RefToken rT1)
+{
+  antlr::Token& T1=*rT1;
+
+  // search for T1.getText() in function table and path
+  string searchName=StrUpCase(T1.getText());
+
+//  cout << "IsFun: Searching for: " << searchName << endl;
+
+// Speeds up the process of finding (in gdlc.g) if a syntax like foo(bar) is a call to the function 'foo'
+// or the 'bar' element of array 'foo'.
+  LibProListT::iterator p=find_if(libProList.begin(),libProList.end(),
+			       Is_eq<DLibPro>(searchName));
+  if( p != libProList.end()) if( *p != NULL) return true;
+
+  ProListT::iterator q=find_if(proList.begin(),proList.end(),
+			       Is_eq<DPro>(searchName));
+  if( q != proList.end()) if( *q != NULL) return true;
+
+  // newly compiled DPro. ?
+  for ( UnknownProListT::iterator r=unknownProList.begin(); r!=unknownProList.end(); ++r) {
+    if( (*r) == searchName )  return true;
+  }
+
   //  cout << "Not found: " << searchName << endl;
 
   return false;

--- a/src/objects.hpp
+++ b/src/objects.hpp
@@ -137,6 +137,7 @@ int LibProIx(const std::string& n);
 int LibFunIx(const std::string& n);
 
 bool IsFun(antlr::RefToken); // used by Lexer and Parser
+bool IsPro(antlr::RefToken); // used by Lexer and Parser
 bool IsTracingSyntaxErrors(); //tells if syntax is not strict (i.e. parenthesis for array indexes).
 void SetTraceSyntaxErrors(bool value);
 

--- a/testsuite/LIST
+++ b/testsuite/LIST
@@ -16,15 +16,10 @@ test_bug_2892631.pro
 test_bug_2949487.pro
 test_bug_3033108.pro
 test_bug_3054361.pro
-test_bug_3055720.pro
-test_bug_3057511.pro
-test_bug_3057520.pro
-test_bug_3061072.pro
 test_bug_3081887.pro
 test_bug_3085858.pro
 test_bug_3091599.pro
 test_bug_3091610.pro
-test_bug_3100945.pro
 test_bug_3104214.pro
 test_bug_3104349.pro
 test_bug_3147146.pro

--- a/testsuite/test_bug_3055720.pro
+++ b/testsuite/test_bug_3055720.pro
@@ -1,4 +1,5 @@
 pro test_bug_3055720
+; must be called from test_netcdf
   if ~ncdf_exists() then exit, status=77
   nc = ncdf_create('test_bug_3055720.nc', /clo)
   nc_va = ncdf_vardef(nc, 'A', [ncdf_dimdef(nc, 'X', 10)])

--- a/testsuite/test_bug_3057511.pro
+++ b/testsuite/test_bug_3057511.pro
@@ -1,4 +1,5 @@
 pro test_bug_3057511
+; must be called from test_netcdf
   if ~ncdf_exists() then exit, status=77
   if execute("a = ncdf_dimdef(ncdf_create('/dev/null',/clo), 'x')") eq 1 then exit, status=1
   if execute("a = ncdf_dimdef(ncdf_create('bug.nc',/clo), 'x', /unlimited)") ne 1 then exit, status=1

--- a/testsuite/test_bug_3057520.pro
+++ b/testsuite/test_bug_3057520.pro
@@ -3,6 +3,7 @@
 ;
 pro TEST_BUG_3057520
 ;
+; must be called from test_netcdf
 if ~NCDF_EXISTS() then begin
    MESSAGE, /continue, 'GDL was compiled without NetCDF !'
    EXIT, status=77

--- a/testsuite/test_bug_3061072.pro
+++ b/testsuite/test_bug_3061072.pro
@@ -1,4 +1,5 @@
 pro test_bug_3061072
+; must be called from test_netcdf
   if ~ncdf_exists() then exit, status=77
 
   n = ncdf_create('/dev/null',/clo)

--- a/testsuite/test_bug_3100945.pro
+++ b/testsuite/test_bug_3100945.pro
@@ -1,4 +1,5 @@
 pro test_bug_3100945
+; must be called from test_netcdf
   if ~ncdf_exists() then exit, status=77
   nc = ncdf_create('/dev/null', /clobber)
   ncdf_attput, nc, 'gatt0', 0., /global

--- a/testsuite/test_netcdf.pro
+++ b/testsuite/test_netcdf.pro
@@ -21,6 +21,8 @@ if ~NCDF_EXISTS() then begin
 endif
 ;
 NC_TEST
+; /dev/null (used in below tests) WILL NOT be a file on Windows, come on!
+if !version.os_family eq 'Windows' then return
 TEST_BUG_3055720
 TEST_BUG_3057511
 TEST_BUG_3057520


### PR DESCRIPTION
1.  solve #2070 : the Parser would not accept  a.HasKey("+lat_0") at line 446 in  map_proj_init because the procedure map_proj_init is with compile_opt IDL2, and in this 'fussy' mode, the rule examined ("arrayindex_list") was ignoring the possibility of '(' . As we are more ore less stuck in the present overall structure of the ANTLR2 code, it seemed best to just enable the possibility of a '(' using a new rule, instead of trying to have the  parser behave similarly for '->' (MEMBER) and '.' (DOT), noting that a construct with MEMBER does not pass at all in the same parser rules as an equivalent construct with DOT.

2. enable autoprint on simple sentences such as !x.crange  
```
GDL> !x.crange
       0.0000000000000000       0.0000000000000000
```
however sentences such as
`GDL> !x.crange,dist(10)`
will fail to be printed.