### PR TITLE
Obj creation support in dlm

### DIFF
--- a/src/export.hpp
+++ b/src/export.hpp
@@ -486,7 +486,8 @@ EXPORT_VPTR GDL_ToVPTR(BaseGDL* var, bool global = false, bool is_kw = false, EX
 		SizeT nelts = objstruct->N_Elements();
 		SizeT arr = 0;
 		SizeT ret = GdlStructDump(objstruct, arr, s);
-		h->hash = NULL;
+		h->hash = (export_heap_variable*) var; //save here the actual DObj. For the moment, even if here we return an IDL Obj,
+													//only the DObj will be used in the return function VPTR_ToGDL
 		h->flags = 0;
 		h->refcount = refcount;
 		h->hash_id = MimickedHeap.size();
@@ -936,8 +937,9 @@ BaseGDL* VPTR_ToGDL(EXPORT_VPTR v, bool protectVPTRData=false, EXPORT_ARRAY* new
 		dimension dim(arraydim, rank);
 		return GDL_MakeGDLStruct(v, dim);
 	} else if (v->type == GDL_TYP_OBJREF) {
-		ExitDlmFunctionAndThrow(__func__ , "Exchange of Objects with a DLM is not yet written, please report!");
-		return NULL;
+		EXPORT_HEAP_VPTR h=IDL_HeapVarHashFind(v->value.hvid);
+		if (h->hash == NULL) ExitDlmFunctionAndThrow(__func__ , "Exchange of Objects with a DLM is not yet written, please report!");
+		return (BaseGDL*)h->hash; //storing a GDL-created DObjGDL.
 	} else if (v->type == GDL_TYP_PTR) {
 		ExitDlmFunctionAndThrow(__func__ , "Exchange of Pointers with a DLM is not yet written, please report!");
 //		EXPORT_HEAP_VPTR h = IDL_HeapVarHashFind(v->value.hvid);
@@ -2514,7 +2516,7 @@ if (requested.specified != NULL) { // need write 0 or 1 in a special int in KW s
 }
 if (requested.value != NULL) { // need to pass either an address of a EXPORT_VPTR or fill in static elements of the structure exchanged with routine
 	size_t global_address = (size_t) (kw_result)+(size_t) (requested.value);
-	if (isoutput && !global) ExitDlmFunctionAndWarn("Keyword " + std::string(requested.keyword) + " must be a named variable.");
+	//if (isoutput && !global) ExitDlmFunctionAndWarn("Keyword " + std::string(requested.keyword) + " must be a named variable.");
 	BaseGDL* var = passed.gdlVarPtr;
 	//if requested var is NULL here, it is an undefined var, which MAY be returned as good value.
 	if (var == NULL && !isoutput) ExitDlmFunctionAndWarn("GDLExportKeyword: variable " + std::string(requested.keyword) + " is not defined.");
@@ -2800,9 +2802,9 @@ DLL_PUBLIC int  GDL_CDECL IDL_KWProcessByOffset(int argc, EXPORT_VPTR *argv, cha
 		//rewind: 
 		for (it = requested.begin(); it != requested.end(); ++it) {
 			int ipassed = it->second;
-			argk[ipassed].out = false;
 			if (ipassed == KEYWORD_ACCEPT) GdlExportAbsentKeyword(kw_requested[it->first], kw_result);
 			else if (ipassed >= 0) {
+			    argk[ipassed].out = false;
 				EXPORT_VPTR ret=GdlExportPresentKeyword(kw_requested[it->first], argk[it->second], kw_result);
 			    if (ret != NULL) {
 					argk[ipassed].out=true;
@@ -3249,10 +3251,10 @@ if (ntags == 0) ExitDlmFunctionAndWarn("IDL_MakeStruct(): structure creation nee
 DLL_PUBLIC EXPORT_MEMINT  GDL_CDECL IDL_StructTagInfoByName(EXPORT_StructDefPtr sdef, char *name, int msg_action, EXPORT_VPTR *var) { TRACE_ROUTINE(__FUNCTION__,__FILE__,__LINE__)
 		int l = strlen(name);
 		for (auto i = 0; i < sdef->ntags; ++i) {
-			if (sdef->tags[i].id->len == l && strncmp(name, sdef->tags[i].id->name, l)) {
+			if (sdef->tags[i].id->len == l && (strncmp(name, sdef->tags[i].id->name, l)==0)) {
 			if (var) *var=&(sdef->tags[i].var);
-			}
 			return sdef->tags[i].offset;
+			}
 		}
 		char* mess=(char*)calloc(256,1);
 		strncat(mess,"Tag name ",10);strncat(mess,name,200);strncat(mess," is undefined for structure ",29);
@@ -3504,6 +3506,7 @@ DLL_PUBLIC EXPORT_VPTR GDL_CDECL IDL_conj(EXPORT_VPTR v){		TRACE_ROUTINE(__FUNCT
 		strcat (pathbuf, file);
 		if (flags == 0) strcat (pathbuf, dot); //???
 		strcat (pathbuf, ext);
+		std::cerr<<pathbuf<<std::endl;
 		return pathbuf;
   }
 
@@ -3549,19 +3552,47 @@ DLL_PUBLIC  EXPORT_HEAP_VPTR GDL_CDECL IDL_HeapVarHashFind(EXPORT_HVID hash_id){
 try {pointed=MimickedHeap.at(hash_id);} catch (const std::out_of_range& oor) {ExitDlmFunctionAndThrow(__func__,"Invalid Heap.");}
 	return pointed;
 }
-DLL_PUBLIC UCHAR* IDL_ObjGetInstanceData(EXPORT_VPTR v){TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
-		return v->value.s.arr->data;}
+DLL_PUBLIC UCHAR* IDL_ObjGetInstanceData(EXPORT_VPTR v, char * what){TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+		return IDL_ObjReference(v)->value.s.arr->data;
+}
 DLL_PUBLIC EXPORT_VPTR GDL_CDECL  IDL_ObjNew(int argc, EXPORT_VPTR* argv, char* keywords_list){TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 	// in all cases argv[0] is the OBJECT name. Thus argc=1 min. argc=0 makes a void object and this is an error.
 	// this defines the new object.
 	// then all following argvs[1..n] are passed to OBJECT::init. if keywords are accepted by the ::INIT, then keywords_list CAN point
 	// to a chain of strings ("\0KEYWORD1\0KEYWORD2\0...") BUT starting with as many \0 as there are parameters
 	// passed to ::INIT, including "self". So if there are 3 parameters, that make 4 with "self", the keywords_list string starts with 4 \0 .
-return NULL;
+    static int funIx = LibFunIx("OBJ_NEW");
+    EnvT* newEnv = new EnvT(DInterpreter::CallStackBack()->CallingNode(), libFunList[funIx]);
+	int nargs=0;
+	int pos=1; //for keywords "compact strings" position
+	newEnv->SetNextPar(new DStringGDL(argv[nargs++]->value.str.s)); //the object name
+	// OBJ_NEW has only _REF_EXTRA as Keyword
+	while (nargs < argc ) { //the init args for obj_new
+		if (keywords_list) {
+			char* keyword=&keywords_list[pos];
+			int l=strlen(keyword);
+			if (l) {
+				pos+=(l+1);
+				BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+				newEnv->SetKeyword(std::string(keyword),par);
+			} else {
+				pos++; // the \0 in string
+				BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+				newEnv->SetNextPar(par);
+			}
+		} else {
+			BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+			newEnv->SetNextPar(par);
+		}
+	}
+	// the following ResolveExtra is always needed, as long as we pass keywords. Should check it is always the case in the GDL code source.
+	newEnv->ResolveExtra();
+	DObjGDL* ret = static_cast<DObjGDL*> (static_cast<DLibFun*>(newEnv->GetPro())->Fun()(newEnv));
+    return  GDL_ToVPTR(ret);
 }
 //IDL_ObjCallMethodByString
 //char* Method, IDL_HVID hvid, void* return_vptr, int argc, IDL_VPTR* argv, char* keywords)
-DLL_PUBLIC EXPORT_VPTR GDL_CDECL IDL_ObjCallMethodByString(char* Method, EXPORT_HVID hvid, void* return_vptr, int argc, EXPORT_VPTR* argv, char* keywords){TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
+DLL_PUBLIC void GDL_CDECL IDL_ObjCallMethodByString(char* method, EXPORT_HVID hvid, EXPORT_VPTR* return_vptr, int argc, EXPORT_VPTR* argv, char* keywords_list){TRACE_ROUTINE(__FUNCTION__, __FILE__, __LINE__)
 // if Method has Keywords, then see IDL_ObjNew(). For example with 
 		// toto=obj_new('IDLgrWindow')
 		// toto->setproperty,dimensions=[100,100] 
@@ -3569,8 +3600,63 @@ DLL_PUBLIC EXPORT_VPTR GDL_CDECL IDL_ObjCallMethodByString(char* Method, EXPORT_
 		// we could have also IDL_ObjCallMethodByString("GetProperty", object's_hvid, NULL, 1, vptr out, "\0DIMENSIONS\0" )
 // if method has no kw, idem.
 		//if method returns a value (it is a function) it is in return_vptr (and is GDL_V_TEMP)
-return NULL;
-}
+
+// make some checks beforehand
+    EXPORT_HEAP_VPTR h=IDL_HeapVarHashFind(hvid);
+	DStructGDL* oStruct;
+	DObjGDL* obj=(DObjGDL*)h->hash;
+	if (obj==NULL) ExitDlmFunctionAndThrow(__func__,"No GDL object at hvid, please report.");
+	DObj objIx;
+      if (!obj->Scalar(objIx)) ExitDlmFunctionAndThrow(__func__,"Parameter must be a scalar or 1 element array in this context: ");
+      if (objIx == 0) ExitDlmFunctionAndThrow(__func__,"Unable to invoke method on NULL object reference");
+      try {
+	    oStruct = GDLInterpreter::GetObjHeap(objIx);
+      }
+      catch ( GDLInterpreter::HeapException)
+	{
+	  ExitDlmFunctionAndThrow(__func__,"Object not valid.");
+	}
+    EnvT* newEnv;
+    if (return_vptr) { //a function
+      static int funIx = LibFunIx("CALL_METHOD");
+      newEnv = new EnvT(DInterpreter::CallStackBack()->CallingNode(), libFunList[funIx]);
+    } else { //a procedure
+      static int proIx = LibProIx("CALL_METHOD");
+      newEnv = new EnvT(DInterpreter::CallStackBack()->CallingNode(), libProList[proIx]);
+	}
+	newEnv->SetNextPar(new DStringGDL(method)); //CALL_METHOD,Method,...
+	newEnv->SetNextPar(obj); //ITEM,...
+	int nargs=0;
+	int pos=1; //for keywords "compact strings" position
+	// complete with all arguments
+	while (nargs < argc ) { //the init args for obj_new
+		if (keywords_list) {
+			char* keyword=&keywords_list[pos];
+			int l=strlen(keyword);
+			if (l) {
+				pos+=(l+1);
+				BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+				newEnv->SetKeyword(std::string(keyword),par);
+			} else {
+				pos++; // the \0 in string
+				BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+				newEnv->SetNextPar(par);
+			}
+		} else {
+			BaseGDL* par=VPTR_ToGDL(argv[nargs++]);
+			newEnv->SetNextPar(par);
+		}
+	}
+	newEnv->ResolveExtra();
+	try{
+    if (return_vptr) {
+		BaseGDL* ret = static_cast<DLibFun*>(newEnv->GetPro())->Fun()(newEnv);
+		*return_vptr = GDL_ToVPTR(ret);
+    } else {
+		static_cast<DLibPro*>(newEnv->GetPro())->Pro()(newEnv);
+	}
+	} catch ( GDLException e) {ExitDlmFunctionAndThrow(__func__,e.getMessage());}
+} 
 #include "export_notsupported.hpp"
 }
 #endif

--- a/src/gdlwidget.cpp
+++ b/src/gdlwidget.cpp
@@ -3368,12 +3368,13 @@ std::vector<int> GDLWidgetTable::GetSortedSelectedRowsOrColsList(DLongGDL* selec
 
 DStringGDL* CallStringFunction(BaseGDL* val, BaseGDL* format) {
   int stringIx = LibFunIx("GDL_TOSTRING");
-  EnvT *newEnv = new EnvT(NULL, libFunList[stringIx]);
+  EnvT *newEnv = new EnvT(DInterpreter::CallStackBack()->CallingNode(), libFunList[stringIx]);
   Guard<EnvT> guard(newEnv);
   newEnv->SetNextPar(val); // pass as local
   if (format != NULL) newEnv->SetKeyword("FORMAT", format);
-  DStringGDL* s = static_cast<DStringGDL*> (lib::gdl_tostring_fun(newEnv));
-  guard.release();
+  DStringGDL* s = static_cast<DStringGDL*> (static_cast<DLibFun*>(newEnv->GetPro())->Fun()(newEnv));
+  // equivalent: static_cast<DStringGDL*> (lib::gdl_tostring_fun(newEnv));
+//  guard.release();
   for (auto i = 0; i < s->N_Elements(); ++i) StrTrim((*s)[i]);
   s->SetDim(val->Dim()); //necessary
   return s;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -134,7 +134,7 @@ static BaseGDL* GetNodeData(DPtr &Node)
 
 static  BaseGDL* hash_create( EnvT* e, bool isordered );
 static BaseGDL* structP_tohash( EnvT* e,BaseGDL* par,
-                        bool foldcasekw, bool extractkw, bool isordered );
+                        bool foldcasekw, bool extractkw, bool lowercasekw, bool isordered );
 
 static DStructGDL* GetOBJ( BaseGDL* Objptr, EnvUDT* e)
   {
@@ -672,12 +672,8 @@ DObj new_hashStruct(  DLong initialTableSize, DStructGDL*& hashTable,
 
 
 static BaseGDL* struct_tohash( EnvT* e,DStructGDL* parStruct,
-                        bool foldcasekw, bool extractkw, bool isordered=false)
+                        bool foldcasekw, bool extractkw, bool keytolower, bool isordered=false)
 {
-
-    static int kwLOWERCASEIx = e->KeywordIx("LOWERCASE");
-
-    bool keytolower = e->KeywordSet(kwLOWERCASEIx);
     DStructDesc* desc = parStruct->Desc();
     DStructGDL* hashTable;
     DLong initialTableSize = GetInitialTableSize( desc->NTags());
@@ -698,7 +694,7 @@ static BaseGDL* struct_tohash( EnvT* e,DStructGDL* parStruct,
           BaseGDL* par = parStruct->GetTag(t,0);
           assert(par != NULL);
           if( extractkw and par->Type() == GDL_STRUCT and (par->N_Elements()==1))
-                    structData = structP_tohash( e, par, foldcasekw, extractkw, isordered);
+                    structData = structP_tohash( e, par, foldcasekw, extractkw, keytolower, isordered);
           else structData = par->Dup();
           
           InsertIntoHashTable( hashStruct, hashTable, structKey, structData);
@@ -708,12 +704,12 @@ static BaseGDL* struct_tohash( EnvT* e,DStructGDL* parStruct,
     return newObj;
 }
 
-static BaseGDL* structP_tohash( EnvT* e,BaseGDL* par, bool foldcasekw, bool extractkw, bool isordered=false)
+static BaseGDL* structP_tohash( EnvT* e,BaseGDL* par, bool foldcasekw, bool extractkw, bool lowercasekw, bool isordered=false)
 {
     if(par->N_Elements() != 1)
             e->Throw(" only a single struct may be hashed");
     DStructGDL* parStruct = static_cast<DStructGDL*>(par);
-    return struct_tohash( e, parStruct, foldcasekw, extractkw, isordered);
+    return struct_tohash( e, parStruct, foldcasekw, extractkw, lowercasekw, isordered);
 }
 
   BaseGDL* hash_tostruct( DStructGDL* self ,
@@ -2229,13 +2225,54 @@ BaseGDL* hash_subset(DStructGDL* thisTable, BaseGDL* index, bool isfoldcase);
                     parX->NewIx(kIx), rValue->NewIx(kIx));
             }
         }
+  }
+
+  void HASH__Set(EnvUDT* e) {
+    //    static unsigned par1Ix = 4;
+    static unsigned prmbeg = 2;
+    //    trace_me = lib::trace_arg();
+    std::string trcn = trace_me ? "\n;" : ";";
+
+    SizeT nParam = e->NParam(1);
+    if (nParam < 3) ThrowFromInternalUDSub(e,
+        "Three parameters are needed: OBJREF, KEY, VAL");
+
+    BaseGDL* key = e->GetTheKW(1);
+    if (key == NULL) key = NullGDL::GetSingleInstance();
+
+    // Generalize from  self to theStruct
+    DStructGDL* self = GetOBJ(e->GetTheKW(0), e);
+    DStructGDL* theStruct = self;
+
+    DPtr Ptr = DPtrTABLE_DATA(theStruct);
+    DStructGDL* hashTable = static_cast<DStructGDL*> (BaseGDL::interpreter->GetHeap(Ptr));
+    bool isfoldcase = Hashisfoldcase(theStruct);
+
+    // This section copied and slightly adapted from LIST_OVERLOADLEFT
+    BaseGDL* theref = NULL;
+    int iprm = 0;
+
+    SizeT listSize = 0;
+    BaseGDL* val = e->GetKW(2);
+    if (val == NULL )
+      ThrowFromInternalUDSub(e, "Parameter is undefined ");
+
+    isfoldcase = Hashisfoldcase(theStruct);
+    DLong hashIndex = HashIndex(hashTable, key, isfoldcase);
+    if (hashIndex >= 0) {
+      DPtr pValue = DPtrVALUE(hashTable, hashIndex);
+      BaseGDL::interpreter->GetHeap(pValue) = val->Dup();
+      return;
+    } else { // hashIndex >= 0
+      InsertIntoHashTable( theStruct, hashTable, key, val->Dup());
+      return;
     }
- 
+
+  }
+  
   void HASH___OverloadBracketsLeftSide( EnvUDT* e)
   {
     
-    
-
 //    static unsigned par1Ix = 4;
     static unsigned isRangeIx = 3;
     static unsigned prmbeg = isRangeIx+1;
@@ -2823,12 +2860,10 @@ BaseGDL* hash_duplicate(DStructGDL* self) {
     static int kwFOLD_CASEIx = e->KeywordIx("FOLD_CASE");
     static unsigned fold_case_mask = 0x00000001;
     static int kwEXTRACTIx = e->KeywordIx("EXTRACT");   // still new
+    static int kwLOWERCASEIx = e->KeywordIx("LOWERCASE");
     trace_me = false; // lib::trace_arg();
 
     SizeT nParam = e->NParam();   
-
-    ProgNodeP cN = e->CallingNode();
-    DInterpreter* ip = e->Interpreter();
 
     // because of .RESET_SESSION, we cannot use static here
     DStructDesc* hashDesc=structDesc::HASH;
@@ -2838,6 +2873,7 @@ BaseGDL* hash_duplicate(DStructGDL* self) {
     
      bool foldcasekw = e->KeywordSet( kwFOLD_CASEIx);
      bool extractkw = e->KeywordSet( kwEXTRACTIx);
+     bool lowercasekw = e->KeywordSet( kwLOWERCASEIx);
 
     BaseGDL* key;
     SizeT nEntries = 0;
@@ -2846,12 +2882,12 @@ BaseGDL* hash_duplicate(DStructGDL* self) {
       if(trace_me) std::cout << " hash(nParam=1) ";
       if(  key->Type() == GDL_STRUCT ) {
                 if(trace_me) std::cout << " . " ;
-            return structP_tohash( e, key, foldcasekw, extractkw, isordered);
+            return structP_tohash( e, key, foldcasekw, extractkw, lowercasekw, isordered);
           }// direct return for the case of struct --> hash
       else if ( key->Type() == GDL_OBJ and key->StrictScalar())
       {    // GDL extension: put object structure directly into a hash.
             DStructGDL* oStructGDL= GetOBJ( key, NULL);
-            return struct_tohash( e, oStructGDL, foldcasekw, extractkw, isordered);
+            return struct_tohash( e, oStructGDL, foldcasekw, extractkw, lowercasekw, isordered);
         }   else {  // key->Type() == GDL_STRUCT || key->Type() == GDL_OBJ
          // 1-element hash table, value=null);
          nEntries = key->N_Elements();

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -56,6 +56,7 @@ namespace lib {
 
   BaseGDL* hash_fun( EnvT* e);
   BaseGDL* orderedhash_fun( EnvT* e);
+  void HASH__Set( EnvUDT* e);
 }
 
 #endif

--- a/src/overload.cpp
+++ b/src/overload.cpp
@@ -715,6 +715,12 @@ void SetupOverloadSubroutines() {
   treePro = new WRAPPED_PRONode(lib::hash__remove_pro);
   DProHASH__REMOVE->SetTree(treePro);
   hashDesc->ProList().push_back(DProHASH__REMOVE);
+  // HASH::SET PRO
+  DPro *DProHASH__SET = new DPro("SET", "HASH", INTERNAL_LIBRARY_STR);
+  DProHASH__SET->AddPar("KEY")->AddPar("VALUE");
+  treePro = new WRAPPED_PRONode(lib::HASH__Set);
+  DProHASH__SET->SetTree(treePro);
+  hashDesc->ProList().push_back(DProHASH__SET);
   // HASH::HASKEY()
   DFun *DFunHASH__HASKEY = new DFun("HASKEY", "HASH", INTERNAL_LIBRARY_STR);
   DFunHASH__HASKEY->AddPar("KEYLIST");


### PR DESCRIPTION
added some code to be able to create objects in a DLM  (for NASA's cdf_readcdf that returns a hash table). Plus some bugs corrected.
This implied to make HASH accept the undocumented function HASH::SET
Note that there are still problems with NASA's cdf dlm, apparently only for the CDF_READCDF command that is the only one to use object creation.