### PR TITLE
Fix builds on RISC-V

### DIFF
--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -693,7 +693,7 @@ template<> BaseGDL* Data_<SpDFloat>::Convert2(DType destTy, BaseGDL::Convert2Mod
 
   switch (destTy) {
   case GDL_BYTE:
-    DO_CONVERT_START(SpDByte)
+    DO_CONVERT_START_FLOAT_TO_UNSIGNED(SpDByte, DByte, DInt)
     TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
       DO_CONVERT_END
@@ -779,7 +779,7 @@ template<> BaseGDL* Data_<SpDDouble>::Convert2(DType destTy, BaseGDL::Convert2Mo
 
   switch (destTy) {
   case GDL_BYTE:
-    DO_CONVERT_START(SpDByte)
+    DO_CONVERT_START_FLOAT_TO_UNSIGNED(SpDByte, DByte, DInt)
     TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
       DO_CONVERT_END
@@ -1166,7 +1166,7 @@ template<> BaseGDL* Data_<SpDComplex>::Convert2(DType destTy, BaseGDL::Convert2M
 
   switch (destTy) {
   case GDL_BYTE:
-    DO_CONVERT_START_CPX(SpDByte)
+    DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX(SpDByte, DByte, DInt)
     TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
       DO_CONVERT_END_CPX
@@ -1278,7 +1278,7 @@ template<> BaseGDL* Data_<SpDComplexDbl>::Convert2(DType destTy, BaseGDL::Conver
 
   switch (destTy) {
   case GDL_BYTE:
-    DO_CONVERT_START_CPX(SpDByte)
+    DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX(SpDByte, DByte, DInt)
     TRACEOMP(__FILE__, __LINE__)
 #pragma omp parallel for num_threads(GDL_NTHREADS)
       DO_CONVERT_END_CPX

--- a/src/convert2.cpp
+++ b/src/convert2.cpp
@@ -41,7 +41,7 @@ using namespace std;
         if( nEl == 1) { (*dest)[0]=static_cast<unsigned>(static_cast<signed>((*this)[0])); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
         if((GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION))==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=static_cast<unsigned>(static_cast<signed>((*this)[i])); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
 
-#ifdef __aarch64__
+#if defined(__aarch64__) || defined(__riscv)
 #define DO_CONVERT_START_FLOAT_TO_UNSIGNED(tnew, unsigned, signed) DO_CONVERT_START_FLOAT_TO_UNSIGNED_ARM64(tnew, unsigned, signed)
 #else
 #define DO_CONVERT_START_FLOAT_TO_UNSIGNED(tnew, unsigned, signed) DO_CONVERT_START_FLOAT_TO_UNSIGNED_IA64(tnew, unsigned, signed)
@@ -63,7 +63,7 @@ using namespace std;
         Data_<tnew>* dest=new Data_<tnew>( dim, BaseGDL::NOZERO);\
         if( nEl == 1) { (*dest)[0]=static_cast<unsigned>(static_cast<signed>((*this)[0].real())); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest;}\
         if((GDL_NTHREADS=parallelize(nEl,  TP_ARRAY_INITIALISATION))==1) {for( SizeT i=0; i < nEl; ++i) (*dest)[i]=static_cast<unsigned>(static_cast<signed>((*this)[i].real())); if( (mode & BaseGDL::CONVERT) != 0) delete this; return dest; }
-#ifdef __aarch64__
+#if defined(__aarch64__) || defined(__riscv)
 #define DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX(tnew, unsigned, signed) DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX_ARM64(tnew, unsigned, signed)
 #else
 #define DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX(tnew, unsigned, signed) DO_CONVERT_START_FLOAT_TO_UNSIGNED_CPX_IA64(tnew, unsigned, signed)

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -41,7 +41,6 @@ set_tests_properties(${TESTS} PROPERTIES ENVIRONMENT "LC_COLLATE=C;GDL_PATH=${BA
 set(ARM_XFAIL_TESTS
     test_byte_conversion.pro
     test_formats.pro
-    test_rounding.pro
 )
 foreach(test ${ARM_XFAIL_TESTS})
   set_tests_properties(${test} PROPERTIES WILL_FAIL $<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},aarch64>)


### PR DESCRIPTION
The `gdl` package was failing when we tried to build it for Fedora/riscv64:

```
99% tests passed, 1 tests failed out of 212
Total Test time (real) =  91.36 sec
The following tests did not run:
	133 - test_mpi.pro (Skipped)
The following tests FAILED:
	168 - test_rounding.pro (Failed)
Errors while running CTest
```

I decided that our temporary solution (disabling that test) is not a proper solution and gave build log and source to the Claude agent.

At first I got two patches:

- Enable float-to-unsigned conversion workaround on RISC-V
- Use signed cast for float-to-BYTE conversion on non-x86 architectures

And with those applied package built fine on RISC-V and all tests passed.

But then I did [Fedora wide run](https://koji.fedoraproject.org/koji/taskinfo?taskID=149785214) which failed on AArch64:

[build.log](https://kojipkgs.fedoraproject.org//work/tasks/5220/149785220/build.log):

```
169/213 Test #169: test_rounding.pro ..................***Failed    0.80 sec
% Compiled module: DLM_REGISTER.
% Compiled module: TEST_ROUNDING.
% Compiled module: BANNER_FOR_TESTSUITE.
% Compiled module: GDL_IDL_FL.
% TEST_ROUNDING_TYPE: 
===========================================================
% TEST_ROUNDING_TYPE: testing /ROUND
% Compiled module: GIVE_LIST_NUMERIC.
% TEST_ROUNDING_TYPE: 
=                                                         =
% TEST_ROUNDING_TYPE: 
=  NO errors encountered during TEST_ROUNDING_TYPE tests  =
% TEST_ROUNDING_TYPE: 
=                                                         =
% Compiled module: ERRORS_CUMUL.
% TEST_ROUNDING_TYPE: testing /CEIL
% TEST_ROUNDING_TYPE: 
=                                                         =
% TEST_ROUNDING_TYPE: 
=  NO errors encountered during TEST_ROUNDING_TYPE tests  =
% TEST_ROUNDING_TYPE: 
=                                                         =
% TEST_ROUNDING_TYPE: testing /FLOOR
% TEST_ROUNDING_TYPE: 
=                                                         =
% TEST_ROUNDING_TYPE: 
=  NO errors encountered during TEST_ROUNDING_TYPE tests  =
% TEST_ROUNDING_TYPE: 
=                                                         =
% TEST_ROUNDING_TYPE: 
===========================================================
% TEST_ROUNDING_FLOAT: 
============================================================
% TEST_ROUNDING_FLOAT: testing /ROUND
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: 
=  NO errors encountered during TEST_ROUNDING_FLOAT tests  =
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: testing /CEIL
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: 
=  NO errors encountered during TEST_ROUNDING_FLOAT tests  =
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: testing /FLOOR
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: 
=  NO errors encountered during TEST_ROUNDING_FLOAT tests  =
% TEST_ROUNDING_FLOAT: 
=                                                          =
% TEST_ROUNDING_FLOAT: 
============================================================
% TEST_ROUNDING_L64: ==========================================================
% TEST_ROUNDING_L64: testing /ROUND
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: =  NO errors encountered during TEST_ROUNDING_L64 tests  =
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: testing /CEIL
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: =  NO errors encountered during TEST_ROUNDING_L64 tests  =
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: testing /FLOOR
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: =  NO errors encountered during TEST_ROUNDING_L64 tests  =
% TEST_ROUNDING_L64: =                                                        =
% TEST_ROUNDING_L64: ==========================================================
% TEST_ROUNDING: ======================================================
% TEST_ROUNDING: =                                                    =
% TEST_ROUNDING: =  NO errors encountered during TEST_ROUNDING tests  =
% TEST_ROUNDING: =                                                    =
% TEST_ROUNDING: ======================================================
```

Turned out that test passes now while testsuite expects it to fail...

Which brought the 3rd patch:

- Remove test_rounding from ARM_XFAIL_TESTS


I hope that you do not mind use of AI to generate/write fixes. They all are short, precise and describe what they do.