### PR TITLE
Implement LAMBDA and LAMBDAP

### DIFF
--- a/src/GDLInterpreter.cpp
+++ b/src/GDLInterpreter.cpp
@@ -415,15 +415,15 @@ GDLInterpreter::GDLInterpreter()
 	}
 	catch ( GDLException& e) {
 		
-		// errors while typing commands in inner loop (called via Control-C, STOP, error) should be ignored.
-		if (e.Interpreter()->IsInnerInterpreterLoop()) {
-		  e.Interpreter()->SetInnerInterpeterLoop(false);
-		  _retTree=NULL;
-		  debugMode=DEBUG_CLEAR;
-		  // we cannot throw, here, it caused #2017 
-		  Warning(e.getMessage());  //just warn that there was a (typing ?) error see #1855
-		return RC_OK;
-		}
+				// errors while typing commands in inner loop (called via Control-C, STOP, error) should be ignored.
+				if (e.Interpreter()->IsInnerInterpreterLoop()) {
+				  e.Interpreter()->SetInnerInterpeterLoop(false);
+				  _retTree=NULL;
+				  debugMode=DEBUG_CLEAR;
+				  // we cannot throw, here, it caused #2017 
+				  Warning(e.getMessage());  //just warn that there was a (typing ?) error see #1855
+				return RC_OK;
+				}
 			// reset _retTree to last statement
 			// (might otherwise be inside an expression in which case 
 			// .CONTINUE does not work)

--- a/src/GDLInterpreter.hpp
+++ b/src/GDLInterpreter.hpp
@@ -178,7 +178,8 @@ public:
     // procedure (searchForPro == true) or function (searchForPro == false)
     static bool CompileFile(const std::string& f, 
 			    const std::string& untilPro="",
-			    bool searchForPro=true); 
+			    bool searchForPro=true,
+				bool inlined=false); 
     static bool CompileSaveFile(RefDNode theAST); 
     typedef RefHeap<BaseGDL> RefBaseGDL;
     typedef RefHeap<DStructGDL> RefDStructGDL;

--- a/src/basic_fun.cpp
+++ b/src/basic_fun.cpp
@@ -1604,6 +1604,57 @@ namespace lib {
     return int_fun(e);
   }
 
+  BaseGDL* lambda_fun(EnvT* e) {
+    static const std::string EOL("\n");
+    static int lambdanum=1;
+    DStringGDL* GDLexpr = e->GetParAs<DStringGDL>(0);
+    DString expr=(*GDLexpr)[0];
+    size_t pos=expr.find(":",0);
+    if (pos==std::string::npos) e->Throw("Code must be of the form \"arg1,arg2,... : statement\"");
+    std::string arguments=expr.substr(0,pos);
+    string lambdaFunName="IDL$LAMBDAF"+i2s(lambdanum++);
+    std::string functionText;
+    functionText+="FUNCTION ";
+    functionText+=lambdaFunName;
+    functionText+=",";
+    functionText+=arguments;
+    functionText+=EOL;
+    functionText+="COMPILE_OPT IDL2, hidden\nRETURN,";
+    functionText+=expr.substr(pos+1);
+    functionText+=EOL;
+    functionText+="END";
+    bool ok=GDLInterpreter::CompileFile(functionText,"", false, true);
+    if (!ok) e->Throw("Syntax error in code.");
+    
+    return new DStringGDL(lambdaFunName);
+  }
+  
+   BaseGDL* lambda_pro(EnvT* e) {
+    static const std::string EOL("\n");
+    static int lambdanum=1;
+    DStringGDL* GDLexpr = e->GetParAs<DStringGDL>(0);
+    DString expr=(*GDLexpr)[0];
+    size_t pos=expr.find(":",0);
+    if (pos==std::string::npos) e->Throw("Code must be of the form \"arg1,arg2,... : statement\"");
+    std::string arguments=expr.substr(0,pos);
+    string lambdaProName="IDL$LAMBDAP"+i2s(lambdanum++);
+    std::string proText;
+    proText+="PRO ";
+    proText+=lambdaProName;
+    proText+=",";
+    proText+=arguments;
+    proText+=EOL;
+    proText+="COMPILE_OPT IDL2, hidden";
+    proText+=EOL;
+    proText+=expr.substr(pos+1);
+    proText+=EOL;
+    proText+="END";
+    bool ok=GDLInterpreter::CompileFile(proText,"", false, true);
+    if (!ok) e->Throw("Syntax error in code.");
+    
+    return new DStringGDL(lambdaProName);
+  }
+   
   BaseGDL* call_function(EnvT* e) {
     int nParam = e->NParam();
     if (nParam == 0)

--- a/src/basic_fun.hpp
+++ b/src/basic_fun.hpp
@@ -179,7 +179,9 @@ namespace lib {
   BaseGDL** scope_varfetch_reference( EnvT* e); // special version for LEval()
   BaseGDL* scope_varname_fun( EnvT* e);
   BaseGDL* mean_fun(EnvT* e); 
-  BaseGDL* moment_fun(EnvT* e); 
+  BaseGDL* moment_fun(EnvT* e);
+  BaseGDL* lambda_fun(EnvT* e);
+  BaseGDL* lambda_pro(EnvT* e);
 } // namespace
 
 #endif

--- a/src/dinterpreter.cpp
+++ b/src/dinterpreter.cpp
@@ -644,14 +644,16 @@ void GDLInterpreter::ReportCompileError( GDLException& e, const string& file)
 // compiles file, returns success
 // if untilPro is set to "" the whole file is compiled
 // procedure (searchForPro == true (default)) or function (searchForPro == false)
-bool GDLInterpreter::CompileFile(const string& f, const string& untilPro, bool searchForPro) 
+bool GDLInterpreter::CompileFile(const string& f, const string& untilPro, bool searchForPro, bool inlined) 
 {
-  ifstream in(f.c_str());
-  if( !in) return false; // maybe throw exception here
-  
+//Note that std::unique_ptr is better that raw pointers
+std::unique_ptr<std::istream> stream;
+//stream holds a string
+if (inlined) stream = std::make_unique<std::istringstream>(f); else stream = std::make_unique<std::ifstream>(std::ifstream{ f.c_str() });
+
   RefDNode theAST;
   try {  
-    GDLLexer   lexer(in, f, GDLParser::NONE, untilPro, searchForPro);
+    GDLLexer   lexer(*stream, f, GDLParser::NONE, untilPro, searchForPro);
     GDLParser& parser=lexer.Parser();
     
     // parsing

--- a/src/dpro.hpp
+++ b/src/dpro.hpp
@@ -631,6 +631,9 @@ typedef std::vector<DPro*> ProListT;
 typedef std::set<std::string> UnknownFunListT;
 typedef std::set<std::string> UnknownProListT;
 
+typedef std::map<std::string, DFun*> LambdaFunListT;
+typedef std::map<std::string, DPro*> LambdaProListT;
+
 typedef std::vector<DLibFun*> LibFunListT;
 typedef std::vector<DLibPro*> LibProListT;
 

--- a/src/gdlc.i.g
+++ b/src/gdlc.i.g
@@ -231,7 +231,8 @@ public:
     // procedure (searchForPro == true) or function (searchForPro == false)
     static bool CompileFile(const std::string& f, 
 			    const std::string& untilPro="",
-			    bool searchForPro=true); 
+			    bool searchForPro=true,
+				bool inlined=false); 
     static bool CompileSaveFile(RefDNode theAST); 
     typedef RefHeap<BaseGDL> RefBaseGDL;
     typedef RefHeap<DStructGDL> RefDStructGDL;

--- a/src/libinit.cpp
+++ b/src/libinit.cpp
@@ -113,6 +113,9 @@ void LibInit()
   new DLibFunRetNew(lib::orderedhash_fun,string("ORDEREDHASH"),-1,hashKey);
 
   new DLibFun(lib::scope_level,string("SCOPE_LEVEL"),0);
+  //LAMBDA function
+  new DLibFun(lib::lambda_fun,string("LAMBDA"),1);
+  new DLibFun(lib::lambda_pro,string("LAMBDAP"),1);
 
   //SCOPE_VARFETCH WARNING: changes in lib::scope_varfetch_value must be reported also in lib::scope_varfetch_reference
   const string scope_varfetchKey[]={"LEVEL","ENTER", "REF_EXTRA", "COMMON", KLISTEND};

--- a/testsuite/LIST
+++ b/testsuite/LIST
@@ -121,6 +121,7 @@ test_l64.pro
 test_la_least_squares.pro
 test_la_trired.pro
 test_label_date.pro
+test_lambdas.pro
 test_linfit.pro
 test_list.pro
 test_ludc_lusol.pro

--- a/testsuite/test_lambdas.pro
+++ b/testsuite/test_lambdas.pro
@@ -1,0 +1,32 @@
+;
+; under GNU GPL v3
+PRO test_lambdas,no_exit=no_exit,test=test
+  compile_opt idl2 ; necessary for lambda function to work
+  errors=0
+  L=lambda("x: x^2")
+  a=3.0
+  z=l(a)
+  if z ne a^2 then ERRORS_ADD, errors, 'LAMBDA'
+; this just to exert the function
+  s="ZZZ"
+  q=lambdap("arg: STRPUT,arg,'GDL',0")
+  q,s
+  if s ne 'GDL' then ERRORS_ADD, errors, 'LAMBDAP'
+; tihs to check a new compilation is not needed if lambda is the same
+  oldq=q
+  q=lambdap("arg: STRPUT,arg,'GDL',0")
+  if q ne oldq then ERRORS_ADD, errors, 'LAMBDAP: duplicate LAMBDA error'
+;
+; ----------------- final message ----------
+;
+BANNER_FOR_TESTSUITE, 'TEST_LAMBDAS', errors
+; 
+if (errors GT 0) AND ~KEYWORD_SET(no_exit) then EXIT, status=1
+;
+if KEYWORD_SET(test) then STOP
+;
+end
+;
+
+
+END


### PR DESCRIPTION
3 differences with IDL's LAMBDAS:
 1. lambda text must always be a string (between " "). Needs a change in the ANTLR compiler to do otherwise.
 2. lambdas are here but their use is limited since GDL variables are not yet objects that would know about the MAP, REDUCE and FILTER methods.
 3. Using a lambda in QROMB() needs to have defined it before:
```
GDL> compile_opt idl2
GDL> result = QROMB("LAMBDA(x:x^3 + (x-1)^2 + 3)", -4, 4)
% Function not found: LAMBDA(X:X^3 + (X-1)^2 + 3)
% Execution halted at: $MAIN$          
GDL> zzz=LAMBDA("x:x^3 + (x-1)^2 + 3")
GDL> result = QROMB(zzz, -4, 4)
GDL> result
       74.666664
```
Obviously having lambdas more inlined, thus changing the Parser, would be great.